### PR TITLE
[FIX] Fix build:prod using outdated script command

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -71,7 +71,7 @@
     "test:it": "rm -rf tests-it/out && tsc --sourceMap false -p tests-it && node tests-it/out/main.js",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run build:fast",
-    "build:prod": "yarn run build --mode production --devtool none && yarn run test && yarn run test:it && yarn run pack-extension"
+    "build:prod": "yarn run build --mode production --devtool none && yarn run test && yarn run test:it && yarn run package:prod"
   },
   "jest-junit": {
     "outputDirectory": "./target"


### PR DESCRIPTION
Replace pack-extension with package:prod.

Fixes errors when buidling locally using `yarn build:prod`