### PR TITLE
KOGITO-3703: The pathname is missing on the new Gist URL after a filename update

### DIFF
--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -160,7 +160,9 @@ export function EditorPage(props: Props) {
           editor?.getStateControl().setSavedCommand();
           if (filename !== context.githubService.getCurrentGist()?.filename) {
             // FIXME: KOGITO-1202
-            setUpdateGistFilenameUrl(`${window.location.origin}/?file=${response}#/editor/${fileExtension}`);
+            setUpdateGistFilenameUrl(
+              `${window.location.origin}${window.location.pathname}?file=${response}#/editor/${fileExtension}`
+            );
             setAlert(Alerts.SUCCESS_UPDATE_GIST_FILENAME);
             return;
           }


### PR DESCRIPTION
Add the missing pathname