### PR TITLE
KOGITO-4104: [DMN Designer] Rename 'Dismiss' to 'Skip tour'

### DIFF
--- a/packages/guided-tour/src/__tests__/components/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/guided-tour/src/__tests__/components/__snapshots__/Dialog.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Dialog when negative reinforcement appears renders negative reinforceme
             data-ouia-safe="true"
             type="button"
           >
-            Dismiss
+            Skip tour
           </button>
         </div>
       </div>
@@ -163,7 +163,7 @@ exports[`Dialog when negative reinforcement appears renders negative reinforceme
             >
               Click on 
               <b>
-                Dismiss
+                Skip tour
               </b>
                to stop it or 
               <b>
@@ -195,7 +195,7 @@ exports[`Dialog when negative reinforcement appears renders negative reinforceme
             data-ouia-safe="true"
             type="button"
           >
-            Dismiss
+            Skip tour
           </button>
         </div>
       </div>
@@ -249,7 +249,7 @@ exports[`Dialog when the step cannot be loaded renders empty state 1`] = `
           data-ouia-safe="true"
           type="button"
         >
-          Dismiss
+          Skip tour
         </button>
       </div>
     </div>

--- a/packages/guided-tour/src/__tests__/components/__snapshots__/GuidedTour.test.tsx.snap
+++ b/packages/guided-tour/src/__tests__/components/__snapshots__/GuidedTour.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`GuidedTour renders 1`] = `
           data-ouia-safe="true"
           type="button"
         >
-          Dismiss
+          Skip tour
         </button>
       </div>
     </div>

--- a/packages/guided-tour/src/components/utils/GuidedTourContent.tsx
+++ b/packages/guided-tour/src/components/utils/GuidedTourContent.tsx
@@ -87,7 +87,7 @@ export const NegativeReinforcementDialog = (step: Step | undefined, onCloseActio
           </EmptyStateBody>
           <EmptyStateSecondaryActions>
             <Button onClick={onCloseAction} variant="link">
-              {i18n.terms.dismiss}
+              {i18n.skipTour}
             </Button>
           </EmptyStateSecondaryActions>
         </EmptyState>
@@ -114,7 +114,7 @@ export const NegativeReinforcementDialog = (step: Step | undefined, onCloseActio
           </Button>
           <EmptyStateSecondaryActions>
             <Button onClick={onCloseAction} variant="link">
-              {i18n.terms.dismiss}
+              {i18n.skipTour}
             </Button>
           </EmptyStateSecondaryActions>
         </EmptyState>
@@ -133,7 +133,7 @@ export const EmptyDialog = (onCloseAction: () => void) => {
           {i18n.oops}
         </Title>
         <EmptyStateBody>{i18n.somethingWrong}</EmptyStateBody>
-        <Button onClick={onCloseAction}>{i18n.terms.dismiss}</Button>
+        <Button onClick={onCloseAction}>{i18n.skipTour}</Button>
       </EmptyState>
     </>
   );

--- a/packages/guided-tour/src/i18n/GuidedTourI18n.ts
+++ b/packages/guided-tour/src/i18n/GuidedTourI18n.ts
@@ -24,6 +24,7 @@ interface GuidedTourDictionary extends ReferenceDictionary<GuidedTourDictionary>
   options: string;
   oops: string;
   somethingWrong: string;
+  skipTour: string;
 }
 
 export interface GuidedTourI18n extends GuidedTourDictionary, CommonI18n {}

--- a/packages/guided-tour/src/i18n/locales/en.ts
+++ b/packages/guided-tour/src/i18n/locales/en.ts
@@ -22,7 +22,8 @@ export const en: GuidedTourI18n = {
   great: "Great",
   stop: "Do you want to stop the tour?",
   notFollowing: "Seems like you didn't follow the suggested action. Do you want to stop the tour?",
-  options: `Click on ${"Dismiss".bold()} to stop it or ${"Continue".bold()} to resume your tour`,
+  options: `Click on ${"Skip tour".bold()} to stop it or ${"Continue".bold()} to resume your tour`,
   oops: "Oops!",
   somethingWrong: "Something went wrong and the content could not be loaded.",
+  skipTour: "Skip tour",
 };

--- a/packages/online-editor/src/common/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/common/i18n/OnlineI18n.ts
@@ -152,6 +152,7 @@ interface OnlineDictionary extends ReferenceDictionary<OnlineDictionary> {
       title: string;
       learnMore: string;
       letsGo: string;
+      skipTour: string;
     };
     end: {
       title: string;

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -154,7 +154,8 @@ export const en: OnlineI18n = {
     init: {
       title: "Welcome to this 5-minute tour",
       learnMore: `Learn more about the DMN online editor by taking this brief and interactive tour.`,
-      letsGo: "Let's go"
+      letsGo: "Let's go",
+      skipTour: "Skip tour"
     },
     end: {
       title: "Congratulations",

--- a/packages/online-editor/src/tour/GuidedTourInitializer.tsx
+++ b/packages/online-editor/src/tour/GuidedTourInitializer.tsx
@@ -61,7 +61,7 @@ function getOnlineEditorTutorial(i18n: OnlineI18n) {
           </Button>
           <Text>{"  "}</Text>
           <Button onClick={props.dismiss} variant="link">
-            {i18n.terms.dismiss}
+            {i18n.guidedTour.init.skipTour}
           </Button>
         </div>
       )


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-4104

This PR just renamed the "Dismiss" button to "Exit the tour". This was a suggestion from one of our users, and the new label was approved by @lclay2 :-)