### PR TITLE
Introduce GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
      - name: Fetch editors from last release
        uses: actions/checkout@v1
        with:
+         repository: kiegroup/kogito-tooling
          ref: 0.2.0
      
      - name: Upload DMN editor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,29 @@ on:
     
 
 jobs:
+  fetch-editors:
+   runs-on: macOS-latest
+   steps:
+     - name: Fetch editors from last release
+       uses: actions/checkout@v1
+       with:
+         ref: 0.2.0
+     
+     - name: Upload DMN editor
+       uses: actions/upload-artifact@v1
+       with:
+         name: dmn-editor
+         path: packages/unpacked-gwt-editors/dmn
+ 
+     - name: Upload BPMN editor
+       uses: actions/upload-artifact@v1
+       with:
+         name: bpmn-editor
+         path: packages/unpacked-gwt-editors/bpmn
+   
+     
   build:
+    needs: fetch-editors
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -62,6 +84,18 @@ jobs:
     - name: Unit tests
       run: npx lerna run test --stream
       continue-on-error: true
+      
+    - name: Download DMN editor
+      uses: actions/upload-artifact@v1
+      with:
+        name: dmn-editor
+        path: packages/unpacked-gwt-editors/dmn
+
+    - name: Download BPMN editor
+      uses: actions/upload-artifact@v1
+      with:
+        name: bpmn-editor
+        path: packages/unpacked-gwt-editors/bpmn
     
     - name: "Build :: prod"
       if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  DISPLAY: ":99.0"
-
 on:
   push:
     branches: [master]
@@ -33,10 +30,13 @@ jobs:
          path: packages/unpacked-gwt-editors/bpmn
    
      
-  build:
+  build:    
     needs: fetch-editors
     runs-on: ${{ matrix.os }}
 
+    env:
+      DISPLAY: ":99.0"
+    
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,15 @@ jobs:
     - name: Pack artifacts
       run: npx lerna run pack-extension --stream
 
-    - name: Upload VSCode Extension
+    - name: Upload VSCode Extension (Ubuntu only)
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v1
       with:
         name: vscode-extension
         path: packages/vscode-extension-pack-kogito-kie-editors/dist
 
-    - name: Upload Chrome Extension
+    - name: Upload Chrome Extension (Ubuntu only)
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v1
       with:
         name: chrome-extension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - uses: actions/checkout@v1
-      name: Checkout to base_ref
+    - name: Checkout to PRs base branch -> ${{ github.base_ref }} (PR only)
+      uses: actions/checkout@v1
       if: github.base_ref
       with:
         ref: ${{ github.base_ref }}
 
-    - name: Merge with base ref
+    - name: Merge PR branch with PRs base branch (PR only)
       if: github.base_ref
       run: git merge ${{ github.sha }}
     
@@ -81,7 +81,7 @@ jobs:
       run: npx lerna run lint --stream
       continue-on-error: true
     
-    - name: Unit tests
+    - name: Run unit tests
       run: npx lerna run test --stream
       continue-on-error: true
       
@@ -102,8 +102,9 @@ jobs:
       run: npx lerna run --stream build:fast -- --mode production --devtool none
       continue-on-error: false
     
-    - name: Integration tests
+    - name: Run integration tests
       run: npx lerna run test:it --stream
+      continue-on-error: true
       
     - name: Pack artifacts
       run: npx lerna run pack-extension --stream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+env:
