### PR TITLE
KOGITO-3517: Stunner: InlineEditor Keyboard events are triggering shortcuts in VSCode

### DIFF
--- a/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
+++ b/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
@@ -256,11 +256,6 @@ function getProcessableKeyboardEvent(
     return null;
   }
 
-  // FIXME: KOGITO-3517
-  if (keyboardEvent.target instanceof Element && keyboardEvent.target.matches(`div.inlineNameEditBoxNameBox`)) {
-    return null;
-  }
-
   if (keyboardEvent.repeat && !opts?.repeat) {
     return null;
   }


### PR DESCRIPTION
Hey @romartin: Please, could you review this PR?

**JIRA**: [KOGITO-3517](https://issues.redhat.com/browse/KOGITO-3517)

**Referenced Pull Requests**:
* [Stunner](https://github.com/kiegroup/kie-wb-common/pull/3454)

**VS Code**: [plugin](https://drive.google.com/file/d/1DnnlIF-z3NaTLSHxnDG_W67t5hqWOX-s/view?usp=sharing)

Thanks