### PR TITLE
KOGITO-2128: Cannot open a diagram on a new VS Code window

### DIFF
--- a/packages/vscode-extension/src/KogitoWebviewProvider.ts
+++ b/packages/vscode-extension/src/KogitoWebviewProvider.ts
@@ -108,9 +108,9 @@ export class KogitoWebviewProvider implements CustomEditorProvider<KogitoEditabl
   }
 
   private createStorageFolder() {
-    const storagePath = this.context.storagePath!;
+    const storagePath = this.context.storagePath ?? this.context.globalStoragePath;
 
-    if (!fs.existsSync(storagePath)) {
+    if (storagePath && !fs.existsSync(storagePath)) {
       fs.mkdirSync(storagePath);
     }
   }


### PR DESCRIPTION
**Task**: [KOGITO-2128](https://issues.redhat.com/browse/KOGITO-2128)

**Fix**: Using `globalStoragePath` if `storagePath` is not available for backup storage.