### PR TITLE
KOGITO-1879: Fix VSCode install extension on Hub for directories with special characters

### DIFF
--- a/packages/hub/src/electron/index.ts
+++ b/packages/hub/src/electron/index.ts
@@ -25,7 +25,7 @@ import { CommandExecutionResult } from "../common/CommandExecutionResult";
 import { OperatingSystem } from "@kogito-tooling/core-api";
 import IpcMainEvent = Electron.IpcMainEvent;
 
-const vscode_EXTENSION_PATH = getApplicationPathForUnix("lib/vscode_extension.vsix");
+const vscode_EXTENSION_PATH = getApplicationPath("lib/vscode_extension.vsix");
 
 app.on("ready", () => {
   createWindow();
@@ -151,12 +151,9 @@ function createWindow() {
   ipcMain.on("vscode__install_extension", (e: IpcMainEvent, data: { location: string }) => {
     hubUserData.setVsCodeLocation(data.location);
     executeCommand({
-      macOS: `'${hubUserData.getVsCodeLocation()}/Contents/Resources/app/bin/code' --install-extension ${vscode_EXTENSION_PATH}`,
-      linux: `'${hubUserData.getVsCodeLocation()}/bin/code' --install-extension ${vscode_EXTENSION_PATH}`,
-      windows: `"${hubUserData.getVsCodeLocation()}\\bin\\code" --install-extension "${vscode_EXTENSION_PATH.replace(
-        /\\ /g,
-        " "
-      )}"`
+      macOS: `'${hubUserData.getVsCodeLocation()}/Contents/Resources/app/bin/code' --install-extension "${vscode_EXTENSION_PATH}"`,
+      linux: `'${hubUserData.getVsCodeLocation()}/bin/code' --install-extension "${vscode_EXTENSION_PATH}"`,
+      windows: `"${hubUserData.getVsCodeLocation()}\\bin\\code" --install-extension "${vscode_EXTENSION_PATH}"`
     }).then(result => {
       mainWindow.webContents.send("vscode__install_extension_complete", { ...result });
     });
@@ -191,15 +188,11 @@ function createWindow() {
   // DESKTOP
   ipcMain.on("desktop__launch", (e: IpcMainEvent) => {
     executeCommand({
-      linux: `chmod -R u+x ${getApplicationPathForUnix("")} && ${getApplicationPathForUnix(
+      linux: `chmod -R u+x "${getApplicationPath("")}" && "${getApplicationPath(
         "lib/Business Modeler Preview-linux-x64/Business Modeler Preview"
-      )}`,
-      macOS: `open ${getApplicationPathForUnix(
-        "lib/Business Modeler Preview-darwin-x64/Business Modeler Preview.app"
-      )}`,
-      windows: `"${getApplicationPathForWindows(
-        "lib/Business Modeler Preview-win32-x64/Business Modeler Preview.exe"
-      )}"`
+      )}"`,
+      macOS: `open "${getApplicationPath("lib/Business Modeler Preview-darwin-x64/Business Modeler Preview.app")}"`,
+      windows: `"${getApplicationPath("lib/Business Modeler Preview-win32-x64/Business Modeler Preview.exe")}"`
     }).then(result => {
       mainWindow.webContents.send("desktop__launch_complete", result);
     });
@@ -215,11 +208,7 @@ function createWindow() {
   });
 }
 
-function getApplicationPathForUnix(relativePath: string) {
-  return path.join(__dirname, `${relativePath}`).replace(/(\s+)/g, "\\$1");
-}
-
-function getApplicationPathForWindows(relativePath: string) {
+function getApplicationPath(relativePath: string) {
   return path.join(__dirname, `${relativePath}`);
 }
 


### PR DESCRIPTION
When a '(' character is part of the application path, the VS Code extension can not be correctly installed and the Desktop app cannot be launched.

This is another critical issue, but not blocker, because has a workaround.