### PR TITLE
Update KIE editors to version 7.43.0-SNAPSHOT

### DIFF
--- a/packages/kie-bc-editors-unpacked/pom.xml
+++ b/packages/kie-bc-editors-unpacked/pom.xml
@@ -37,9 +37,9 @@
     </repositories>
 
     <properties>
-        <version.dmn.webapp>7.42.0-SNAPSHOT</version.dmn.webapp>
-        <version.bpmn.webapp>7.42.0-SNAPSHOT</version.bpmn.webapp>
-        <version.scesim.webapp>7.42.0-SNAPSHOT</version.scesim.webapp>
+        <version.dmn.webapp>7.43.0-SNAPSHOT</version.dmn.webapp>
+        <version.bpmn.webapp>7.43.0-SNAPSHOT</version.bpmn.webapp>
+        <version.scesim.webapp>7.43.0-SNAPSHOT</version.scesim.webapp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Hey @ederign @karreiro 

Just noticed this repo is using an old snaphost version for KIE editors. Here is the version update!

CC @handreyrc @inodeman Please notice this version upgrade is pending if you need to generate and upload any VSCode extension in your PRs for testing... 

Thanks!