### PR TITLE
KOGITO-2533 Icon with link to Online editor is not present in the GitHub file list

### DIFF
--- a/packages/chrome-extension/src/app/Dependencies.ts
+++ b/packages/chrome-extension/src/app/Dependencies.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,14 +58,8 @@ export class Dependencies {
 
     linksToFiles: () => {
       return Array.from(
-        document.querySelectorAll('div[role="grid"] > div[role="row"] > div[role="rowheader"] > span > a')
+        document.querySelectorAll('div[role="grid"] > div[role="row"] > div[role="rowheader"] > span > a[href*=blob]')
       ) as HTMLAnchorElement[];
-    },
-
-    fileSpanElements: () => {
-      return Array.from(
-        document.querySelectorAll('div[role="grid"] > div[role="row"] > div[role="rowheader"] > span')
-      ) as HTMLSpanElement[];
     }
   };
 

--- a/packages/chrome-extension/src/app/Dependencies.ts
+++ b/packages/chrome-extension/src/app/Dependencies.ts
@@ -58,8 +58,14 @@ export class Dependencies {
 
     linksToFiles: () => {
       return Array.from(
-        document.querySelectorAll("table.files > tbody > tr > td.content > span > a[href*=blob]")
+        document.querySelectorAll('div[role="grid"] > div[role="row"] > div[role="rowheader"] > span > a')
       ) as HTMLAnchorElement[];
+    },
+
+    fileSpanElements: () => {
+      return Array.from(
+        document.querySelectorAll('div[role="grid"] > div[role="row"] > div[role="rowheader"] > span')
+      ) as HTMLSpanElement[];
     }
   };
 

--- a/packages/chrome-extension/src/app/components/tree/FileTreeWithExternalLink.tsx
+++ b/packages/chrome-extension/src/app/components/tree/FileTreeWithExternalLink.tsx
@@ -35,6 +35,7 @@ export function FileTreeWithExternalLink() {
   const [links, setLinksToFiles] = useState<HTMLAnchorElement[]>([]);
 
   useEffect(() => {
+    removeDisplayBlockClass(dependencies.treeView.fileSpanElements());
     const newLinks = filterLinks(dependencies.treeView.linksToFiles(), router);
     if (newLinks.length === 0) {
       return;
@@ -44,6 +45,7 @@ export function FileTreeWithExternalLink() {
 
   useEffect(() => {
     const observer = new MutationObserver(mutations => {
+      removeDisplayBlockClass(dependencies.treeView.fileSpanElements());
       const addedNodes = mutations.reduce((l, r) => [...l, ...Array.from(r.addedNodes)], []);
       if (addedNodes.length <= 0) {
         return;
@@ -85,14 +87,19 @@ export function FileTreeWithExternalLink() {
 }
 
 function filterLinks(links: HTMLAnchorElement[], router: Router): HTMLAnchorElement[] {
-  return links.filter(fileLink =>
-    router.getLanguageData(extractOpenFileExtension(fileLink.href) as any)
-    && !document.getElementById(externalLinkId(fileLink))
+  return links.filter(
+    fileLink =>
+      router.getLanguageData(extractOpenFileExtension(fileLink.href) as any) &&
+      !document.getElementById(externalLinkId(fileLink))
   );
 }
 
 function externalLinkId(fileLink: HTMLAnchorElement): string {
   return "external_editor_" + fileLink.id;
+}
+
+function removeDisplayBlockClass(spans: HTMLSpanElement[]) {
+  spans.forEach(span => span.classList.remove("d-block"));
 }
 
 export function createTargetUrl(pathname: string, externalEditorManager?: ExternalEditorManager): string {

--- a/packages/chrome-extension/src/app/components/tree/OpenExternalEditorButton.tsx
+++ b/packages/chrome-extension/src/app/components/tree/OpenExternalEditorButton.tsx
@@ -19,12 +19,8 @@ import { ArrowIcon } from "@patternfly/react-icons";
 
 export function OpenExternalEditorButton(props: { id: string; href: string }) {
   return (
-    <>
-      <div id={props.id} className="float-right">
-        <a href={props.href} target="blank" title="Open in Online Editor">
-          <ArrowIcon />
-        </a>
-      </div>
-    </>
+    <a className="float-right" href={props.href} target="blank" title="Open in Online Editor">
+      <ArrowIcon />
+    </a>
   );
 }


### PR DESCRIPTION
This PR fixes https://issues.redhat.com/browse/KOGITO-2533

## Demo
Repo: https://github.com/ljmotta/bpmn-dmn-examples/tree/samples
![image](https://user-images.githubusercontent.com/24302289/85789595-4941f400-b705-11ea-84a6-20c377d1ecfe.png)
