### PR TITLE
KOGITO-1394: [DMN Designer] Update sample on online editor (removing colors)

### DIFF
--- a/packages/online-editor/static/samples/sample.dmn
+++ b/packages/online-editor/static/samples/sample.dmn
@@ -565,7 +565,7 @@ else "Insufficient"</dmn:text>
       </di:extension>
       <dmndi:DMNShape id="dmnshape-_4C89E59C-FDDA-438C-8D1F-0B1194EF6DAE" dmnElementRef="_4C89E59C-FDDA-438C-8D1F-0B1194EF6DAE" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="216" blue="138"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -574,7 +574,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_4C788DBD-C672-4F41-9AFE-9C7D2C145734" dmnElementRef="_4C788DBD-C672-4F41-9AFE-9C7D2C145734" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="173" green="222" blue="255"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -592,7 +592,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_FAF9080E-F4EF-49F7-AEFD-0D2990D8FFDA" dmnElementRef="_FAF9080E-F4EF-49F7-AEFD-0D2990D8FFDA" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="173" green="222" blue="255"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -601,7 +601,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_1CF5CEFA-AF97-46F9-9CD5-9A8AEBB20B4E" dmnElementRef="_1CF5CEFA-AF97-46F9-9CD5-9A8AEBB20B4E" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="216" blue="138"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -637,7 +637,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_6E3205AF-7E3D-4ABE-A367-96F3F6E8210E" dmnElementRef="_6E3205AF-7E3D-4ABE-A367-96F3F6E8210E" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="216" blue="138"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -646,7 +646,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_DA5CCF62-90A8-4CFC-A137-98B528522588" dmnElementRef="_DA5CCF62-90A8-4CFC-A137-98B528522588" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="173" green="222" blue="255"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>
@@ -655,7 +655,7 @@ else "Insufficient"</dmn:text>
       </dmndi:DMNShape>
       <dmndi:DMNShape id="dmnshape-_C98BE939-B9C7-43E0-83E8-EE7A16C5276D" dmnElementRef="_C98BE939-B9C7-43E0-83E8-EE7A16C5276D" isCollapsed="false">
         <dmndi:DMNStyle>
-          <dmndi:FillColor red="173" green="222" blue="255"/>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
           <dmndi:StrokeColor red="0" green="0" blue="0"/>
           <dmndi:FontColor red="0" green="0" blue="0"/>
         </dmndi:DMNStyle>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-1394 / https://github.com/kiegroup/kogito-tooling/pull/76

---

@paulovmr, this PR implements feedback from @porcelli regarding the colors in the sample diagram:

<img width="1400" alt="Screen Shot 2020-03-10 at 19 31 58" src="https://user-images.githubusercontent.com/1079279/76365350-d9e6f680-6305-11ea-85e9-2b08b4861264.png">



