### PR TITLE
KOGITO-652: Context for editors

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/envelope/index.ts
@@ -17,6 +17,7 @@
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
 import { DefaultXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/kie-bc-editors";
 import { EnvelopeBusMessage } from "@kogito-tooling/microeditor-envelope-protocol";
+import { ChannelType } from "@kogito-tooling/core-api";
 
 const gwtAppFormerApi = new GwtAppFormerApi();
 gwtAppFormerApi.setClientSideOnly(true);
@@ -28,5 +29,6 @@ MicroEditorEnvelope.init({
       window.parent.postMessage(message, targetOrigin!, _);
     }
   },
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter())
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter()),
+  editorContext : { channel: ChannelType.GITHUB }
 });

--- a/packages/chrome-extension/src/app/components/common/IsolatedEditor.tsx
+++ b/packages/chrome-extension/src/app/components/common/IsolatedEditor.tsx
@@ -21,6 +21,7 @@ import { useGitHubApi } from "./GitHubContext";
 
 interface Props {
   getFileContents: () => Promise<string | undefined>;
+  contentPath: string;
   openFileExtension: string;
   readonly: boolean;
   textMode: boolean;
@@ -37,6 +38,7 @@ const RefForwardingIsolatedEditor: React.RefForwardingComponent<IsolatedEditorRe
         <KogitoEditorIframe
           key={githubApi.token}
           ref={forwardedRef}
+          contentPath={props.contentPath}
           openFileExtension={props.openFileExtension}
           getFileContents={props.getFileContents}
           readonly={props.readonly}

--- a/packages/chrome-extension/src/app/components/pr/IsolatedPrEditor.tsx
+++ b/packages/chrome-extension/src/app/components/pr/IsolatedPrEditor.tsx
@@ -52,6 +52,7 @@ export function IsolatedPrEditor(props: {
   prInfo: PrInfo;
   prFileContainer: HTMLElement;
   fileExtension: string;
+  contentPath: string;
   githubTextEditorToReplace: HTMLElement;
   unprocessedFilePath: string;
 }) {
@@ -166,6 +167,7 @@ export function IsolatedPrEditor(props: {
           ref={isolatedEditorRef}
           textMode={textMode}
           getFileContents={getFileContents}
+          contentPath={props.contentPath}
           openFileExtension={props.fileExtension}
           readonly={true}
           keepRenderedEditorInTextMode={false}

--- a/packages/chrome-extension/src/app/components/pr/PrEditorsApp.tsx
+++ b/packages/chrome-extension/src/app/components/pr/PrEditorsApp.tsx
@@ -22,7 +22,7 @@ import * as dependencies__ from "../../dependencies";
 import { getOriginalFilePath, IsolatedPrEditor, PrInfo } from "./IsolatedPrEditor";
 import { Logger } from "../../../Logger";
 
-export function PrEditorsApp(props: { prInfo: PrInfo }) {
+export function PrEditorsApp(props: { prInfo: PrInfo, contentPath: string }) {
   const globals = useGlobals();
   const [prFileContainers, setPrFileContainers] = useState(supportedPrFileElements(globals.logger, globals.router));
 
@@ -52,6 +52,7 @@ export function PrEditorsApp(props: { prInfo: PrInfo }) {
         <IsolatedPrEditor
           key={getUnprocessedFilePath(container)}
           prInfo={props.prInfo}
+          contentPath={props.contentPath}
           prFileContainer={container}
           fileExtension={getFileExtension(container)}
           unprocessedFilePath={getUnprocessedFilePath(container)}

--- a/packages/chrome-extension/src/app/components/pr/prEditors.tsx
+++ b/packages/chrome-extension/src/app/components/pr/prEditors.tsx
@@ -27,7 +27,7 @@ import {
 import * as dependencies__ from "../../dependencies";
 import { PrInfo } from "./IsolatedPrEditor";
 
-export function renderPrEditorsApp(args: Globals) {
+export function renderPrEditorsApp(args: Globals & { contentPath: string }) {
   // Necessary because GitHub apparently "caches" DOM structures between changes on History.
   // Without this method you can observe duplicated elements when using back/forward browser buttons.
   cleanup(args.id);
@@ -43,7 +43,7 @@ export function renderPrEditorsApp(args: Globals) {
       resourceContentServiceFactory={args.resourceContentServiceFactory}
       externalEditorManager={args.externalEditorManager}
     >
-      <PrEditorsApp prInfo={parsePrInfo()} />
+      <PrEditorsApp prInfo={parsePrInfo()} contentPath={args.contentPath} />
     </Main>,
     createAndGetMainContainer(args.id, dependencies__.all.body()),
     () => args.logger.log("Mounted.")

--- a/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
@@ -61,6 +61,7 @@ export function SingleEditorApp(props: {
   const IsolatedEditorComponent = (
     <IsolatedEditor
       getFileContents={props.getFileContents}
+      contentPath={props.fileInfo.path}
       openFileExtension={props.openFileExtension}
       textMode={textMode}
       readonly={props.readonly}

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -122,7 +122,8 @@ function init(args: Globals) {
       extensionIconUrl: args.extensionIconUrl,
       editorIndexPath: args.editorIndexPath,
       resourceContentServiceFactory: args.resourceContentServiceFactory,
-      externalEditorManager: args.externalEditorManager
+      externalEditorManager: args.externalEditorManager,
+      contentPath: fileInfo.path
     });
     return;
   }

--- a/packages/core-api/src/appformer/Editor.ts
+++ b/packages/core-api/src/appformer/Editor.ts
@@ -28,7 +28,7 @@ export abstract class Editor extends Component {
     super({ type: ComponentTypes.EDITOR, af_componentId: componentId });
   }
 
-  public abstract setContent(content: string): Promise<void>;
+  public abstract setContent(path: string, content: string): Promise<void>; 
 
   public abstract getContent(): Promise<string>;
 

--- a/packages/core-api/src/core/ChannelType.ts
+++ b/packages/core-api/src/core/ChannelType.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { Element } from "./Component";
-export { ChannelType } from "./ChannelType";
+export enum ChannelType {
+    VSCODE = "VSCODE",
+    ONLINE = "ONLINE",
+    GITHUB = "GITHUB"
+}

--- a/packages/core-api/src/router/EditorContent.ts
+++ b/packages/core-api/src/router/EditorContent.ts
@@ -1,0 +1,5 @@
+export interface EditorContent {
+    content: string;
+    path?: string;
+    context?: Map<string, string>;
+}

--- a/packages/core-api/src/router/index.ts
+++ b/packages/core-api/src/router/index.ts
@@ -16,3 +16,4 @@
 
 export * from "./Router";
 export * from "./LangaugeData";
+export * from "./EditorContent";

--- a/packages/kie-bc-editors/src/GwtEditor.ts
+++ b/packages/kie-bc-editors/src/GwtEditor.ts
@@ -16,6 +16,6 @@
 
 export interface GwtEditor {
   getContent(): Promise<string>;
-  setContent(content: string): void;
+  setContent(path: string, content: string): void;
   isDirty(): boolean;
 }

--- a/packages/kie-bc-editors/src/GwtEditorWrapper.tsx
+++ b/packages/kie-bc-editors/src/GwtEditorWrapper.tsx
@@ -68,10 +68,10 @@ export class GwtEditorWrapper extends AppFormer.Editor {
     return this.gwtEditor.isDirty();
   }
 
-  public setContent(content: string) {
+  public setContent(path: string, content: string) {
     //FIXME: Make setContent return a promise.
     try {
-      this.gwtEditor.setContent(content.trim());
+      this.gwtEditor.setContent(path, content.trim());
       setTimeout(() => this.removeBusinessCentralPanelHeader(), 100);
     } catch (e) {
       this.messageBus.notify_setContentError(

--- a/packages/kie-bc-editors/src/__tests__/GwtEditorWrapper.test.ts
+++ b/packages/kie-bc-editors/src/__tests__/GwtEditorWrapper.test.ts
@@ -30,8 +30,8 @@ const wrapper = new GwtEditorWrapper("MockEditorId", mockEditor, mockMessageBus 
 
 describe("GwtEditorWrapper", () => {
   test("set content", async () => {
-    await wrapper.setContent(" a content ");
-    expect(mockEditor.setContent).toHaveBeenCalledWith("a content");
+    await wrapper.setContent("path", " a content ");
+    expect(mockEditor.setContent).toHaveBeenCalledWith("path", "a content");
   });
 
   test("set content error", async () => {
@@ -39,8 +39,8 @@ describe("GwtEditorWrapper", () => {
       throw new Error();
     });
 
-    await wrapper.setContent(" a content ");
-    expect(mockEditor.setContent).toHaveBeenCalledWith("a content");
+    await wrapper.setContent("path", " a content ");
+    expect(mockEditor.setContent).toHaveBeenCalledWith("path", "a content");
     expect(mockMessageBus.notify_setContentError).toHaveBeenCalled();
   });
 

--- a/packages/microeditor-envelope-protocol/src/EnvelopeBusOuterMessageHandler.ts
+++ b/packages/microeditor-envelope-protocol/src/EnvelopeBusOuterMessageHandler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { LanguageData, ResourceContent, ResourcesList } from "@kogito-tooling/core-api";
+import { LanguageData, ResourceContent, ResourcesList, EditorContent } from "@kogito-tooling/core-api";
 import { EnvelopeBusMessage } from "./EnvelopeBusMessage";
 import { EnvelopeBusMessageType } from "./EnvelopeBusMessageType";
 import { EnvelopeBusApi } from "./EnvelopeBusApi";
@@ -75,7 +75,7 @@ export class EnvelopeBusOuterMessageHandler {
     this.busApi.postMessage({ type: EnvelopeBusMessageType.RETURN_LANGUAGE, data: languageData });
   }
 
-  public respond_contentRequest(content: string) {
+  public respond_contentRequest(content: EditorContent) {
     this.busApi.postMessage({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: content });
   }
 

--- a/packages/microeditor-envelope-protocol/src/__tests__/EnvelopeBusOuterMessageHandler.test.ts
+++ b/packages/microeditor-envelope-protocol/src/__tests__/EnvelopeBusOuterMessageHandler.test.ts
@@ -17,6 +17,7 @@
 import { EnvelopeBusOuterMessageHandler } from "../EnvelopeBusOuterMessageHandler";
 import { EnvelopeBusMessage } from "../EnvelopeBusMessage";
 import { EnvelopeBusMessageType } from "../EnvelopeBusMessageType";
+import { ChannelType } from "@kogito-tooling/core-api";
 
 let sentMessages: Array<EnvelopeBusMessage<any>>;
 let receivedMessages: string[];
@@ -168,7 +169,8 @@ describe("send", () => {
   });
 
   test("respond contentRequest", () => {
-    handler.respond_contentRequest("bar");
-    expect(sentMessages).toEqual([{ type: EnvelopeBusMessageType.RETURN_CONTENT, data: "bar" }]);
+    const content = { content: "bar" };
+    handler.respond_contentRequest(content);
+    expect(sentMessages).toEqual([{ type: EnvelopeBusMessageType.RETURN_CONTENT, data: content }]);
   });
 });

--- a/packages/microeditor-envelope/src/EditorContext.ts
+++ b/packages/microeditor-envelope/src/EditorContext.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { Element } from "./Component";
-export { ChannelType } from "./ChannelType";
+import { ChannelType } from "@kogito-tooling/core-api";
+
+export interface EditorContext {
+    channel: ChannelType;
+}

--- a/packages/microeditor-envelope/src/EnvelopeBusInnerMessageHandler.ts
+++ b/packages/microeditor-envelope/src/EnvelopeBusInnerMessageHandler.ts
@@ -19,10 +19,10 @@ import {
   EnvelopeBusMessage,
   EnvelopeBusMessageType
 } from "@kogito-tooling/microeditor-envelope-protocol";
-import { LanguageData, ResourceContent, ResourcesList } from "@kogito-tooling/core-api";
+import { LanguageData, ResourceContent, ResourcesList, EditorContent, ChannelType } from "@kogito-tooling/core-api";
 
 export interface Impl {
-  receive_contentResponse(content: string): void;
+  receive_contentResponse(content: EditorContent): void;
   receive_languageResponse(languageData: LanguageData): void;
   receive_contentRequest(): void;
   receive_resourceContentResponse(content: ResourceContent): void;
@@ -67,7 +67,7 @@ export class EnvelopeBusInnerMessageHandler {
     return this.send({ type: EnvelopeBusMessageType.RETURN_INIT, data: undefined });
   }
 
-  public respond_contentRequest(content: string) {
+  public respond_contentRequest(content: EditorContent) {
     return this.send({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: content });
   }
 
@@ -116,13 +116,14 @@ export class EnvelopeBusInnerMessageHandler {
   public receive(message: EnvelopeBusMessage<any>) {
     switch (message.type) {
       case EnvelopeBusMessageType.REQUEST_INIT:
-        this.receive_initRequest({ origin: message.data as string, busId: message.busId as string });
+        const origin = message.data as string;
+        this.receive_initRequest({ origin: origin, busId: message.busId as string });
         break;
       case EnvelopeBusMessageType.RETURN_LANGUAGE:
         this.impl.receive_languageResponse(message.data as LanguageData);
         break;
       case EnvelopeBusMessageType.RETURN_CONTENT:
-        this.impl.receive_contentResponse(message.data as string);
+        this.impl.receive_contentResponse(message.data as EditorContent);
         break;
       case EnvelopeBusMessageType.REQUEST_CONTENT:
         this.impl.receive_contentRequest();

--- a/packages/microeditor-envelope/src/__tests__/DummyEditor.tsx
+++ b/packages/microeditor-envelope/src/__tests__/DummyEditor.tsx
@@ -38,7 +38,7 @@ export class DummyEditor extends AppFormer.Editor {
     return false;
   }
 
-  public setContent(content: string) {
+  public setContent(path: string, content: string) {
     return this.ref!.setContent(content);
   }
 }

--- a/packages/microeditor-envelope/src/__tests__/EditorEnvelopeController.test.tsx
+++ b/packages/microeditor-envelope/src/__tests__/EditorEnvelopeController.test.tsx
@@ -96,6 +96,7 @@ describe("EditorEnvelopeController", () => {
   test("receives init request", async () => {
     const render = await startController();
     await incomingMessage({ type: EnvelopeBusMessageType.REQUEST_INIT, data: "test-target-origin" });
+
     expect(sentMessages).toEqual([
       { type: EnvelopeBusMessageType.RETURN_INIT, data: undefined },
       { type: EnvelopeBusMessageType.REQUEST_LANGUAGE, data: undefined }
@@ -106,6 +107,7 @@ describe("EditorEnvelopeController", () => {
   test("receives language response", async () => {
     await startController();
     await incomingMessage({ type: EnvelopeBusMessageType.REQUEST_INIT, data: "test-target-origin" });
+
     sentMessages = [];
     await incomingMessage({ type: EnvelopeBusMessageType.RETURN_LANGUAGE, data: languageData });
 
@@ -116,9 +118,10 @@ describe("EditorEnvelopeController", () => {
     const render = await startController();
 
     await incomingMessage({ type: EnvelopeBusMessageType.REQUEST_INIT, data: "test-target-origin" });
+
     await incomingMessage({ type: EnvelopeBusMessageType.RETURN_LANGUAGE, data: languageData });
     sentMessages = [];
-    await incomingMessage({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: "test content" });
+    await incomingMessage({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: { content: "test content"} });
 
     expect(sentMessages).toEqual([]);
     expect(render.update()).toMatchSnapshot();
@@ -128,9 +131,10 @@ describe("EditorEnvelopeController", () => {
     const render = await startController();
 
     await incomingMessage({ type: EnvelopeBusMessageType.REQUEST_INIT, data: "test-target-origin" });
+
     await incomingMessage({ type: EnvelopeBusMessageType.RETURN_LANGUAGE, data: languageData });
     sentMessages = [];
-    await incomingMessage({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: "test content" });
+    await incomingMessage({ type: EnvelopeBusMessageType.RETURN_CONTENT, data: { content: "test content" } });
     await delay(EditorEnvelopeController.ESTIMATED_TIME_TO_WAIT_AFTER_EMPTY_SET_CONTENT);
 
     expect(sentMessages).toEqual([]);

--- a/packages/microeditor-envelope/src/__tests__/EnvelopeBusInnerMessageHandler.test.ts
+++ b/packages/microeditor-envelope/src/__tests__/EnvelopeBusInnerMessageHandler.test.ts
@@ -16,7 +16,7 @@
 
 import { EnvelopeBusInnerMessageHandler } from "../EnvelopeBusInnerMessageHandler";
 import { EnvelopeBusMessageType } from "@kogito-tooling/microeditor-envelope-protocol";
-import { LanguageData, ResourcesList, ResourceContent } from "@kogito-tooling/core-api";
+import { LanguageData, ResourcesList, ResourceContent, EditorContent } from "@kogito-tooling/core-api";
 
 let handler: EnvelopeBusInnerMessageHandler;
 let receivedMessages: any[];
@@ -31,7 +31,7 @@ beforeEach(() => {
       postMessage: (message, targetOrigin) => sentMessages.push([message, targetOrigin])
     },
     self => ({
-      receive_contentResponse: (content: string) => {
+      receive_contentResponse: (content: EditorContent) => {
         receivedMessages.push(["contentResponse", content]);
       },
       receive_languageResponse: (languageData: LanguageData) => {
@@ -180,8 +180,9 @@ describe("send", () => {
   });
 
   test("respond contentRequest", () => {
-    handler.respond_contentRequest("some");
-    expect(sentMessages).toEqual([[{ type: EnvelopeBusMessageType.RETURN_CONTENT, data: "some" }, "tgt-orgn"]]);
+    const content = { content: "some" };
+    handler.respond_contentRequest(content);
+    expect(sentMessages).toEqual([[{ type: EnvelopeBusMessageType.RETURN_CONTENT, data: content }, "tgt-orgn"]]);
   });
 
   test("notify setContentError", () => {

--- a/packages/microeditor-envelope/src/__tests__/ResourceContentEditorCoordinator.test.ts
+++ b/packages/microeditor-envelope/src/__tests__/ResourceContentEditorCoordinator.test.ts
@@ -1,7 +1,7 @@
 
 import { ResourceContentEditorCoordinator } from "../ResourceContentEditorCoordinator";
 import { EnvelopeBusInnerMessageHandler } from "../EnvelopeBusInnerMessageHandler";
-import { LanguageData, ResourceContent, ResourcesList } from "@kogito-tooling/core-api";
+import { LanguageData, ResourceContent, ResourcesList, EditorContent } from "@kogito-tooling/core-api";
 import { ResourceContentEditorService } from "../ResourceContentEditorService";
 
 let coordinator: ResourceContentEditorCoordinator;
@@ -14,7 +14,7 @@ const handler = new EnvelopeBusInnerMessageHandler(
     }
   },
   self => ({
-    receive_contentResponse: (content: string) => {
+    receive_contentResponse: (content: EditorContent) => {
       // do nothing
     },
     receive_languageResponse: (languageData: LanguageData) => {

--- a/packages/microeditor-envelope/src/index.ts
+++ b/packages/microeditor-envelope/src/index.ts
@@ -23,14 +23,18 @@ import { ReactElement } from "react";
 import { EditorFactory } from "./EditorFactory";
 import { ResourceContentEditorCoordinator } from "./ResourceContentEditorCoordinator";
 import { ResourceContentEditorService } from "./ResourceContentEditorService";
+import { EditorContext } from "./EditorContext";
+import { ChannelType } from "@kogito-tooling/core-api";
 
 export * from "./EditorFactory";
+export * from "./EditorContext";
 export * from "./EnvelopeBusInnerMessageHandler";
 
 declare global {
   interface Window {
     envelope: {
-      resourceContentEditorService: ResourceContentEditorService;
+      resourceContentEditorService?: ResourceContentEditorService;
+      editorContext: EditorContext
     }
   }
 }
@@ -49,9 +53,8 @@ class ReactDomRenderer implements Renderer {
  * @param args.busApi The implementation of EnvelopeBusApi to send messages out of the envelope.
  * @param args.editorFactory The factory of Editors using a LanguageData implementation.
  */
-export function init(args: { container: HTMLElement; busApi: EnvelopeBusApi; editorFactory: EditorFactory<any> }) {
+export function init(args: { container: HTMLElement; busApi: EnvelopeBusApi; editorFactory: EditorFactory<any>, editorContext: EditorContext }) {
   const specialDomElements = new SpecialDomElements();
-
   const renderer = new ReactDomRenderer();
   const resourceContentEditorCoordinator = new ResourceContentEditorCoordinator();
   const editorEnvelopeController = new EditorEnvelopeController(
@@ -63,7 +66,8 @@ export function init(args: { container: HTMLElement; busApi: EnvelopeBusApi; edi
 
   return editorEnvelopeController.start(args.container).then(messageBus => {
     window.envelope = {
-      resourceContentEditorService: resourceContentEditorCoordinator.exposed(messageBus)
+      resourceContentEditorService: resourceContentEditorCoordinator.exposed(messageBus),
+      editorContext: args.editorContext
     }
   });
 

--- a/packages/online-editor/src/editor/Editor.tsx
+++ b/packages/online-editor/src/editor/Editor.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { useContext, useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import { GlobalContext } from "../common/GlobalContext";
 import { useLocation } from "react-router";
-import { ResourceContent, ResourcesList } from "@kogito-tooling/core-api";
+import { ResourceContent, ResourcesList, ChannelType } from "@kogito-tooling/core-api";
 
 interface Props {
   fullscreen: boolean;
@@ -48,7 +48,7 @@ const RefForwardingEditor: React.RefForwardingComponent<EditorRef, Props> = (pro
         props.onContentResponse(content);
       },
       receive_contentRequest() {
-        context.file.getFileContents().then(c => self.respond_contentRequest(c || ""));
+        context.file.getFileContents().then(c => self.respond_contentRequest({ content: c || "" }));
       },
       receive_setContentError() {
         console.info("Set content error");

--- a/packages/online-editor/src/envelope/index.ts
+++ b/packages/online-editor/src/envelope/index.ts
@@ -17,6 +17,7 @@
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
 import { DefaultXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/kie-bc-editors";
 import { EnvelopeBusMessage } from "@kogito-tooling/microeditor-envelope-protocol";
+import { ChannelType } from "@kogito-tooling/core-api";
 
 const gwtAppFormerApi = new GwtAppFormerApi();
 gwtAppFormerApi.setClientSideOnly(true);
@@ -28,5 +29,6 @@ MicroEditorEnvelope.init({
       window.parent.postMessage(message, "*", _);
     }
   },
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter())
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter()),
+  editorContext : { channel: ChannelType.ONLINE }
 });

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/webview/index.ts
@@ -16,6 +16,7 @@
 
 import { DefaultXmlFormatter, GwtAppFormerApi, GwtEditorWrapperFactory } from "@kogito-tooling/kie-bc-editors";
 import * as MicroEditorEnvelope from "@kogito-tooling/microeditor-envelope";
+import { ChannelType } from "@kogito-tooling/core-api";
 
 declare global {
   export const acquireVsCodeApi: any;
@@ -27,5 +28,6 @@ gwtAppFormerApi.setClientSideOnly(true);
 MicroEditorEnvelope.init({
   container: document.getElementById("envelope-app")!,
   busApi: acquireVsCodeApi(),
-  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter())
+  editorFactory: new GwtEditorWrapperFactory(gwtAppFormerApi, new DefaultXmlFormatter()),
+  editorContext : { channel: ChannelType.VSCODE }
 });

--- a/packages/vscode-extension/src/KogitoEditor.ts
+++ b/packages/vscode-extension/src/KogitoEditor.ts
@@ -18,12 +18,13 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import { EnvelopeBusOuterMessageHandler } from "@kogito-tooling/microeditor-envelope-protocol";
 import { KogitoEditorStore } from "./KogitoEditorStore";
-import { Router, ResourceContentService, ResourceContent } from "@kogito-tooling/core-api";
+import { Router, ResourceContentService, ResourceContent, ChannelType } from "@kogito-tooling/core-api";
 
 export class KogitoEditor {
   private static readonly DIRTY_INDICATOR = " *";
 
   private readonly path: string;
+  private readonly relativePath: string;
   private readonly webviewLocation: string;
   private readonly context: vscode.ExtensionContext;
   private readonly router: Router;
@@ -31,8 +32,9 @@ export class KogitoEditor {
   private readonly editorStore: KogitoEditorStore;
   private readonly envelopeBusOuterMessageHandler: EnvelopeBusOuterMessageHandler;
   private readonly resourceContentService: ResourceContentService;
-
+  
   public constructor(
+    relativePath: string,
     path: string,
     panel: vscode.WebviewPanel,
     context: vscode.ExtensionContext,
@@ -41,6 +43,7 @@ export class KogitoEditor {
     editorStore: KogitoEditorStore,
     resourceContentService: ResourceContentService
   ) {
+    this.relativePath = relativePath;
     this.path = path;
     this.panel = panel;
     this.context = context;
@@ -67,7 +70,11 @@ export class KogitoEditor {
           vscode.window.setStatusBarMessage("Saved successfully!", 3000);
         },
         receive_contentRequest: () => {
-          self.respond_contentRequest(fs.readFileSync(this.path).toString());
+          const content = {
+            content: fs.readFileSync(this.path).toString(),
+            path: this.relativePath
+          };
+          self.respond_contentRequest(content);
         },
         receive_setContentError: (errorMessage: string) => {
           vscode.window.showErrorMessage(errorMessage);

--- a/packages/vscode-extension/src/KogitoEditorFactory.ts
+++ b/packages/vscode-extension/src/KogitoEditorFactory.ts
@@ -45,9 +45,10 @@ export class KogitoEditorFactory {
     if (path.length <= 0) {
       throw new Error("parameter 'path' cannot be empty");
     }
-
+    
+    const workspacePath = vscode.workspace.asRelativePath(path);
     const panel = this.openNewPanel(path);
-    const editor = new KogitoEditor(path, panel, this.context, this.router, this.webviewLocation, this.editorStore, this.resourceContentService);
+    const editor = new KogitoEditor(workspacePath, path, panel, this.context, this.router, this.webviewLocation, this.editorStore, this.resourceContentService);
     this.editorStore.addAsActive(editor);
     editor.setupEnvelopeBus();
     editor.setupPanelActiveStatusChange();


### PR DESCRIPTION
Creates context for editors where they can retrieve the editor channel using `window.envelope.editorContext.channel` and the channel value is a String which currently has three possible values:

* ONLINE
* VSCODE
* GITHUB 

Also pass the content path when calling `setContent`.

Part of an ensemble:

https://github.com/kiegroup/appformer/pull/873
https://github.com/kiegroup/kie-wb-common/pull/3099