### PR TITLE
KOGITO-733: Kogito Tooling Online Editor Improvements

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/src/OnlineEditorManager.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/OnlineEditorManager.ts
@@ -15,6 +15,7 @@
  */
 
 import { ExternalEditorManager } from "@kogito-tooling/chrome-extension";
+import { extractFileExtension } from "./utils";
 
 export class OnlineEditorManager implements ExternalEditorManager {
   public name = "Online Editor";
@@ -29,6 +30,10 @@ export class OnlineEditorManager implements ExternalEditorManager {
         }
       }
     );
+  }
+
+  public getLink(filePath: string) {
+    return `$_{WEBPACK_REPLACE__onlineEditor_url}/?file=https://raw.githubusercontent.com/${filePath}#/editor/${extractFileExtension(filePath)}`;
   }
 
   public listenToComeBack(setFileName: (fileName: string) => void, setFileContent: (fileContent: string) => void) {

--- a/packages/chrome-extension-pack-kogito-kie-editors/src/background.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/background.ts
@@ -15,6 +15,7 @@
  */
 
 import HttpHeader = chrome.webRequest.HttpHeader;
+import { removeDirectories, removeFileExtension, extractFileExtension } from "./utils";
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log("Kogito Tooling extension is running.");
@@ -126,24 +127,4 @@ function updateGitHub(request: any, sender: chrome.runtime.MessageSender) {
       }
     }
   );
-}
-
-// FIXME: Move the functions below to a common place to avoid duplicated code.
-
-function extractFileExtension(fileName: string) {
-  return fileName.split(".").pop()?.match(/[\w\d]+/)?.pop();
-}
-
-function removeFileExtension(fileName: string) {
-  const fileExtension = extractFileExtension(fileName);
-
-  if (!fileExtension) {
-    return fileName;
-  }
-
-  return fileName.substr(0, fileName.length - fileExtension.length - 1);
-}
-
-function removeDirectories(filePath: string) {
-  return filePath.split("/").pop();
 }

--- a/packages/chrome-extension-pack-kogito-kie-editors/src/utils.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/utils.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,24 @@
  * limitations under the License.
  */
 
