### PR TITLE
FAI-336: Fix undoing new fields (DD, Outputs, Characteristics) not exiting editing mode

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
@@ -74,12 +74,13 @@ export const CharacteristicsTable = (props: CharacteristicsTableProps) => {
     }
   }, [activeOperation]);
 
+  //Exit "edit mode" when the User adds a new entry and then immediately undoes it.
   useEffect(() => {
     if (selectedCharacteristicIndex === characteristics.length) {
       setSelectedCharacteristicIndex(undefined);
       setActiveOperation(Operation.NONE);
     }
-  }, [characteristics]);
+  }, [characteristics, selectedCharacteristicIndex]);
 
   const onEdit = (index: number | undefined) => {
     setSelectedCharacteristicIndex(index);

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
@@ -74,6 +74,13 @@ export const CharacteristicsTable = (props: CharacteristicsTableProps) => {
     }
   }, [activeOperation]);
 
+  useEffect(() => {
+    if (selectedCharacteristicIndex === characteristics.length) {
+      setSelectedCharacteristicIndex(undefined);
+      setActiveOperation(Operation.NONE);
+    }
+  }, [characteristics]);
+
   const onEdit = (index: number | undefined) => {
     setSelectedCharacteristicIndex(index);
     setActiveOperation(Operation.UPDATE_CHARACTERISTIC);

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
@@ -62,6 +62,13 @@ const OutputFieldsTable = (props: OutputFieldsTableProps) => {
     }
   }, [activeOperation]);
 
+  useEffect(() => {
+    if (selectedOutputIndex === outputs.length) {
+      setSelectedOutputIndex(undefined);
+      setActiveOperation(Operation.NONE);
+    }
+  }, [outputs]);
+
   const onEdit = (index: number | undefined) => {
     setSelectedOutputIndex(index);
     setActiveOperation(Operation.UPDATE_OUTPUT);

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
@@ -62,12 +62,13 @@ const OutputFieldsTable = (props: OutputFieldsTableProps) => {
     }
   }, [activeOperation]);
 
+  //Exit "edit mode" when the User adds a new entry and then immediately undoes it.
   useEffect(() => {
     if (selectedOutputIndex === outputs.length) {
       setSelectedOutputIndex(undefined);
       setActiveOperation(Operation.NONE);
     }
-  }, [outputs]);
+  }, [outputs, selectedOutputIndex]);
 
   const onEdit = (index: number | undefined) => {
     setSelectedOutputIndex(index);


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-336

Since this the editor remains a PoC there are still no Unit Tests...