### PR TITLE
KOGITO-2512: Setup patternfly-base to be used as dependency

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/package.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/package.json
@@ -11,7 +11,8 @@
     "@kogito-tooling/chrome-extension": "0.5.2",
     "@kogito-tooling/kie-bc-editors": "0.5.2",
     "@kogito-tooling/microeditor-envelope": "0.5.2",
-    "@kogito-tooling/microeditor-envelope-protocol": "0.5.2"
+    "@kogito-tooling/microeditor-envelope-protocol": "0.5.2",
+    "@kogito-tooling/patternfly-base": "0.5.2"
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",

--- a/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
@@ -18,7 +18,7 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const ZipPlugin = require("zip-webpack-plugin");
 const packageJson = require("./package.json");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
   const tagName = require("child_process")

--- a/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/chrome-extension-pack-kogito-kie-editors/webpack.config.js
@@ -18,7 +18,7 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const ZipPlugin = require("zip-webpack-plugin");
 const packageJson = require("./package.json");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
   const tagName = require("child_process")
@@ -153,7 +153,7 @@ module.exports = async (env, argv) => {
           exclude: /node_modules/,
           use: ["babel-loader"]
         },
-        ...envelope.patternflyLoaders
+        ...pfWebpackUtils.patternflyLoaders
       ]
     },
     resolve: {

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",
@@ -84,7 +84,7 @@ module.exports = [
     entry: {
       "webview/index": "./src/webview/index.tsx"
     },
-    module: { rules: [...commonConfig.module.rules, ...envelope.patternflyLoaders] },
+    module: { rules: [...commonConfig.module.rules, ...pfWebpackUtils.patternflyLoaders] },
     plugins: [
       new CopyPlugin([
         { from: "./static/samples", to: "./samples" },

--- a/packages/desktop/webpack.config.js
+++ b/packages/desktop/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",

--- a/packages/embedded-editor/package.json
+++ b/packages/embedded-editor/package.json
@@ -16,7 +16,8 @@
     "@kogito-tooling/core-api": "0.5.2",
     "@kogito-tooling/kie-bc-editors": "0.5.2",
     "@kogito-tooling/microeditor-envelope": "0.5.2",
-    "@kogito-tooling/microeditor-envelope-protocol": "0.5.2"
+    "@kogito-tooling/microeditor-envelope-protocol": "0.5.2",
+    "@kogito-tooling/patternfly-base": "0.5.2"
   },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",

--- a/packages/embedded-editor/webpack.config.js
+++ b/packages/embedded-editor/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",
@@ -41,7 +41,7 @@ const commonConfig = {
         exclude: /node_modules/,
         use: ["babel-loader"]
       },
-      ...envelope.patternflyLoaders
+      ...pfWebpackUtils.patternflyLoaders
     ]
   },
   resolve: {

--- a/packages/embedded-editor/webpack.config.js
+++ b/packages/embedded-editor/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",

--- a/packages/hub/webpack.config.js
+++ b/packages/hub/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 const packageJson = require("./package.json");
 const os = require("os");
 
@@ -110,7 +110,7 @@ module.exports = [
       "webview/index": "./src/webview/index.tsx"
     },
     module: {
-      rules: [...commonConfig.module.rules, ...envelope.patternflyLoaders]
+      rules: [...commonConfig.module.rules, ...pfWebpackUtils.patternflyLoaders]
     },
     plugins: [new CopyPlugin([{ from: "static/index.html" }])]
   }

--- a/packages/hub/webpack.config.js
+++ b/packages/hub/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 const packageJson = require("./package.json");
 const os = require("os");
 

--- a/packages/microeditor-envelope/webpack.config.js
+++ b/packages/microeditor-envelope/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 module.exports = {
   mode: "development",

--- a/packages/microeditor-envelope/webpack.config.js
+++ b/packages/microeditor-envelope/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 module.exports = {
   mode: "development",
@@ -57,7 +57,7 @@ module.exports = {
         exclude: /node_modules/,
         use: ["babel-loader"]
       },
-      ...envelope.patternflyLoaders
+      ...pfWebpackUtils.patternflyLoaders
     ]
   },
   resolve: {

--- a/packages/online-editor/webpack.config.js
+++ b/packages/online-editor/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
   const tagName = require("child_process")
@@ -117,7 +117,7 @@ module.exports = async (env, argv) => {
             ]
           }
         },
-        ...envelope.patternflyLoaders
+        ...pfWebpackUtils.patternflyLoaders
       ]
     },
     devServer: {

--- a/packages/online-editor/webpack.config.js
+++ b/packages/online-editor/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 function getLatestGitTag() {
   const tagName = require("child_process")

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "license": "Apache-2.0",
   "files": [
-    "dist"
+    "webpackUtils.js"
   ],
   "repository": {
     "type": "git",

--- a/packages/patternfly-base/webpackUtils.js
+++ b/packages/patternfly-base/webpackUtils.js
@@ -17,6 +17,15 @@
 const path = require("path");
 const BG_IMAGES_DIRNAME = "bgimages";
 
+/**
+ * Two scenarios for node_modules_dir:
+ * (1) When using @kogito-tooling/patternfly-base library as dependency for other projects, 
+ *     __dirname is already on node_modules folder.
+ * (2) When developing for kogito-tooling, 
+ *     patternfly-base is accessed directly so node_modules_dir needs node_modules appended.
+ */
+const node_modules_dir = "../.." + (__dirname.includes("node_modules") ? "" : "/node_modules");
+
 module.exports = {
   patternflyLoaders: [
     {
@@ -32,11 +41,11 @@ module.exports = {
       // only process modules with this loader
       // if they live under a 'fonts' or 'pficon' directory
       include: [
-        path.resolve(__dirname, "../../node_modules/patternfly/dist/fonts"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/react-core/dist/styles/assets/fonts"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/react-core/dist/styles/assets/pficon"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/patternfly/assets/fonts"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/patternfly/assets/pficon")
+        path.resolve(__dirname, node_modules_dir + "/patternfly/dist/fonts"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/fonts"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/pficon"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/fonts"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/pficon")
       ],
       use: {
         loader: "file-loader",
@@ -90,21 +99,22 @@ module.exports = {
       test: /\.(jpg|jpeg|png|gif)$/i,
       include: [
         path.resolve(__dirname, "src"),
-        path.resolve(__dirname, "../../node_modules/patternfly"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/patternfly/assets/images"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/react-styles/css/assets/images"),
-        path.resolve(__dirname, "../../node_modules/@patternfly/react-core/dist/styles/assets/images"),
+        path.resolve(__dirname, node_modules_dir + "/patternfly"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/images"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-styles/css/assets/images"),
+        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/images"),
         path.resolve(
           __dirname,
-          "../../node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images"
+          node_modules_dir + "/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images"
         ),
         path.resolve(
           __dirname,
-          "../../node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images"
+          node_modules_dir + "/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images"
         ),
         path.resolve(
           __dirname,
-          "../../node_modules/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images"
+          node_modules_dir +
+            "/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images"
         )
       ],
       use: [

--- a/packages/patternfly-base/webpackUtils.js
+++ b/packages/patternfly-base/webpackUtils.js
@@ -18,13 +18,13 @@ const path = require("path");
 const BG_IMAGES_DIRNAME = "bgimages";
 
 /**
- * Two scenarios for node_modules_dir:
+ * Two scenarios for nodeModulesDir:
  * (1) When using @kogito-tooling/patternfly-base library as dependency for other projects, 
  *     __dirname is already on node_modules folder.
  * (2) When developing for kogito-tooling, 
- *     patternfly-base is accessed directly so node_modules_dir needs node_modules appended.
+ *     patternfly-base is accessed directly so nodeModulesDir needs node_modules appended.
  */
-const node_modules_dir = "../.." + (__dirname.includes("node_modules") ? "" : "/node_modules");
+const nodeModulesDir = "../.." + (__dirname.includes("node_modules") ? "" : "/node_modules");
 
 module.exports = {
   patternflyLoaders: [
@@ -41,11 +41,11 @@ module.exports = {
       // only process modules with this loader
       // if they live under a 'fonts' or 'pficon' directory
       include: [
-        path.resolve(__dirname, node_modules_dir + "/patternfly/dist/fonts"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/fonts"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/pficon"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/fonts"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/pficon")
+        path.resolve(__dirname, nodeModulesDir + "/patternfly/dist/fonts"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/react-core/dist/styles/assets/fonts"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/react-core/dist/styles/assets/pficon"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/patternfly/assets/fonts"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/patternfly/assets/pficon")
       ],
       use: {
         loader: "file-loader",
@@ -99,21 +99,21 @@ module.exports = {
       test: /\.(jpg|jpeg|png|gif)$/i,
       include: [
         path.resolve(__dirname, "src"),
-        path.resolve(__dirname, node_modules_dir + "/patternfly"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/patternfly/assets/images"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-styles/css/assets/images"),
-        path.resolve(__dirname, node_modules_dir + "/@patternfly/react-core/dist/styles/assets/images"),
+        path.resolve(__dirname, nodeModulesDir + "/patternfly"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/patternfly/assets/images"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/react-styles/css/assets/images"),
+        path.resolve(__dirname, nodeModulesDir + "/@patternfly/react-core/dist/styles/assets/images"),
         path.resolve(
           __dirname,
-          node_modules_dir + "/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images"
+          nodeModulesDir + "/@patternfly/react-core/node_modules/@patternfly/react-styles/css/assets/images"
         ),
         path.resolve(
           __dirname,
-          node_modules_dir + "/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images"
+          nodeModulesDir + "/@patternfly/react-table/node_modules/@patternfly/react-styles/css/assets/images"
         ),
         path.resolve(
           __dirname,
-          node_modules_dir +
+          nodeModulesDir +
             "/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images"
         )
       ],

--- a/packages/pmml-editor/webpack.config.js
+++ b/packages/pmml-editor/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 module.exports = async (env, argv) => {
   return {

--- a/packages/pmml-editor/webpack.config.js
+++ b/packages/pmml-editor/webpack.config.js
@@ -16,7 +16,7 @@
 
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 module.exports = async (env, argv) => {
   return {
@@ -57,7 +57,7 @@ module.exports = async (env, argv) => {
           exclude: /node_modules/,
           use: ["babel-loader"]
         },
-        ...envelope.patternflyLoaders
+        ...pfWebpackUtils.patternflyLoaders
       ]
     },
     devServer: {

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -93,6 +93,7 @@
     "@kogito-tooling/kie-bc-editors-unpacked": "0.5.2",
     "@kogito-tooling/microeditor-envelope": "0.5.2",
     "@kogito-tooling/microeditor-envelope-protocol": "0.5.2",
-    "@kogito-tooling/vscode-extension": "0.5.2"
+    "@kogito-tooling/vscode-extension": "0.5.2",
+    "@kogito-tooling/patternfly-base": "0.5.2"
   }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/vscode-extension-pack-kogito-kie-editors/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const envelope = require("../patternfly-base/webpackUtils");
+const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",

--- a/packages/vscode-extension-pack-kogito-kie-editors/webpack.config.js
+++ b/packages/vscode-extension-pack-kogito-kie-editors/webpack.config.js
@@ -17,7 +17,7 @@
 const path = require("path");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const envelope = require("@kogito-tooling/patternfly-base/webpackUtils");
+const pfWebpackUtils = require("@kogito-tooling/patternfly-base/webpackUtils");
 
 const commonConfig = {
   mode: "development",
@@ -77,7 +77,7 @@ module.exports = [
       "webview/index": "./src/webview/index.ts"
     },
     module: {
-      rules: [...commonConfig.module.rules, ...envelope.patternflyLoaders]
+      rules: [...commonConfig.module.rules, ...pfWebpackUtils.patternflyLoaders]
     },
     plugins: [
       new CopyWebpackPlugin([


### PR DESCRIPTION
**Note**: A new release including these changes must be published to npmjs before using `@kogito-tooling/patternfly-base` as dependency to projects living out of kogito-tooling. 