### PR TITLE
[KOGITO-3884] Save SVG file using the kieserver naming convention

### DIFF
--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -42,7 +42,7 @@ export async function generateSvg(
   }
 
   const parsedPath = __path.parse(editor.document.uri.fsPath);
-  const svgFileName = `${parsedPath.name}${parsedPath.ext}.svg`;
+  const svgFileName = `${parsedPath.name}-svg.svg`;
   const svgAbsoluteFilePath = __path.join(parsedPath.dir, svgFileName);
   fs.writeFileSync(svgAbsoluteFilePath, previewSvg);
 


### PR DESCRIPTION
It would be more comfortable for RHPAM users to get the SVG saved accordingly the kieserver naming convention:

${process id}-svg.svg.

<img width="1275" alt="Screen Shot 2020-11-30 at 5 20 57 PM" src="https://user-images.githubusercontent.com/531351/100673321-42ad4d80-3331-11eb-8b57-3a0dace798db.png">
<img width="1351" alt="Screen Shot 2020-11-30 at 5 26 06 PM" src="https://user-images.githubusercontent.com/531351/100673366-5062d300-3331-11eb-8dc4-c1fed9a8c488.png">
