### PR TITLE
KOGITO-3743: Online Editor - Open from source can't open GitHub URLs

### DIFF
--- a/packages/online-editor/src/__tests__/common/GithubService.test.ts
+++ b/packages/online-editor/src/__tests__/common/GithubService.test.ts
@@ -86,9 +86,15 @@ describe("githubService::extractGistIdFromRawUrl", () => {
 });
 
 describe("githubService::extractUserLoginFromGistRawUrl", () => {
-  test("extract user login from raw url", () => {
+  test("extract user login from gist raw url", () => {
     const rawUrl = "https://gist.githubusercontent.com/test/gist-id/raw/commit-hash/test.bpmn";
-    const userLogin = githubService.extractUserLoginFromGistRawUrl(rawUrl);
+    const userLogin = githubService.extractUserLoginFromFileUrl(rawUrl);
+    expect(userLogin).toEqual("test");
+  });
+
+  test("extract user login from repo raw url", () => {
+    const rawUrl = "https://raw.githubusercontent.com/test/gist-id/raw/commit-hash/test.bpmn";
+    const userLogin = githubService.extractUserLoginFromFileUrl(rawUrl);
     expect(userLogin).toEqual("test");
   });
 });

--- a/packages/online-editor/src/__tests__/editor/EditorToolbar.test.tsx
+++ b/packages/online-editor/src/__tests__/editor/EditorToolbar.test.tsx
@@ -119,7 +119,7 @@ describe("EditorToolbar", () => {
     test("Update Gist button should be disable with invalid user", async () => {
       const githubService = new GithubService();
       jest.spyOn(githubService, "getLogin").mockImplementation(() => "user1");
-      jest.spyOn(githubService, "extractUserLoginFromGistRawUrl").mockImplementation(() => "user2");
+      jest.spyOn(githubService, "extractUserLoginFromFileUrl").mockImplementation(() => "user2");
 
       const { getByTestId } = render(
         usingTestingOnlineI18nContext(
@@ -152,7 +152,7 @@ describe("EditorToolbar", () => {
     test("Update Gist button should be enable with valid user", () => {
       const githubService = new GithubService();
       jest.spyOn(githubService, "getLogin").mockImplementation(() => "user1");
-      jest.spyOn(githubService, "extractUserLoginFromGistRawUrl").mockImplementation(() => "user1");
+      jest.spyOn(githubService, "extractUserLoginFromFileUrl").mockImplementation(() => "user1");
 
       const { getByTestId } = render(
         usingTestingOnlineI18nContext(

--- a/packages/online-editor/src/__tests__/home/HomePage.test.tsx
+++ b/packages/online-editor/src/__tests__/home/HomePage.test.tsx
@@ -80,7 +80,7 @@ describe("HomePage", () => {
 
       test("should show a not found url - github", async () => {
         const githubService = new GithubService();
-        jest.spyOn(githubService, "checkFileExistence").mockImplementation((url: string) => Promise.resolve(false));
+        jest.spyOn(githubService, "getGithubRawUrl").mockImplementation((url: string) => Promise.reject());
 
         const { findByText, getByTestId } = render(
           usingTestingOnlineI18nContext(
@@ -196,7 +196,11 @@ describe("HomePage", () => {
 
       test("should enable the open from source button - github", async () => {
         const githubService = new GithubService();
-        jest.spyOn(githubService, "checkFileExistence").mockImplementation((url: string) => Promise.resolve(true));
+        jest
+          .spyOn(githubService, "getGithubRawUrl")
+          .mockImplementation((url: string) =>
+            Promise.resolve("https://raw.githubusercontent.com/test-owner/test-repo/hash/test.txt")
+          );
 
         const { getByTestId } = render(
           usingTestingOnlineI18nContext(

--- a/packages/online-editor/src/common/GithubService.ts
+++ b/packages/online-editor/src/common/GithubService.ts
@@ -90,7 +90,12 @@ export class GithubService {
     const testOctokit = new Octokit({ auth: token });
     return testOctokit.users
       .getAuthenticated()
-      .then(res => Promise.resolve(res.data.login))
+      .then(res => {
+        if ((res.headers as any)["x-oauth-scopes"].split(", ").indexOf("gist") > -1) {
+          return Promise.resolve(res.data.login);
+        }
+        return Promise.resolve(undefined);
+      })
       .catch(() => Promise.resolve(undefined));
   }
 

--- a/packages/online-editor/src/common/GithubService.ts
+++ b/packages/online-editor/src/common/GithubService.ts
@@ -161,8 +161,8 @@ export class GithubService {
     return url.split(GIST_RAW_URL)[1].split("/")[1];
   }
 
-  public extractUserLoginFromGistRawUrl(url: string): string {
-    return url.split(GIST_RAW_URL)[1].split("/")[0];
+  public extractUserLoginFromFileUrl(url: string): string {
+    return url.split("githubusercontent.com")[1].split("/")[1];
   }
 
   public removeCommitHashFromGistRawUrl(rawUrl: string): string {
@@ -216,7 +216,7 @@ export class GithubService {
         return fetch(
           `https://raw.githubusercontent.com/${fileInfo.org}/${fileInfo.repo}/${fileInfo.gitRef}/${fileInfo.path}`
         ).then(res => {
-          return res.ok ? res.text() : Promise.reject("Not able to retrieve file content from Github.");
+          return res.ok ? res.text() : Promise.reject("Not able to retrieve file content from GitHub.");
         });
       });
   }
@@ -229,20 +229,6 @@ export class GithubService {
       this.currentGist = { filename, id: gistId };
       return (response.data as any).files[filename].content;
     });
-  }
-
-  public checkFileExistence(fileUrl: string): Thenable<boolean> {
-    const fileInfo = this.retrieveFileInfo(fileUrl);
-
-    return this.octokitGet(fileInfo)
-      .then(res => true)
-      .catch(octokitError => {
-        return fetch(
-          `https://raw.githubusercontent.com/${fileInfo.org}/${fileInfo.repo}/${fileInfo.gitRef}/${fileInfo.path}`
-        )
-          .then(res => res.ok)
-          .catch(fetchError => false);
-      });
   }
 
   public createGist(args: CreateGistArgs): Promise<string> {
@@ -263,7 +249,7 @@ export class GithubService {
     return this.octokit.gists
       .create(gistContent)
       .then(response => this.removeCommitHashFromGistRawUrl((response.data as any).files[args.filename].raw_url))
-      .catch(e => Promise.reject("Not able to create gist on Github."));
+      .catch(e => Promise.reject("Not able to create gist on GitHub."));
   }
 
   public async updateGist(args: UpdateGistArgs) {
@@ -298,9 +284,16 @@ export class GithubService {
       .get({ gist_id: gistId })
       .then(response => {
         const filename = gistFilename ? gistFilename : Object.keys(response.data.files)[0];
-
         return this.removeCommitHashFromGistRawUrl((response.data as any).files[filename].raw_url);
       })
-      .catch(e => Promise.reject("Not able to get gist from Github."));
+      .catch(e => Promise.reject("Not able to get gist from GitHub."));
+  }
+
+  public getGithubRawUrl(fileUrl: string): Promise<string> {
+    const fileInfo = this.retrieveFileInfo(fileUrl);
+
+    return this.octokitGet(fileInfo)
+      .then(res => (res.data as any).download_url)
+      .catch(e => Promise.reject("Not able to get raw URL from GitHub."));
   }
 }

--- a/packages/online-editor/src/common/GithubService.ts
+++ b/packages/online-editor/src/common/GithubService.ts
@@ -90,13 +90,8 @@ export class GithubService {
     const testOctokit = new Octokit({ auth: token });
     return testOctokit.users
       .getAuthenticated()
-      .then(res => {
-        if ((res.headers as any)["x-oauth-scopes"].split(", ").indexOf("gist") > -1) {
-          return Promise.resolve(res.data.login);
-        }
-        return Promise.resolve(undefined);
-      })
-      .catch(() => Promise.resolve(undefined));
+      .then(res => this.hasGistScope(res.headers) ? res.data.login : undefined)
+      .catch(() => undefined);
   }
 
   public reset(): void {
@@ -182,6 +177,10 @@ export class GithubService {
 
   public extractGistFilenameFromRawUrl(url: string): string {
     return url.substr(url.lastIndexOf("/") + 1);
+  }
+
+  public hasGistScope(headers: any) {
+    return headers["x-oauth-scopes"].split(", ").indexOf("gist") > -1
   }
 
   public retrieveFileInfo(fileUrl: string): FileInfo {

--- a/packages/online-editor/src/common/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/common/i18n/OnlineI18n.ts
@@ -67,6 +67,7 @@ interface OnlineDictionary extends ReferenceDictionary<OnlineDictionary> {
     downloadSVG: string;
     setGitHubToken: string;
     gistIt: string;
+    gistItTooltip: string;
     fileActions: string;
     updateGist: string;
     updateGistTooltip: string;

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -68,6 +68,7 @@ export const en: OnlineI18n = {
     downloadSVG: `${en_common.terms.download} ${en_common.names.svg}`,
     setGitHubToken: `Set up your ${en_common.names.github} token`,
     gistIt: "Gist it!",
+    gistItTooltip: `Set up your ${en_common.names.github} token to be able to create gists!`,
     fileActions: "File actions",
     updateGist: "Update gist",
     updateGistTooltip: `To be able to update a gist you need to have access to it through your ${en_common.names.github} token.`

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -54,7 +54,7 @@ export const en: OnlineI18n = {
       },
       invalidCurrentGist: `Your current gist ${en_common.names.url} is invalid. If you've updated its filename, it's necessary to update your ${en_common.names.url} as well.`,
       invalidGistFilename: "Invalid filename. This gist already has a file with this name.",
-      error: "An error occurred trying to perform the last operation. Try again later.",
+      error: `An error occurred trying to perform the last operation. Check if your ${en_common.names.github} token is still valid and try again later.`,
       unsaved: {
         title: "Unsaved changes will be lost",
         message: "Click Save to download your progress before closing.",

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -113,13 +113,12 @@ export function EditorPage(props: Props) {
     setAlert(Alerts.GITHUB_TOKEN_MODAL);
   }, []);
 
+  const closeSetGitHubToken = useCallback(() => {
+    setAlert(Alerts.NONE);
+  }, []);
+
   const requestExportGist = useCallback(() => {
     editor?.getContent().then(content => {
-      if (!context.githubService.isAuthenticated()) {
-        setAlert(Alerts.GITHUB_TOKEN_MODAL);
-        return;
-      }
-
       context.githubService
         .createGist({
           filename: `${context.file.fileName}.${context.file.fileExtension}`,
@@ -138,11 +137,6 @@ export function EditorPage(props: Props) {
 
   const requestUpdateGist = useCallback(() => {
     editor?.getContent().then(content => {
-      if (!context.githubService.isAuthenticated()) {
-        setAlert(Alerts.GITHUB_TOKEN_MODAL);
-        return;
-      }
-
       const filename = `${context.file.fileName}.${context.file.fileExtension}`;
       context.githubService
         .updateGist({ filename, content })
@@ -206,13 +200,6 @@ export function EditorPage(props: Props) {
   const toggleFullScreen = useCallback(() => {
     setFullscreen(!fullscreen);
   }, [fullscreen]);
-
-  const continueExport = useCallback(() => {
-    setAlert(Alerts.NONE);
-    if (fileUrl && !context.githubService.isGistRaw(fileUrl)) {
-      requestExportGist();
-    }
-  }, [requestExportGist, window.location]);
 
   const onReady = useCallback(() => setIsEditorReady(true), []);
 
@@ -362,7 +349,6 @@ export function EditorPage(props: Props) {
           <GithubTokenModal
             isOpen={alert === Alerts.GITHUB_TOKEN_MODAL}
             onClose={closeAlert}
-            onContinue={continueExport}
           />
         )}
         {fullscreen && <FullScreenToolbar onExitFullScreen={exitFullscreen} />}

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -113,10 +113,6 @@ export function EditorPage(props: Props) {
     setAlert(Alerts.GITHUB_TOKEN_MODAL);
   }, []);
 
-  const closeSetGitHubToken = useCallback(() => {
-    setAlert(Alerts.NONE);
-  }, []);
-
   const requestExportGist = useCallback(() => {
     editor?.getContent().then(content => {
       context.githubService
@@ -131,7 +127,10 @@ export function EditorPage(props: Props) {
           // FIXME: KOGITO-1202
           window.location.href = `?file=${gistUrl}#/editor/${fileExtension}`;
         })
-        .catch(() => setAlert(Alerts.GITHUB_TOKEN_MODAL));
+        .catch(err => {
+          console.error(err);
+          setAlert(Alerts.ERROR);
+        });
     });
   }, [context.file.fileName, editor]);
 

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -93,8 +93,10 @@ export function EditorToolbar(props: Props) {
 
   useEffect(() => {
     if (fileUrl) {
-      const userLogin = context.githubService.extractUserLoginFromGistRawUrl(fileUrl);
-      setUserCanUpdateGist(userLogin === context.githubService.getLogin());
+      const userLogin = context.githubService.extractUserLoginFromFileUrl(fileUrl);
+      if (userLogin === context.githubService.getLogin() && context.githubService.isGist(fileUrl)) {
+        setUserCanUpdateGist(true);
+      }
     }
   }, [fileUrl, context.githubService.getLogin()]);
 

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -145,9 +145,20 @@ export function EditorToolbar(props: Props) {
       >
         {i18n.editorToolbar.setGitHubToken}
       </DropdownItem>,
-      <DropdownItem key={`dropdown-${dropdownId}-export-gist`} component="button" onClick={props.onExportGist}>
-        {i18n.editorToolbar.gistIt}
-      </DropdownItem>,
+      <Tooltip
+        data-testid={"gist-it-tooltip"}
+        key={`dropdown-${dropdownId}-export-gist`}
+        content={<div>{i18n.editorToolbar.gistItTooltip}</div>}
+        trigger={!context.githubService.isAuthenticated() ? "mouseenter click" : ""}
+      >
+        <DropdownItem
+          component="button"
+          onClick={props.onExportGist}
+          isDisabled={!context.githubService.isAuthenticated()}
+        >
+          {i18n.editorToolbar.gistIt}
+        </DropdownItem>
+      </Tooltip>,
       <Tooltip
         data-testid={"update-gist-tooltip"}
         key={`dropdown-${dropdownId}-update-gist`}

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -91,14 +91,16 @@ export function EditorToolbar(props: Props) {
     [saveNewName, cancelNewName]
   );
 
+  const isGist = useMemo(() => context.githubService.isGist(fileUrl), [fileUrl, context]);
+
   useEffect(() => {
     if (fileUrl) {
       const userLogin = context.githubService.extractUserLoginFromFileUrl(fileUrl);
-      if (userLogin === context.githubService.getLogin() && context.githubService.isGist(fileUrl)) {
+      if (userLogin === context.githubService.getLogin() && isGist) {
         setUserCanUpdateGist(true);
       }
     }
-  }, [fileUrl, context.githubService.getLogin()]);
+  }, [fileUrl, context.githubService.getLogin(), isGist]);
 
   const kebabItems = useCallback(
     (dropdownId: string) => [
@@ -161,21 +163,24 @@ export function EditorToolbar(props: Props) {
           {i18n.editorToolbar.gistIt}
         </DropdownItem>
       </Tooltip>,
-      <Tooltip
-        data-testid={"update-gist-tooltip"}
-        key={`dropdown-${dropdownId}-update-gist`}
-        content={<div>{i18n.editorToolbar.updateGistTooltip}</div>}
-        trigger={!userCanUpdateGist ? "mouseenter click" : ""}
-      >
-        <DropdownItem
-          data-testid={"update-gist-button"}
-          component="button"
-          onClick={props.onUpdateGist}
-          isDisabled={!userCanUpdateGist}
-        >
-          {i18n.editorToolbar.updateGist}
-        </DropdownItem>
-      </Tooltip>
+      <React.Fragment key={`dropdown-${dropdownId}-update-gist`}>
+        {isGist && (
+          <Tooltip
+            data-testid={"update-gist-tooltip"}
+            content={<div>{i18n.editorToolbar.updateGistTooltip}</div>}
+            trigger={!userCanUpdateGist ? "mouseenter click" : ""}
+          >
+            <DropdownItem
+              data-testid={"update-gist-button"}
+              component="button"
+              onClick={props.onUpdateGist}
+              isDisabled={!userCanUpdateGist}
+            >
+              {i18n.editorToolbar.updateGist}
+            </DropdownItem>
+          </Tooltip>
+        )}
+      </React.Fragment>
     ],
     [
       context.external,

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -98,6 +98,8 @@ export function EditorToolbar(props: Props) {
       const userLogin = context.githubService.extractUserLoginFromFileUrl(fileUrl);
       if (userLogin === context.githubService.getLogin() && isGist) {
         setUserCanUpdateGist(true);
+      } else {
+        setUserCanUpdateGist(false);
       }
     }
   }, [fileUrl, context.githubService.getLogin(), isGist]);

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -239,19 +239,20 @@ export function HomePage(props: Props) {
       urlToOpen: undefined
     });
     if (context.githubService.isGithub(inputFileUrl)) {
-      if (await context.githubService.checkFileExistence(inputFileUrl)) {
+      const rawUrl = await context.githubService.getGithubRawUrl(inputFileUrl);
+      try {
         setInputFileUrlState({
           urlValidation: InputFileUrlState.VALID,
-          urlToOpen: inputFileUrl
+          urlToOpen: rawUrl
+        });
+        return;
+      } catch (err) {
+        setInputFileUrlState({
+          urlValidation: InputFileUrlState.NOT_FOUND_URL,
+          urlToOpen: undefined
         });
         return;
       }
-
-      setInputFileUrlState({
-        urlValidation: InputFileUrlState.NOT_FOUND_URL,
-        urlToOpen: undefined
-      });
-      return;
     }
 
     try {

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -239,8 +239,8 @@ export function HomePage(props: Props) {
       urlToOpen: undefined
     });
     if (context.githubService.isGithub(inputFileUrl)) {
-      const rawUrl = await context.githubService.getGithubRawUrl(inputFileUrl);
       try {
+        const rawUrl = await context.githubService.getGithubRawUrl(inputFileUrl);
         setInputFileUrlState({
           urlValidation: InputFileUrlState.VALID,
           urlToOpen: rawUrl


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-3743

This PR fixes some functionallities that were introduced on https://github.com/kiegroup/kogito-tooling/pull/289 

## Test
Some URLs can be opened on the `Open from Source` functionality and all of them should be working properly. Here are some examples:
- GitHub Raw: https://raw.githubusercontent.com/ljmotta/bpmn-dmn-examples/master/sample.bpmn
- GitHub Normal: https://github.com/ljmotta/bpmn-dmn-examples/blob/master/sample.bpmn
- Gist Raw: https://gist.githubusercontent.com/ljmotta/45e76c172c596397e02c6cef4aae28b5/raw/3be5cde9f1605c04e017503ca77ba0f08a922117/Drawing%25201-3.dmn
- Gist Normal: https://gist.github.com/ljmotta/45e76c172c596397e02c6cef4aae28b5
- Gist Specific: https://gist.github.com/ljmotta/db1c79d9919ffa3eb40ad8b7cada5b7f#file-test1000-bpmn