### PR TITLE
FAI-181: Score Cards: Refactor the Linear Regression Viewer to use new UI model (marshaller changes)

### DIFF
--- a/packages/pmml-editor/src/__tests__/marshaller/RegressionModel.test.ts
+++ b/packages/pmml-editor/src/__tests__/marshaller/RegressionModel.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PMML2XML, XML2PMML } from "../../marshaller";
+import {
+  CategoricalPredictor,
+  DataDictionary,
+  MiningField,
+  Model,
+  NumericPredictor,
+  PMML,
+  RegressionModel,
+  RegressionTable
+} from "../../marshaller/model/pmml4_4";
+import {
+  LINEAR_REGRESSION_MODEL_1,
+  LINEAR_REGRESSION_MODEL_2,
+  LINEAR_REGRESSION_MODEL_3
+} from "./TestData_LinearRegressions";
+
+describe("RegressionModel tests", () => {
+  test("RegressionModel::DataDictionary", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+
+    expect(pmml).not.toBeNull();
+
+    const dataDictionary: DataDictionary = pmml.DataDictionary;
+    expect(dataDictionary.DataField.length).toBe(4);
+    expect(dataDictionary.DataField[0].name).toBe("age");
+    expect(dataDictionary.DataField[0].dataType).toBe("double");
+    expect(dataDictionary.DataField[0].optype).toBe("continuous");
+
+    expect(dataDictionary.DataField[1].name).toBe("salary");
+    expect(dataDictionary.DataField[1].dataType).toBe("double");
+    expect(dataDictionary.DataField[1].optype).toBe("continuous");
+
+    expect(dataDictionary.DataField[2].name).toBe("car_location");
+    expect(dataDictionary.DataField[2].dataType).toBe("string");
+    expect(dataDictionary.DataField[2].optype).toBe("categorical");
+
+    expect(dataDictionary.DataField[3].name).toBe("number_of_claims");
+    expect(dataDictionary.DataField[3].dataType).toBe("integer");
+    expect(dataDictionary.DataField[3].optype).toBe("continuous");
+  });
+
+  test("RegressionModel::Models", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+
+    expect(pmml).not.toBeNull();
+
+    expect(pmml.models).not.toBeUndefined();
+    const models: Model[] = pmml.models ?? [];
+    expect(models.length).toBe(1);
+
+    const model: Model = models[0];
+    expect(model).toBeInstanceOf(RegressionModel);
+
+    const regressionModel: RegressionModel = model as RegressionModel;
+    expect(regressionModel.modelName).toBe("Sample for linear regression");
+    expect(regressionModel.functionName).toBe("regression");
+    expect(regressionModel.algorithmName).toBe("linearRegression");
+    expect(regressionModel.targetFieldName).toBe("number_of_claims");
+    expect(regressionModel.modelType).toBeUndefined();
+    expect(regressionModel.isScorable).toBeUndefined();
+  });
+
+  test("RegressionModel::MiningSchema", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const models: Model[] = pmml.models ?? [];
+    const regressionModel: RegressionModel = models[0] as RegressionModel;
+
+    expect(regressionModel.MiningSchema.MiningField.length).toBe(4);
+    const miningFields: MiningField[] = regressionModel.MiningSchema.MiningField;
+    expect(miningFields[0].name).toBe("age");
+    expect(miningFields[0].usageType).toBeUndefined();
+    expect(miningFields[0].invalidValueTreatment).toBeUndefined();
+
+    expect(miningFields[1].name).toBe("salary");
+    expect(miningFields[1].usageType).toBeUndefined();
+    expect(miningFields[1].invalidValueTreatment).toBeUndefined();
+
+    expect(miningFields[2].name).toBe("car_location");
+    expect(miningFields[2].usageType).toBeUndefined();
+    expect(miningFields[2].invalidValueTreatment).toBeUndefined();
+
+    expect(miningFields[3].name).toBe("number_of_claims");
+    expect(miningFields[3].usageType).toBe("target");
+    expect(miningFields[3].invalidValueTreatment).toBeUndefined();
+  });
+
+  test("RegressionModel::Output", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const models: Model[] = pmml.models ?? [];
+    const regressionModel: RegressionModel = models[0] as RegressionModel;
+
+    expect(regressionModel.Output?.OutputField.length).toBe(0);
+  });
+
+  test("RegressionModel::RegressionTable", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const models: Model[] = pmml.models ?? [];
+    const regressionModel: RegressionModel = models[0] as RegressionModel;
+
+    expect(regressionModel.RegressionTable?.length).toBe(1);
+
+    const regressionTable: RegressionTable = regressionModel.RegressionTable[0];
+
+    expect(regressionTable.intercept).toBe(132.37);
+  });
+
+  test("RegressionModel::RegressionTable::NumericPredictor", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const models: Model[] = pmml.models ?? [];
+    const regressionModel: RegressionModel = models[0] as RegressionModel;
+    const regressionTable: RegressionTable = regressionModel.RegressionTable[0];
+
+    expect(regressionTable.NumericPredictor).not.toBeUndefined();
+
+    const numericPredicators: NumericPredictor[] = regressionTable.NumericPredictor as NumericPredictor[];
+    expect(numericPredicators.length).toBe(1);
+
+    const numericPredictor: NumericPredictor = numericPredicators[0];
+
+    expect(numericPredictor.name).toBe("age");
+    expect(numericPredictor.coefficient).toBe(7.1);
+    expect(numericPredictor.exponent).toBe(1);
+  });
+
+  test("RegressionModel::RegressionTable::CategoricalPredictor", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const models: Model[] = pmml.models ?? [];
+    const regressionModel: RegressionModel = models[0] as RegressionModel;
+    const regressionTable: RegressionTable = regressionModel.RegressionTable[0];
+
+    expect(regressionTable.CategoricalPredictor).not.toBeUndefined();
+
+    const categoricalPredicators: CategoricalPredictor[] = regressionTable.CategoricalPredictor as CategoricalPredictor[];
+    expect(categoricalPredicators.length).toBe(3);
+
+    const categoricalPredicator0: CategoricalPredictor = categoricalPredicators[0];
+    expect(categoricalPredicator0.name).toBe("car_location");
+    expect(categoricalPredicator0.coefficient).toBe(41.1);
+    expect(categoricalPredicator0.value).toBe("carpark");
+
+    const categoricalPredicator1: CategoricalPredictor = categoricalPredicators[1];
+    expect(categoricalPredicator1.name).toBe("car_location");
+    expect(categoricalPredicator1.coefficient).toBe(325.03);
+    expect(categoricalPredicator1.value).toBe("street");
+
+    const categoricalPredicator2: CategoricalPredictor = categoricalPredicators[2];
+    expect(categoricalPredicator2.name).toBe("car_location");
+    expect(categoricalPredicator2.coefficient).toBe(-500.0);
+    expect(categoricalPredicator2.value).toBe("garage");
+  });
+
+  test("RegressionModel::RoundTrip1", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const xml: string = PMML2XML(pmml);
+    expect(xml).not.toBeNull();
+
+    const pmml2: PMML = XML2PMML(xml);
+    expect(pmml).toEqual(pmml2);
+  });
+
+  test("RegressionModel::RoundTrip2", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_2);
+    const xml: string = PMML2XML(pmml);
+    expect(xml).not.toBeNull();
+
+    const pmml2: PMML = XML2PMML(xml);
+    expect(pmml).toEqual(pmml2);
+  });
+
+  test("RegressionModel::RoundTrip3", () => {
+    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_3);
+    const xml: string = PMML2XML(pmml);
+    expect(xml).not.toBeNull();
+
+    const pmml2: PMML = XML2PMML(xml);
+    expect(pmml).toEqual(pmml2);
+  });
+});