+  DISPLAY: ":99.0"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: "**"
+    
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.13.0]
+        yarn: [1.19.0]
+
+    
+    steps:
+    - uses: actions/checkout@v1
+    
+    - uses: actions/checkout@v1
+      name: Checkout to base_ref
+      if: github.base_ref
+      with:
+        ref: ${{ github.base_ref }}
+
+    - name: Merge with base ref
+      if: github.base_ref
+      run: git merge ${{ github.sha }}
+    
+    - uses: actions/setup-node@v1
+      name: Setup Node
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: Setup Yarn
+      run: npm install -g yarn@${{ matrix.yarn }}
+    
+    - name: Start Xvfb (Ubuntu only)
+      if: matrix.os == 'ubuntu-latest'
+      run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+    
+    - name: Download dependencies
+      run: yarn run init
+   
+    - name: "Build :: dev"
+      if: success()
+      run: npx lerna run build:fast --stream
+      continue-on-error: false
+    
+    - name: Lint
+      run: npx lerna run lint --stream
+      continue-on-error: true
+    
+    - name: Unit tests
+      run: npx lerna run test --stream
+      continue-on-error: true
+    
+    - name: "Build :: prod"
+      if: success()
+      run: npx lerna run --stream build:fast -- --mode production --devtool none
+      continue-on-error: false
+    
+    - name: Integration tests
+      run: npx lerna run test:it --stream
+      
+    - name: Pack artifacts
+      run: npx lerna run pack-extension --stream
+
+    - name: Upload VSCode Extension
+      uses: actions/upload-artifact@v1
+      with:
+        name: vscode-extension
+        path: packages/vscode-extension-pack-kogito-kie-editors/dist
+
+    - name: Upload Chrome Extension
+      uses: actions/upload-artifact@v1
+      with:
+        name: chrome-extension
+        path: packages/chrome-extension/dist
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
         node: [12.13.0]
         yarn: [1.19.0]
 
-    
     steps:
     - uses: actions/checkout@v1
     
@@ -87,17 +86,17 @@ jobs:
       continue-on-error: true
       
     - name: Download DMN editor
-      uses: actions/upload-artifact@v1
+      uses: actions/download-artifact@v1
       with:
         name: dmn-editor
         path: packages/unpacked-gwt-editors/dmn
 
     - name: Download BPMN editor
-      uses: actions/upload-artifact@v1
+      uses: actions/download-artifact@v1
       with:
         name: bpmn-editor
         path: packages/unpacked-gwt-editors/bpmn
-    
+
     - name: "Build :: prod"
       if: success()
       run: npx lerna run --stream build:fast -- --mode production --devtool none

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -56,6 +56,7 @@
     "watch": "1.0.2",
     "webpack": "4.41.2",
     "webpack-cli": "3.3.9",
-    "webpack-dev-server": "3.8.2"
+    "webpack-dev-server": "3.8.2",
+    "zip-webpack-plugin": "3.0.0"
   }
 }

--- a/packages/chrome-extension/webpack.config.js
+++ b/packages/chrome-extension/webpack.config.js
@@ -16,6 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
+const ZipPlugin = require("zip-webpack-plugin");
 
 module.exports = (env, argv) => {
   const isProd = argv.mode === "production";
@@ -47,7 +48,11 @@ module.exports = (env, argv) => {
         { from: "./static/manifest.json" },
         { from: "./static/resources", to: "./resources" },
         { from: "./static/envelope", to: "./envelope" }
-      ])
+      ]),
+      new ZipPlugin({
+        filename: "kiegroup_kogito_chrome_extension_" + packageJson.version + ".zip",
+        pathPrefix: "dist"
+      })
     ],
     module: {
       rules: [

--- a/packages/chrome-extension/webpack.config.js
+++ b/packages/chrome-extension/webpack.config.js
@@ -17,6 +17,7 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const ZipPlugin = require("zip-webpack-plugin");
+const packageJson = require("./package.json");
 
 module.exports = (env, argv) => {
   const isProd = argv.mode === "production";


### PR DESCRIPTION
On this PR:

- Introducing GitHub Workflow for CI on PRs and on `master` branch. Currently running on Ubuntu and on macOS.
- Configure `chrome-extension` module to produce a .zip file with its bundled files so that we can download it directly from the Checks tab on PRs on the Artifacts link. 

NOTE: This Workflow produces complete VSCode and Chrome Extension artifacts. It uses the 0.2.0 tag as reference point to download the editors.