### PR TITLE
KOGITO-2953: Fix Guided Tour styles

### DIFF
--- a/packages/guided-tour/src/components/Dialog.sass
+++ b/packages/guided-tour/src/components/Dialog.sass
@@ -18,11 +18,10 @@
 
 .pf-c-modal-box.kgt-dialog
   position: fixed
-  width: fit-content
   min-height: 160px
   width: max-content
   max-width: 600px
-  padding-bottom: 50px
+  padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--xl) var(--pf-global--spacer--2xl)
   left: 50%
   top: 50%
   transition: all .5s ease-out


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-2953


This PR adds a missing padding property, which became required with the last PatternFly update.

Before:
![image](https://user-images.githubusercontent.com/24302289/89310478-26332a00-d64b-11ea-9f6c-9e82a4b7f4cd.png)

After:
![image](https://user-images.githubusercontent.com/24302289/89310535-34814600-d64b-11ea-9868-f136a19d475d.png)
