### PR TITLE
KOGITO-229: Configure sonarcloud for kogito-tooling

### DIFF
--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -22,8 +22,8 @@ pipeline {
         }
         stage('Prepare') {
             steps {
-                sh "npm install -g yarn"
-                sh "yarn install"
+                sh "npm install -g yarn --registry=${NPM_REGISTRY_URL}"
+                sh "yarn config set registry ${NPM_REGISTRY_URL}"
                 sh "export XAUTHORITY=$HOME/.Xauthority"
                 sh "chmod 600 $HOME/.vnc/passwd"
             }

--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -1,0 +1,72 @@
+ 6111526b5bac57891e382cea71ec74bc056882ed@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        label 'kie-rhel7&&kie-mem8g'
+    }
+    tools {
+        nodejs "nodejs-11.0.0"
+    }
+    options {
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
+        timeout(time: 90, unit: 'MINUTES')
+    }
+    environment {
+        SONARCLOUD_TOKEN = credentials('SONARCLOUD_TOKEN')
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                sh 'printenv'
+            }
+        }
+        stage('Prepare') {
+            steps {
+                sh "npm install -g yarn"
+                sh "yarn install"
+                sh "export XAUTHORITY=$HOME/.Xauthority"
+                sh "chmod 600 $HOME/.vnc/passwd"
+            }
+        }
+        stage('Build kogito-tooling') {
+            steps {
+                dir("kogito-tooling") {
+                    script {
+                        githubscm.checkoutIfExists('kogito-tooling', "$CHANGE_AUTHOR", "$CHANGE_BRANCH", 'kiegroup', "$CHANGE_TARGET")
+                        wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+                            sh('yarn run init && yarn build:prod')
+                        }
+                    }
+                }
+            }
+        }
+        stage('Run sonar analysis on kogito-tooling') {
+             steps {
+                 dir("kogito-tooling") {
+                     script {
+                         sh('sonar-scanner -Dsonar.login=${SONARCLOUD_TOKEN}')
+                     }
+                 }
+             }
+         }
+    }
+    post {
+        unstable {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        failure {
+            script {
+                mailer.sendEmailFailure()
+            }
+        }
+        always {
+            junit '**/**/junit.xml'
+            // Temporary workaround to avoid failing builds due to missing reports
+            // TODO: Uncomment when https://issues.jboss.org/browse/KOGITO-158 is fixed
+            // junit '**/**/vscode-it-test-report.xml'
+            cleanWs()
+        }
+    }
+}

--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -1,4 +1,4 @@
- 6111526b5bac57891e382cea71ec74bc056882ed@Library('jenkins-pipeline-shared-libraries')_
+@Library('jenkins-pipeline-shared-libraries')_
 
 pipeline {
     agent {

--- a/packages/gwt-editors/package.json
+++ b/packages/gwt-editors/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",
-    "test": "jest",
+    "test": "jest --collectCoverage",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
     "build:prod": "yarn run build --mode production --devtool none "

--- a/packages/microeditor-envelope-protocol/package.json
+++ b/packages/microeditor-envelope-protocol/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",
-    "test": "jest",
+    "test": "jest --collectCoverage",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
     "build:prod": "yarn run build --mode production --devtool none "

--- a/packages/microeditor-envelope/package.json
+++ b/packages/microeditor-envelope/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",
-    "test": "jest",
+    "test": "jest --collectCoverage",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
     "build:prod": "yarn run build --mode production --devtool none"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,11 +14,14 @@ sonar.sources=packages/afjs-core/src,\
   packages/microeditor-envelope-protocol/src,\
   packages/vscode-extension-pack-kogito-bpmn/src,\
   packages/vscode-extension-pack-simple-react/src,\
-  packages/vscode-extension/src
+  packages/vscode-extension/src,\
+  packages/chrome-extension/src,\
+  packages/gwt-editors/src
 sonar.tests=packages/microeditor-envelope-protocol/src/__tests__,\
   packages/microeditor-envelope/src/__tests__,\
-  packages/vscode-extension-pack-kogito-bpmn/src/__tests__,\
-  packages/vscode-extension-pack-kogito-bpmn/tests-it/suite,
+  packages/vscode-extension/__tests__,\
+  packages/vscode-extension-pack-kogito-bpmn/tests-it/suite,\
+  packages/gwt-editors/src/__tests__
 sonar.ts.tslintconfigpath=tslint.json
 sonar.host.url=https://sonarcloud.io
 sonar.organization=kiegroup

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,25 @@
+sonar.exclusions=**/dist/**,\
+  **/target/**,\
+  **/node_modules/**,\
+  **/*.spec.ts,\
+  **/coverage/**,\
+  **/__tests__/**,\
+  **/*.config.js,\
+  **/jest-env-setup.js,\
+  **/*.html,
+sonar.typescript.lcov.reportPaths=packages/microeditor-envelope/coverage/lcov.info,\
+  packages/microeditor-envelope-protocol/coverage/lcov.info,
+sonar.sources=packages/afjs-core/src,\
+  packages/microeditor-envelope/src,\
+  packages/microeditor-envelope-protocol/src,\
+  packages/vscode-extension-pack-kogito-bpmn/src,\
+  packages/vscode-extension-pack-simple-react/src,\
+  packages/vscode-extension/src
+sonar.tests=packages/microeditor-envelope-protocol/src/__tests__,\
+  packages/microeditor-envelope/src/__tests__,\
+  packages/vscode-extension-pack-kogito-bpmn/src/__tests__,\
+  packages/vscode-extension-pack-kogito-bpmn/tests-it/suite,
+sonar.ts.tslintconfigpath=tslint.json
+sonar.host.url=https://sonarcloud.io
+sonar.organization=kiegroup
+sonar.projectKey=org.kie.kogito:kogito-tooling


### PR DESCRIPTION
Adds `sonar-project.properties` that will be later used by daily job for sonar analysis.

Next, I will send a new PR with Jenkinsfile and CI job setup.

@tiagobento  please review and let me know if there are some files missing from the analysis. Frankly I can't use glob patterns for `sonar.tests` and `sonar.sources`...
