### PR TITLE
Updating publish_artifacts.yml to publish `@kogito-tooling/kie-bc-editors-unpacked` to NPM

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -83,4 +83,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.KIEGROUP_NPM_TOKEN }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          cd kogito-tooling && npx lerna exec --scope @kogito-tooling/* --ignore @kogito-tooling/kie-bc-editors-unpacked --ignore @kogito-tooling/desktop --ignore @kogito-tooling/hub --ignore @kogito-tooling/pmml-editor -- npm publish --access public && cd -
+          cd kogito-tooling && npx lerna exec --scope @kogito-tooling/* --ignore @kogito-tooling/desktop --ignore @kogito-tooling/hub --ignore @kogito-tooling/pmml-editor -- npm publish --access public && cd -

--- a/packages/kie-bc-editors-unpacked/package.json
+++ b/packages/kie-bc-editors-unpacked/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.1",
   "description": "",
   "license": "Apache-2.0",
+  "files": [
+    "pom.xml"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/kiegroup/kogito-tooling.git"


### PR DESCRIPTION
Since `@kogito-tooling/kie-bc-editors` now depend on `@kogito-tooling/kie-bc-editors-unpacked`, we must publish this to NPM too, to make our packages usable by 3rd parties. We don't wanna publish the unpacked editors, so I added just the `pom.xml` file to it.