### PR TITLE
Modify Chrome Extension FDB to run integration tests on local servers

### DIFF
--- a/.github/workflows/pull_request_full_downstream_ci.yml
+++ b/.github/workflows/pull_request_full_downstream_ci.yml
@@ -292,19 +292,28 @@ jobs:
           git push origin gh-pages
           cd -
 
+      # Rebuilds packages, starts and waits for the local servers and runs integration tests for the Chrome plugin
       - name: Run Chrome plugin integration tests
         env:
           DISPLAY: ":99.0"
-        run: cd kogito-tooling/packages/chrome-extension-pack-kogito-kie-editors && yarn run test:it
+          ROUTER_targetOrigin: "https://localhost:9000"
+          ROUTER_relativePath: ""
+          ONLINEEDITOR_url: "http://localhost:9001"
 
-      - name: Archive it test screenshots	
+        run: |
+          cd packages/online-editor && yarn run build:fast && yarn run start &
+          cd packages/chrome-extension-pack-kogito-kie-editors && yarn run build:fast && yarn run serve-envelope &
+          sleep 20  
+          cd packages/chrome-extension-pack-kogito-kie-editors && yarn run test:it
+
+      - name: Archive Chrome plugin integration tests screenshots	
         if: success() || failure()	
         uses: actions/upload-artifact@v1	
         with:	
           name: chrome-extension-it-tests-screenshots-${{ matrix.os }}	
           path: kogito-tooling/packages/chrome-extension-pack-kogito-kie-editors/screenshots	
 
-      - name: Archive it test logs	
+      - name: Archive Chrome plugin integration tests logs	
         if: success() || failure()	
         uses: actions/upload-artifact@v1	
         with:	

--- a/.github/workflows/pull_request_full_downstream_ci.yml
+++ b/.github/workflows/pull_request_full_downstream_ci.yml
@@ -301,8 +301,8 @@ jobs:
           ONLINEEDITOR_url: "http://localhost:9001"
 
         run: |
-          cd packages/online-editor && yarn run build:fast && yarn run start &
-          cd packages/chrome-extension-pack-kogito-kie-editors && yarn run build:fast && yarn run serve-envelope &
+          cd packages/online-editor && yarn run build:prod && yarn run start &
+          cd packages/chrome-extension-pack-kogito-kie-editors && yarn run build:prod && yarn run serve-envelope &
           sleep 20  
           cd packages/chrome-extension-pack-kogito-kie-editors && yarn run test:it
 


### PR DESCRIPTION
Chrome plugin integration tests often failed because of publishing to GithHub pages takes from several seconds to 60 and more minutes. (I measured the time between pushing to kogito-online-ci and getting http 200 on https://kiegroup.github.io/kogito-online-ci/pull/{build.nuber}/# and I got almost 2 hours  ) We cannot afford wait that amount of time in the CI. Chrome plugin tests have to be run on local servers.