### PR TITLE
KOGITO-1815: Chrome Extension Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,8 @@ on:
     branches: "**"
 
 jobs:
-
   build:
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/publish_chrome_ext.yml
+++ b/.github/workflows/publish_chrome_ext.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Upload Chrome Extension to the Chrome Store
         id: update_extension
         run: |
-          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.CLIENT_ID }}&client_secret=${{ secrets.CLIENT_SECRET }}&refresh_token=${{ secrets.REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
-          uploadResponse=$(curl -X PUT -sS "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${{ secrets.EXTENSION_ID }}" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -T chrome_extension_kogito_kie_editors_${{ steps.release-tag.outputs.tag }}.zip)
+          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_CLIENT_ID }}&client_secret=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_CLIENT_SECRET }}&refresh_token=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
+          uploadResponse=$(curl -X PUT -sS "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${{ secrets.CHROME_EXTENSION_ID }}" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -T chrome_extension_kogito_kie_editors_${{ steps.release-tag.outputs.tag }}.zip)
           echo "$uploadResponse"
           echo ::set-output name=upload_status::$(echo "$uploadResponse" | jq -r '.uploadState')
 
@@ -49,8 +49,8 @@ jobs:
       - name: Publish Chrome Extension for users
         id: publish_extension
         run: |
-          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.CLIENT_ID }}&client_secret=${{ secrets.CLIENT_SECRET }}&refresh_token=${{ secrets.REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
-          publishResponse=$(curl -X POST -sS "https://www.googleapis.com/chromewebstore/v1.1/items/${{ secrets.EXTENSION_ID }}/publish" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -H "Content-Length:0")
+          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_CLIENT_ID }}&client_secret=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_CLIENT_SECRET }}&refresh_token=${{ secrets.GOOGLE_DEVELOPER_CONSOLE_REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
+          publishResponse=$(curl -X POST -sS "https://www.googleapis.com/chromewebstore/v1.1/items/${{ secrets.CHROME_EXTENSION_ID }}/publish" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -H "Content-Length:0")
           echo "$publishResponse"
           echo ::set-output name=publish_status::$(echo "$publishResponse" | jq -r '.status | .[0]')
 

--- a/.github/workflows/publish_chrome_ext.yml
+++ b/.github/workflows/publish_chrome_ext.yml
@@ -1,4 +1,4 @@
-name: Publish Chrome Extension on the Chrome Store
+name: Publish Chrome Extension to the Chrome Web Store
 
 on:
   release:

--- a/.github/workflows/publish_chrome_ext.yml
+++ b/.github/workflows/publish_chrome_ext.yml
@@ -1,0 +1,59 @@
+name: Publish Chrome Extension on the Chrome Store
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload_extension:
+    runs-on: ubuntu-latest
+    if: github.repository == 'kiegroup/kogito-tooling'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: kogito-tooling
+
+      # This bash script returns the `tag` name for the release. Will match "/refs/[tags/heads]/[tag]"
+      - name: Parse `tag`
+        id: release-tag
+        run: |
+          echo ::set-output name=tag::$(node -e "console.log('${{ github.ref }}'.match(/^.*\/(.+)$/)[1])")
+
+      # This bash script returns 0 if equal and 1 otherwise. Will fail if versions are not equal.
+      - name: Check release `tag` against `lerna.json.version`
+        run: |
+          echo "$(node -e "console.log(require('./kogito-tooling/lerna.json').version);")"
+          [ "${{ steps.release-tag.outputs.tag }}" == "$(node -e "console.log(require('./kogito-tooling/lerna.json').version);")" ]
+
+      - name: Download Chrome Extension related to the `tag`
+        run: |
+          curl -vsSLJO https://github.com/kiegroup/kogito-tooling/releases/download/${{ steps.release-tag.outputs.tag }}/chrome_extension_kogito_kie_editors_${{ steps.release-tag.outputs.tag }}.zip
+
+      - name: Upload Chrome Extension to the Chrome Store
+        id: update_extension
+        run: |
+          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.CLIENT_ID }}&client_secret=${{ secrets.CLIENT_SECRET }}&refresh_token=${{ secrets.REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
+          uploadResponse=$(curl -X PUT -sS "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${{ secrets.EXTENSION_ID }}" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -T chrome_extension_kogito_kie_editors_${{ steps.release-tag.outputs.tag }}.zip)
+          echo "$uploadResponse"
+          echo ::set-output name=upload_status::$(echo "$uploadResponse" | jq -r '.uploadState')
+
+      - name: Check Upload
+        run: |
+          [ "${{ steps.update_extension.outputs.upload_status }}" == 'SUCCESS' ]
+
+  publish_extension:
+    needs: upload_extension
+    runs-on: ubuntu-latest
+    if: github.repository == 'kiegroup/kogito-tooling'
+    steps:
+      - name: Publish Chrome Extension for users
+        id: publish_extension
+        run: |
+          access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.CLIENT_ID }}&client_secret=${{ secrets.CLIENT_SECRET }}&refresh_token=${{ secrets.REFRESH_TOKEN }}&grant_type=refresh_token" | jq -r '.access_token')
+          publishResponse=$(curl -X POST -sS "https://www.googleapis.com/chromewebstore/v1.1/items/${{ secrets.EXTENSION_ID }}/publish" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -H "Content-Length:0")
+          echo "$publishResponse"
+          echo ::set-output name=publish_status::$(echo "$publishResponse" | jq -r '.status | .[0]')
+
+      - name: Check Publish
+        run: |
+          [[ "${{ steps.update_extension.outputs.publish_status }}" == 'OK' ] || [ "${{ steps.update_extension.outputs.publish_status }}" == 'PUBLISHED_WITH_FRICTION_WARNING' ]]

