### PR TITLE
FAI-173: Embed kogito-tooling editors in trusty-ai. Part 2 (trusty-ai changes)

### DIFF
--- a/packages/core-api/src/core/ChannelType.ts
+++ b/packages/core-api/src/core/ChannelType.ts
@@ -15,8 +15,9 @@
  */
 
 export enum ChannelType {
-    VSCODE = "VSCODE",
-    ONLINE = "ONLINE",
-    GITHUB = "GITHUB",
-    DESKTOP = "DESKTOP"
+  VSCODE = "VSCODE",
+  ONLINE = "ONLINE",
+  GITHUB = "GITHUB",
+  DESKTOP = "DESKTOP",
+  EMBEDDED = "EMBEDDED"
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-173

@ederign This adds a new channel type for `EMBEDDED`.

It seams reasonable to distinguish from `ONLINE` WDYT? 

I'm happy to make it more explicit if you prefer; i.e. add `TRUSTY-AI` instead. AFAIK the flag is only used (by DMN for example) to determine some setup, like whether to add a dock to the `EAST` or `WEST` or to enable a feature etc. I checked DMN and it only [checks](changes)) for `VSCODE` and `GITHUB` otherwise everything is the same. 

Please let me know your thoughts.