### PR TITLE
FAI-344: Score Cards: Characteristic row is not rendered following pressing ESC to cancel

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsTable.tsx
@@ -127,7 +127,7 @@ export const CharacteristicsTable = (props: CharacteristicsTableProps) => {
                 onCancel={onCancel}
               />
             )}
-            {selectedCharacteristicIndex !== ic.index && (
+            {(selectedCharacteristicIndex !== ic.index || activeOperation !== Operation.UPDATE_CHARACTERISTIC) && (
               <CharacteristicsTableRow
                 characteristic={ic}
                 dataFields={dataFields}


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-344

Unit Tests are covered by the "PMML editor migration" document.