### PR TITLE
KOGITO-735: Make Chrome Extension and Online Editor point to the same static resources on kogito-online

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -231,6 +231,8 @@ jobs:
           cp -r ../kogito-tooling/packages/chrome-extension-pack-kogito-kie-editors/dist/envelope $KOGITO_ONLINE_CHROME_EXT_DIR/
           rm -rf $KOGITO_ONLINE_EDITOR_STAGING_DIR
           cp -r ../kogito-tooling/packages/online-editor/dist $KOGITO_ONLINE_EDITOR_STAGING_DIR
+          rm -rf $KOGITO_ONLINE_EDITOR_STAGING_DIR/gwt-editors
+          ln -s ../$KOGITO_ONLINE_CHROME_EXT_DIR $KOGITO_ONLINE_EDITOR_STAGING_DIR/gwt-editors
           git config --global user.email "kietooling@gmail.com"
           git config --global user.name "Kogito Tooling Bot (kiegroup)"
           git add . && git commit -m "${{ steps.release_json.outputs.tag }} resources" || echo "No changes."

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -69,6 +69,8 @@ jobs:
           cp -r ../kogito-tooling/packages/kie-bc-editors-unpacked/scesim $KOGITO_ONLINE_CHROME_EXT_EDITOR_DIR/
           cp -r ../kogito-tooling/packages/chrome-extension-pack-kogito-kie-editors/dist/envelope $KOGITO_ONLINE_CHROME_EXT_EDITOR_DIR/
           cp -r ../kogito-tooling/packages/online-editor/dist/* $KOGITO_ONLINE_EDITOR_DIR
+          rm -rf $KOGITO_ONLINE_EDITOR_DIR/gwt-editors
+          ln -s $KOGITO_ONLINE_CHROME_EXT_EDITOR_DIR $KOGITO_ONLINE_EDITOR_DIR/gwt-editors
           rm -rf ./online-editor-staging
           git config --global user.email "kietooling@gmail.com"
           git config --global user.name "Kogito Tooling Bot"

--- a/.github/workflows/pull_request_full_downstream_ci.yml
+++ b/.github/workflows/pull_request_full_downstream_ci.yml
@@ -20,6 +20,18 @@ jobs:
       MERGE_WARNING_MESSAGE: "ATTENTION: A merge attempt is being made to get your changes. If a conflict happens, please do a rebase/merge manually in your branch to get the latest kiegroup/master commits."
 
     steps:
+      - name: Check user membership to kiegroup
+        if: github.event_name == 'issue_comment'
+        uses: octokit/request-action@v2.x
+        id: checkUserMembership
+        with:
+          route: GET /orgs/kiegroup/members/:username
+          username: ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          [ "204" == "${{ steps.checkUserMembership.outputs.status }}" ]
+
       - name: Output Build info
         id: buildInfo
         run: |

--- a/.github/workflows/pull_request_full_downstream_ci.yml
+++ b/.github/workflows/pull_request_full_downstream_ci.yml
@@ -20,7 +20,7 @@ jobs:
       MERGE_WARNING_MESSAGE: "ATTENTION: A merge attempt is being made to get your changes. If a conflict happens, please do a rebase/merge manually in your branch to get the latest kiegroup/master commits."
 
     steps:
-      - name: Check user membership to kiegroup
+      - name: Fetch user membership to kiegroup
         if: github.event_name == 'issue_comment'
         uses: octokit/request-action@v2.x
         id: checkUserMembership
@@ -29,7 +29,10 @@ jobs:
           username: ${{ github.actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+
+      - name: Check user membership to kiegroup
+        if: github.event_name == 'issue_comment'
+        run: |
           [ "204" == "${{ steps.checkUserMembership.outputs.status }}" ]
 
       - name: Output Build info

--- a/README.md
+++ b/README.md
@@ -106,9 +106,17 @@ Develop
 Contribute
 --------------------
 - When opening PRs, please make sure to provide a detailed description of the issue along with the JIRA, if there's one.
-- Also, since we depend on BPMN, DMN and Test Scenario editors and our CI build is *not* integrated with the editors, when you need an updated version of the editors to be used, **please provide a VSIX bundle so people can at least test your changes easily on VSCode. Also, it's a good pratice to put a note on your PR saying that the editors have changed too**.
+- If you are a member of [kiegroup](https://github.com/kiegroup) and want to test a change you made in our tooling, you 
+can go to our [Run FDB issue](https://github.com/kiegroup/kogito-tooling/issues/221) and make a comment following the 
+format `Build: {github-username}/{branch-name}`. This will trigger a job that will fetch the forks (1) of `{github-username}`, 
+merge `{branch-name}` into master, and build them.
+In a few seconds you should see a new comment on the same issue, saying that a new build was triggered for you. The 
+GitHub Actions bot will also provide a link so you can follow the build logs and download artifacts, and another link to 
+access an Online Editor instance (2) containing your changes, once it's finished running. 
 
+(1) This process considers the following repositories: `droolsjbpm-build-bootstrap`, `kie-soup`, `appformer`, `kie-wb-common`, `drools-wb` and `kogito-tooling`.
 
+(2) The Online Editor instance will be accessible for 30 days.   
 
 Contributing to Kogito
 --------------------


### PR DESCRIPTION
* Makes Chrome Extension and Online Editor point to the same static resources on kogito-online.
* Restricts the "Run FDB" issue build to kiegroup members only.
* Updates the README with the "Run FDB" instructions.