### PR TITLE
KOGITO-1556: DMN online editor can not be used properly in full screen mode

### DIFF
--- a/packages/online-editor/src/editor/EditorFullScreenToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorFullScreenToolbar.tsx
@@ -24,7 +24,7 @@ interface Props {
 export function FullScreenToolbar(props: Props) {
   return (
     <div className="kogito--full-screen__toolbar">
-      <Button variant="primary" onClick={props.onExitFullScreen}>
+      <Button className="kogito--full-screen__toolbar-button" variant="primary" onClick={props.onExitFullScreen}>
         Exit full screen
       </Button>
     </div>

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -165,6 +165,11 @@
   display: flex;
   justify-content: center;
   width: 100%;
+  pointer-events: none;
+}
+
+.kogito--full-screen__toolbar-button {
+  pointer-events: visible;
 }
 
 .kogito--alert-container {


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-1556

## Demo
DMN:
![kogito-1556](https://user-images.githubusercontent.com/24302289/77676420-0e48ec80-6f6d-11ea-877c-bdaaa0505cff.gif)

BPMN:
![kogito-1556-bpmn](https://user-images.githubusercontent.com/24302289/77677197-1ead9700-6f6e-11ea-9d07-684c816b2d5e.gif)