--- a/packages/pmml-editor/src/__tests__/marshaller/TestData_LinearRegressions.ts
+++ b/packages/pmml-editor/src/__tests__/marshaller/TestData_LinearRegressions.ts
@@ -46,7 +46,7 @@ export const LINEAR_REGRESSION_MODEL_1: string = `
 export const LINEAR_REGRESSION_MODEL_2: string = `
 <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4"> 
   <Header copyright="DMG.org"/>
-  <DataDictionary numberOfFields="2">
+  <DataDictionary numberOfFields="3">
     <DataField name="water_temperature" optype="continuous" dataType="double"/>
     <DataField name="hemisphere" optype="categorical" dataType="string">
       <Value value="northern"/>

--- a/packages/pmml-editor/src/marshaller/Marshaller.ts
+++ b/packages/pmml-editor/src/marshaller/Marshaller.ts
@@ -18,18 +18,10 @@ import * as JSONata from "jsonata";
 import { Expression } from "jsonata";
 import * as XMLJS from "xml-js";
 import { JSON2UI_TRANSFORMATION as json2ui } from "./jsonata/JSON2UI";
+import { regressionModelFactory } from "./jsonata/json2ui/RegressionModel";
+import { scorecardFactory } from "./jsonata/json2ui/Scorecard";
 import { UI2JSON_TRANSFORMATION as ui2json } from "./jsonata/UI2JSON";
