### PR TITLE
FAI-173: Embed kogito-tooling editors in trusty-ai. Part 2 (trusty-ai changes) 

### DIFF
--- a/packages/embedded-editor/package.json
+++ b/packages/embedded-editor/package.json
@@ -5,6 +5,9 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/kiegroup/kogito-tooling.git"


### PR DESCRIPTION
Add /dist as the deployable unit.

I was unable to use the newly published 0.5.0 on [npmjs](https://www.npmjs.com/package/@kogito-tooling/embedded-editor) as attempts to add it to another project lead to "module not found" errors. On inspection it appears that I missed a configuration entry.

If I copy `kogito-tooling/packages/embedded-editor/dist` to the `node_modules/@kogito-tooling/embedded-editor` folder of my new project everything works fine.