### PR TITLE
KOGITO-1505: Stunner - CDATA block missing

### DIFF
--- a/packages/kie-bc-editors/src/DefaultXmlFormatter.ts
+++ b/packages/kie-bc-editors/src/DefaultXmlFormatter.ts
@@ -21,7 +21,7 @@ let cachedXsltProcessor: XSLTProcessor;
 function newXsltProcessor() {
   const xsltDoc = new DOMParser().parseFromString(
     [
-      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">',
+      '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:drools="http://www.jboss.org/drools" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" version="3.0">',
       '  <xsl:strip-space elements="*"/>',
       '  <xsl:template match="para[content-style][not(text())]">',
       '    <xsl:value-of select="normalize-space(.)"/>',
@@ -29,7 +29,9 @@ function newXsltProcessor() {
       '  <xsl:template match="node()|@*">',
       '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
       "  </xsl:template>",
-      '  <xsl:output indent="yes"/>',
+      // indent="yes" prettifies output
+      // cdata-section-elements="list of nodes with cdata separated by space"
+      '  <xsl:output indent="yes" encoding="UTF-8" cdata-section-elements="bpmn2:completionCondition bpmn2:condition bpmn2:conditionExpression bpmn2:from bpmn2:to bpmn2:documentation drools:metaValue drools:script"/>',
       "</xsl:stylesheet>"
     ].join("\n"),
     "application/xml"


### PR DESCRIPTION
PR fixes CDATA missing block for following elements:
* bpmn2:completionCondition
* bpmn2:condition
* bpmn2:conditionExpression
* bpmn2:from
* bpmn2:to
* bpmn2:documentation
* drools:metaValue
* drools:script

Unfortunately **XSLTProcessor** doesn't support option `is CDATA present, just keep it`. The only possible solution is `put CDATA always for elements from the list`.

I checked big process with all elements and properties from [KOGITO-395](https://issues.redhat.com/browse/KOGITO-395) and didn't find any further elements with CDATA.

Most of the values with CDATA are present in our custom `drools:metaValue`

The only concern for me were `bpmn2:from` and `bpmn2:to`. It is attributes of Data Assignments. The concern was that `bpmn2:from` and `bpmn2:to` can contain not only content, but also an ID of another element. See example of data Input Association:
```xml
      <bpmn2:dataInputAssociation>
        <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:targetRef>
        <bpmn2:assignment>
          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[managers]]></bpmn2:from>
          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX]]></bpmn2:to>
        </bpmn2:assignment>
      </bpmn2:dataInputAssociation>
```
In Input and Output this value with ID is reversed so it is not possible to make one of it (for example `bpmn2:from`) with CDATA and the second without.

But I did the same test as I did in in this comment https://github.com/kiegroup/kie-wb-common/pull/3170#issuecomment-600958885 (the only change is that repo moved from **kogito-quickstarts** to **kogito-examples**) and it was successful, so I assume that it is OK to store IDs in CDATA.