-import {
-  Characteristics,
-  CompoundPredicate,
-  False,
-  FieldName,
-  MiningSchema,
-  PMML,
-  Scorecard,
-  SimplePredicate,
-  True
-} from "./model/pmml4_4";
+import { CompoundPredicate, False, FieldName, PMML, SimplePredicate, True } from "./model/pmml4_4";
 
 export function XML2PMML(xml: string): PMML {
   const doc: XMLJS.Element = XMLJS.xml2js(xml) as XMLJS.Element;
@@ -37,6 +29,7 @@ export function XML2PMML(xml: string): PMML {
   expression.registerFunction("merge", merge);
   expression.registerFunction("singletonArray", singletonArray);
   expression.registerFunction("scorecardFactory", scorecardFactory);
+  expression.registerFunction("regressionModelFactory", regressionModelFactory);
   expression.registerFunction("json2uiSimplePredicateFactory", json2uiSimplePredicateFactory);
   expression.registerFunction("json2uiCompoundPredicateFactory", json2uiCompoundPredicateFactory);
   expression.registerFunction("json2uiTruePredicateFactory", json2uiTruePredicateFactory);
@@ -78,18 +71,6 @@ function singletonArray(value: any): any[] {
     return value;
   }
   return [value];
-}
-
-//Construction of a Scorecard data-structure can be peformed in the JSONata mapping however
-//TypeScript's instanceof operator relies on the applicable constructor function having been
-//called and therefore we must instantiate the object itself. Furthermore the recurrsive hieracical
-//nature of CompoundPredicates cannot be handled by a JSONata mapping.
-function scorecardFactory(): Scorecard {
-  return new Scorecard({
-    MiningSchema: new MiningSchema({ MiningField: [] }),
-    Characteristics: new Characteristics({ Characteristic: [] }),
-    functionName: "regression"
-  });
 }
 
 function json2uiSimplePredicateFactory(): SimplePredicate {

--- a/packages/pmml-editor/src/marshaller/jsonata/JSON2UI.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/JSON2UI.ts
@@ -16,13 +16,23 @@
 import { DATA_DICTIONARY } from "./json2ui/DataDictionary";
 import { HEADER } from "./json2ui/Header";
 import { SCORE_CARD } from "./json2ui/Scorecard";
+import { REGRESSION_MODEL } from "./json2ui/RegressionModel";
 
 export const JSON2UI_TRANSFORMATION: string = `(
   $bootstrap := function($node) {
     { 
       ${HEADER}, 
       ${DATA_DICTIONARY}, 
-      "models": $singletonArray($append([], ${SCORE_CARD})) }
+      "models": $singletonArray(
+        $append(
+          [],
+          $append(
+              ${SCORE_CARD}, 
+              ${REGRESSION_MODEL}
+          )
+        )
+      )
+    }
   };
 
   $json2uiPredicateFactory := function($node) {

--- a/packages/pmml-editor/src/marshaller/jsonata/UI2JSON.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/UI2JSON.ts
@@ -15,9 +15,16 @@
  */
 import { DATA_DICTIONARY } from "./ui2json/DataDictionary";
 import { HEADER } from "./ui2json/Header";
-import { MODELS_SCORECARD } from "./ui2json/Scorecard";
+import { SCORE_CARD } from "./ui2json/Scorecard";
+import { REGRESSION_MODEL } from "./ui2json/RegressionModel";
 
-const MODELS: string = `$append([], ${MODELS_SCORECARD})`;
+const MODELS: string = `$append(
+  [],
+  $append(
+    ${SCORE_CARD},
+    ${REGRESSION_MODEL}
+  )
+)`;
 
 const PMML: string = `
 "elements": [

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/LocalTransformation.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/LocalTransformation.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const LOCAL_TRANSFORMATION: string = `
+  "LocalTransformations": $v.elements[(name = "LocalTransformations")] ~> $map(function($v, $i) {
+    $v
+})`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/LocalTransformations.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/LocalTransformations.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const LOCAL_TRANSFORMATION: string = `
+export const LOCAL_TRANSFORMATIONS: string = `
   "LocalTransformations": $v.elements[(name = "LocalTransformations")] ~> $map(function($v, $i) {
     $v
 })`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelExplanation.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelExplanation.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_EXPLANATION: string = `
+  "ModelExplanation": $v.elements[(name = "ModelExplanation")] ~> $map(function($v, $i) {
+    $v
+})`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelStats.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelStats.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_STATS: string = `
+  "ModelStats": $v.elements[(name = "ModelStats")] ~> $map(function($v, $i) {
+    $v
+})`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelVerification.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/ModelVerification.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_VERIFICATION: string = `
+  "ModelVerification": $v.elements[(name = "ModelVerification")] ~> $map(function($v, $i) {
+    $v
+})`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/Output.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/Output.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const OUTPUT: string = `
+"Output": {
+  "OutputField": [$v.elements[(name = "Output")].elements[(name = "OutputField")] ~> $map(function($v, $i) {
+    $merge([
+      $v.attributes,
+      {
+        "rank": $number($v.attributes.rank)
+      }
+    ])
+  })] 
+}`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/RegressionModel.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/RegressionModel.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MiningSchema, RegressionModel, RegressionTable } from "../../model/pmml4_4";
+import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
+import { MINING_SCHEMA } from "./MiningSchema";
+import { MODEL_EXPLANATION } from "./ModelExplanation";
+import { MODEL_STATS } from "./ModelStats";
+import { MODEL_VERIFICATION } from "./ModelVerification";
+import { OUTPUT } from "./Output";
+import { TARGETS } from "./Targets";
+
+const NUMERIC_PREDICTOR: string = `
+"NumericPredictor": $singletonArray(
+  $v.elements[(name = "NumericPredictor")] ~> $map(function($v, $i) {
+    $merge([
+      $v.attributes,
+      {
+        "exponent": $number($v.attributes.exponent),
+        "coefficient": $number($v.attributes.coefficient)
+      }
+    ])
+  })
+)`;
+
+const CATEGORICAL_PREDICTOR: string = `
+"CategoricalPredictor": $singletonArray(
+  $v.elements[(name = "CategoricalPredictor")] ~> $map(function($v, $i) {
+    $merge([
+      $v.attributes,
+      {
+        "coefficient": $number($v.attributes.coefficient)
+      }
+    ])
+  })
+)`;
+
+const PREDICTOR_TERM: string = `
+  "PredictorTerm": $v.elements[(name = "PredictorTerm")] ~> $map(function($v, $i) {
+    $v
+})`;
+
+const REGRESSION_TABLE: string = `
+"RegressionTable": $singletonArray(
+  $v.elements[(name = "RegressionTable")] ~> $map(function($v, $i) {
+    $merge([
+      $v.attributes,
+      {
+        "intercept": $number($v.attributes.intercept)
+      },
+      {
+        ${NUMERIC_PREDICTOR},
+        ${CATEGORICAL_PREDICTOR},
+        ${PREDICTOR_TERM}
+      }
+    ])
+  })
+)`;
+
+export const REGRESSION_MODEL: string = `
+elements.elements[(name = "RegressionModel")] ~> $map(function($v, $i) {
+  $merge([
+    $regressionModelFactory(),
+    $v.attributes,
+    {
+      "_type": $v.name
+    },
+    {
+      ${MINING_SCHEMA}, 
+      ${OUTPUT},
+      ${MODEL_STATS},
+      ${MODEL_EXPLANATION},
+      ${MODEL_VERIFICATION},
+      ${TARGETS},
+      ${LOCAL_TRANSFORMATION},
+      ${REGRESSION_TABLE}
+    }
+  ])
+})`;
+
+//Construction of a RegressionModel data-structure can be peformed in the JSONata mapping however
+//TypeScript's instanceof operator relies on the applicable constructor function having been
+//called and therefore we must instantiate the object itself.
+export function regressionModelFactory(): RegressionModel {
+  return new RegressionModel({
+    MiningSchema: new MiningSchema({ MiningField: [] }),
+    RegressionTable: [new RegressionTable({ intercept: 0.0 })],
+    functionName: "regression"
+  });
+}

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/RegressionModel.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/RegressionModel.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { MiningSchema, RegressionModel, RegressionTable } from "../../model/pmml4_4";
-import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
+import { LOCAL_TRANSFORMATIONS } from "./LocalTransformations";
 import { MINING_SCHEMA } from "./MiningSchema";
 import { MODEL_EXPLANATION } from "./ModelExplanation";
 import { MODEL_STATS } from "./ModelStats";
@@ -84,7 +84,7 @@ elements.elements[(name = "RegressionModel")] ~> $map(function($v, $i) {
       ${MODEL_EXPLANATION},
       ${MODEL_VERIFICATION},
       ${TARGETS},
-      ${LOCAL_TRANSFORMATION},
+      ${LOCAL_TRANSFORMATIONS},
       ${REGRESSION_TABLE}
     }
   ])

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/Scorecard.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/Scorecard.ts
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Characteristics, MiningSchema, Scorecard } from "../../model/pmml4_4";
+import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
 import { MINING_SCHEMA } from "./MiningSchema";
+import { MODEL_EXPLANATION } from "./ModelExplanation";
+import { MODEL_STATS } from "./ModelStats";
+import { MODEL_VERIFICATION } from "./ModelVerification";
+import { OUTPUT } from "./Output";
+import { TARGETS } from "./Targets";
 
 const COMPLEX_PARTIAL_SCORE: string = `
   "ComplexPartialScore": $v.elements[(name = "ComplexPartialScore")] ~> $map(function($v, $i) {
@@ -47,43 +54,6 @@ const CHARACTERISTICS: string = `
   })]
 }`;
 
-const OUTPUT: string = `
-"Output": {
-  "OutputField": [$v.elements[(name = "Output")].elements[(name = "OutputField")] ~> $map(function($v, $i) {
-    $merge([
-      $v.attributes,
-      {
-        "rank": $number($v.attributes.rank)
-      }
-    ])
-  })] 
-}`;
-
-const MODEL_STATS: string = `
-  "ModelStats": $v.elements[(name = "ModelStats")] ~> $map(function($v, $i) {
-    $v
-})`;
-
-const MODEL_EXPLANATION: string = `
-  "ModelExplanation": $v.elements[(name = "ModelExplanation")] ~> $map(function($v, $i) {
-    $v
-})`;
-
-const MODEL_VERIFICATION: string = `
-  "ModelVerification": $v.elements[(name = "ModelVerification")] ~> $map(function($v, $i) {
-    $v
-})`;
-
-const TARGETS: string = `
-  "Targets": $v.elements[(name = "Targets")] ~> $map(function($v, $i) {
-    $v
-})`;
-
-const LOCAL_TRANSFORMATION: string = `
-  "LocalTransformations": $v.elements[(name = "LocalTransformations")] ~> $map(function($v, $i) {
-    $v
-})`;
-
 export const SCORE_CARD: string = `
 elements.elements[(name = "Scorecard")] ~> $map(function($v, $i) {
   $merge([
@@ -104,3 +74,15 @@ elements.elements[(name = "Scorecard")] ~> $map(function($v, $i) {
     }
   ])
 })`;
+
+//Construction of a Scorecard data-structure can be peformed in the JSONata mapping however
+//TypeScript's instanceof operator relies on the applicable constructor function having been
+//called and therefore we must instantiate the object itself. Furthermore the recurrsive hieracical
+//nature of CompoundPredicates cannot be handled by a JSONata mapping.
+export function scorecardFactory(): Scorecard {
+  return new Scorecard({
+    MiningSchema: new MiningSchema({ MiningField: [] }),
+    Characteristics: new Characteristics({ Characteristic: [] }),
+    functionName: "regression"
+  });
+}

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/Scorecard.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/Scorecard.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Characteristics, MiningSchema, Scorecard } from "../../model/pmml4_4";
-import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
+import { LOCAL_TRANSFORMATIONS } from "./LocalTransformations";
 import { MINING_SCHEMA } from "./MiningSchema";
 import { MODEL_EXPLANATION } from "./ModelExplanation";
 import { MODEL_STATS } from "./ModelStats";
@@ -70,7 +70,7 @@ elements.elements[(name = "Scorecard")] ~> $map(function($v, $i) {
       ${MODEL_EXPLANATION},
       ${MODEL_VERIFICATION},
       ${TARGETS},
-      ${LOCAL_TRANSFORMATION}
+      ${LOCAL_TRANSFORMATIONS}
     }
   ])
 })`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/Targets.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/Targets.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const TARGETS: string = `
+  "Targets": $v.elements[(name = "Targets")] ~> $map(function($v, $i) {
+    $v
+})`;

--- a/packages/pmml-editor/src/marshaller/jsonata/json2ui/index.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/json2ui/index.ts
@@ -15,7 +15,7 @@
  */
 export * from "./DataDictionary";
 export * from "./Header";
-export * from "./LocalTransformation";
+export * from "./LocalTransformations";
 export * from "./MiningSchema";
 export * from "./ModelExplanation";
 export * from "./ModelStats";

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/LocalTransformation.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/LocalTransformation.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const LOCAL_TRANSFORMATION: string = `[
+  $v.LocalTransformations ~> $map(function($v, $i) {
+    $v
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/LocalTransformations.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/LocalTransformations.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const LOCAL_TRANSFORMATION: string = `[
+export const LOCAL_TRANSFORMATIONS: string = `[
   $v.LocalTransformations ~> $map(function($v, $i) {
     $v
   })

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelExplanation.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelExplanation.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_EXPLANATION: string = `[
+  $v.ModelExplanation ~> $map(function($v, $i) {
+    $v
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelStats.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelStats.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_STATS: string = `[
+  $v.ModelStats ~> $map(function($v, $i) {
+    $v
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelVerification.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/ModelVerification.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const MODEL_VERIFICATION: string = `[
+  $v.ModelVerification ~> $map(function($v, $i) {
+    $v
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/Output.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/Output.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const OUTPUT_FIELD: string = `[
+  $v.OutputField ~> $map(function($v, $i) {
+    {
+      "type": "element", 
+      "name": "OutputField", 
+      "attributes": {
+        "name": $v.name,
+        "displayName": $v.displayName,
+        "optype": $v.optype,
+        "dataType": $v.dataType,
+        "targetField": $v.targetField,
+        "feature": $v.feature,
+        "value": $v.value,
+        "ruleFeature": $v.ruleFeature,
+        "algorithm": $v.algorithm,
+        "rank": $v.rank,
+        "rankBasis": $v.rankBasis,
+        "rankOrder": RankOrder$v.rankOrder,
+        "isMultiValued": $v.isMultiValued, 
+        "segmentId": $v.segmentId,
+        "isFinalResult": $v.isFinalResult      
+      },
+      "elements": $append([], [])
+    }
+  })
+]`;
+
+export const OUTPUT: string = `[
+  $v.Output ~> $map(function($v, $i) {
+    {
+      "type": "element",
+      "name": "Output",
+      "elements": ${OUTPUT_FIELD}
+    }
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/RegressionModel.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/RegressionModel.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
+import { LOCAL_TRANSFORMATIONS } from "./LocalTransformations";
 import { MINING_SCHEMA } from "./MiningSchema";
 import { MODEL_EXPLANATION } from "./ModelExplanation";
 import { MODEL_STATS } from "./ModelStats";
@@ -94,7 +94,7 @@ export const REGRESSION_MODEL: string = `[
                           $append(${MODEL_EXPLANATION},
                             $append(${MODEL_VERIFICATION},
                               $append(${TARGETS},
-                                $append([], ${LOCAL_TRANSFORMATION})
+                                $append([], ${LOCAL_TRANSFORMATIONS})
                               )
                             )
                           )

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/Scorecard.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/Scorecard.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { LOCAL_TRANSFORMATION } from "./LocalTransformation";
+import { LOCAL_TRANSFORMATIONS } from "./LocalTransformations";
 import { MINING_SCHEMA } from "./MiningSchema";
 import { MODEL_EXPLANATION } from "./ModelExplanation";
 import { MODEL_STATS } from "./ModelStats";
@@ -93,7 +93,7 @@ export const SCORE_CARD: string = `[
                           $append(${MODEL_EXPLANATION},
                             $append(${MODEL_VERIFICATION},
                               $append(${TARGETS},
-                                $append([], ${LOCAL_TRANSFORMATION})
+                                $append([], ${LOCAL_TRANSFORMATIONS})
                               )
                             )
                           )

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/Targets.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/Targets.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from "./DataDictionary";
-export * from "./Header";
-export * from "./LocalTransformation";
-export * from "./MiningSchema";
-export * from "./ModelExplanation";
-export * from "./ModelStats";
-export * from "./ModelVerification";
-export * from "./Output";
-export * from "./RegressionModel";
-export * from "./Scorecard";
-export * from "./Targets";
+export const TARGETS: string = `[
+  $v.Targets ~> $map(function($v, $i) {
+    $v
+  })
+]`;

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/index.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/index.ts
@@ -15,7 +15,7 @@
  */
 export * from "./DataDictionary";
 export * from "./Header";
-export * from "./LocalTransformation";
+export * from "./LocalTransformations";
 export * from "./MiningSchema";
 export * from "./ModelExplanation";
 export * from "./ModelStats";

--- a/packages/pmml-editor/src/marshaller/jsonata/ui2json/index.ts
+++ b/packages/pmml-editor/src/marshaller/jsonata/ui2json/index.ts
@@ -15,5 +15,12 @@
  */
 export * from "./DataDictionary";
 export * from "./Header";
+export * from "./LocalTransformation";
 export * from "./MiningSchema";
+export * from "./ModelExplanation";
+export * from "./ModelStats";
+export * from "./ModelVerification";
+export * from "./Output";
+export * from "./RegressionModel";
 export * from "./Scorecard";
+export * from "./Targets";


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-181

This PR adds the model classes for Linear Regressions; replacing the [existing](https://github.com/kiegroup/trusty-ai-sandbox/tree/master/front-end-poc/src/ModelLookup/pmml/generated) one. When this PR is merged I will be updating the [UI](https://github.com/kiegroup/trusty-ai-sandbox/tree/master/front-end-poc/src/ModelLookup/pmml) side to use this model.