### PR TITLE
KOGITO-1301: Adding support for icons in Work Items

### DIFF
--- a/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
+++ b/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
@@ -53,10 +53,10 @@ class ChromeResourceContentService implements ResourceContentService {
     this.repoInfo = repoInfo;
   }
 
-  public get(path: string, opts: ResourceContentOptions): Promise<ResourceContent | undefined> {
-    opts = opts ? opts : { type: ContentType.TEXT };
-    return fetchFile(this.octokit, this.repoInfo.owner, this.repoInfo.repo, this.repoInfo.gitref, path, opts.type)
-      .then(resourceContent => new ResourceContent(path, resourceContent, opts.type))
+  public get(path: string, opts?: ResourceContentOptions): Promise<ResourceContent | undefined> {
+    opts = opts ?? { type: ContentType.TEXT };
+    return fetchFile(this.octokit, this.repoInfo.owner, this.repoInfo.repo, this.repoInfo.gitref, path, opts!.type)
+      .then(resourceContent => new ResourceContent(path, resourceContent, opts!.type))
       .catch(e => {
         console.debug(e);
         console.debug(`Error retrieving content from URI ${path}`);

--- a/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
+++ b/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
@@ -18,7 +18,8 @@ import {
   ResourceContent,
   ResourceContentService,
   ResourcesList,
-  ResourceContentOptions
+  ResourceContentOptions,
+  ContentType
 } from "@kogito-tooling/core-api";
 import { fetchFile } from "../../github/api";
 import * as minimatch from "minimatch";
@@ -52,9 +53,10 @@ class ChromeResourceContentService implements ResourceContentService {
     this.repoInfo = repoInfo;
   }
 
-  public get(path: string, opts?: ResourceContentOptions): Promise<ResourceContent | undefined> {
-    return fetchFile(this.octokit, this.repoInfo.owner, this.repoInfo.repo, this.repoInfo.gitref, path, opts?.type)
-      .then(resourceContent => new ResourceContent(path, resourceContent, opts?.type))
+  public get(path: string, opts: ResourceContentOptions): Promise<ResourceContent | undefined> {
+    opts = opts ? opts : { type: ContentType.TEXT };
+    return fetchFile(this.octokit, this.repoInfo.owner, this.repoInfo.repo, this.repoInfo.gitref, path, opts.type)
+      .then(resourceContent => new ResourceContent(path, resourceContent, opts.type))
       .catch(e => {
         console.debug(e);
         console.debug(`Error retrieving content from URI ${path}`);

--- a/packages/vscode-extension/src/VsCodeResourceContentService.ts
+++ b/packages/vscode-extension/src/VsCodeResourceContentService.ts
@@ -8,69 +8,48 @@ import {
 } from "@kogito-tooling/core-api";
 
 export class VsCodeResourceContentService implements ResourceContentService {
-  public get(path: string, opts?: ResourceContentOptions): Promise<ResourceContent | undefined> {
+  public async get(path: string, opts?: ResourceContentOptions): Promise<ResourceContent | undefined> {
     const contentPath = this.resolvePath(path)!;
-    const type = opts?.type;
-    if (contentPath) {
-      return new Promise(resolve => {
-        vscode.workspace.fs.stat(vscode.Uri.parse(contentPath)).then(
-          fileStat => {
-            if (type === ContentType.BINARY) {
-              this.retrieveBinaryContent(contentPath, resolve, path);
-            } else {
-              this.retrieveTextContent(contentPath, resolve, path);
-            }
-          },
-          e => this.errorRetrievingFile(e, path, resolve)
-        );
-      });
+    if (!contentPath) {
+      return new ResourceContent(path, undefined);
     }
-    return Promise.resolve(new ResourceContent(path, undefined));
-  }
-
-  public list(pattern: string): Promise<ResourcesList> {
-    return new Promise((resolve, error) => {
-      vscode.workspace.findFiles(pattern).then(files => {
-        const paths: string[] = files.map(f => f.path).map(f => vscode.workspace.asRelativePath(f));
-        resolve(new ResourcesList(pattern, paths));
-      });
-    });
-  }
-
-  private resolvePath(uri: string) {
-    const folders: vscode.WorkspaceFolder[] = vscode.workspace!.workspaceFolders!;
-    if (folders) {
-      const rootPath = folders[0].uri.path;
-      if (!uri.startsWith("/")) {
-        uri = "/" + uri;
-      }
-      return rootPath + uri;
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.parse(contentPath));
+    } catch (e) {
+      console.debug(`Error checking file ${path}: ${e}`);
+      return new ResourceContent(path, undefined);
     }
-    return null;
+    return this.retrieveContent(opts?.type, path, contentPath);
   }
 
-  private errorRetrievingFile(errorMsg: string, uri: string, resolve: (value: any) => void): void {
-    console.error(`Error retrieving file ${uri}: ${errorMsg}`);
-    resolve(new ResourceContent(uri, undefined));
+  public async list(pattern: string): Promise<ResourcesList> {
+    const files = await vscode.workspace.findFiles(pattern);
+    const paths = files.map(f => vscode.workspace.asRelativePath(f.path));
+    return new ResourcesList(pattern, paths);
   }
 
-  private retrieveTextContent(contentPath: string, resolve: (value: ResourceContent) => void, path: string) {
-    vscode.workspace.openTextDocument(contentPath).then(
-      textDoc => {
-        const textContent = textDoc.getText();
-        resolve(new ResourceContent(path, textContent, ContentType.TEXT));
-      },
-      e => this.errorRetrievingFile(e, contentPath, resolve)
-    );
+  private resolvePath(path: string) {
+    const folders = vscode.workspace!.workspaceFolders!;
+    if (!folders) {
+      return null;
+    }
+
+    const rootPath = folders[0].uri.path;
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+    return rootPath + path;
   }
 
-  private retrieveBinaryContent(contentPath: string, resolve: (value: ResourceContent) => void, path: string) {
-    vscode.workspace.fs.readFile(vscode.Uri.parse(contentPath)).then(
-      content => {
-        const base64Content = new Buffer(content).toString("base64");
-        resolve(new ResourceContent(path, base64Content, ContentType.BINARY));
-      },
-      e => this.errorRetrievingFile(e, contentPath, resolve)
-    );
+  private retrieveContent(type: ContentType | undefined, path: string, contentPath: string): Thenable<ResourceContent> {
+    if (type === ContentType.BINARY) {
+      return vscode.workspace.fs
+        .readFile(vscode.Uri.parse(contentPath))
+        .then(content => new ResourceContent(path, Buffer.from(content).toString("base64"), ContentType.BINARY));
+    } else {
+      return vscode.workspace
+        .openTextDocument(contentPath)
+        .then(textDoc => new ResourceContent(path, textDoc.getText(), ContentType.TEXT));
+    }
   }
 }


### PR DESCRIPTION
KOGITO-1301: Adding support for icons in Work Items
--

A fix in VSCode resource content handler was needed to make icons work in VSCode

PART OF AN ENSEMBLE, Merge with:

https://github.com/kiegroup/kie-wb-common/pull/3195