### PR TITLE
Update Editors versions to 7.36.0-SNAPSHOT

### DIFF
--- a/packages/kie-bc-editors-unpacked/pom.xml
+++ b/packages/kie-bc-editors-unpacked/pom.xml
@@ -37,8 +37,8 @@
     </repositories>
 
     <properties>
-        <version.dmn.webapp>7.35.0-SNAPSHOT</version.dmn.webapp>
-        <version.bpmn.webapp>7.35.0-SNAPSHOT</version.bpmn.webapp>
+        <version.dmn.webapp>7.36.0-SNAPSHOT</version.dmn.webapp>
+        <version.bpmn.webapp>7.36.0-SNAPSHOT</version.bpmn.webapp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Hey @ederign @jesuino 

Are we ready to move to editors' latest snapshot versions?

CC @inodeman @handreyrc @Josephblt @hasys notice if you're up to date with master, and testing the editor in vscode, you'll have to change this locally until this gets fixed.

Thanks! 