### PR TITLE
KOGITO-3820: Fix open from source Gist URLs double encoded

### DIFF
--- a/packages/online-editor/src/__tests__/home/HomePage.test.tsx
+++ b/packages/online-editor/src/__tests__/home/HomePage.test.tsx
@@ -157,7 +157,7 @@ describe("HomePage", () => {
         );
 
         fireEvent.change(getByTestId("url-text-input"), { target: { value: "https://gist.github.com/test/aaaa" } });
-        expect(await findByText(`Enter a valid gist URL.`)).toBeTruthy();
+        expect(await findByText(`Enter a valid gist URL. If you're using a specific gist URL remember its name can't have whitespaces and upper-case letters.`)).toBeTruthy();
       });
 
       test("should show an invalid gist error", async () => {

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -100,7 +100,7 @@ export const en: OnlineI18n = {
       validating: `Validating ${en_common.names.url}`,
       invalidGistExtension: "File type on the provided gist is not supported.",
       invalidExtension: `File type on the provided ${en_common.names.url} is not supported.`,
-      invalidGist: `Enter a valid gist ${en_common.names.url}.`,
+      invalidGist: `Enter a valid gist ${en_common.names.url}. If you're using a specific gist ${en_common.names.url} remember its name can't have whitespaces and upper-case letters.`,
       invalidUrl: `This ${en_common.names.url} is not valid (don't forget "https://"!).`,
       notFoundUrl: `This ${en_common.names.url} does not exist.`,
       corsNotAvailable: `This ${en_common.names.url} cannot be opened because it doesn't allow other websites to access it.`,


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-3820