### PR TITLE
KOGITO-779: Exclude html files from webapps

### DIFF
--- a/packages/kie-bc-editors-unpacked/pom.xml
+++ b/packages/kie-bc-editors-unpacked/pom.xml
@@ -71,6 +71,7 @@
                         </goals>
                         <configuration>
                             <excludes>WEB-INF/</excludes>
+                            <excludes>**/*.html</excludes>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.kie.workbench</groupId>
@@ -93,6 +94,7 @@
                         </goals>
                         <configuration>
                             <excludes>WEB-INF/</excludes>
+                            <excludes>**/*.html</excludes>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.kie.workbench.stunner</groupId>


### PR DESCRIPTION
Hey @manstis @tiagobento 

Thanks for pointing this out! Excluded `html` files from the webapps...

Assembly with:
https://github.com/kiegroup/kie-wb-common/pull/3203
https://github.com/kiegroup/kie-wb-common/pull/3205