### PR TITLE
Add XML formatting to DMN/BPMN editor outputs

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
@@ -15,7 +15,7 @@
  */
 
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
-import { GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
+import { BrowserXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
 import { EnvelopeBusMessage } from "@kogito-tooling/microeditor-envelope-protocol";
 
 const gwtAppFormerApi = new GwtAppFormerApi();
@@ -28,5 +28,5 @@ MicroEditorEnvelope.init({
       window.parent.postMessage(message, targetOrigin!, _);
     }
   },
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi)
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new BrowserXmlFormatter())
 });

--- a/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
@@ -15,7 +15,7 @@
  */
 
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
-import { BrowserXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
+import { DefaultXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
 import { EnvelopeBusMessage } from "@kogito-tooling/microeditor-envelope-protocol";
 
 const gwtAppFormerApi = new GwtAppFormerApi();
@@ -28,5 +28,5 @@ MicroEditorEnvelope.init({
       window.parent.postMessage(message, targetOrigin!, _);
     }
   },
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new BrowserXmlFormatter())
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter())
 });

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -27,8 +27,7 @@
     "test": "echo 'No tests to run.'",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
-    "build:prod": "yarn run build --mode production --devtool none",
-    "serve-envelope": "webpack-dev-server"
+    "build:prod": "yarn run build --mode production --devtool none"
   },
   "babel": {
     "presets": [

--- a/packages/chrome-extension/src/app/components/common/KogitoEditorIframe.tsx
+++ b/packages/chrome-extension/src/app/components/common/KogitoEditorIframe.tsx
@@ -63,6 +63,10 @@ const RefForwardingKogitoEditorIframe: React.RefForwardingComponent<IsolatedEdit
             if (props.readonly) {
               return;
             }
+
+            //keep line breaks
+            content = content.split("\n").join("\\n");
+
             runScriptOnPage(
               `document.querySelector("${GITHUB_CODEMIRROR_EDITOR_SELECTOR}").CodeMirror.setValue('${content}')`
             );

--- a/packages/gwt-editors/package.json
+++ b/packages/gwt-editors/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@kogito-tooling/core-api": "0.2.2",
-    "@kogito-tooling/microeditor-envelope": "0.2.2"
+    "@kogito-tooling/microeditor-envelope": "0.2.2",
+    "prettify-xml": "1.2.0"
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",

--- a/packages/gwt-editors/src/BrowserXmlFormatter.ts
+++ b/packages/gwt-editors/src/BrowserXmlFormatter.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { XmlFormatter } from "./XmlFormatter";
+
+export class BrowserXmlFormatter implements XmlFormatter {
+  private static XSLT_DOC: Document;
+
+  private xsltDoc() {
+    if (BrowserXmlFormatter.XSLT_DOC) {
+      return BrowserXmlFormatter.XSLT_DOC;
+    }
+
+    return new DOMParser().parseFromString(
+      [
+        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
+        '  <xsl:strip-space elements="*"/>',
+        '  <xsl:template match="para[content-style][not(text())]">',
+        '    <xsl:value-of select="normalize-space(.)"/>',
+        "  </xsl:template>",
+        '  <xsl:template match="node()|@*">',
+        '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
+        "  </xsl:template>",
+        '  <xsl:output indent="yes"/>',
+        "</xsl:stylesheet>"
+      ].join("\n"),
+      "application/xml"
+    );
+  }
+
+  public format(xml: string) {
+    const xmlDoc = new DOMParser().parseFromString(xml, "application/xml");
+    const xsltProcessor = new XSLTProcessor();
+    xsltProcessor.importStylesheet(this.xsltDoc());
+    const resultDoc = xsltProcessor.transformToDocument(xmlDoc);
+    return new XMLSerializer().serializeToString(resultDoc);
+  }
+}

--- a/packages/gwt-editors/src/BrowserXmlFormatter.ts
+++ b/packages/gwt-editors/src/BrowserXmlFormatter.ts
@@ -15,37 +15,10 @@
  */
 
 import { XmlFormatter } from "./XmlFormatter";
+import * as prettifyXml from "prettify-xml";
 
 export class BrowserXmlFormatter implements XmlFormatter {
-  private static XSLT_DOC: Document;
-
-  private xsltDoc() {
-    if (BrowserXmlFormatter.XSLT_DOC) {
-      return BrowserXmlFormatter.XSLT_DOC;
-    }
-
-    return new DOMParser().parseFromString(
-      [
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
-        '  <xsl:strip-space elements="*"/>',
-        '  <xsl:template match="para[content-style][not(text())]">',
-        '    <xsl:value-of select="normalize-space(.)"/>',
-        "  </xsl:template>",
-        '  <xsl:template match="node()|@*">',
-        '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-        "  </xsl:template>",
-        '  <xsl:output indent="yes"/>',
-        "</xsl:stylesheet>"
-      ].join("\n"),
-      "application/xml"
-    );
-  }
-
   public format(xml: string) {
-    const xmlDoc = new DOMParser().parseFromString(xml, "application/xml");
-    const xsltProcessor = new XSLTProcessor();
-    xsltProcessor.importStylesheet(this.xsltDoc());
-    const resultDoc = xsltProcessor.transformToDocument(xmlDoc);
-    return new XMLSerializer().serializeToString(resultDoc);
+    return prettifyXml(xml, { indent: 2, newLine: "\n" });
   }
 }

--- a/packages/gwt-editors/src/DefaultXmlFormatter.ts
+++ b/packages/gwt-editors/src/DefaultXmlFormatter.ts
@@ -19,6 +19,6 @@ import * as prettifyXml from "prettify-xml";
 
 export class DefaultXmlFormatter implements XmlFormatter {
   public format(xml: string) {
-    return prettifyXml(xml, { indent: 2, newLine: "\n" });
+    return prettifyXml(xml, { indent: 2, newLine: '\n' });
   }
 }

--- a/packages/gwt-editors/src/DefaultXmlFormatter.ts
+++ b/packages/gwt-editors/src/DefaultXmlFormatter.ts
@@ -17,7 +17,7 @@
 import { XmlFormatter } from "./XmlFormatter";
 import * as prettifyXml from "prettify-xml";
 
-export class BrowserXmlFormatter implements XmlFormatter {
+export class DefaultXmlFormatter implements XmlFormatter {
   public format(xml: string) {
     return prettifyXml(xml, { indent: 2, newLine: "\n" });
   }

--- a/packages/gwt-editors/src/GwtEditorWrapper.tsx
+++ b/packages/gwt-editors/src/GwtEditorWrapper.tsx
@@ -19,6 +19,7 @@ import * as AppFormer from "@kogito-tooling/core-api";
 import { GwtEditor } from "./GwtEditor";
 import { EnvelopeBusInnerMessageHandler } from "@kogito-tooling/microeditor-envelope";
 import { editors } from "./GwtEditorRoutes";
+import { XmlFormatter } from "./XmlFormatter";
 
 const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
 
@@ -27,15 +28,22 @@ export class GwtEditorWrapper extends AppFormer.Editor {
   public readonly editorId: string;
 
   private readonly gwtEditor: GwtEditor;
+  private readonly xmlFormatter: XmlFormatter;
   private readonly messageBus: EnvelopeBusInnerMessageHandler;
 
-  constructor(editorId: string, gwtEditor: GwtEditor, messageBus: EnvelopeBusInnerMessageHandler) {
+  constructor(
+    editorId: string,
+    gwtEditor: GwtEditor,
+    messageBus: EnvelopeBusInnerMessageHandler,
+    xmlFormatter: XmlFormatter
+  ) {
     super("gwt-editor-wrapper");
     this.af_componentTitle = editorId;
     this.af_isReact = true;
     this.gwtEditor = gwtEditor;
     this.messageBus = messageBus;
     this.editorId = editorId;
+    this.xmlFormatter = xmlFormatter;
   }
 
   public af_onOpen() {
@@ -53,7 +61,7 @@ export class GwtEditorWrapper extends AppFormer.Editor {
   }
 
   public getContent() {
-    return this.gwtEditor.getContent();
+    return this.gwtEditor.getContent().then(content => this.xmlFormatter.format(content));
   }
 
   public isDirty() {

--- a/packages/gwt-editors/src/GwtEditorWrapperFactory.ts
+++ b/packages/gwt-editors/src/GwtEditorWrapperFactory.ts
@@ -20,18 +20,28 @@ import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
 import { EnvelopeBusInnerMessageHandler } from "@kogito-tooling/microeditor-envelope";
 import { GwtEditorWrapper } from "./GwtEditorWrapper";
 import { GwtLanguageData, Resource } from "./GwtLanguageData";
+import { XmlFormatter } from "./XmlFormatter";
 
 export class GwtEditorWrapperFactory implements MicroEditorEnvelope.EditorFactory<GwtLanguageData> {
   private readonly appFormerGwtApi: GwtAppFormerApi;
+  private readonly xmlFormatter: XmlFormatter;
 
-  constructor(appFormerGwtApi: GwtAppFormerApi) {
+  constructor(appFormerGwtApi: GwtAppFormerApi, xmlFormatter: XmlFormatter) {
     this.appFormerGwtApi = appFormerGwtApi;
+    this.xmlFormatter = xmlFormatter;
   }
 
   public createEditor(languageData: GwtLanguageData, messageBus: EnvelopeBusInnerMessageHandler) {
     const gwtFinishedLoading = new Promise<AppFormer.Editor>(res => {
       this.appFormerGwtApi.onFinishedLoading(() => {
-        res(new GwtEditorWrapper(languageData.editorId, this.appFormerGwtApi.getEditor(languageData.editorId), messageBus));
+        res(
+          new GwtEditorWrapper(
+            languageData.editorId,
+            this.appFormerGwtApi.getEditor(languageData.editorId),
+            messageBus,
+            this.xmlFormatter
+          )
+        );
         messageBus.notify_ready();
         return Promise.resolve();
       });

--- a/packages/gwt-editors/src/PrettifyXmlLib.d.ts
+++ b/packages/gwt-editors/src/PrettifyXmlLib.d.ts
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-import { BrowserXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
-import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
-
-declare global {
-  export const acquireVsCodeApi: any;
+declare module "prettify-xml" {
+  const module: (xml: string, options: { indent: number; newLine: string }) => string;
+  export = module;
 }
-
-const gwtAppFormerApi = new GwtAppFormerApi();
-gwtAppFormerApi.setClientSideOnly(true);
-
-MicroEditorEnvelope.init({
-  container: document.getElementById("envelope-app")!,
-  busApi: acquireVsCodeApi(),
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new BrowserXmlFormatter())
-});

--- a/packages/gwt-editors/src/XmlFormatter.ts
+++ b/packages/gwt-editors/src/XmlFormatter.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-export * from "./GwtAppFormerApi";
-export * from "./GwtEditor";
-export * from "./GwtEditorWrapper";
-export * from "./GwtEditorWrapperFactory";
-export * from "./GwtLanguageData";
-export * from "./GwtEditorRoutes";
-export * from "./XmlFormatter";
-export * from "./BrowserXmlFormatter";
+export interface XmlFormatter {
+  format(xml: string): string;
+}

--- a/packages/gwt-editors/src/__tests__/DefaultXmlFormatter.test.ts
+++ b/packages/gwt-editors/src/__tests__/DefaultXmlFormatter.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DefaultXmlFormatter } from "../DefaultXmlFormatter";
+
+describe("format works", () => {
+  test("", () => {
+    const xmlFormatter = new DefaultXmlFormatter();
+    const formatted = xmlFormatter.format("<foo><bar /></foo>");
+    expect(formatted).toEqual("<foo>\n  <bar />\n</foo>");
+  });
+});

--- a/packages/gwt-editors/src/__tests__/GwtEditorWrapper.test.ts
+++ b/packages/gwt-editors/src/__tests__/GwtEditorWrapper.test.ts
@@ -24,8 +24,9 @@ const MockEditor = jest.fn(() => ({
 
 const mockEditor = new MockEditor();
 const mockMessageBus = { notify_setContentError: jest.fn() };
+const mockXmlFormatter = { format: (c: string) => c };
 
-const wrapper = new GwtEditorWrapper("MockEditorId", mockEditor, mockMessageBus as any);
+const wrapper = new GwtEditorWrapper("MockEditorId", mockEditor, mockMessageBus as any, mockXmlFormatter);
 
 describe("GwtEditorWrapper", () => {
   test("set content", async () => {

--- a/packages/gwt-editors/src/__tests__/GwtEditorWrapperFactory.test.ts
+++ b/packages/gwt-editors/src/__tests__/GwtEditorWrapperFactory.test.ts
@@ -61,7 +61,9 @@ const testLanguageData: GwtLanguageData = {
   resources: [cssResource, jsResource]
 };
 
-const gwtEditorWrapperFactory: GwtEditorWrapperFactory = new GwtEditorWrapperFactory(gwtAppFormerApi);
+const gwtEditorWrapperFactory: GwtEditorWrapperFactory = new GwtEditorWrapperFactory(gwtAppFormerApi, {
+  format: (c: string) => c
+});
 
 function waitForNScriptsToLoad(remaining: number) {
   if (remaining <= 0) {

--- a/packages/gwt-editors/src/index.ts
+++ b/packages/gwt-editors/src/index.ts
@@ -21,4 +21,4 @@ export * from "./GwtEditorWrapperFactory";
 export * from "./GwtLanguageData";
 export * from "./GwtEditorRoutes";
 export * from "./XmlFormatter";
-export * from "./BrowserXmlFormatter";
+export * from "./DefaultXmlFormatter";

--- a/packages/microeditor-envelope/src/EditorEnvelopeController.tsx
+++ b/packages/microeditor-envelope/src/EditorEnvelopeController.tsx
@@ -24,31 +24,6 @@ import { EditorFactory } from "./EditorFactory";
 import { SpecialDomElements } from "./SpecialDomElements";
 import { Renderer } from "./Renderer";
 
-// describes how we want to modify the XML - indent everything
-const xsltDoc = new DOMParser().parseFromString(
-  [
-    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
-    '  <xsl:strip-space elements="*"/>',
-    '  <xsl:template match="para[content-style][not(text())]">', // change to just text() to strip space in text nodes
-    '    <xsl:value-of select="normalize-space(.)"/>',
-    "  </xsl:template>",
-    '  <xsl:template match="node()|@*">',
-    '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-    "  </xsl:template>",
-    '  <xsl:output indent="yes"/>',
-    "</xsl:stylesheet>"
-  ].join("\n"),
-  "application/xml"
-);
-
-function prettifyXml(sourceXml: string) {
-  const xmlDoc = new DOMParser().parseFromString(sourceXml, "application/xml");
-  const xsltProcessor = new XSLTProcessor();
-  xsltProcessor.importStylesheet(xsltDoc);
-  const resultDoc = xsltProcessor.transformToDocument(xmlDoc);
-  return new XMLSerializer().serializeToString(resultDoc);
-}
-
 export class EditorEnvelopeController {
   public static readonly ESTIMATED_TIME_TO_WAIT_AFTER_EMPTY_SET_CONTENT = 10;
 
@@ -82,10 +57,7 @@ export class EditorEnvelopeController {
       receive_contentRequest: () => {
         const editor = this.getEditor();
         if (editor) {
-          editor
-            .getContent()
-            .then(content => prettifyXml(content))
-            .then(content => self.respond_contentRequest(content));
+          editor.getContent().then(content => self.respond_contentRequest(content));
         }
       },
       receive_languageResponse: (languageData: LanguageData) => {

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BrowserXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
+import { DefaultXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/gwt-editors";
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
 
 declare global {
@@ -27,5 +27,5 @@ gwtAppFormerApi.setClientSideOnly(true);
 MicroEditorEnvelope.init({
   container: document.getElementById("envelope-app")!,
   busApi: acquireVsCodeApi(),
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new BrowserXmlFormatter())
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter())
 });

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
@@ -27,5 +27,5 @@ gwtAppFormerApi.setClientSideOnly(true);
 MicroEditorEnvelope.init({
   container: document.getElementById("envelope-app")!,
   busApi: acquireVsCodeApi(),
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi)
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, { format: c => c })
 });


### PR DESCRIPTION
This PR partially fixes #31.

There's still the issue with the ids on the BPMN editor, but diffs are now better than a one-liner.