### PR TITLE
KOGITO-3504: Interrogation mark cannot be used on new inline editor

### DIFF
--- a/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
+++ b/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
@@ -256,6 +256,11 @@ function getProcessableKeyboardEvent(
     return null;
   }
 
+  // FIXME: KOGITO-3517
+  if (keyboardEvent.target instanceof Element && keyboardEvent.target.matches(`div.inlineNameEditBoxNameBox`)) {
+    return null;
+  }
+
   if (keyboardEvent.repeat && !opts?.repeat) {
     return null;
   }


### PR DESCRIPTION
@romartin, @tiagobento: Please, could you reveiew this PR?

* [KOGITO-3504](https://issues.redhat.com/browse/KOGITO-3504)
* [Plugin](https://drive.google.com/file/d/1SHgGvat_a3CvUWAKRAhBy4azX2qWte0b/view?usp=sharing)

Thanks!
