### PR TITLE
KOGITO-3314: Broken link on popup due to circular dependency issue

### DIFF
--- a/packages/kie-bc-editors/src/i18n/locales/en.ts
+++ b/packages/kie-bc-editors/src/i18n/locales/en.ts
@@ -15,7 +15,8 @@
  */
 
 import { KieBcEditorsI18n } from "../KieBcEditorsI18n";
-import { KOGITO_JIRA_LINK } from ".";
+
+const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO"
 
 export const en: KieBcEditorsI18n = {
   unsupportedFile: `This file contains a construct that is not yet supported. Please refer to ${KOGITO_JIRA_LINK} and report an issue. Don't forget to upload the current file.`

--- a/packages/kie-bc-editors/src/i18n/locales/index.ts
+++ b/packages/kie-bc-editors/src/i18n/locales/index.ts
@@ -16,4 +16,3 @@
 
 export { en } from "./en";
 
-export const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";


### PR DESCRIPTION
This PR fix a circular dependency on `en.ts` and `index.ts`.