### PR TITLE
Revert "Fetch git tags automatically (#166)"

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
@@ -21,8 +21,6 @@ const packageJson = require("./package.json");
 const envelope = require("../patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
-  require("child_process").execSync("git fetch --tags --all");
-  
   const tagName = require("child_process")
     .execSync("git rev-list --tags --max-count=1")
     .toString()

--- a/packages/online-editor/webpack.config.js
+++ b/packages/online-editor/webpack.config.js
@@ -19,8 +19,6 @@ const CopyPlugin = require("copy-webpack-plugin");
 const envelope = require("../patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
-  require("child_process").execSync("git fetch --tags --all");
-
   const tagName = require("child_process")
     .execSync("git rev-list --tags --max-count=1")
     .toString()


### PR DESCRIPTION
This reverts commit 91b545d60984b2af7bb801bfb39c09a193232099.

Some remotes on my local were not working because the tags were conflicting. Since I need them to review pull request properly and I have no control over the tags on other's forks, we cannot ensure that this command will work for everyone.