### PR TITLE
KOGITO-739: Configure pom.xml to download and unpack DMN/BPMN editors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,32 +7,8 @@ on:
     branches: "**"
 
 jobs:
-  fetch-editors:
-    runs-on: macOS-latest
-    steps:
-      - name: Checkout upstream
-        uses: actions/checkout@v1
-        with:
-          repository: kiegroup/kogito-tooling
-          ref: master
-
-      - name: Checkout to lastest tag
-        run: git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
-
-      - name: Upload DMN editor
-        uses: actions/upload-artifact@v1
-        with:
-          name: dmn-editor
-          path: packages/kie-bc-editors-unpacked/dmn
-
-      - name: Upload BPMN editor
-        uses: actions/upload-artifact@v1
-        with:
-          name: bpmn-editor
-          path: packages/kie-bc-editors-unpacked/bpmn
 
   build:
-    needs: fetch-editors
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -44,6 +20,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Checkout upstream
+        uses: actions/checkout@v1
+        with:
+          repository: kiegroup/kogito-tooling
+          ref: master
 
       - name: Checkout to PRs base branch -> ${{ github.base_ref }} (PR only)
         uses: actions/checkout@v1
@@ -88,18 +70,6 @@ jobs:
         run: npx lerna run test --stream
         continue-on-error: true
 
-      - name: Download DMN editor
-        uses: actions/download-artifact@v1
-        with:
-          name: dmn-editor
-          path: packages/kie-bc-editors-unpacked/dmn
-
-      - name: Download BPMN editor
-        uses: actions/download-artifact@v1
-        with:
-          name: bpmn-editor
-          path: packages/kie-bc-editors-unpacked/bpmn
-
       - name: "Build :: prod"
         if: success()
         run: npx lerna run --stream build:fast -- --mode production --devtool none
@@ -112,6 +82,18 @@ jobs:
 
       - name: Pack artifacts
         run: npx lerna run pack-extension --stream
+
+      - name: Upload DMN editor
+        uses: actions/upload-artifact@v1
+        with:
+          name: dmn-editor
+          path: packages/kie-bc-editors-unpacked/dmn
+
+      - name: Upload BPMN editor
+        uses: actions/upload-artifact@v1
+        with:
+          name: bpmn-editor
+          path: packages/kie-bc-editors-unpacked/bpmn
 
       - name: Upload VSCode Extension (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/packages/kie-bc-editors-unpacked/bpmn/.gitignore
+++ b/packages/kie-bc-editors-unpacked/bpmn/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/packages/kie-bc-editors-unpacked/dmn/.gitignore
+++ b/packages/kie-bc-editors-unpacked/dmn/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/packages/kie-bc-editors-unpacked/package.json
+++ b/packages/kie-bc-editors-unpacked/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "test": "echo 'No tests to run'",
-    "build:fast": "echo 'Maven unpack' #mvn clean package",
+    "build:fast": "rm -rf bpmn/* dmn/* && mvn clean package -B -nsu",
     "build": "yarn run build:fast",
-    "build:prod": "yarn run build:fast"
+    "build:prod": "rm -rf bpmn/* dmn/* && mvn clean package -B #--no-transfer-progress"
   }
 }

--- a/packages/kie-bc-editors-unpacked/package.json
+++ b/packages/kie-bc-editors-unpacked/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "echo 'No tests to run'",
-    "build:fast": "rm -rf bpmn/* dmn/* && mvn clean package -B -nsu",
+    "build:fast": "rm -rf bpmn/* dmn/* && mvn clean package -B -nsu #",
     "build": "yarn run build:fast",
     "build:prod": "rm -rf bpmn/* dmn/* && mvn clean package -B #--no-transfer-progress"
   }

--- a/packages/kie-bc-editors-unpacked/pom.xml
+++ b/packages/kie-bc-editors-unpacked/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kie-bc-editors-unpacked</artifactId>
+    <groupId>org.kogito-tooling</groupId>
+    <packaging>jar</packaging>
+    <version>0.0.0</version>
+
+    <repositories>
+        <repository>
+            <id>JBoss Nexus</id>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <properties>
+        <version.dmn.webapp>7.32.0-SNAPSHOT</version.dmn.webapp>
+        <version.bpmn.webapp>7.32.0-SNAPSHOT</version.bpmn.webapp>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.kie.workbench</groupId>
+            <artifactId>kie-wb-common-dmn-webapp-kogito-runtime</artifactId>
+            <version>${version.dmn.webapp}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.kie.workbench.stunner</groupId>
+            <artifactId>kie-wb-common-bpmn-kogito-runtime</artifactId>
+            <version>${version.bpmn.webapp}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <!-- UNPACK -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-dmn</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>WEB-INF/</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.kie.workbench</groupId>
+                                    <artifactId>kie-wb-common-dmn-webapp-kogito-runtime</artifactId>
+                                    <version>${version.dmn.webapp}</version>
+                                    <type>war</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/dmn</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-bpmn</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>WEB-INF/</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.kie.workbench.stunner</groupId>
+                                    <artifactId>kie-wb-common-bpmn-kogito-runtime</artifactId>
+                                    <version>${version.dmn.webapp}</version>
+                                    <type>war</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/bpmn</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- COPY -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dmn-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/dmn</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/dmn/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-bpmn-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/bpmn</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/bpmn/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
On this PR:

- Configure pom.xml to download and unpack DMN/BPMN editors
- Update CI configuration to skip downloading DMN/BPMN editors from latest tag
- Update build commands to execute Maven