### PR TITLE
FAI-226: Score Cards: Refactor the Linear Regression Viewer to use new UI model (UI changes)

### DIFF
--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@patternfly/patternfly": "4.16.7",
     "@patternfly/react-core": "4.23.1",
-    "@patternfly/react-icons": "4.4.2"
+    "@patternfly/react-icons": "4.4.2",
+    "@patternfly/react-charts": "6.5.4"
   }
 }

--- a/packages/pmml-editor/src/editor/PMMLModelHelper.ts
+++ b/packages/pmml-editor/src/editor/PMMLModelHelper.ts
@@ -154,7 +154,7 @@ export const PMMLModels: Array<PMMLModelMapping<any>> = new Array<PMMLModelMappi
     model: RegressionModel,
     type: "Regression Model",
     iconUrl: "card-icon-default.svg",
-    isSupported: false,
+    isSupported: true,
     factory: undefined
   },
   {

--- a/packages/pmml-editor/src/editor/components/EditorCore/atoms/ModelTitle.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorCore/atoms/ModelTitle.tsx
@@ -25,7 +25,7 @@ import { OperationContext } from "../../../PMMLEditor";
 
 interface HeaderTitleProps {
   modelName: string;
-  commitModelName: (_modelName: string) => void;
+  commitModelName?: (_modelName: string) => void;
 }
 
 export const ModelTitle = (props: HeaderTitleProps) => {
@@ -46,7 +46,9 @@ export const ModelTitle = (props: HeaderTitleProps) => {
 
   const onCommit = () => {
     if (modelName.value !== props.modelName) {
-      commitModelName(modelName.value);
+      if (commitModelName !== undefined) {
+        commitModelName(modelName.value);
+      }
     }
     onCancel();
   };
@@ -75,7 +77,9 @@ export const ModelTitle = (props: HeaderTitleProps) => {
               tabIndex={0}
               onKeyDown={e => {
                 if (e.key === "Enter") {
-                  setActiveOperation(Operation.UPDATE_NAME);
+                  if (commitModelName !== undefined) {
+                    setActiveOperation(Operation.UPDATE_NAME);
+                  }
                 }
               }}
             >
@@ -83,7 +87,11 @@ export const ModelTitle = (props: HeaderTitleProps) => {
                 size="3xl"
                 headingLevel="h2"
                 className="modelTitle__truncate"
-                onClick={e => setActiveOperation(Operation.UPDATE_NAME)}
+                onClick={e => {
+                  if (commitModelName !== undefined) {
+                    setActiveOperation(Operation.UPDATE_NAME);
+                  }
+                }}
               >
                 {modelName.value}
               </Title>

--- a/packages/pmml-editor/src/editor/components/EditorCore/molecules/EditorHeader.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorCore/molecules/EditorHeader.tsx
@@ -21,7 +21,11 @@ import { OutputsHandler } from "../../Outputs/organisms";
 import { MiningSchema, Output, OutputField } from "@kogito-tooling/pmml-editor-marshaller";
 import MiningSchemaHandler from "../../MiningSchema/MiningSchemaHandler/MiningSchemaHandler";
 
-interface EditorHeaderProps {
+interface EditorHeaderViewerProps {
+  modelName: string;
+}
+
+interface EditorHeaderEditorProps {
   modelName: string;
   modelIndex: number;
   output?: Output;
@@ -32,41 +36,61 @@ interface EditorHeaderProps {
   commitModelName: (modelName: string) => void;
 }
 
-export const EditorHeader = (props: EditorHeaderProps) => {
-  const {
-    modelName,
-    miningSchema,
-    modelIndex,
-    output,
-    validateOutputFieldName,
-    deleteOutputField,
-    commitOutputField,
-    commitModelName
-  } = props;
+type EditorHeaderProps = EditorHeaderViewerProps | EditorHeaderEditorProps;
 
-  return (
-    <Split hasGutter={true}>
-      <SplitItem>
-        <ModelTitle modelName={modelName} commitModelName={commitModelName} />
-      </SplitItem>
-      <SplitItem isFilled={true}>
-        <div>&nbsp;</div>
-      </SplitItem>
-      <SplitItem>
-        <DataDictionaryHandler />
-      </SplitItem>
-      <SplitItem>
-        <MiningSchemaHandler miningSchema={miningSchema} modelIndex={modelIndex} />
-      </SplitItem>
-      <SplitItem>
-        <OutputsHandler
-          modelIndex={modelIndex}
-          output={output}
-          validateOutputFieldName={validateOutputFieldName}
-          deleteOutputField={deleteOutputField}
-          commitOutputField={commitOutputField}
-        />
-      </SplitItem>
-    </Split>
-  );
+const isEditor = (props: EditorHeaderProps): props is EditorHeaderEditorProps => {
+  return (props as EditorHeaderEditorProps).modelIndex !== undefined;
+};
+
+export const EditorHeader = (props: EditorHeaderProps) => {
+  const { modelName } = props;
+
+  if (isEditor(props)) {
+    const {
+      miningSchema,
+      modelIndex,
+      output,
+      validateOutputFieldName,
+      deleteOutputField,
+      commitOutputField,
+      commitModelName
+    } = props;
+
+    return (
+      <Split hasGutter={true}>
+        <SplitItem>
+          <ModelTitle modelName={modelName} commitModelName={commitModelName} />
+        </SplitItem>
+        <SplitItem isFilled={true}>
+          <div>&nbsp;</div>
+        </SplitItem>
+        <SplitItem>
+          <DataDictionaryHandler />
+        </SplitItem>
+        <SplitItem>
+          <MiningSchemaHandler miningSchema={miningSchema} modelIndex={modelIndex} />
+        </SplitItem>
+        <SplitItem>
+          <OutputsHandler
+            modelIndex={modelIndex}
+            output={output}
+            validateOutputFieldName={validateOutputFieldName}
+            deleteOutputField={deleteOutputField}
+            commitOutputField={commitOutputField}
+          />
+        </SplitItem>
+      </Split>
+    );
+  } else {
+    return (
+      <Split hasGutter={true}>
+        <SplitItem>
+          <ModelTitle modelName={modelName} />
+        </SplitItem>
+        <SplitItem isFilled={true}>
+          <div>&nbsp;</div>
+        </SplitItem>
+      </Split>
+    );
+  }
 };

--- a/packages/pmml-editor/src/editor/components/EditorCore/organisms/SingleEditorRouter.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorCore/organisms/SingleEditorRouter.tsx
@@ -22,6 +22,7 @@ import { useSelector } from "react-redux";
 import { EmptyStateModelNotFound } from ".";
 import { UnsupportedModelPage } from "../templates";
 import { Operation } from "../../EditorScorecard";
+import { LinearRegressionViewerPage } from "../../LinearRegressionViewer/templates";
 
 interface ModelParams {
   index?: string;
@@ -61,6 +62,9 @@ export const SingleEditorRouter = (props: SingleEditorRouterProps) => {
       {!_isSupportedModelType && <UnsupportedModelPage path={props.path} model={model} />}
       {_isSupportedModelType && modelType === "Scorecard" && (
         <ScorecardEditorPage path={props.path} modelIndex={_index} />
+      )}
+      {_isSupportedModelType && modelType === "Regression Model" && (
+        <LinearRegressionViewerPage path={props.path} modelIndex={_index} />
       )}
     </div>
   );

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionView.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionView.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 import { Chart, ChartAxis, ChartGroup, ChartLabel, ChartLine, ChartVoronoiContainer } from "@patternfly/react-charts";
 
-class Line {
+export class Line {
   //y=mx+c
   public readonly m: number;
   public readonly c: number;
@@ -29,7 +29,7 @@ class Line {
   }
 }
 
-class Range {
+export class Range {
   public readonly min: number;
   public readonly max: number;
 
@@ -50,28 +50,28 @@ interface LinearRegressionViewProps {
   rangeY: Range;
 }
 
-const LinearRegressionView = (props: LinearRegressionViewProps) => {
-  function roundedToFixed(_float: number, _digits: number): string {
-    const rounded = Math.pow(10, _digits);
-    return (Math.round(_float * rounded) / rounded).toFixed(_digits);
-  }
+const roundedToFixed = (_float: number, _digits: number): string => {
+  const rounded = Math.pow(10, _digits);
+  return (Math.round(_float * rounded) / rounded).toFixed(_digits);
+};
 
-  function getTicks(range: Range, count: number): number[] {
-    const start: number = range.min;
-    const end: number = range.max;
-    const step: number = (end - start) / count;
-    const ticks: number[] = new Array<number>();
-    let v: number = start;
-    while (v <= end) {
-      ticks.push(v);
-      v = v + step;
-    }
-    if (ticks[ticks.length - 1] !== end) {
-      ticks.push(end);
-    }
-    return ticks;
+const getTicks = (range: Range, count: number): number[] => {
+  const start: number = range.min;
+  const end: number = range.max;
+  const step: number = (end - start) / count;
+  const ticks: number[] = new Array<number>();
+  let v: number = start;
+  while (v <= end) {
+    ticks.push(v);
+    v = v + step;
   }
+  if (ticks[ticks.length - 1] !== end) {
+    ticks.push(end);
+  }
+  return ticks;
+};
 
+export const LinearRegressionView = (props: LinearRegressionViewProps) => {
   const legendData: any = [];
   props.lines.forEach(line => {
     legendData.push({ name: line.title });
@@ -134,5 +134,3 @@ const LinearRegressionView = (props: LinearRegressionViewProps) => {
     </div>
   );
 };
-
-export { LinearRegressionView, Line, Range };

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionView.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionView.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { Chart, ChartAxis, ChartGroup, ChartLabel, ChartLine, ChartVoronoiContainer } from "@patternfly/react-charts";
+
+class Line {
+  //y=mx+c
+  public readonly m: number;
+  public readonly c: number;
+  public readonly title: string;
+
+  constructor(m: number, c: number, title: string) {
+    this.m = m;
+    this.c = c;
+    this.title = title;
+  }
+}
+
+class Range {
+  public readonly min: number;
+  public readonly max: number;
+
+  constructor(min: number, max: number) {
+    this.min = min;
+    this.max = max;
+  }
+}
+
+interface LinearRegressionViewProps {
+  modelName: string;
+  independentAxisTitle: string;
+  dependentAxisTitle: string;
+  width?: number;
+  height?: number;
+  lines: Line[];
+  rangeX: Range;
+  rangeY: Range;
+}
+
+const LinearRegressionView = (props: LinearRegressionViewProps) => {
+  function roundedToFixed(_float: number, _digits: number): string {
+    const rounded = Math.pow(10, _digits);
+    return (Math.round(_float * rounded) / rounded).toFixed(_digits);
+  }
+
+  function getTicks(range: Range, count: number): number[] {
+    const start: number = range.min;
+    const end: number = range.max;
+    const step: number = (end - start) / count;
+    const ticks: number[] = new Array<number>();
+    let v: number = start;
+    while (v <= end) {
+      ticks.push(v);
+      v = v + step;
+    }
+    if (ticks[ticks.length - 1] !== end) {
+      ticks.push(end);
+    }
+    return ticks;
+  }
+
+  const legendData: any = [];
+  props.lines.forEach(line => {
+    legendData.push({ name: line.title });
+  });
+
+  const { modelName = "undefined", width = 500, height = 500 } = props;
+
+  return (
+    <div style={{ height: height, width: width }}>
+      <Chart
+        ariaTitle={modelName}
+        containerComponent={
+          <ChartVoronoiContainer
+            labels={({ datum }) => `${roundedToFixed(datum._x, 2)}, ${roundedToFixed(datum._y, 2)}`}
+            constrainToVisibleArea={true}
+          />
+        }
+        legendData={legendData}
+        legendOrientation="horizontal"
+        legendPosition="bottom"
+        padding={{
+          bottom: 100,
+          left: 50,
+          right: 50,
+          top: 50
+        }}
+        height={height}
+        width={width}
+      >
+        <ChartLabel text={modelName} x={width / 2} y={30} textAnchor="middle" />
+        <ChartAxis
+          label={props.independentAxisTitle}
+          showGrid={true}
+          tickValues={getTicks(props.rangeX, 8)}
+          tickFormat={x => roundedToFixed(x, 2)}
+        />
+        <ChartAxis
+          label={props.dependentAxisTitle}
+          dependentAxis={true}
+          showGrid={true}
+          tickValues={getTicks(props.rangeY, 8)}
+          tickFormat={x => roundedToFixed(x, 2)}
+        />
+        <ChartGroup>
+          {props.lines.map(line => {
+            return (
+              <ChartLine
+                key={line.title}
+                samples={100}
+                domain={{
+                  x: [props.rangeX.min, props.rangeX.max],
+                  y: [props.rangeY.min, props.rangeY.max]
+                }}
+                y={(datum: any) => line.m * datum.x + line.c}
+              />
+            );
+          })}
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+};
+
+export { LinearRegressionView, Line, Range };

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
@@ -34,7 +34,7 @@ interface LinearRegressionViewAdaptorProps {
   model: RegressionModel;
 }
 
-const LinearRegressionViewAdaptor = (props: LinearRegressionViewAdaptorProps) => {
+export const LinearRegressionViewAdaptor = (props: LinearRegressionViewAdaptorProps) => {
   const { model } = props;
 
   const dataDictionary = useSelector<PMML, DataDictionary>((state: PMML) => state.DataDictionary);
@@ -78,23 +78,23 @@ const LinearRegressionViewAdaptor = (props: LinearRegressionViewAdaptorProps) =>
   );
 };
 
-function getRegressionTable(model: RegressionModel): RegressionTable | undefined {
+const getRegressionTable = (model: RegressionModel): RegressionTable | undefined => {
   const tables: RegressionTable[] = model.RegressionTable;
   if (tables === undefined || tables.length > 1) {
     return undefined;
   }
   return tables[0];
-}
+};
 
-function getNumericPredictorType(table: RegressionTable): NumericPredictor | undefined {
+const getNumericPredictorType = (table: RegressionTable): NumericPredictor | undefined => {
   const predicates: NumericPredictor[] | undefined = table.NumericPredictor;
   if (predicates === undefined || predicates.length > 1) {
     return undefined;
   }
   return predicates[0];
-}
+};
 
-function getLines(table: RegressionTable, numericPredictor: NumericPredictor): Line[] {
+const getLines = (table: RegressionTable, numericPredictor: NumericPredictor): Line[] => {
   const c: number = table.intercept;
   const line: Line = { m: numericPredictor.coefficient, c: c, title: "base" };
   const lines: Line[] = new Array<Line>(line);
@@ -110,73 +110,68 @@ function getLines(table: RegressionTable, numericPredictor: NumericPredictor): L
   });
 
   return lines;
-}
+};
 
-function getYRange(dataDictionary: DataDictionary, model: RegressionModel): Range | undefined {
+const getYRange = (dataDictionary: DataDictionary, model: RegressionModel): Range | undefined => {
   const targetField: MiningField | undefined = getTargetMiningField(model);
   if (targetField === undefined) {
     return undefined;
   }
   const targetFieldIntervals: Interval[] | undefined = getMiningFieldIntervals(dataDictionary, targetField.name);
   return getIntervalsMaximumRange(targetFieldIntervals);
-}
+};
 
-function getTargetMiningField(model: RegressionModel): MiningField | undefined {
+const getTargetMiningField = (model: RegressionModel): MiningField | undefined => {
   const targetFields: MiningField[] = model.MiningSchema.MiningField.filter(mf => mf.usageType === "target");
   if (targetFields === undefined || targetFields.length !== 1) {
     return undefined;
   }
   return targetFields[0];
-}
+};
 
-function getXRange(dataDictionary: DataDictionary, numericPredictor: NumericPredictor): Range | undefined {
+const getXRange = (dataDictionary: DataDictionary, numericPredictor: NumericPredictor): Range | undefined => {
   const predictorFieldIntervals: Interval[] | undefined = getMiningFieldIntervals(
     dataDictionary,
     numericPredictor.name
   );
   return getIntervalsMaximumRange(predictorFieldIntervals);
-}
+};
 
-function getMiningFieldIntervals(dataDictionary: DataDictionary, fieldName: FieldName): Interval[] | undefined {
+const getMiningFieldIntervals = (dataDictionary: DataDictionary, fieldName: FieldName): Interval[] => {
   const dataFields: DataField[] = dataDictionary.DataField.filter(
     df => df.name === fieldName && df.optype === "continuous"
   );
   if (dataFields === undefined || dataFields.length !== 1) {
-    return undefined;
+    return [];
   }
   const intervals: Interval[] | undefined = dataFields[0].Interval;
   if (intervals === undefined) {
-    return undefined;
+    return [];
   }
 
   return intervals;
-}
+};
 
-function getIntervalsMaximumRange(intervals: Interval[] | undefined): Range | undefined {
-  if (intervals === undefined) {
-    return undefined;
-  }
+const getIntervalsMaximumRange = (intervals: Interval[]): Range | undefined => {
   if (intervals.length === 0) {
     return undefined;
   }
   const min: number = intervals.map(interval => interval.leftMargin ?? 0).reduce((pv, cv) => Math.min(pv, cv));
   const max: number = intervals.map(interval => interval.rightMargin ?? 0).reduce((pv, cv) => Math.max(pv, cv));
   return new Range(min, max);
-}
+};
 
-function getDefaultYRange(lines: Line[]): Range {
+const getDefaultYRange = (lines: Line[]): Range => {
   const maxIntersect: number = Math.max(...lines.map(line => line.c));
   const defaultMaxY: number = maxIntersect * 2;
   const defaultMinY: number = -defaultMaxY;
   return new Range(defaultMinY, defaultMaxY);
-}
+};
 
-function getDefaultXRange(lines: Line[], rangeY: Range): Range {
+const getDefaultXRange = (lines: Line[], rangeY: Range): Range => {
   const minGradient: number = Math.min(...lines.map(line => line.m));
   const maxIntersect: number = Math.max(...lines.map(line => line.c));
   const defaultMaxX: number = (rangeY.max - maxIntersect) / minGradient;
   const defaultMinX: number = -defaultMaxX;
   return new Range(defaultMinX, defaultMaxX);
-}
-
-export { LinearRegressionViewAdaptor };
+};

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
@@ -87,16 +87,16 @@ function getRegressionTable(model: RegressionModel): RegressionTable | undefined
 }
 
 function getNumericPredictorType(table: RegressionTable): NumericPredictor | undefined {
-  const predicators: NumericPredictor[] | undefined = table.NumericPredictor;
-  if (predicators === undefined || predicators.length > 1) {
+  const predicates: NumericPredictor[] | undefined = table.NumericPredictor;
+  if (predicates === undefined || predicates.length > 1) {
     return undefined;
   }
-  return predicators[0];
+  return predicates[0];
 }
 
-function getLines(table: RegressionTable, numbericPredictor: NumericPredictor): Line[] {
+function getLines(table: RegressionTable, numericPredictor: NumericPredictor): Line[] {
   const c: number = table.intercept;
-  const line: Line = { m: numbericPredictor.coefficient, c: c, title: "base" };
+  const line: Line = { m: numericPredictor.coefficient, c: c, title: "base" };
   const lines: Line[] = new Array<Line>(line);
 
   //We need to duplicate the line for each CategoricalPredictor
@@ -106,7 +106,7 @@ function getLines(table: RegressionTable, numbericPredictor: NumericPredictor): 
   }
 
   categoricalPredictors.forEach(cp => {
-    lines.push({ m: line.m, c: line.c + cp.coefficient, title: line.title + " (" + cp.value + ")" });
+    lines.push({ m: line.m, c: line.c + cp.coefficient, title: `${line.title} (${cp.value})` });
   });
 
   return lines;

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
@@ -159,7 +159,7 @@ function getIntervalsMaximumRange(intervals: Interval[] | undefined): Range | un
   if (intervals.length === 0) {
     return undefined;
   }
-  let min: number = intervals.map(interval => interval.leftMargin ?? 0).reduce((pv, cv) => Math.min(pv, cv));
+  const min: number = intervals.map(interval => interval.leftMargin ?? 0).reduce((pv, cv) => Math.min(pv, cv));
   const max: number = intervals.map(interval => interval.rightMargin ?? 0).reduce((pv, cv) => Math.max(pv, cv));
   return new Range(min, max);
 }

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import {
+  CategoricalPredictor,
+  DataDictionary,
+  DataField,
+  FieldName,
+  Interval,
+  MiningField,
+  MiningSchema,
+  NumericPredictor,
+  PMML,
+  RegressionModel,
+  RegressionTable
+} from "@kogito-tooling/pmml-editor-marshaller";
+import { Line, LinearRegressionView, Range } from "./LinearRegressionView";
+import { useSelector } from "react-redux";
+
+interface LinearRegressionViewAdaptorProps {
+  model: RegressionModel;
+}
+
+const LinearRegressionViewAdaptor = (props: LinearRegressionViewAdaptorProps) => {
+  const { model } = props;
+
+  const dataDictionary = useSelector<PMML, DataDictionary>((state: PMML) => state.DataDictionary);
+
+  const table: RegressionTable | undefined = getRegressionTable(model);
+  if (table === undefined) {
+    return <div>Unsupported</div>;
+  }
+
+  const numericPredictor: NumericPredictor | undefined = getNumericPredictorType(table);
+  if (numericPredictor === undefined) {
+    return <div>Unsupported</div>;
+  }
+
+  const modelName: string | undefined = model.modelName;
+  const miningSchema: MiningSchema = model.MiningSchema;
+  const dependentAxisTitle = miningSchema.MiningField.filter(mf => mf.usageType === "target")[0].name;
+  const lines: Line[] = getLines(table, numericPredictor);
+
+  //Get Ranges from DataDictionary or use reasonable defaults
+  let rangeY: Range | undefined = getYRange(dataDictionary, model);
+  if (rangeY === undefined) {
+    rangeY = getDefaultYRange(lines);
+  }
+  let rangeX: Range | undefined = getXRange(dataDictionary, numericPredictor);
+  if (rangeX === undefined) {
+    rangeX = getDefaultXRange(lines, rangeY);
+  }
+
+  return (
+    <div>
+      <LinearRegressionView
+        modelName={modelName ?? "<Undefined>"}
+        independentAxisTitle={numericPredictor.name as string}
+        dependentAxisTitle={dependentAxisTitle as string}
+        lines={lines}
+        rangeX={rangeX}
+        rangeY={rangeY}
+      />
+    </div>
+  );
+};
+
+function getRegressionTable(model: RegressionModel): RegressionTable | undefined {
+  const tables: RegressionTable[] = model.RegressionTable;
+  if (tables === undefined || tables.length > 1) {
+    return undefined;
+  }
+  return tables[0];
+}
+
+function getNumericPredictorType(table: RegressionTable): NumericPredictor | undefined {
+  const predicators: NumericPredictor[] | undefined = table.NumericPredictor;
+  if (predicators === undefined || predicators.length > 1) {
+    return undefined;
+  }
+  return predicators[0];
+}
+
+function getLines(table: RegressionTable, numbericPredictor: NumericPredictor): Line[] {
+  const c: number = table.intercept;
+  const line: Line = { m: numbericPredictor.coefficient, c: c, title: "base" };
+  const lines: Line[] = new Array<Line>(line);
+
+  //We need to duplicate the line for each CategoricalPredictor
+  const categoricalPredictors: CategoricalPredictor[] | undefined = table.CategoricalPredictor;
+  if (categoricalPredictors === undefined) {
+    return lines;
+  }
+
+  categoricalPredictors.forEach(cp => {
+    lines.push({ m: line.m, c: line.c + cp.coefficient, title: line.title + " (" + cp.value + ")" });
+  });
+
+  return lines;
+}
+
+function getYRange(dataDictionary: DataDictionary, model: RegressionModel): Range | undefined {
+  const targetField: MiningField | undefined = getTargetMiningField(model);
+  if (targetField === undefined) {
+    return undefined;
+  }
+  const targetFieldIntervals: Interval[] | undefined = getMiningFieldIntervals(dataDictionary, targetField.name);
+  return getIntervalsMaximumRange(targetFieldIntervals);
+}
+
+function getTargetMiningField(model: RegressionModel): MiningField | undefined {
+  const targetFields: MiningField[] = model.MiningSchema.MiningField.filter(mf => mf.usageType === "target");
+  if (targetFields === undefined || targetFields.length !== 1) {
+    return undefined;
+  }
+  return targetFields[0];
+}
+
+function getXRange(dataDictionary: DataDictionary, numericPredictor: NumericPredictor): Range | undefined {
+  const predictorFieldIntervals: Interval[] | undefined = getMiningFieldIntervals(
+    dataDictionary,
+    numericPredictor.name
+  );
+  return getIntervalsMaximumRange(predictorFieldIntervals);
+}
+
+function getMiningFieldIntervals(dataDictionary: DataDictionary, fieldName: FieldName): Interval[] | undefined {
+  const dataFields: DataField[] = dataDictionary.DataField.filter(
+    df => df.name === fieldName && df.optype === "continuous"
+  );
+  if (dataFields === undefined || dataFields.length !== 1) {
+    return undefined;
+  }
+  const intervals: Interval[] | undefined = dataFields[0].Interval;
+  if (intervals === undefined) {
+    return undefined;
+  }
+
+  return intervals;
+}
+
+function getIntervalsMaximumRange(intervals: Interval[] | undefined): Range | undefined {
+  if (intervals === undefined) {
+    return undefined;
+  }
+  if (intervals.length === 0) {
+    return undefined;
+  }
+  let min: number = intervals.map(interval => interval.leftMargin ?? 0).reduce((pv, cv) => Math.min(pv, cv));
+  const max: number = intervals.map(interval => interval.rightMargin ?? 0).reduce((pv, cv) => Math.max(pv, cv));
+  return new Range(min, max);
+}
+
+function getDefaultYRange(lines: Line[]): Range {
+  const maxIntersect: number = Math.max(...lines.map(line => line.c));
+  const defaultMaxY: number = maxIntersect * 2;
+  const defaultMinY: number = -defaultMaxY;
+  return new Range(defaultMinY, defaultMaxY);
+}
+
+function getDefaultXRange(lines: Line[], rangeY: Range): Range {
+  const minGradient: number = Math.min(...lines.map(line => line.m));
+  const maxIntersect: number = Math.max(...lines.map(line => line.c));
+  const defaultMaxX: number = (rangeY.max - maxIntersect) / minGradient;
+  const defaultMinX: number = -defaultMaxX;
+  return new Range(defaultMinX, defaultMaxX);
+}
+
+export { LinearRegressionViewAdaptor };

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/index.ts
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./LinearRegressionView";
+export * from "./LinearRegressionViewAdaptor";

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.scss
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.scss
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.editor {
+  position: relative;
+  height: calc(100vh - 48px);
+}

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.tsx
@@ -14,20 +14,11 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useCallback, useMemo } from "react";
 import { PageSection, PageSectionVariants } from "@patternfly/react-core";
 import { EditorHeader } from "../../EditorCore/molecules";
-import {
-  MiningSchema,
-  Model,
-  Output,
-  OutputField,
-  PMML,
-  RegressionModel
-} from "@kogito-tooling/pmml-editor-marshaller";
+import { Model, PMML, RegressionModel } from "@kogito-tooling/pmml-editor-marshaller";
 import { getModelName } from "../../..";
-import { Actions } from "../../../reducers";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import "./LinearRegressionViewerPage.scss";
 import { EmptyStateModelNotFound } from "../../EditorCore/organisms";
 import { LinearRegressionViewAdaptor } from "../molecules";
@@ -38,10 +29,6 @@ interface LinearRegressionViewerPageProps {
 }
 
 export const LinearRegressionViewerPage = (props: LinearRegressionViewerPageProps) => {
-  const { modelIndex } = props;
-
-  const dispatch = useDispatch();
-
   const model: RegressionModel | undefined = useSelector<PMML, RegressionModel | undefined>((state: PMML) => {
     const _model: Model | undefined = state.models ? state.models[props.modelIndex] : undefined;
     if (_model && _model instanceof RegressionModel) {
@@ -53,74 +40,13 @@ export const LinearRegressionViewerPage = (props: LinearRegressionViewerPageProp
     return undefined;
   });
 
-  const miningSchema: MiningSchema | undefined = useMemo(() => model?.MiningSchema, [model]);
-  const output: Output | undefined = useMemo(() => model?.Output, [model]);
-
-  const validateOutputName = useCallback(
-    (index: number | undefined, name: string): boolean => {
-      if (name === undefined || name.trim() === "") {
-        return false;
-      }
-      const existing: OutputField[] = output?.OutputField ?? [];
-      const matching = existing.filter((c, _index) => _index !== index && c.name === name);
-      return matching.length === 0;
-    },
-    [output]
-  );
-
   return (
     <div data-testid="editor-page" className={"editor"}>
       {!model && <EmptyStateModelNotFound />}
       {model && (
         <>
           <PageSection variant={PageSectionVariants.light} isFilled={false}>
-            <EditorHeader
-              modelName={getModelName(model)}
-              modelIndex={modelIndex}
-              miningSchema={miningSchema}
-              output={output}
-              validateOutputFieldName={validateOutputName}
-              deleteOutputField={_index => {
-                if (window.confirm(`Delete Output "${_index}"?`)) {
-                  dispatch({
-                    type: Actions.DeleteOutput,
-                    payload: {
-                      modelIndex: modelIndex,
-                      outputIndex: _index
-                    }
-                  });
-                }
-              }}
-              commitOutputField={(_index, _outputField: OutputField) => {
-                if (_index === undefined) {
-                  dispatch({
-                    type: Actions.AddOutput,
-                    payload: {
-                      modelIndex: modelIndex,
-                      outputField: _outputField
-                    }
-                  });
-                } else {
-                  dispatch({
-                    type: Actions.UpdateOutput,
-                    payload: {
-                      modelIndex: modelIndex,
-                      outputIndex: _index,
-                      outputField: _outputField
-                    }
-                  });
-                }
-              }}
-              commitModelName={(_modelName: string) => {
-                dispatch({
-                  type: Actions.Scorecard_SetModelName,
-                  payload: {
-                    modelIndex: modelIndex,
-                    modelName: _modelName
-                  }
-                });
-              }}
-            />
+            <EditorHeader modelName={getModelName(model)} />
           </PageSection>
 
           <PageSection isFilled={true} style={{ paddingTop: "0px" }}>

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/LinearRegressionViewerPage.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from "react";
+import { useCallback, useMemo } from "react";
+import { PageSection, PageSectionVariants } from "@patternfly/react-core";
+import { EditorHeader } from "../../EditorCore/molecules";
+import {
+  MiningSchema,
+  Model,
+  Output,
+  OutputField,
+  PMML,
+  RegressionModel
+} from "@kogito-tooling/pmml-editor-marshaller";
+import { getModelName } from "../../..";
+import { Actions } from "../../../reducers";
+import { useDispatch, useSelector } from "react-redux";
+import "./LinearRegressionViewerPage.scss";
+import { EmptyStateModelNotFound } from "../../EditorCore/organisms";
+import { LinearRegressionViewAdaptor } from "../molecules";
+
+interface LinearRegressionViewerPageProps {
+  path: string;
+  modelIndex: number;
+}
+
+export const LinearRegressionViewerPage = (props: LinearRegressionViewerPageProps) => {
+  const { modelIndex } = props;
+
+  const dispatch = useDispatch();
+
+  const model: RegressionModel | undefined = useSelector<PMML, RegressionModel | undefined>((state: PMML) => {
+    const _model: Model | undefined = state.models ? state.models[props.modelIndex] : undefined;
+    if (_model && _model instanceof RegressionModel) {
+      const _regressionModel = _model as RegressionModel;
+      if (_regressionModel.functionName === "regression" && _regressionModel.algorithmName === "linearRegression") {
+        return _regressionModel;
+      }
+    }
+    return undefined;
+  });
+
+  const miningSchema: MiningSchema | undefined = useMemo(() => model?.MiningSchema, [model]);
+  const output: Output | undefined = useMemo(() => model?.Output, [model]);
+
+  const validateOutputName = useCallback(
+    (index: number | undefined, name: string): boolean => {
+      if (name === undefined || name.trim() === "") {
+        return false;
+      }
+      const existing: OutputField[] = output?.OutputField ?? [];
+      const matching = existing.filter((c, _index) => _index !== index && c.name === name);
+      return matching.length === 0;
+    },
+    [output]
+  );
+
+  return (
+    <div data-testid="editor-page" className={"editor"}>
+      {!model && <EmptyStateModelNotFound />}
+      {model && (
+        <>
+          <PageSection variant={PageSectionVariants.light} isFilled={false}>
+            <EditorHeader
+              modelName={getModelName(model)}
+              modelIndex={modelIndex}
+              miningSchema={miningSchema}
+              output={output}
+              validateOutputFieldName={validateOutputName}
+              deleteOutputField={_index => {
+                if (window.confirm(`Delete Output "${_index}"?`)) {
+                  dispatch({
+                    type: Actions.DeleteOutput,
+                    payload: {
+                      modelIndex: modelIndex,
+                      outputIndex: _index
+                    }
+                  });
+                }
+              }}
+              commitOutputField={(_index, _outputField: OutputField) => {
+                if (_index === undefined) {
+                  dispatch({
+                    type: Actions.AddOutput,
+                    payload: {
+                      modelIndex: modelIndex,
+                      outputField: _outputField
+                    }
+                  });
+                } else {
+                  dispatch({
+                    type: Actions.UpdateOutput,
+                    payload: {
+                      modelIndex: modelIndex,
+                      outputIndex: _index,
+                      outputField: _outputField
+                    }
+                  });
+                }
+              }}
+              commitModelName={(_modelName: string) => {
+                dispatch({
+                  type: Actions.Scorecard_SetModelName,
+                  payload: {
+                    modelIndex: modelIndex,
+                    modelName: _modelName
+                  }
+                });
+              }}
+            />
+          </PageSection>
+
+          <PageSection isFilled={true} style={{ paddingTop: "0px" }}>
+            <LinearRegressionViewAdaptor model={model} />
+          </PageSection>
+        </>
+      )}
+    </div>
+  );
+};

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/index.ts
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/templates/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./LinearRegressionViewerPage";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,34 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.16.7.tgz#6343eb530528e5b6c2670d24b115031e135f15ad"
   integrity sha512-B5jP/xG1MxNNDO3p52rx7a2DJspq8aUJFixYdPk1peK7SaC5X9ju2oCyE9xN1Nfe1AjlPxAOpNWPd9TWw88yLQ==
 
+"@patternfly/react-charts@6.5.4":
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.5.4.tgz#46d732429e3d932ae507c22558191cb628a4b0a5"
+  integrity sha512-pyOOCozFrlLfkbp3kG+1RqZX9xu6YQEXgkt0gxT530yr/uEgfj18fLgZ5ef6+pirVpCG7HLStAJrHdG9VoYHPA==
+  dependencies:
+    "@patternfly/patternfly" "4.16.7"
+    "@patternfly/react-styles" "^4.4.2"
+    "@patternfly/react-tokens" "^4.5.2"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.15"
+    tslib "^1.11.1"
+    victory "^34.3.12"
+    victory-area "^34.3.12"
+    victory-axis "^34.3.12"
+    victory-bar "^34.3.12"
+    victory-chart "^34.3.12"
+    victory-core "^34.3.12"
+    victory-create-container "^34.3.12"
+    victory-group "^34.3.12"
+    victory-legend "^34.3.12"
+    victory-line "^34.3.12"
+    victory-pie "^34.3.12"
+    victory-scatter "^34.3.12"
+    victory-stack "^34.3.12"
+    victory-tooltip "^34.3.12"
+    victory-voronoi-container "^34.3.12"
+    victory-zoom-container "^34.3.12"
+
 "@patternfly/react-core@4.23.1":
   version "4.23.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.23.1.tgz#b497a6f4104b5094029b5f25cb944aaca99cf4b7"
@@ -5650,6 +5678,90 @@ cypress@^6.0.1:
     url "^0.11.0"
     yauzl "^2.10.0"
 
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-array@^2.4.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.9.1.tgz#f355cc72b46c8649b3f9212029e2d681cb5b9643"
+  integrity sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg==
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+d3-ease@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
+
+d3-format@1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
+
+d3-interpolate@1, d3-interpolate@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-scale@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.7.tgz#fa90324b3ea8a776422bd0472afab0b252a0945d"
+  integrity sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@^1.0.0, d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.3.0.tgz#107bdc028667788a8924ba040faf1fbccd5a7850"
+  integrity sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+d3-timer@^1.0.0:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+d3-voronoi@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -5883,6 +5995,18 @@ del@^5.1.0:
     p-map "^3.0.0"
     rimraf "^3.0.0"
     slash "^3.0.0"
+
+delaunator@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
+  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
+
+delaunay-find@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/delaunay-find/-/delaunay-find-0.0.5.tgz#5fb37e6509da934881b4b16c08898ac89862c097"
+  integrity sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==
+  dependencies:
+    delaunator "^4.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -11768,7 +11892,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12009,6 +12133,11 @@ react-dropzone@9.0.0:
     file-selector "^0.1.8"
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
+
+react-fast-compare@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-fast-compare@^3.0.1:
   version "3.2.0"
@@ -14676,6 +14805,305 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+victory-area@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-34.3.12.tgz#875e261aa67079fb0898c58848561578a5dac6f6"
+  integrity sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-axis@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-34.3.12.tgz#bc8ae9a744ba61c31cdc163ec029d1cb19c67756"
+  integrity sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-bar@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-34.3.12.tgz#40b9c4ec12ba5ecd7f55b21c1cf78d934aa652c6"
+  integrity sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-box-plot@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-34.3.12.tgz#9dbb67f76b0e35186632e54bd87dc0486f2144d6"
+  integrity sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==
+  dependencies:
+    d3-array "^1.2.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-brush-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-34.3.12.tgz#1f6e3e52ae575ba7f6ba43f368ac4019b6394bc4"
+  integrity sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+
+victory-brush-line@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-34.3.12.tgz#ddd41280c4a44f16345e992d1bca909a3598052b"
+  integrity sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+
+victory-candlestick@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-34.3.12.tgz#7c3c08cf65babe2debd5c507090119472e9bc999"
+  integrity sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-chart@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-34.3.12.tgz#0df60c572333617d72438df0462ecf93d6ae7182"
+  integrity sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-axis "^34.3.12"
+    victory-core "^34.3.12"
+    victory-polar-axis "^34.3.12"
+    victory-shared-events "^34.3.12"
+
+victory-core@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-34.3.12.tgz#6c5faabf72ed04f43bb01b80f6b4c521680c3da2"
+  integrity sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==
+  dependencies:
+    d3-ease "^1.0.0"
+    d3-interpolate "^1.1.1"
+    d3-scale "^1.0.0"
+    d3-shape "^1.2.0"
+    d3-timer "^1.0.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+
+victory-create-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-34.3.12.tgz#25189e7bff64b4b1fe3b33509da3a29906c461be"
+  integrity sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==
+  dependencies:
+    lodash "^4.17.15"
+    victory-brush-container "^34.3.12"
+    victory-core "^34.3.12"
+    victory-cursor-container "^34.3.12"
+    victory-selection-container "^34.3.12"
+    victory-voronoi-container "^34.3.12"
+    victory-zoom-container "^34.3.12"
+
+victory-cursor-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz#83dd201fbc8ef0f39ce92f320f579222a33442da"
+  integrity sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-errorbar@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-34.3.12.tgz#cffe1b1fd12cc8952674f5c4d78c681d86d4a6ba"
+  integrity sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-group@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-34.3.12.tgz#1acd0056e9709acc3cf9292107cd1e0bafbf4f8d"
+  integrity sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+    victory-shared-events "^34.3.12"
+
+victory-histogram@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-34.3.12.tgz#2a08a84cb2a9cba008b2bcd748dd6ae887845028"
+  integrity sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==
+  dependencies:
+    d3-array "^2.4.0"
+    d3-scale "^1.0.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-bar "^34.3.12"
+    victory-core "^34.3.12"
+
+victory-legend@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-34.3.12.tgz#acaddccbd8861f0ee69f98a20eff34e6757cdcff"
+  integrity sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-line@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-34.3.12.tgz#0841bd6feb9f09050a95d1e1a507d670395ac45f"
+  integrity sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-pie@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-34.3.12.tgz#08c4fe53719c1a99f85c5e777ab753fcc0bfd70e"
+  integrity sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==
+  dependencies:
+    d3-shape "^1.0.0"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-polar-axis@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz#4ed6f38c5d8bf447af317b4b5fc905a955d05b7e"
+  integrity sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-scatter@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-34.3.12.tgz#e688428f6f19991cd382361cc13bfea3323b5f4e"
+  integrity sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-selection-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-34.3.12.tgz#c73c45a17e585382e0dd5c773742a543a5125498"
+  integrity sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-shared-events@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-34.3.12.tgz#0e6659d00dc98e4cdc07710a5c0d11c437e8cc93"
+  integrity sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+
+victory-stack@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-34.3.12.tgz#431b3a7c73dcb5a629c433b32873ea6a9686add2"
+  integrity sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+    victory-shared-events "^34.3.12"
+
+victory-tooltip@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-34.3.12.tgz#d811f5653d44683c3c1b7a7dff10633b6ae6c47c"
+  integrity sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-voronoi-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz#42865e54725165cbaff5d0c75b87fc9bbfc2b80a"
+  integrity sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==
+  dependencies:
+    delaunay-find "0.0.5"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^34.3.12"
+    victory-tooltip "^34.3.12"
+
+victory-voronoi@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-34.3.12.tgz#89a47a612c5acabf1d130d8e1b3fb8918a4f79c5"
+  integrity sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==
+  dependencies:
+    d3-voronoi "^1.1.2"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory-zoom-container@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz#696b96f5fbd2e86ed1fcebf2ac8c613cb13c46a7"
+  integrity sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^34.3.12"
+
+victory@^34.3.12:
+  version "34.3.12"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-34.3.12.tgz#91f87677333843870d11d1187832a73e992a91e7"
+  integrity sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==
+  dependencies:
+    victory-area "^34.3.12"
+    victory-axis "^34.3.12"
+    victory-bar "^34.3.12"
+    victory-box-plot "^34.3.12"
+    victory-brush-container "^34.3.12"
+    victory-brush-line "^34.3.12"
+    victory-candlestick "^34.3.12"
+    victory-chart "^34.3.12"
+    victory-core "^34.3.12"
+    victory-create-container "^34.3.12"
+    victory-cursor-container "^34.3.12"
+    victory-errorbar "^34.3.12"
+    victory-group "^34.3.12"
+    victory-histogram "^34.3.12"
+    victory-legend "^34.3.12"
+    victory-line "^34.3.12"
+    victory-pie "^34.3.12"
+    victory-polar-axis "^34.3.12"
+    victory-scatter "^34.3.12"
+    victory-selection-container "^34.3.12"
+    victory-shared-events "^34.3.12"
+    victory-stack "^34.3.12"
+    victory-tooltip "^34.3.12"
+    victory-voronoi "^34.3.12"
+    victory-voronoi-container "^34.3.12"
+    victory-zoom-container "^34.3.12"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-226

This PR moves an old "Linear Regression (model) viewer" from Trusty's "sandbox" to the PMML editor.

I have updated the "PMML Editor migration" document to include the new components added herein.