### PR TITLE
KOGITO-1725: Links are being duplicated when the back button is clicked

### DIFF
--- a/packages/chrome-extension/src/app/components/tree/FileTreeWithExternalLink.tsx
+++ b/packages/chrome-extension/src/app/components/tree/FileTreeWithExternalLink.tsx
@@ -35,7 +35,11 @@ export function FileTreeWithExternalLink() {
   const [links, setLinksToFiles] = useState<HTMLAnchorElement[]>([]);
 
   useEffect(() => {
-    setLinksToFiles(filterLinks(dependencies.treeView.linksToFiles(), router));
+    const newLinks = filterLinks(dependencies.treeView.linksToFiles(), router);
+    if (newLinks.length === 0) {
+      return;
+    }
+    setLinksToFiles(newLinks);
   }, []);
 
   useEffect(() => {
@@ -45,8 +49,13 @@ export function FileTreeWithExternalLink() {
         return;
       }
 
+      const newLinks = filterLinks(dependencies.treeView.linksToFiles(), router);
+      if (newLinks.length === 0) {
+        return;
+      }
+
       logger.log("Found new links...");
-      setLinksToFiles(filterLinks(dependencies.treeView.linksToFiles(), router));
+      setLinksToFiles(newLinks);
     });
 
     observer.observe(dependencies.treeView.repositoryContainer()!, {
@@ -76,7 +85,10 @@ export function FileTreeWithExternalLink() {
 }
 
 function filterLinks(links: HTMLAnchorElement[], router: Router): HTMLAnchorElement[] {
-  return links.filter(fileLink => router.getLanguageData(extractOpenFileExtension(fileLink.href) as any));
+  return links.filter(fileLink =>
+    router.getLanguageData(extractOpenFileExtension(fileLink.href) as any)
+    && !document.getElementById(externalLinkId(fileLink))
+  );
 }
 
 function externalLinkId(fileLink: HTMLAnchorElement): string {


### PR DESCRIPTION
**Task**: [KOGITO-1725](https://issues.redhat.com/browse/KOGITO-1725)

**Bug**:
Links are being duplicated when going back to the files page using the back button.
Like this:
![Screenshot from 2020-04-06 15-08-18](https://user-images.githubusercontent.com/638737/78931034-90f89e00-7a7b-11ea-99a0-f9917a9f35d7.png)

**Result**:
![KOGITO-1725](https://user-images.githubusercontent.com/638737/78931047-97871580-7a7b-11ea-9435-a7b081311461.gif)