### PR TITLE
AF-2004: Configure CI tooling for Kogito - PR Check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,58 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        label 'submarine-static || kie-rhel7'
+    }
+    tools {
+        nodejs "nodejs-11.0.0"
+    }
+    options {
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
+        timeout(time: 90, unit: 'MINUTES')
+    }
+    environment {
+        SONARCLOUD_TOKEN = credentials('SONARCLOUD_TOKEN')
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                sh 'printenv'
+            }
+        }
+        stage('Prepare') {
+            steps {
+                sh "npm install -g yarn"
+                sh "yarn install"
+            }
+        }
+        stage('Build kogito-tooling') {
+            steps {
+                dir("kogito-tooling") {
+                    script {
+                        githubscm.checkoutIfExists('kogito-tooling', "$CHANGE_AUTHOR", "$CHANGE_BRANCH", 'kiegroup', "$CHANGE_TARGET")
+                        wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+                            sh('yarn run build:prod')
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unstable {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        failure {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        always {
+            junit '**/**/junit.xml'
+            cleanWs()
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ pipeline {
         }
         always {
             junit '**/**/junit.xml'
+            junit '**/**/vscode-it-test-report.xml'
             cleanWs()
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'submarine-static || kie-rhel7'
+        label 'kogito-tooling-test'
     }
     tools {
         nodejs "nodejs-11.0.0"
@@ -24,6 +24,8 @@ pipeline {
             steps {
                 sh "npm install -g yarn"
                 sh "yarn install"
+                sh "export XAUTHORITY=$HOME/.Xauthority"
+                sh "chmod 600 $HOME/.vnc/passwd"
             }
         }
         stage('Build kogito-tooling') {
@@ -32,7 +34,7 @@ pipeline {
                     script {
                         githubscm.checkoutIfExists('kogito-tooling', "$CHANGE_AUTHOR", "$CHANGE_BRANCH", 'kiegroup', "$CHANGE_TARGET")
                         wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-                            sh('yarn run build:prod')
+                            sh('yarn run init && yarn build:prod')
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'kogito-tooling-test'
+        label 'kie-rhel7&&kie-mem8g'
     }
     tools {
         nodejs "nodejs-11.0.0"
@@ -54,7 +54,9 @@ pipeline {
         }
         always {
             junit '**/**/junit.xml'
-            junit '**/**/vscode-it-test-report.xml'
+            // Temporary workaround to avoid failing builds due to missing reports
+            // TODO: Uncomment when https://issues.jboss.org/browse/KOGITO-158 is fixed
+            // junit '**/**/vscode-it-test-report.xml'
             cleanWs()
         }
     }

--- a/packages/vscode-extension-pack-kogito/tests-it/suite/index.ts
+++ b/packages/vscode-extension-pack-kogito/tests-it/suite/index.ts
@@ -22,7 +22,13 @@ export function run(testsRoot: string, callback: (error: any, failures?: number)
   const mocha = new Mocha({
     ui: "tdd",
     useColors: true,
-    timeout: 10000
+    timeout: 10000,
+    reporter: "mocha-jenkins-reporter",
+    reporterOptions: {
+      junit_report_name: "VSCode Extension Tests",
+      junit_report_path: "vscode-it-test-report.xml",
+      junit_report_stack: 1
+    }
   });
 
   glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -72,6 +72,7 @@
     "jest-junit": "6.3.0",
     "mocha": "6.1.4",
     "ts-jest": "23.1.3",
+    "mocha-jenkins-reporter": "^0.4.2",
     "tslint": "5.12.1",
     "typescript": "3.3.1",
     "vsce": "1.59.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,6 +2786,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
+
 commander@^2.12.1, commander@^2.19.0, commander@^2.8.1, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
@@ -3424,6 +3429,11 @@ diff@3.5.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -4441,6 +4451,18 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -4636,6 +4658,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 he@1.2.0:
   version "1.2.0"
@@ -6557,6 +6584,16 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.
   dependencies:
     minimist "0.0.8"
 
+mocha-jenkins-reporter@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.2.tgz#122023651b13b9b99b915940950608f833655540"
+  integrity sha512-ofQ41SUX5Uh3eHLn/ki4UTsh/7Yuk6p8N3RbxB275TLPErjkJGXuiT5i0haJ51UdJ+bkUhdyIpcCOHS3XSNVsg==
+  dependencies:
+    diff "4.0.1"
+    mkdirp "0.5.1"
+    mocha "^5.2.0"
+    xml "^1.0.1"
+
 mocha@6.1.4:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.1.4.tgz#e35fada242d5434a7e163d555c705f6875951640"
@@ -6585,6 +6622,23 @@ mocha@6.1.4:
     yargs "13.2.2"
     yargs-parser "13.0.0"
     yargs-unparser "1.5.0"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -8846,6 +8900,13 @@ strong-log-transformer@^2.0.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
+
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@6.0.0:
   version "6.0.0"


### PR DESCRIPTION
@ederign @tiagobento Please take a look. This adds pull request checks. Simple example is here: https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/kogito/job/kogito-tooling/ It builds my fork for now I will switch it to this repo in CI.

Two notes. I will be updating the label once we have new slave image with required changes. Once this is merged I will fine tune it.

Changes to slaves are in this PR:
https://github.com/kiegroup/kie-jenkins-scripts/pull/508 