--- a/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
@@ -1,8 +1,8 @@
 {
-  "name": "BPMN and DMN Editors :: GitHub Extension",
+  "name": "Kie Group GitHub Chrome Extension",
   "version": "0.4.2",
   "manifest_version": 2,
-  "description": "KIE Group :: GitHub Extension",
+  "description": "Visualize and edit BPMN or DMN files on GitHub",
   "content_scripts": [
     {
       "run_at": "document_idle",

--- a/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Kie Group GitHub Chrome Extension",
+  "name": "KIE Group GitHub Chrome Extension",
   "version": "0.4.2",
   "manifest_version": 2,
   "description": "Visualize and edit BPMN or DMN files on GitHub",

--- a/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/static/manifest.json
@@ -7,7 +7,7 @@
     {
       "run_at": "document_idle",
       "js": ["content_scripts/github.js"],
-      "matches": ["https://github.com/*"],
+      "matches": ["https://*.github.com/*"],
       "all_frames": true
     },
     {
@@ -20,14 +20,11 @@
   "background": { "scripts": ["background.js"], "persistent": true },
   "web_accessible_resources": ["resources/*"],
   "permissions": [
-    "cookies",
-    "webRequestBlocking",
-    "webRequest",
-    "https://*/*",
-    "http://*/*",
+    "https://*.github.com/*",
+    "http://*.github.com/*",
     "tabs",
-    "declarativeContent",
-    "background"
+    "webRequest",
+    "webRequestBlocking"
   ],
   "content_security_policy": "script-src 'self' https://raw.githubusercontent.com; object-src 'self'",
   "externally_connectable": {


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-1858
https://issues.redhat.com/browse/KOGITO-1859

## Description
 - Remove unnecessary permissions of the Chrome Extension over the browser
 - Add a GitHub Actions workflow to upload and publish the released Chrome Extension on Chrome Store.

## Before accept this PR
It's necessary to set up these secret variables on the repository:
   - GOOGLE_DEVELOPER_CONSOLE_CLIENT_ID
   - GOOGLE_DEVELOPER_CONSOLE_CLIENT_SECRET
   - GOOGLE_DEVELOPER_CONSOLE_REFRESH_TOKEN
   - CHROME_EXTENSION_ID

## Video Overview
https://www.youtube.com/watch?v=TXuWErf6-Bo