-export interface ExternalEditorManager {
-  name: string;
-  open(filePath: string, fileContent: string, readonly: boolean): void;
-  getLink(filePath: string): string;
-  listenToComeBack(
-    setFileName: (fileName: string) => unknown,
-    setFileContent: (content: string) => unknown
-  ): { stopListening: () => void };
+export function extractFileExtension(fileName: string) {
+  return fileName
+    .split(".")
+    .pop()
+    ?.match(/[\w\d]+/)
+    ?.pop();
+}
+
+export function removeFileExtension(fileName: string) {
+  const fileExtension = extractFileExtension(fileName);
+
+  if (!fileExtension) {
+    return fileName;
+  }
+
+  return fileName.substr(0, fileName.length - fileExtension.length - 1);
+}
+
+export function removeDirectories(filePath: string) {
+  return filePath.split("/").pop();
 }

--- a/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
@@ -120,7 +120,7 @@ module.exports = async (env, argv) => {
           }
         },
         {
-          test: /background\.ts$/,
+          test: /background\.ts|OnlineEditorManager\.ts$/,
           loader: "string-replace-loader",
           options: {
             multiple: [

--- a/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import * as ReactDOM from "react-dom";
 import { FullScreenToolbar } from "./FullScreenToolbar";
 import { SingleEditorToolbar } from "./SingleEditorToolbar";
@@ -47,7 +47,7 @@ export function SingleEditorApp(props: {
   toolbarContainer: HTMLElement;
   iframeContainer: HTMLElement;
   githubTextEditorToReplace: HTMLElement;
-  fileInfo: FileInfo
+  fileInfo: FileInfo;
 }) {
   const [textMode, setTextMode] = useState(false);
   const [textModeEnabled, setTextModeEnabled] = useState(false);
@@ -80,17 +80,23 @@ export function SingleEditorApp(props: {
 
   const openExternalEditor = () => {
     props.getFileContents().then(fileContent => {
-      globals.externalEditorManager ?.open(props.fileName, fileContent!, props.readonly);
+      globals.externalEditorManager?.open(props.fileName, fileContent!, props.readonly);
     });
   };
 
+  const linkToExternalEditor = useMemo(() => {
+    return globals.externalEditorManager?.getLink(
+      `${props.fileInfo.org}/${props.fileInfo.repo}/${props.fileInfo.gitRef}/${props.fileInfo.path}`
+    );
+  }, [globals.externalEditorManager]);
+
   useEffect(() => {
-    const listener = globals.externalEditorManager ?.listenToComeBack(fileName => {
+    const listener = globals.externalEditorManager?.listenToComeBack(fileName => {
       dependencies__.all.edit__githubFileNameInput()!.value = fileName;
-    }, isolatedEditorRef.current ?.setContent!);
+    }, isolatedEditorRef.current?.setContent!);
 
     return () => {
-      listener ?.stopListening();
+      listener?.stopListening();
     };
   }, [globals.externalEditorManager]);
 
@@ -117,6 +123,7 @@ export function SingleEditorApp(props: {
                 onSeeAsDiagram={deactivateTextMode}
                 onSeeAsSource={activateTextMode}
                 onOpenInExternalEditor={openExternalEditor}
+                linkToExternalEditor={linkToExternalEditor!}
                 onFullScreen={goFullScreen}
                 readonly={props.readonly}
               />,

--- a/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
@@ -123,7 +123,7 @@ export function SingleEditorApp(props: {
                 onSeeAsDiagram={deactivateTextMode}
                 onSeeAsSource={activateTextMode}
                 onOpenInExternalEditor={openExternalEditor}
-                linkToExternalEditor={linkToExternalEditor!}
+                linkToExternalEditor={linkToExternalEditor}
                 onFullScreen={goFullScreen}
                 readonly={props.readonly}
               />,

--- a/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
@@ -26,10 +26,10 @@ export function SingleEditorToolbar(props: {
   onSeeAsSource: () => void;
   onSeeAsDiagram: () => void;
   onOpenInExternalEditor: () => void;
-  linkToExternalEditor: string;
+  linkToExternalEditor: string | undefined;
 }) {
   const globals = useGlobals();
-  const linkToExternalEditorTextArea = useRef<HTMLTextAreaElement>(null);
+  const linkToExternalEditorTextAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const goFullScreen = (e: any) => {
     e.preventDefault();
@@ -53,7 +53,7 @@ export function SingleEditorToolbar(props: {
 
   const copyLinkToExternalEditor = (e: any) => {
     e.preventDefault();
-    linkToExternalEditorTextArea.current?.select();
+    linkToExternalEditorTextAreaRef.current?.select();
     document.execCommand("copy");
     e.target.focus();
   };
@@ -87,7 +87,7 @@ export function SingleEditorToolbar(props: {
           </button>
         )}
         <textarea
-          ref={linkToExternalEditorTextArea}
+          ref={linkToExternalEditorTextAreaRef}
           value={props.linkToExternalEditor}
           style={{ opacity: 0, width: 0, height: 0 }}
         />

--- a/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as React from "react";
+import { useRef } from "react";
 import { useGlobals } from "../common/GlobalContext";
 
 export function SingleEditorToolbar(props: {
@@ -25,8 +26,10 @@ export function SingleEditorToolbar(props: {
   onSeeAsSource: () => void;
   onSeeAsDiagram: () => void;
   onOpenInExternalEditor: () => void;
+  linkToExternalEditor: string;
 }) {
   const globals = useGlobals();
+  const linkToExternalEditorTextArea = useRef<HTMLTextAreaElement>(null);
 
   const goFullScreen = (e: any) => {
     e.preventDefault();
@@ -47,7 +50,14 @@ export function SingleEditorToolbar(props: {
     e.preventDefault();
     props.onOpenInExternalEditor();
   };
-  
+
+  const copyLinkToExternalEditor = (e: any) => {
+    e.preventDefault();
+    linkToExternalEditorTextArea.current?.select();
+    document.execCommand("copy");
+    e.target.focus();
+  };
+
   return (
     <>
       <div style={{ display: "flex" }}>
@@ -66,11 +76,21 @@ export function SingleEditorToolbar(props: {
             Open in {globals.externalEditorManager.name}
           </button>
         )}
+        {globals.externalEditorManager && props.linkToExternalEditor && (
+          <button className={"btn btn-sm kogito-button"} onClick={copyLinkToExternalEditor}>
+            Copy link to {globals.externalEditorManager.name}
+          </button>
+        )}
         {!props.textMode && (
           <button className={"btn btn-sm kogito-button"} onClick={goFullScreen}>
             Full screen
           </button>
         )}
+        <textarea
+          ref={linkToExternalEditorTextArea}
+          value={props.linkToExternalEditor}
+          style={{ opacity: 0, width: 0, height: 0 }}
+        />
       </div>
       {props.readonly && !props.textMode && (
         <>

--- a/packages/online-editor/src/common/utils.ts
+++ b/packages/online-editor/src/common/utils.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,24 @@
  * limitations under the License.
  */
 
-export interface ExternalEditorManager {
-  name: string;
-  open(filePath: string, fileContent: string, readonly: boolean): void;
-  getLink(filePath: string): string;
-  listenToComeBack(
-    setFileName: (fileName: string) => unknown,
-    setFileContent: (content: string) => unknown
-  ): { stopListening: () => void };
+export function extractFileExtension(fileName: string) {
+  return fileName
+    .split(".")
+    .pop()
+    ?.match(/[\w\d]+/)
+    ?.pop();
+}
+
+export function removeFileExtension(fileName: string) {
+  const fileExtension = extractFileExtension(fileName);
+
+  if (!fileExtension) {
+    return fileName;
+  }
+
+  return fileName.substr(0, fileName.length - fileExtension.length - 1);
+}
+
+export function removeDirectories(filePath: string) {
+  return filePath.split("/").pop();
 }

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -52,17 +52,17 @@ export function EditorPage(props: Props) {
 
   const requestSave = useCallback(() => {
     action = ActionType.SAVE;
-    editorRef.current!.requestContent();
+    editorRef.current?.requestContent();
   }, []);
 
   const requestDownload = useCallback(() => {
     action = ActionType.DOWNLOAD;
-    editorRef.current!.requestContent();
+    editorRef.current?.requestContent();
   }, []);
 
   const requestCopyContentToClipboard = useCallback(() => {
     action = ActionType.COPY;
-    editorRef.current!.requestContent();
+    editorRef.current?.requestContent();
   }, []);
 
   const enterFullscreen = useCallback(() => {

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -32,7 +32,8 @@ interface Props {
 enum ActionType {
   NONE,
   SAVE,
-  DOWNLOAD
+  DOWNLOAD,
+  COPY
 }
 
 // FIXME: This action should be moved inside the React hooks lifecycle.
@@ -44,6 +45,7 @@ export function EditorPage(props: Props) {
   const history = useHistory();
   const editorRef = useRef<EditorRef>(null);
   const downloadRef = useRef<HTMLAnchorElement>(null);
+  const copyContentTextArea = useRef<HTMLTextAreaElement>(null);
   const [fullscreen, setFullscreen] = useState(false);
 
   const close = useCallback(() => history.replace(context.routes.home.url({}), {}), []);
@@ -55,6 +57,11 @@ export function EditorPage(props: Props) {
 
   const requestDownload = useCallback(() => {
     action = ActionType.DOWNLOAD;
+    editorRef.current!.requestContent();
+  }, []);
+
+  const requestCopyContentToClipboard = useCallback(() => {
+    action = ActionType.COPY;
     editorRef.current!.requestContent();
   }, []);
 
@@ -96,6 +103,10 @@ export function EditorPage(props: Props) {
         const fileBlob = new Blob([content], { type: "text/plain" });
         downloadRef.current.href = URL.createObjectURL(fileBlob);
         downloadRef.current.click();
+      } else if (action === ActionType.COPY && copyContentTextArea.current) {
+        copyContentTextArea.current.value = content;
+        copyContentTextArea.current.select();
+        document.execCommand("copy");
       }
     },
     [fileNameWithExtension]
@@ -133,17 +144,22 @@ export function EditorPage(props: Props) {
                 onDownload={requestDownload}
                 onClose={close}
                 onFileNameChanged={props.onFileNameChanged}
+                onCopyContentToClipboard={requestCopyContentToClipboard}
               />
             )}
 
             {fullscreen && <FullScreenToolbar onExitFullScreen={exitFullscreen} />}
           </StackItem>
 
-          <StackItem className="pf-m-fill" style={fullscreen ? { height: "calc(100vh - 5px)" } : { height: "calc(100vh - 60px)" }}>
+          <StackItem
+            className="pf-m-fill"
+            style={fullscreen ? { height: "calc(100vh - 5px)" } : { height: "calc(100vh - 60px)" }}
+          >
             <Editor ref={editorRef} fullscreen={fullscreen} onContentResponse={onContentResponse} />
           </StackItem>
         </Stack>
         <a ref={downloadRef} />
+        <textarea ref={copyContentTextArea} style={{ opacity: 0, width: 0, height: 0 }} />
       </PageSection>
     </Page>
   );

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -20,6 +20,16 @@ import { GlobalContext } from "../common/GlobalContext";
 import { Button, PageSection, TextInput, Title, Toolbar, ToolbarGroup, ToolbarItem } from "@patternfly/react-core";
 import { EditIcon } from "@patternfly/react-icons";
 import { useLocation } from "react-router";
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownPosition,
+  DropdownDirection,
+  KebabToggle
+} from "@patternfly/react-core";
+import { ThIcon } from "@patternfly/react-icons";
 
 interface Props {
   onFileNameChanged: (fileName: string) => void;
@@ -27,6 +37,7 @@ interface Props {
   onSave: () => void;
   onDownload: () => void;
   onClose: () => void;
+  onCopyContentToClipboard: () => void;
 }
 
 export function EditorToolbar(props: Props) {
@@ -34,6 +45,7 @@ export function EditorToolbar(props: Props) {
   const location = useLocation();
   const [editingName, setEditingName] = useState(false);
   const [name, setName] = useState(context.file.fileName);
+  const [isKebabOpen, setKebabOpen] = useState(false);
 
   const editorType = useMemo(() => {
     return context.routes.editor.args(location.pathname).type;
@@ -64,6 +76,18 @@ export function EditorToolbar(props: Props) {
       }
     },
     [saveNewName, cancelNewName]
+  );
+
+  const kebabItems = useMemo(
+    () => [
+      <DropdownItem key="copy" component="button" onClick={props.onCopyContentToClipboard}>
+        Copy content to clipboard
+      </DropdownItem>,
+      <DropdownItem key="fullscreen" component="button" onClick={props.onFullScreen}>
+        Full Screen
+      </DropdownItem>
+    ],
+    []
   );
 
   return (
@@ -108,13 +132,6 @@ export function EditorToolbar(props: Props) {
           </ToolbarGroup>
         )}
         <ToolbarGroup className="kogito--right">
-          <ToolbarItem>
-            <Button variant="link" onClick={props.onFullScreen}>
-              Full Screen
-            </Button>
-          </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarGroup>
           {context.external && !context.readonly && (
             <ToolbarItem className="pf-u-mr-sm">
               <Button variant="primary" onClick={props.onSave}>
@@ -134,6 +151,16 @@ export function EditorToolbar(props: Props) {
               </Button>
             </ToolbarItem>
           )}
+          <ToolbarItem className="pf-u-mr-sm">
+            <Dropdown
+              onSelect={() => setKebabOpen(false)}
+              toggle={<KebabToggle onToggle={isOpen => setKebabOpen(isOpen)} />}
+              isOpen={isKebabOpen}
+              isPlain={true}
+              dropdownItems={kebabItems}
+              position={DropdownPosition.right}
+            />
+          </ToolbarItem>
         </ToolbarGroup>
       </Toolbar>
     </PageSection>

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -127,13 +127,13 @@ export function HomePage(props: Props) {
   }, [context, history, fileTypeSelect]);
 
   const trySample = useCallback(() => {
-    if (fileTypeSelect && fileTypeSelect.value) {
+    if (fileTypeSelect?.value) {
       const fileName = "sample";
       const fileExtension = fileTypeSelect.value!.toLowerCase();
       const filePath = `samples/${fileName}.${fileExtension}`;
       props.onFileOpened({
         fileName: fileName,
-        getFileContents: () => fetch(filePath).then(response => Promise.resolve(response.text()))
+        getFileContents: () => fetch(filePath).then(response => response.text())
       });
       history.replace(context.routes.editor.url({ type: fileExtension }));
     }

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -34,6 +34,7 @@ import {
   Toolbar,
   ToolbarItem
 } from "@patternfly/react-core";
+import { removeDirectories } from "../common/utils";
 
 interface Props {
   onFileOpened: (file: UploadFile) => void;
@@ -125,6 +126,19 @@ export function HomePage(props: Props) {
     }
   }, [context, history, fileTypeSelect]);
 
+  const trySample = useCallback(() => {
+    if (fileTypeSelect && fileTypeSelect.value) {
+      const fileName = "sample";
+      const fileExtension = fileTypeSelect.value!.toLowerCase();
+      const filePath = `samples/${fileName}.${fileExtension}`;
+      props.onFileOpened({
+        fileName: fileName,
+        getFileContents: () => fetch(filePath).then(response => Promise.resolve(response.text()))
+      });
+      history.replace(context.routes.editor.url({ type: fileExtension }));
+    }
+  }, [context, history, fileTypeSelect]);
+
   return (
     <Page>
       <PageSection variant="light">
@@ -158,6 +172,9 @@ export function HomePage(props: Props) {
                     <ToolbarItem>
                       <Button className="pf-u-ml-md" variant="secondary" onClick={createFile}>
                         Create
+                      </Button>
+                      <Button className="pf-u-ml-md" variant="secondary" onClick={trySample}>
+                        Try Sample
                       </Button>
                     </ToolbarItem>
                   </Toolbar>
@@ -202,7 +219,11 @@ export function HomePage(props: Props) {
 }
 
 function extractFileExtension(fileName: string) {
-  return fileName.split(".").pop()?.match(/[\w\d]+/)?.pop();
+  return fileName
+    .split(".")
+    .pop()
+    ?.match(/[\w\d]+/)
+    ?.pop();
 }
 
 function removeFileExtension(fileName: string) {

--- a/packages/online-editor/src/index.tsx
+++ b/packages/online-editor/src/index.tsx
@@ -18,14 +18,11 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { App } from "./App";
 import { EMPTY_FILE } from "./common/File";
+import { removeDirectories, removeFileExtension } from "./common/utils";
 
 const urlParams = new URLSearchParams(window.location.search);
-if (!urlParams.has("ext")) {
-  ReactDOM.render(
-    <App iframeTemplateRelativePath={"envelope/index.html"} file={EMPTY_FILE} readonly={false} external={false} />,
-    document.getElementById("app")!
-  );
-} else {
+
+if (urlParams.has("ext")) {
   window.addEventListener("loadOnlineEditor", (e: CustomEvent) => {
     const file = { fileName: e.detail.fileName, getFileContents: () => Promise.resolve(e.detail.fileContent) };
     ReactDOM.render(
@@ -39,4 +36,23 @@ if (!urlParams.has("ext")) {
       document.getElementById("app")!
     );
   });
+}
+
+if (urlParams.has("file")) {
+  const filePath = urlParams.get("file")!;
+  const file = {
+    fileName: removeFileExtension(removeDirectories(filePath)!)!,
+    getFileContents: () => fetch(filePath).then(response => Promise.resolve(response.text()))
+  };
+  ReactDOM.render(
+    <App iframeTemplateRelativePath={"envelope/index.html"} file={file} readonly={false} external={false} />,
+    document.getElementById("app")!
+  );
+}
+
+if (!urlParams.has("ext") && !urlParams.has("file")) {
+  ReactDOM.render(
+    <App iframeTemplateRelativePath={"envelope/index.html"} file={EMPTY_FILE} readonly={false} external={false} />,
+    document.getElementById("app")!
+  );
 }

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -17,12 +17,12 @@
 .kogito--upload-box > div {
   box-sizing: border-box;
   border: var(--pf-global--BorderWidth--lg) dashed var(--pf-global--BorderColor--100);
-  width: 15em;
-  height: 15em;
+  width: 20em;
+  height: 20em;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: var(--pf-global--spacer--2xl);
+  padding: var(--pf-global--spacer--xl);
 }
 
 .kogito--upload-box > div.hover {
@@ -47,6 +47,10 @@
 .kogito--editor__toolbar-section h3:hover {
   border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
   border-radius: var(--pf-global--BorderRadius--sm);
+}
+
+.kogito--editor__toolbar-section button {
+  outline: none;
 }
 
 .kogito--editor__toolbar-name-container {
@@ -85,6 +89,7 @@
 .kogito--upload-btn-container {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .kogito--upload-btn {
@@ -95,7 +100,6 @@
 }
 
 .kogito--upload-btn button {
-  width: 13em;
   margin-left: 0 !important;
 }
 
@@ -105,6 +109,7 @@
   top: 0;
   opacity: 0;
   cursor: pointer;
+  width: 10.2em;
 }
 
 .kogito--right {

--- a/packages/online-editor/static/samples/sample.bpmn
+++ b/packages/online-editor/static/samples/sample.bpmn
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_gfw8oEcJEemyodG9iPy-Bw" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_orderItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="_approverItem" isCollection="false" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:itemDefinition id="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" isCollection="false" structureRef="org.kie.kogito.examples.demo.Order"/>
+  <bpmn2:process id="demo.orders" drools:packageName="org.kie.kogito.examples" drools:version="1.0" drools:adHoc="false" name="orders" isExecutable="true">
+    <bpmn2:documentation id="_gfw8oUcJEemyodG9iPy-Bw"><![CDATA[Deals with orders created by customer]]></bpmn2:documentation>
+    <bpmn2:property id="order" itemSubjectRef="_orderItem" name="order"/>
+    <bpmn2:property id="approver" itemSubjectRef="_approverItem" name="approver"/>
+    <bpmn2:sequenceFlow id="_8216C810-34D8-4BFA-B814-1AA01907810F" sourceRef="_9484CB12-FE52-434C-AE9F-3C3C267D1C96" targetRef="_2D876EF2-93F4-4CBE-959A-04EF7BFA9CED"/>
+    <bpmn2:sequenceFlow id="_58684613-0155-48B2-8746-7675AFF24439" sourceRef="_0617D7DF-047A-4EC4-85E7-E201D640F4F5" targetRef="_9484CB12-FE52-434C-AE9F-3C3C267D1C96">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_B7B4282B-F317-4BF9-95E9-962B046EE815" sourceRef="_B44545AB-8B78-4FE4-B6B9-1D467954C070" targetRef="_0617D7DF-047A-4EC4-85E7-E201D640F4F5"/>
+    <bpmn2:scriptTask id="_0617D7DF-047A-4EC4-85E7-E201D640F4F5" name="Dump order" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Dump order]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_B7B4282B-F317-4BF9-95E9-962B046EE815</bpmn2:incoming>
+      <bpmn2:outgoing>_58684613-0155-48B2-8746-7675AFF24439</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;Order has been created &quot; + order + &quot; with assigned approver &quot; + approver.toUpperCase());</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_2D876EF2-93F4-4CBE-959A-04EF7BFA9CED">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_8216C810-34D8-4BFA-B814-1AA01907810F</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:callActivity id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96" drools:independent="false" drools:waitForCompletion="true" name="Add items" calledElement="demo.orderItems">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Add items]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_58684613-0155-48B2-8746-7675AFF24439</bpmn2:incoming>
+      <bpmn2:outgoing>_8216C810-34D8-4BFA-B814-1AA01907810F</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_gfw8okcJEemyodG9iPy-Bw">
+        <bpmn2:dataInput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputXItem" name="order"/>
+        <bpmn2:dataOutput id="_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX" drools:dtype="org.kie.kogito.examples.demo.Order" itemSubjectRef="__9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputXItem" name="order"/>
+        <bpmn2:inputSet id="_gfw8o0cJEemyodG9iPy-Bw">
+          <bpmn2:dataInputRefs>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_gfw8pEcJEemyodG9iPy-Bw">
+          <bpmn2:dataOutputRefs>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_gfw8pUcJEemyodG9iPy-Bw">
+        <bpmn2:sourceRef>order</bpmn2:sourceRef>
+        <bpmn2:targetRef>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_gfw8pkcJEemyodG9iPy-Bw">
+        <bpmn2:sourceRef>_9484CB12-FE52-434C-AE9F-3C3C267D1C96_orderOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>order</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:callActivity>
+    <bpmn2:startEvent id="_B44545AB-8B78-4FE4-B6B9-1D467954C070">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_B7B4282B-F317-4BF9-95E9-962B046EE815</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_gfw8p0cJEemyodG9iPy-Bw">
+    <bpmndi:BPMNPlane id="_gfw8qEcJEemyodG9iPy-Bw" bpmnElement="demo.orders">
+      <bpmndi:BPMNShape id="shape__B44545AB-8B78-4FE4-B6B9-1D467954C070" bpmnElement="_B44545AB-8B78-4FE4-B6B9-1D467954C070">
+        <dc:Bounds height="56.0" width="56.0" x="100.0" y="100.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__9484CB12-FE52-434C-AE9F-3C3C267D1C96" bpmnElement="_9484CB12-FE52-434C-AE9F-3C3C267D1C96" isExpanded="true">
+        <dc:Bounds height="101.0" width="153.0" x="458.5" y="78.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="11.0" width="41.0" x="514.0" y="123.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__2D876EF2-93F4-4CBE-959A-04EF7BFA9CED" bpmnElement="_2D876EF2-93F4-4CBE-959A-04EF7BFA9CED">
+        <dc:Bounds height="56.0" width="56.0" x="712.0" y="100.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__0617D7DF-047A-4EC4-85E7-E201D640F4F5" bpmnElement="_0617D7DF-047A-4EC4-85E7-E201D640F4F5">
+        <dc:Bounds height="102.0" width="154.0" x="236.0" y="77.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="11.0" width="48.0" x="289.0" y="122.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__B44545AB-8B78-4FE4-B6B9-1D467954C070_to_shape__0617D7DF-047A-4EC4-85E7-E201D640F4F5" bpmnElement="_B7B4282B-F317-4BF9-95E9-962B046EE815" sourceElement="shape__B44545AB-8B78-4FE4-B6B9-1D467954C070" targetElement="shape__0617D7DF-047A-4EC4-85E7-E201D640F4F5">
+        <di:waypoint xsi:type="dc:Point" x="156.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="236.0" y="128.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__0617D7DF-047A-4EC4-85E7-E201D640F4F5_to_shape__9484CB12-FE52-434C-AE9F-3C3C267D1C96" bpmnElement="_58684613-0155-48B2-8746-7675AFF24439" sourceElement="shape__0617D7DF-047A-4EC4-85E7-E201D640F4F5" targetElement="shape__9484CB12-FE52-434C-AE9F-3C3C267D1C96">
+        <di:waypoint xsi:type="dc:Point" x="313.0" y="128.0"/>
+        <di:waypoint xsi:type="dc:Point" x="458.5" y="128.5"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__9484CB12-FE52-434C-AE9F-3C3C267D1C96_to_shape__2D876EF2-93F4-4CBE-959A-04EF7BFA9CED" bpmnElement="_8216C810-34D8-4BFA-B814-1AA01907810F" sourceElement="shape__9484CB12-FE52-434C-AE9F-3C3C267D1C96" targetElement="shape__2D876EF2-93F4-4CBE-959A-04EF7BFA9CED">
+        <di:waypoint xsi:type="dc:Point" x="535.0" y="128.5"/>
+        <di:waypoint xsi:type="dc:Point" x="740.0" y="128.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/packages/online-editor/static/samples/sample.dmn
+++ b/packages/online-editor/static/samples/sample.dmn
@@ -1,0 +1,230 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_1C792953-80DB-4B32-99EB-25FBE32BAF9E" name="Traffic Violation" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_63824D3F-9173-446D-A940-6A7F0FA056BB" name="tDriver" isCollection="false">
+    <dmn:itemComponent id="_9DAB5DAA-3B44-4F6D-87F2-95125FB2FEE4" name="Name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_856BA8FA-EF7B-4DF9-A1EE-E28263CE9955" name="Age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_FDC2CE03-D465-47C2-A311-98944E8CC23F" name="State" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_D6FD34C4-00DC-4C79-B1BF-BBCF6FC9B6D7" name="City" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_7110FE7E-1A38-4C39-B0EB-AEEF06BA37F4" name="Points" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_40731093-0642-4588-9183-1660FC55053B" name="tViolation" isCollection="false">
+    <dmn:itemComponent id="_39E88D9F-AE53-47AD-B3DE-8AB38D4F50B3" name="Code" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_1648EA0A-2463-4B54-A12A-D743A3E3EE7B" name="Date" isCollection="false">
+      <dmn:typeRef>date</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_9F129EAA-4E71-4D99-B6D0-84EEC3AC43CC" name="Type" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="enumeration" id="_626A8F9C-9DD1-44E0-9568-0F6F8F8BA228">
+        <dmn:text>"speed", "parking", "driving under the influence"</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_DDD10D6E-BD38-4C79-9E2F-8155E3A4B438" name="Speed Limit" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_229F80E4-2892-494C-B70D-683ABF2345F6" name="Actual Speed" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_2D4F30EE-21A6-4A78-A524-A5C238D433AE" name="tFine" isCollection="false">
+    <dmn:itemComponent id="_B9F70BC7-1995-4F51-B949-1AB65538B405" name="Amount" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_F49085D6-8F08-4463-9A1A-EF6B57635DBD" name="Points" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_1929CBD5-40E0-442D-B909-49CEDE0101DC" name="Violation">
+    <dmn:variable id="_C16CF9B1-5FAB-48A0-95E0-5FCD661E0406" name="Violation" typeRef="tViolation"/>
+  </dmn:inputData>
+  <dmn:decision id="_4055D956-1C47-479C-B3F4-BAEB61F1C929" name="Fine">
+    <dmn:variable id="_8C1EAC83-F251-4D94-8A9E-B03ACF6849CD" name="Fine" typeRef="tFine"/>
+    <dmn:informationRequirement id="_800A3BBB-90A3-4D9D-BA5E-A311DED0134F">
+      <dmn:requiredInput href="#_1929CBD5-40E0-442D-B909-49CEDE0101DC"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_C8F7F579-E06C-4A2F-8485-65FAFAC3FE6A" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_B53A6F0D-F72C-41EF-96B3-F31269AC0FED">
+        <dmn:inputExpression id="_974C8D01-728F-4CE5-8C69-BE884125B859" typeRef="string">
+          <dmn:text>Violation.Type</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_D5319F80-1C59-4736-AF2D-D29DE6B7E76D">
+        <dmn:inputExpression id="_3FEB4DE3-90C6-438E-99BF-9BB1BF5B078A" typeRef="number">
+          <dmn:text>Violation.Actual Speed - Violation.Speed Limit</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_9012031F-9C01-44E5-8CD2-E6704D594504" name="Amount" typeRef="number"/>
+      <dmn:output id="_7CAC8240-E1A5-4FEB-A0D4-B8613F0DE54B" name="Points" typeRef="number"/>
+      <dmn:rule id="_424A80AE-916F-4451-9B6B-71557F7EC65A">
+        <dmn:inputEntry id="_EDA4F336-AA28-4F5F-ADFC-401E6DCC8D35">
+          <dmn:text>"speed"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_246AAB08-A945-4599-9220-7C24B6716FDD">
+          <dmn:text>[10..30)</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E49345EE-51D3-47C7-B658-3607E723FF37">
+          <dmn:text>500</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_1D56F3CB-6BAE-4415-940F-00F37121813D">
+          <dmn:text>3</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_B1ECE6A9-6B82-4A85-A7CA-5F96CDB0DCB6">
+        <dmn:inputEntry id="_2390F686-65CF-40FF-BF9A-72DFBAEBACAC">
+          <dmn:text>"speed"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_8CEBE4D5-DBEF-46EF-BD95-7B96148B6D8A">
+          <dmn:text>&gt;= 30</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_5FCC56B7-6BAA-4B09-AC61-7EB9D4CD58C3">
+          <dmn:text>1000</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_79FF8FDD-3299-4DFD-AA14-D2022504BDAD">
+          <dmn:text>7</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_8FC7068C-A3FD-44D9-AC2B-69C160A12E5D">
+        <dmn:inputEntry id="_02EEE8A9-1AD7-4708-8EC8-9B4177B05167">
+          <dmn:text>"parking"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_A5141FF4-8D63-49DB-8979-3B64A3BD9A82">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_EFDA632D-113D-46C9-94B8-78E9F9770CA4">
+          <dmn:text>100</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_05F86973-52CE-4C9D-B785-47B6340D10FD">
+          <dmn:text>1</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_A742DF2B-DC91-4166-9773-6EF86A45A625">
+        <dmn:inputEntry id="_F5B5AE87-D9E6-4142-B01D-D79D4BA49EEE">
+          <dmn:text>"driving under the influence"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_BD2A43F5-46D8-436A-B8A1-D98747C836B1">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_ECAF3378-46B6-4F40-B95A-E90DB700BF7D">
+          <dmn:text>1000</dmn:text>
+        </dmn:outputEntry>
+        <dmn:outputEntry id="_F0016A9C-D1D0-472A-9FB3-ABE77AD15F7D">
+          <dmn:text>5</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:inputData id="_1F9350D7-146D-46F1-85D8-15B5B68AF22A" name="Driver">
+    <dmn:variable id="_A80F16DF-0DB4-43A2-B041-32900B1A3F3D" name="Driver" typeRef="tDriver"/>
+  </dmn:inputData>
+  <dmn:decision id="_8A408366-D8E9-4626-ABF3-5F69AA01F880" name="Should the driver be suspended?">
+    <dmn:question>Should the driver be suspended due to points on his license?</dmn:question>
+    <dmn:allowedAnswers>"Yes", "No"</dmn:allowedAnswers>
+    <dmn:variable id="_40387B66-5D00-48C8-BB90-E83EE3332C72" name="Should the driver be suspended?" typeRef="string"/>
+    <dmn:informationRequirement id="_982211B1-5246-49CD-BE85-3211F71253CF">
+      <dmn:requiredInput href="#_1F9350D7-146D-46F1-85D8-15B5B68AF22A"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_AEC4AA5F-50C3-4FED-A0C2-261F90290731">
+      <dmn:requiredDecision href="#_4055D956-1C47-479C-B3F4-BAEB61F1C929"/>
+    </dmn:informationRequirement>
+    <dmn:context id="_F39732F1-0AA7-468F-86C4-DCC07E6F81CF">
+      <dmn:contextEntry>
+        <dmn:variable id="_09385E8D-68E0-4DFD-AAD8-141C15C96B71" name="Total Points" typeRef="number"/>
+        <dmn:literalExpression id="_F1BEBF16-033F-4A25-9523-CAC23ACC5DFC">
+          <dmn:text>Driver.Points + Fine.Points</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+      <dmn:contextEntry>
+        <dmn:literalExpression id="_1929D813-B1C9-43C5-9497-CE5D8B2B040C">
+          <dmn:text>if Total Points >= 20 then "Yes" else "No"</dmn:text>
+        </dmn:literalExpression>
+      </dmn:contextEntry>
+    </dmn:context>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_C8F7F579-E06C-4A2F-8485-65FAFAC3FE6A">
+            <kie:width>50.0</kie:width>
+            <kie:width>254.0</kie:width>
+            <kie:width>329.0</kie:width>
+            <kie:width>119.0</kie:width>
+            <kie:width>100.0</kie:width>
+            <kie:width>186.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_F39732F1-0AA7-468F-86C4-DCC07E6F81CF">
+            <kie:width>50.0</kie:width>
+            <kie:width>100.0</kie:width>
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_F1BEBF16-033F-4A25-9523-CAC23ACC5DFC">
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_1929D813-B1C9-43C5-9497-CE5D8B2B040C">
+            <kie:width>398.0</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_1929CBD5-40E0-442D-B909-49CEDE0101DC" dmnElementRef="_1929CBD5-40E0-442D-B909-49CEDE0101DC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="708" y="350" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_4055D956-1C47-479C-B3F4-BAEB61F1C929" dmnElementRef="_4055D956-1C47-479C-B3F4-BAEB61F1C929" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="709" y="210" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_1F9350D7-146D-46F1-85D8-15B5B68AF22A" dmnElementRef="_1F9350D7-146D-46F1-85D8-15B5B68AF22A" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="369" y="344" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_8A408366-D8E9-4626-ABF3-5F69AA01F880" dmnElementRef="_8A408366-D8E9-4626-ABF3-5F69AA01F880" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="534" y="83" width="133" height="63"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_800A3BBB-90A3-4D9D-BA5E-A311DED0134F" dmnElementRef="_800A3BBB-90A3-4D9D-BA5E-A311DED0134F">
+        <di:waypoint x="758" y="375"/>
+        <di:waypoint x="759" y="235"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_982211B1-5246-49CD-BE85-3211F71253CF" dmnElementRef="_982211B1-5246-49CD-BE85-3211F71253CF">
+        <di:waypoint x="419" y="369"/>
+        <di:waypoint x="600.5" y="114.5"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_AEC4AA5F-50C3-4FED-A0C2-261F90290731" dmnElementRef="_AEC4AA5F-50C3-4FED-A0C2-261F90290731">
+        <di:waypoint x="759" y="235"/>
+        <di:waypoint x="600.5" y="114.5"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
KOGITO-742: Make it possible to open a GitHub asset from a query param
KOGITO-756: Create a 'Magic Link' on Chrome Extension pointing to Online Editor
KOGITO-763: Create a Sample DMN and BPMN on online editor
KOGITO-788: Add ability to copy BPMN/DMN XML from Online Editor to clipboard