### PR TITLE
KOGITO-3846: Add Notifications API

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "publish:productization": "npx lerna exec --scope @kogito-tooling/* --ignore @kogito-tooling/online-editor --ignore @kogito-tooling/desktop --ignore @kogito-tooling/hub --ignore @kogito-tooling/pmml-editor -- npm publish --access public"
   },
   "dependencies": {
-    "@kogito-tooling/bpmn-editor-unpacked": "7.49.0-SNAPSHOT-20210126.222335",
-    "@kogito-tooling/dmn-editor-unpacked": "7.49.0-SNAPSHOT-20210126.222335",
+    "@kogito-tooling/bpmn-editor-unpacked": "7.50.0-SNAPSHOT-20210203.151532",
+    "@kogito-tooling/dmn-editor-unpacked": "7.50.0-SNAPSHOT-20210203.151532",
     "@kogito-tooling/quarkus-runner-unpacked": "0.7.0-SNAPSHOT",
-    "@kogito-tooling/scesim-editor-unpacked": "7.49.0-SNAPSHOT-20210126.222335",
+    "@kogito-tooling/scesim-editor-unpacked": "7.50.0-SNAPSHOT-20210203.151532",
     "react": "16.12.0",
     "react-dom": "16.12.0"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,7 @@
     "@kogito-tooling/i18n": "0.8.3",
     "@kogito-tooling/i18n-common-dictionary": "0.8.3",
     "@kogito-tooling/workspace": "0.8.3",
+    "@kogito-tooling/notifications": "0.8.3",
     "@types/semver": "^7.3.3",
     "axios": "^0.19.2",
     "fast-xml-parser": "^3.17.4",

--- a/packages/editor/src/api/Editor.ts
+++ b/packages/editor/src/api/Editor.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 import { Rect } from "@kogito-tooling/guided-tour/dist/api";
 
 /**
@@ -39,4 +40,5 @@ export interface EditorApi {
   getElementPosition(selector: string): Promise<Rect | undefined>;
   undo(): Promise<void>;
   redo(): Promise<void>;
+  validate(): Promise<Notification[]>;
 }

--- a/packages/editor/src/api/KogitoEditorChannelApi.ts
+++ b/packages/editor/src/api/KogitoEditorChannelApi.ts
@@ -16,6 +16,7 @@
 
 import { CapabilityChannelApi } from "@kogito-tooling/backend/dist/channel-api";
 import { KogitoToolingChannelCommonApi } from "@kogito-tooling/channel-common-api";
+import { NotificationsApi } from "@kogito-tooling/notifications/dist/api";
 import { GuidedTourChannelApi } from "@kogito-tooling/guided-tour/dist/api";
 import { I18nChannelApi } from "@kogito-tooling/i18n/dist/api";
 import { WorkspaceApi } from "@kogito-tooling/workspace/dist/api";
@@ -27,7 +28,8 @@ export interface KogitoEditorChannelApi
     GuidedTourChannelApi,
     I18nChannelApi,
     CapabilityChannelApi,
-    WorkspaceApi {
+    WorkspaceApi,
+    NotificationsApi {
   receive_setContentError(errorMessage: string): void;
   receive_stateControlCommandUpdate(command: StateControlCommand): void;
   receive_contentRequest(): Promise<EditorContent>;

--- a/packages/editor/src/api/KogitoEditorEnvelopeApi.ts
+++ b/packages/editor/src/api/KogitoEditorEnvelopeApi.ts
@@ -18,6 +18,7 @@ import { EditorContent } from "./EditorContent";
 import { KeyboardShortcutsEnvelopeApi } from "@kogito-tooling/keyboard-shortcuts/dist/api";
 import { GuidedTourEnvelopeApi } from "@kogito-tooling/guided-tour/dist/api";
 import { I18nEnvelopeApi } from "@kogito-tooling/i18n/dist/api";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export interface Association {
   origin: string;
@@ -38,4 +39,5 @@ export interface KogitoEditorEnvelopeApi extends KeyboardShortcutsEnvelopeApi, G
   receive_initRequest(association: Association, editorInit: EditorInitArgs): Promise<void>;
   receive_contentRequest(): Promise<EditorContent>;
   receive_previewRequest(): Promise<string>;
+  validate(): Promise<Notification[]>;
 }

--- a/packages/editor/src/embedded/__tests__/stateControl/Hooks.test.ts
+++ b/packages/editor/src/embedded/__tests__/stateControl/Hooks.test.ts
@@ -35,6 +35,7 @@ describe("useDirtyState", () => {
       getContent: jest.fn(),
       getPreview: jest.fn(),
       setContent: jest.fn(),
+      validate: jest.fn(),
       getElementPosition: jest.fn()
     };
   });

--- a/packages/editor/src/embedded/embedded/EmbeddedEditor.tsx
+++ b/packages/editor/src/embedded/embedded/EmbeddedEditor.tsx
@@ -137,7 +137,8 @@ const RefForwardingEmbeddedEditor: React.RefForwardingComponent<EmbeddedEditorRe
         getContent: () => envelopeServer.envelopeApi.requests.receive_contentRequest().then(c => c.content),
         getPreview: () => envelopeServer.envelopeApi.requests.receive_previewRequest(),
         setContent: async content =>
-          envelopeServer.envelopeApi.notifications.receive_contentChanged({ content: content })
+          envelopeServer.envelopeApi.notifications.receive_contentChanged({ content: content }),
+        validate: () => envelopeServer.envelopeApi.requests.validate()
       };
     },
     [envelopeServer, stateControl]

--- a/packages/editor/src/embedded/embedded/KogitoEditorChannelApiImpl.ts
+++ b/packages/editor/src/embedded/embedded/KogitoEditorChannelApiImpl.ts
@@ -26,6 +26,7 @@ import {
   ResourcesList
 } from "@kogito-tooling/channel-common-api";
 import { File } from "../../channel";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
   constructor(
@@ -90,5 +91,15 @@ export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
 
   public receive_getLocale(): Promise<string> {
     return Promise.resolve(this.locale);
+  }
+
+  public createNotification(notification: Notification): void {
+    this.overrides.createNotification?.(notification);
+  }
+  public setNotifications(path: string, notifications: Notification[]): void {
+    this.overrides.setNotifications?.(path, notifications);
+  }
+  public removeNotifications(path: string): void {
+    this.overrides.removeNotifications?.(path);
   }
 }

--- a/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
+++ b/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
@@ -144,6 +144,10 @@ export class KogitoEditorEnvelopeApiImpl implements KogitoEditorEnvelopeApi {
     return this.args.envelopeContext.services.i18n.executeOnLocaleChangeSubscriptions(locale);
   }
 
+  public validate() {
+    return this.editor.validate();
+  }
+
   private setupI18n(initArgs: EditorInitArgs) {
     this.i18n.setLocale(initArgs.initialLocale);
     this.args.envelopeContext.services.i18n.subscribeToLocaleChange(locale => {

--- a/packages/editor/src/envelope/__tests__/DummyEditor.tsx
+++ b/packages/editor/src/envelope/__tests__/DummyEditor.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 import { Editor } from "../../api";
 import { DEFAULT_RECT } from "@kogito-tooling/guided-tour/dist/api";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export class DummyEditor implements Editor {
   private ref: DummyEditorComponent;
@@ -50,6 +51,10 @@ export class DummyEditor implements Editor {
 
   public getPreview(): Promise<string | undefined> {
     return Promise.resolve(undefined);
+  }
+
+  public validate(): Promise<Notification[]> {
+    return Promise.resolve([]);
   }
 }
 

--- a/packages/kie-bc-editors/src/GwtAppFormerApi.ts
+++ b/packages/kie-bc-editors/src/GwtAppFormerApi.ts
@@ -15,6 +15,7 @@
  */
 
 import { Rect } from "@kogito-tooling/guided-tour/dist/api";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 declare global {
   //Exposed API of AppFormerGwt
@@ -42,6 +43,7 @@ export interface GwtEditor {
   getContent(): Promise<string>;
   setContent(path: string, content: string): Promise<void>;
   getPreview(): Promise<string | undefined>;
+  validate(): Promise<Notification[]>
 }
 
 export class GwtAppFormerApi {

--- a/packages/kie-bc-editors/src/GwtEditorWrapper.tsx
+++ b/packages/kie-bc-editors/src/GwtEditorWrapper.tsx
@@ -23,6 +23,7 @@ import { GwtStateControlService } from "./gwtStateControl";
 import { MessageBusClientApi } from "@kogito-tooling/envelope-bus/dist/api";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
 import { KieBcEditorsI18n } from "./i18n";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export class GwtEditorWrapper implements Editor {
   public readonly af_isReact = true;
@@ -96,6 +97,10 @@ export class GwtEditorWrapper implements Editor {
 
   public getPreview(): Promise<string | undefined> {
     return this.gwtEditor.getPreview();
+  }
+
+  public validate(): Promise<Notification[]> {
+    return this.gwtEditor.validate();
   }
 
   private removeBusinessCentralHeaderPanel() {

--- a/packages/kie-bc-editors/src/GwtEditorWrapperFactory.ts
+++ b/packages/kie-bc-editors/src/GwtEditorWrapperFactory.ts
@@ -14,32 +14,33 @@
  * limitations under the License.
  */
 
-import { GwtAppFormerApi } from "./GwtAppFormerApi";
-import { GwtEditorWrapper } from "./GwtEditorWrapper";
+import { NotificationsApi, Notification } from "@kogito-tooling/notifications/dist/api";
+import { ResourceContentOptions, ResourceListOptions } from "@kogito-tooling/channel-common-api";
 import {
   Editor,
   EditorFactory,
   EditorInitArgs,
   KogitoEditorEnvelopeContextType
 } from "@kogito-tooling/editor/dist/api";
-import { GwtLanguageData, Resource } from "./GwtLanguageData";
-import { XmlFormatter } from "./XmlFormatter";
-import { GwtStateControlService } from "./gwtStateControl";
-import { DefaultXmlFormatter } from "./DefaultXmlFormatter";
 import { Tutorial, UserInteraction } from "@kogito-tooling/guided-tour/dist/api";
-import { ResourceContentOptions, ResourceListOptions } from "@kogito-tooling/channel-common-api";
-import { GuidedTourApi } from "./api/GuidedTourApi";
-import { ResourceContentApi } from "./api/ResourceContentApi";
-import { KeyboardShortcutsApi } from "./api/KeyboardShorcutsApi";
-import { WorkspaceServiceApi } from "./api/WorkspaceServiceApi";
-import { StateControlApi } from "./api/StateControlApi";
-import { EditorContextApi } from "./api/EditorContextApi";
-import { GwtEditorMapping } from "./GwtEditorMapping";
-import { I18nServiceApi } from "./api/I18nServiceApi";
-import { kieBcEditorsI18nDefaults, kieBcEditorsI18nDictionaries } from "./i18n";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
-import { PMMLEditorMarshallerApi } from "./api/PMMLEditorMarshallerApi";
 import { PMMLEditorMarshallerService } from "@kogito-tooling/pmml-editor-marshaller";
+import { EditorContextApi } from "./api/EditorContextApi";
+import { GuidedTourApi } from "./api/GuidedTourApi";
+import { I18nServiceApi } from "./api/I18nServiceApi";
+import { KeyboardShortcutsApi } from "./api/KeyboardShorcutsApi";
+import { PMMLEditorMarshallerApi } from "./api/PMMLEditorMarshallerApi";
+import { ResourceContentApi } from "./api/ResourceContentApi";
+import { StateControlApi } from "./api/StateControlApi";
+import { WorkspaceServiceApi } from "./api/WorkspaceServiceApi";
+import { DefaultXmlFormatter } from "./DefaultXmlFormatter";
+import { GwtAppFormerApi } from "./GwtAppFormerApi";
+import { GwtEditorMapping } from "./GwtEditorMapping";
+import { GwtEditorWrapper } from "./GwtEditorWrapper";
+import { GwtLanguageData, Resource } from "./GwtLanguageData";
+import { GwtStateControlService } from "./gwtStateControl";
+import { kieBcEditorsI18nDefaults, kieBcEditorsI18nDictionaries } from "./i18n";
+import { XmlFormatter } from "./XmlFormatter";
 
 declare global {
   interface Window {
@@ -54,10 +55,10 @@ declare global {
       workspaceService: WorkspaceServiceApi;
       i18nService: I18nServiceApi;
       pmmlEditorMarshallerService: PMMLEditorMarshallerApi;
+      notificationsService: NotificationsApi;
     };
   }
 }
-
 
 export class GwtEditorWrapperFactory implements EditorFactory {
   constructor(
@@ -172,7 +173,18 @@ export class GwtEditorWrapperFactory implements EditorFactory {
           envelopeContext.services.i18n.subscribeToLocaleChange(onLocaleChange);
         }
       },
-      pmmlEditorMarshallerService: new PMMLEditorMarshallerService()
+      pmmlEditorMarshallerService: new PMMLEditorMarshallerService(),
+      notificationsService: {
+        createNotification: (notification: Notification) => {
+          envelopeContext.channelApi.notifications.createNotification(notification);
+        },
+        removeNotifications: (path: string) => {
+          envelopeContext.channelApi.notifications.removeNotifications(path);
+        },
+        setNotifications: (path: string, notifications: Notification[]) => {
+          envelopeContext.channelApi.notifications.setNotifications(path, notifications);
+        }
+      }
     };
   }
 

--- a/packages/kie-bc-editors/src/__tests__/DummyEditor.tsx
+++ b/packages/kie-bc-editors/src/__tests__/DummyEditor.tsx
@@ -17,6 +17,7 @@
 import * as React from "react";
 import { Editor } from "@kogito-tooling/editor/dist/api";
 import { DEFAULT_RECT } from "@kogito-tooling/guided-tour/dist/api";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export class DummyEditor implements Editor {
   private ref: DummyEditorComponent;
@@ -50,6 +51,10 @@ export class DummyEditor implements Editor {
 
   public getPreview(): Promise<string | undefined> {
     return Promise.resolve(undefined);
+  }
+
+  public validate(): Promise<Notification[]> {
+    return Promise.resolve([]);
   }
 }
 

--- a/packages/kie-bc-editors/src/__tests__/GwtEditorWrapper.test.ts
+++ b/packages/kie-bc-editors/src/__tests__/GwtEditorWrapper.test.ts
@@ -27,7 +27,8 @@ const MockEditor = jest.fn(() => ({
   getContent: jest.fn(),
   setContent: jest.fn(() => Promise.resolve()),
   isDirty: jest.fn(),
-  getPreview: jest.fn()
+  getPreview: jest.fn(),
+  validate: jest.fn()
 }));
 
 const mockEditor = new MockEditor();

--- a/packages/kie-editors-standalone/src/common/Editor.ts
+++ b/packages/kie-editors-standalone/src/common/Editor.ts
@@ -67,6 +67,9 @@ export const createEditor = (
     close: () => {
       window.removeEventListener("message", listener);
       iframe.remove();
+    },
+    validate: () => {
+      return envelopeServer.envelopeApi.requests.validate();
     }
   };
 };

--- a/packages/kie-editors-standalone/src/envelope/KogitoEditorChannelApiImpl.ts
+++ b/packages/kie-editors-standalone/src/envelope/KogitoEditorChannelApiImpl.ts
@@ -26,6 +26,7 @@ import { KogitoEditorChannelApi, StateControlCommand } from "@kogito-tooling/edi
 import { Tutorial, UserInteraction } from "@kogito-tooling/guided-tour/dist/api";
 import { File, StateControl } from "@kogito-tooling/editor/dist/channel";
 import { Minimatch } from "minimatch";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 
 export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
   constructor(
@@ -115,5 +116,15 @@ export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
 
   public receive_getLocale(): Promise<string> {
     return Promise.resolve(this.locale);
+  }
+
+  public createNotification(notification: Notification): void {
+    this.overrides.createNotification?.(notification);
+  }
+  public setNotifications(path: string, notifications: Notification[]): void {
+    this.overrides.setNotifications?.(path, notifications);
+  }
+  public removeNotifications(path: string): void {
+    this.overrides.removeNotifications?.(path);
   }
 }

--- a/packages/notifications/.gitignore
+++ b/packages/notifications/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+target/
+.idea

--- a/packages/notifications/LICENSE
+++ b/packages/notifications/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -1,0 +1,63 @@
+# Kogito Tooling Notifications
+
+This package provides a type-safe Notifications library for a Typescript project.
+
+## Install
+
+Can be installed with `yarn` or `npm`:
+
+- `yarn add @kogito-tooling/notifications`
+- `npm install @kogito-tooling/notifications`
+
+## Usage
+
+The library is separated into two submodules:
+
+- api
+  All the APIs and the main classes needed are in this submodule.
+
+  to use the core:
+
+  - `import { NotificationsApi } from "@kogito-tooling/notifications/dist/api"`
+  - `import { Notification } from "@kogito-tooling/notifications/dist/api"`
+  - `import { NotificationSeverity } from "@kogito-tooling/notifications/dist/api"`
+  - `import { NotificationType } from "@kogito-tooling/notifications/dist/api"`
+
+- vscode
+
+  All the classes needed to use in vscode channel implementation
+
+  to use the vscode classes:
+
+  ```ts
+  import { VsCodeNotificationsApi } from "@kogito-tooling/i18n/dist/react-components";
+
+  const api: NotificationsApi = new VsCodeNotificationsApi(workspaceApi, i18n);
+  ```
+
+## API
+
+NotificationsApi main attributes:
+
+- messages: The text that will be shown to the user
+- path: File location.
+- severity: `"INFO" | "WARNING" | "ERROR" | "SUCCESS" | "HINT"`
+- type: `"PROBLEM" | "ALERT"`
+
+### VSCode
+
+The VsCodeNotificationsApi is the only "public" class users have access. Under the hood it contains two different implementations depending on `Notification.type`.
+
+So if:
+
+- `Notifications.type === "PROBLEM"` The notifications are going to be shown in Problems Tab.
+- `Notifications.type === "ALERT"` The notifications are going to be shown as Popups.
+
+If, for some reason, there is not type, the default is `PROBLEM`
+
+In both cases path is mandatory and it will let the user to open the file where those notifications come from.
+
+`Notification.severity` also depends on `Notification.type`, if:
+
+- `PROBLEM`, the supported severities are `"INFO" | "WARNING" | "ERROR" | "SUCCESS" | "HINT"`. `SUCCESS` converts to `INFO` which is the default severity.
+- `ALERT`, the supported severities are `"ERROR" | "WARNING" | "INFO"`. Any other types defaults to `INFO`

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kogito-tooling/notifications",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "",
   "license": "Apache-2.0",
   "files": [
@@ -19,9 +19,9 @@
     "build:prod": "yarn run build --mode production --devtool none"
   },
   "dependencies": {
-    "@kogito-tooling/workspace": "0.8.2",
-    "@kogito-tooling/i18n": "0.8.2",
-    "@kogito-tooling/i18n-common-dictionary": "0.8.2"
+    "@kogito-tooling/workspace": "0.8.3",
+    "@kogito-tooling/i18n": "0.8.3",
+    "@kogito-tooling/i18n-common-dictionary": "0.8.3"
   },
   "babel": {
     "presets": [

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,10 +1,8 @@
 {
-  "name": "@kogito-tooling/editor",
-  "version": "0.8.3",
+  "name": "@kogito-tooling/notifications",
+  "version": "0.8.2",
   "description": "",
   "license": "Apache-2.0",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -12,28 +10,26 @@
     "type": "git",
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
-  "dependencies": {
-    "@kogito-tooling/backend": "0.8.3",
-    "@kogito-tooling/envelope": "0.8.3",
-    "@kogito-tooling/envelope-bus": "0.8.3",
-    "@kogito-tooling/guided-tour": "0.8.3",
-    "@kogito-tooling/i18n": "0.8.3",
-    "@kogito-tooling/keyboard-shortcuts": "0.8.3",
-    "@kogito-tooling/workspace": "0.8.3",
-    "@kogito-tooling/notifications": "0.8.3"
-  },
   "scripts": {
     "lint": "tslint -c ../../tslint.json 'src/**/*.{ts,tsx,js,jsx}'",
-    "test": "jest --silent --verbose",
+    "test": "jest --passWithNoTests",
     "test:clearCache": "jest --clearCache",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
     "build:prod": "yarn run build --mode production --devtool none"
+  },
+  "dependencies": {
+    "@kogito-tooling/workspace": "0.8.2",
+    "@kogito-tooling/i18n": "0.8.2",
+    "@kogito-tooling/i18n-common-dictionary": "0.8.2"
   },
   "babel": {
     "presets": [
       "@babel/env",
       "@babel/react"
     ]
+  },
+  "jest-junit": {
+    "outputDirectory": "./target"
   }
 }

--- a/packages/notifications/src/api/Notification.ts
+++ b/packages/notifications/src/api/Notification.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotificationSeverity } from "./NotificationSeverity";
+import { NotificationType } from "./NotificationType";
+
+export interface Notification {
+  path: string;
+  severity: NotificationSeverity;
+  message: string;
+  type: NotificationType;
+}

--- a/packages/notifications/src/api/NotificationSeverity.ts
+++ b/packages/notifications/src/api/NotificationSeverity.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type NotificationSeverity = "INFO" | "WARNING" | "ERROR" | "SUCCESS" | "HINT";

--- a/packages/notifications/src/api/NotificationType.ts
+++ b/packages/notifications/src/api/NotificationType.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type NotificationType = "PROBLEM" | "ALERT";

--- a/packages/notifications/src/api/NotificationsApi.ts
+++ b/packages/notifications/src/api/NotificationsApi.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Notification } from "./Notification";
+
+export interface NotificationsApi {
+  /**
+   * Creates a single notification. This action does not replace an existent notification.
+   * @param notification The notification itself
+   */
+  createNotification(notification: Notification): void;
+
+  /**
+   * Creates a list of notification for a given path. This notifications will replace existent notification for that path.
+   * @param path The path that references the Notification
+   * @param notifications List of Notifications
+   */
+  setNotifications(path: string, notifications: Notification[]): void;
+
+  /**
+   * Removes all the notification from a Path.
+   * @param path The notifications path
+   */
+  removeNotifications(path: string): void;
+}

--- a/packages/notifications/src/api/index.ts
+++ b/packages/notifications/src/api/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./NotificationsApi";
+export * from "./Notification";
+export * from "./NotificationSeverity";
+export * from "./NotificationType";

--- a/packages/notifications/src/vscode/PopupMessagesNotificationHandler.ts
+++ b/packages/notifications/src/vscode/PopupMessagesNotificationHandler.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonI18n } from "@kogito-tooling/i18n-common-dictionary";
+import { I18n } from "@kogito-tooling/i18n/dist/core";
+import { WorkspaceApi } from "@kogito-tooling/workspace/dist/api";
+import * as vscode from "vscode";
+import { Notification, NotificationsApi, NotificationSeverity } from "../api";
+
+export class PopupMessagesNotificationHandler implements NotificationsApi {
+  private readonly currentI18n: CommonI18n;
+
+  constructor(private readonly workspaceApi: WorkspaceApi, private readonly i18n: I18n<CommonI18n>) {
+    this.currentI18n = this.i18n.getCurrent();
+  }
+
+  public createNotification(notification: Notification): void {
+    this.getHandleStrategyForSeverity(notification.severity)(notification.message, notification.path);
+  }
+
+  public setNotifications(path: string, notifications: Notification[]): void {
+    if (notifications.length === 0) {
+      return;
+    }
+    const errors = notifications.filter(n => n.severity === "ERROR");
+    const others = notifications.filter(n => n.severity !== "ERROR");
+
+    const errorsMessage = this.consolidateMessages(errors);
+    const othersMessage = this.consolidateMessages(others);
+
+    this.getHandleStrategyForSeverity("ERROR")(errorsMessage, path);
+    this.getHandleStrategyForSeverity("SUCCESS")(othersMessage, path);
+  }
+
+  public removeNotifications(path: string): void {
+    // Popups can't be removed.
+  }
+
+  private getHandleStrategyForSeverity(severity: NotificationSeverity) {
+    switch (severity) {
+      case "ERROR":
+        return this.handleStrategy(vscode.window.showErrorMessage);
+      case "WARNING":
+        return this.handleStrategy(vscode.window.showWarningMessage);
+      default:
+        return this.handleStrategy(vscode.window.showInformationMessage);
+    }
+  }
+
+  private handleStrategy(showFunction: (message: string, ...items: string[]) => Thenable<string | undefined>) {
+    return (message: string, path: string) =>
+      path.length === 0
+        ? showFunction(message)
+        : showFunction(message, this.currentI18n.terms.open).then(selected => {
+            if (!selected) {
+              return;
+            }
+            this.workspaceApi.receive_openFile(path);
+          });
+  }
+
+  private consolidateMessages(notifications: Notification[]): string {
+    const messages = notifications.map(n => n.message);
+    if (messages.length > 0) {
+      return messages.reduce((accum, current) => `${accum}\n${current}`);
+    } else {
+      return "";
+    }
+  }
+}

--- a/packages/notifications/src/vscode/ProblemsTabNotificationHandler.ts
+++ b/packages/notifications/src/vscode/ProblemsTabNotificationHandler.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from "vscode";
+import { Notification, NotificationsApi, NotificationSeverity } from "../api";
+
+const DIAGNOSTIC_COLLECTION_NAME = "kogito";
+
+type NotificationSeverityConvertionType = {
+  [K in NotificationSeverity]: vscode.DiagnosticSeverity;
+};
+
+const KOGITO_NOTIFICATION_TO_VS_CODE_DIAGNOSTIC_SEVERITY_CONVERTION_MAP: NotificationSeverityConvertionType = {
+  INFO: vscode.DiagnosticSeverity.Information,
+  WARNING: vscode.DiagnosticSeverity.Warning,
+  ERROR: vscode.DiagnosticSeverity.Error,
+  HINT: vscode.DiagnosticSeverity.Hint,
+  SUCCESS: vscode.DiagnosticSeverity.Information
+};
+
+export class ProblemsTabNotificationHandler implements NotificationsApi {
+  private readonly diagnosticCollection = vscode.languages.createDiagnosticCollection(DIAGNOSTIC_COLLECTION_NAME);
+
+  public createNotification(notification: Notification): void {
+    const uri = vscode.Uri.file(notification.path);
+    const diagnostics: vscode.Diagnostic[] = this.diagnosticCollection.get(uri)?.map(elem => elem) || [];
+    diagnostics.push(this.buildDiagnostic(notification));
+    this.diagnosticCollection.set(uri, diagnostics);
+  }
+
+  public setNotifications(path: string, notifications: Notification[]): void {
+    const uri = vscode.Uri.file(path);
+    const diagnostics = notifications.map(notification => this.buildDiagnostic(notification));
+    this.diagnosticCollection.set(uri, diagnostics);
+  }
+
+  public removeNotifications(path: string) {
+    this.diagnosticCollection.delete(vscode.Uri.file(path));
+  }
+
+  private buildDiagnostic(notification: Notification): vscode.Diagnostic {
+    return {
+      message: notification.message,
+      range: new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)),
+      severity: this.getSeverity(notification.severity)
+    };
+  }
+
+  private getSeverity(severity: NotificationSeverity): vscode.DiagnosticSeverity {
+    const diagnostic = KOGITO_NOTIFICATION_TO_VS_CODE_DIAGNOSTIC_SEVERITY_CONVERTION_MAP[severity];
+    return diagnostic ? vscode.DiagnosticSeverity.Information : diagnostic;
+  }
+}

--- a/packages/notifications/src/vscode/VsCodeNotificationsApi.ts
+++ b/packages/notifications/src/vscode/VsCodeNotificationsApi.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Notification, NotificationsApi, NotificationType } from "../api";
+import { WorkspaceApi } from "@kogito-tooling/workspace/dist/api";
+import { PopupMessagesNotificationHandler } from "./PopupMessagesNotificationHandler";
+import { ProblemsTabNotificationHandler } from "./ProblemsTabNotificationHandler";
+import { I18n } from "@kogito-tooling/i18n/dist/core";
+import { CommonI18n } from "@kogito-tooling/i18n-common-dictionary";
+
+type NotificationsApiHandlersMap = {
+  [K in NotificationType]: NotificationsApi;
+};
+
+export class VsCodeNotificationsApi implements NotificationsApi {
+  private readonly strategies: NotificationsApiHandlersMap;
+
+  constructor(private readonly workspaceApi: WorkspaceApi, private readonly i18n: I18n<CommonI18n>) {
+    this.strategies = {
+      PROBLEM: new ProblemsTabNotificationHandler(),
+      ALERT: new PopupMessagesNotificationHandler(this.workspaceApi, this.i18n)
+    };
+  }
+
+  public createNotification(notification: Notification): void {
+    this.handle(notification).createNotification(notification);
+  }
+
+  public setNotifications(path: string, notifications: Notification[]): void {
+    const alerts = notifications.filter(n => n.type === "ALERT");
+    const problems = notifications.filter(n => n.type !== "ALERT");
+
+    this.get("PROBLEM").setNotifications(path, problems);
+    this.get("ALERT").setNotifications(path, alerts);
+  }
+
+  public removeNotifications(path: string): void {
+    this.get("PROBLEM").removeNotifications(path);
+  }
+
+  private handle(notification: Notification): NotificationsApi {
+    return this.get(notification.type);
+  }
+
+  private get(type: NotificationType): NotificationsApi {
+    return this.strategies[type] ?? new ProblemsTabNotificationHandler();
+  }
+}

--- a/packages/notifications/src/vscode/index.ts
+++ b/packages/notifications/src/vscode/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./VsCodeNotificationsApi";

--- a/packages/notifications/tsconfig.json
+++ b/packages/notifications/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/notifications/webpack.config.js
+++ b/packages/notifications/webpack.config.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const nodeExternals = require("webpack-node-externals");
+const { merge } = require("webpack-merge");
+const common = require("../../webpack.common.config");
+
+module.exports = [
+  merge(common, {
+    entry: {
+      "api/index": "./src/api/index.ts"
+    },
+    output: {
+      libraryTarget: "commonjs2"
+    },
+    externals: [nodeExternals({ modulesDir: "../../node_modules" })]
+  }),
+  merge(common, {
+    entry: {
+      "vscode/index": "./src/vscode/index.ts"
+    },
+    target: "node",
+    output: {
+      libraryTarget: "commonjs2"
+    },
+    externals: [{ vscode: "commonjs vscode" }, nodeExternals({ modulesDir: "../../node_modules" })]
+  })
+];

--- a/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
+++ b/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
@@ -15,6 +15,7 @@
  */
 import { Editor, KogitoEditorEnvelopeContextType } from "@kogito-tooling/editor/dist/api";
 import { DEFAULT_RECT } from "@kogito-tooling/guided-tour/dist/api";
+import { Notification } from "@kogito-tooling/notifications/dist/api";
 import * as React from "react";
 import { PMMLEditor } from "./PMMLEditor";
 
@@ -52,5 +53,9 @@ export class PMMLEditorInterface implements Editor {
 
   public async redo(): Promise<void> {
     return this.self.redo();
+  }
+
+  public async validate(): Promise<Notification[]> {
+    return [];
   }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
@@ -19,6 +19,7 @@ import { registerTestScenarioRunnerCommand, VsCodeBackendProxy } from "@kogito-t
 import { I18n } from "@kogito-tooling/i18n/dist/core";
 import * as KogitoVsCode from "@kogito-tooling/vscode-extension";
 import { VsCodeWorkspaceApi } from "@kogito-tooling/workspace/dist/vscode";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/dist/vscode";
 import * as vscode from "vscode";
 
 let backendProxy: VsCodeBackendProxy;
@@ -30,6 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const workspaceApi = new VsCodeWorkspaceApi();
   const backendI18n = new I18n(backendI18nDefaults, backendI18nDictionaries, vscode.env.language);
+  const notificationsApi = new VsCodeNotificationsApi(workspaceApi, backendI18n);
   backendProxy = new VsCodeBackendProxy(context, backendI18n, "kie-group.vscode-extension-backend");
 
   registerTestScenarioRunnerCommand({
@@ -37,7 +39,8 @@ export async function activate(context: vscode.ExtensionContext) {
     context: context,
     backendProxy: backendProxy,
     backendI18n: backendI18n,
-    workspaceApi: workspaceApi
+    workspaceApi: workspaceApi,
+    notificationsApi: notificationsApi
   });
 
   KogitoVsCode.startExtension({
@@ -48,10 +51,22 @@ export async function activate(context: vscode.ExtensionContext) {
     editorEnvelopeLocator: {
       targetOrigin: envelopeTargetOrigin,
       mapping: new Map([
-        ["bpmn", { resourcesPathPrefix: "dist/webview/editors/bpmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }],
-        ["bpmn2", { resourcesPathPrefix: "dist/webview/editors/bpmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }],
-        ["dmn", { resourcesPathPrefix: "dist/webview/editors/dmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }],
-        ["scesim", { resourcesPathPrefix: "dist/webview/editors/scesim", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }]
+        [
+          "bpmn",
+          { resourcesPathPrefix: "dist/webview/editors/bpmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }
+        ],
+        [
+          "bpmn2",
+          { resourcesPathPrefix: "dist/webview/editors/bpmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }
+        ],
+        [
+          "dmn",
+          { resourcesPathPrefix: "dist/webview/editors/dmn", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }
+        ],
+        [
+          "scesim",
+          { resourcesPathPrefix: "dist/webview/editors/scesim", envelopePath: "dist/webview/GwtEditorsEnvelopeApp.js" }
+        ]
       ])
     },
     backendProxy: backendProxy

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -31,7 +31,6 @@ import * as nodePath from "path";
 import { KogitoEditor } from "./KogitoEditor";
 import { KogitoEditorStore } from "./KogitoEditorStore";
 import { VsCodeOutputLogger } from "./VsCodeOutputLogger";
-import * as nodePath from "path";
 
 export class KogitoEditableDocument implements CustomDocument {
   private readonly encoder = new TextEncoder();

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { KogitoEdit } from "@kogito-tooling/channel-common-api";
+import { I18n } from "@kogito-tooling/i18n/dist/core";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode";
 import * as vscode from "vscode";
 import {
   CancellationToken,
@@ -23,16 +26,17 @@ import {
   EventEmitter,
   Uri
 } from "vscode";
-import { KogitoEditorStore } from "./KogitoEditorStore";
-import { KogitoEdit } from "@kogito-tooling/channel-common-api";
-import { KogitoEditor } from "./KogitoEditor";
 import { VsCodeI18n } from "./i18n";
-import { I18n } from "@kogito-tooling/i18n/dist/core";
 import * as nodePath from "path";
+import { KogitoEditor } from "./KogitoEditor";
+import { KogitoEditorStore } from "./KogitoEditorStore";
+import { VsCodeOutputLogger } from "./VsCodeOutputLogger";
 
 export class KogitoEditableDocument implements CustomDocument {
   private readonly encoder = new TextEncoder();
   private readonly decoder = new TextDecoder("utf-8");
+
+  private readonly vsCodeLogger = new VsCodeOutputLogger(KogitoEditableDocument.name);
 
   private readonly _onDidDispose = new EventEmitter<void>();
   public readonly onDidDispose = this._onDidDispose.event;
@@ -44,7 +48,8 @@ export class KogitoEditableDocument implements CustomDocument {
     public readonly uri: Uri,
     public readonly initialBackup: Uri | undefined,
     public readonly editorStore: KogitoEditorStore,
-    private readonly vsCodeI18n: I18n<VsCodeI18n>
+    private readonly vsCodeI18n: I18n<VsCodeI18n>,
+    private readonly vsCodeNotifications: VsCodeNotificationsApi
   ) {}
 
   public dispose() {
@@ -72,15 +77,19 @@ export class KogitoEditableDocument implements CustomDocument {
         return;
       }
 
+      const notifications = await editor.validate();
+      this.vsCodeNotifications.setNotifications(destination.fsPath, notifications);
+
       const content = await editor.getContent();
       if (cancellation.isCancellationRequested) {
+        this.vsCodeLogger.info(cancellation);
         return;
       }
 
       await vscode.workspace.fs.writeFile(destination, this.encoder.encode(content));
       vscode.window.setStatusBarMessage(i18n.savedSuccessfully, 3000);
     } catch (e) {
-      console.error("Error saving.", e);
+      this.vsCodeLogger.error(`Error saving. ${e}`);
     }
   }
 

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -31,6 +31,7 @@ import * as nodePath from "path";
 import { KogitoEditor } from "./KogitoEditor";
 import { KogitoEditorStore } from "./KogitoEditorStore";
 import { VsCodeOutputLogger } from "./VsCodeOutputLogger";
+import * as nodePath from "path";
 
 export class KogitoEditableDocument implements CustomDocument {
   private readonly encoder = new TextEncoder();

--- a/packages/vscode-extension/src/KogitoEditor.ts
+++ b/packages/vscode-extension/src/KogitoEditor.ts
@@ -87,6 +87,10 @@ export class KogitoEditor implements EditorApi {
     return this.envelopeServer.envelopeApi.requests.receive_previewRequest();
   }
 
+  public validate() {
+    return this.envelopeServer.envelopeApi.requests.validate();
+  }
+
   public startInitPolling() {
     this.envelopeServer.startInitPolling();
   }

--- a/packages/vscode-extension/src/KogitoEditorChannelApiImpl.ts
+++ b/packages/vscode-extension/src/KogitoEditorChannelApiImpl.ts
@@ -27,6 +27,7 @@ import { WorkspaceApi } from "@kogito-tooling/workspace/dist/api";
 import * as __path from "path";
 import * as vscode from "vscode";
 import { KogitoEditor } from "./KogitoEditor";
+import { Notification, NotificationsApi } from "@kogito-tooling/notifications/dist/api";
 
 export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
   private readonly decoder = new TextDecoder("utf-8");
@@ -36,6 +37,7 @@ export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
     private readonly resourceContentService: ResourceContentService,
     private readonly workspaceApi: WorkspaceApi,
     private readonly backendProxy: BackendProxy,
+    private readonly notificationsApi: NotificationsApi,
     private initialBackup = editor.document.initialBackup
   ) {}
 
@@ -86,5 +88,15 @@ export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
 
   public receive_getLocale(): Promise<string> {
     return Promise.resolve(vscode.env.language);
+  }
+
+  public createNotification(notification: Notification): void {
+    this.notificationsApi.createNotification(notification);
+  }
+  public setNotifications(path: string, notifications: Notification[]): void {
+    this.notificationsApi.setNotifications(path, notifications);
+  }
+  public removeNotifications(path: string): void {
+    this.notificationsApi.removeNotifications(path);
   }
 }

--- a/packages/vscode-extension/src/KogitoEditorFactory.ts
+++ b/packages/vscode-extension/src/KogitoEditorFactory.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import * as vscode from "vscode";
+import * as nodePath from "path";
+import { NotificationsApi } from "@kogito-tooling/notifications/dist/api";
 import { BackendProxy } from "@kogito-tooling/backend/dist/api";
 import { ResourceContentService } from "@kogito-tooling/channel-common-api";
 import { EditorEnvelopeLocator, EnvelopeMapping } from "@kogito-tooling/editor/dist/api";
 import { WorkspaceApi } from "@kogito-tooling/workspace/dist/api";
-import * as nodePath from "path";
-import * as vscode from "vscode";
 import { Uri, Webview } from "vscode";
 import { EnvelopeBusMessageBroadcaster } from "./EnvelopeBusMessageBroadcaster";
 import { KogitoEditableDocument } from "./KogitoEditableDocument";
@@ -36,7 +37,8 @@ export class KogitoEditorFactory {
     private readonly editorEnvelopeLocator: EditorEnvelopeLocator,
     private readonly messageBroadcaster: EnvelopeBusMessageBroadcaster,
     private readonly workspaceApi: WorkspaceApi,
-    private readonly backendProxy: BackendProxy
+    private readonly backendProxy: BackendProxy,
+    private readonly notificationsApi: NotificationsApi
   ) {}
 
   public configureNew(webviewPanel: vscode.WebviewPanel, document: KogitoEditableDocument) {
@@ -68,7 +70,8 @@ export class KogitoEditorFactory {
       editor,
       resourceContentService,
       this.workspaceApi,
-      this.backendProxy
+      this.backendProxy,
+      this.notificationsApi
     );
 
     this.editorStore.addAsActive(editor);

--- a/packages/vscode-extension/src/KogitoEditorWebviewProvider.ts
+++ b/packages/vscode-extension/src/KogitoEditorWebviewProvider.ts
@@ -31,6 +31,7 @@ import { KogitoEditorStore } from "./KogitoEditorStore";
 import { KogitoEditableDocument } from "./KogitoEditableDocument";
 import { VsCodeI18n } from "./i18n";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode";
 
 export class KogitoEditorWebviewProvider implements CustomEditorProvider<KogitoEditableDocument> {
   private readonly _onDidChangeCustomDocument = new EventEmitter<CustomDocumentEditEvent<KogitoEditableDocument>>();
@@ -41,7 +42,8 @@ export class KogitoEditorWebviewProvider implements CustomEditorProvider<KogitoE
     private readonly viewType: string,
     private readonly editorStore: KogitoEditorStore,
     private readonly editorFactory: KogitoEditorFactory,
-    private readonly vsCodeI18n: I18n<VsCodeI18n>
+    private readonly vsCodeI18n: I18n<VsCodeI18n>,
+    private readonly vsCodeNotificationsApi: VsCodeNotificationsApi
   ) {}
 
   public register() {
@@ -66,7 +68,8 @@ export class KogitoEditorWebviewProvider implements CustomEditorProvider<KogitoE
       uri,
       this.resolveBackup(openContext.backupId),
       this.editorStore,
-      this.vsCodeI18n
+      this.vsCodeI18n,
+      this.vsCodeNotificationsApi
     );
     this.setupListeners(document);
     return document;

--- a/packages/vscode-extension/src/VsCodeOutputLogger.ts
+++ b/packages/vscode-extension/src/VsCodeOutputLogger.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from "vscode";
+
+const channel = vscode.window.createOutputChannel("Kogito");
+
+export class VsCodeOutputLogger {
+  constructor(readonly id: string) {}
+
+  log(level: string, message: any) {
+    const finalMessage = typeof message == "string" ? message : JSON.stringify(message, null, "\t");
+    channel.appendLine(`${new Date().toISOString()} [${level.toUpperCase()}] ${this.id}: ${finalMessage}`);
+  }
+  info(message: any) {
+    this.log("INFO", message);
+  }
+  warn(message: any) {
+    this.log("WARN", message);
+  }
+  debug(message: any) {
+    this.log("DEBUG", message);
+  }
+  error(message: any) {
+    this.log("ERROR", message);
+  }
+}

--- a/packages/vscode-extension/src/__tests__/VsCodeNodeResourceContentService.test.ts
+++ b/packages/vscode-extension/src/__tests__/VsCodeNodeResourceContentService.test.ts
@@ -23,7 +23,6 @@ const testWorkspace = __path.resolve(__dirname, "test-workspace") + __path.sep;
 let resourceContentServie: VsCodeNodeResourceContentService;
 
 describe("VsCodeNodeResourceContentService", () => {
-
   beforeEach(() => {
     resourceContentServie = new VsCodeNodeResourceContentService(testWorkspace);
   });

--- a/packages/vscode-extension/src/index.ts
+++ b/packages/vscode-extension/src/index.ts
@@ -25,6 +25,7 @@ import { vsCodeI18nDefaults, vsCodeI18nDictionaries } from "./i18n";
 import { KogitoEditorFactory } from "./KogitoEditorFactory";
 import { KogitoEditorStore } from "./KogitoEditorStore";
 import { KogitoEditorWebviewProvider } from "./KogitoEditorWebviewProvider";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode/VsCodeNotificationsApi";
 
 /**
  * Starts a Kogito extension.
@@ -49,13 +50,15 @@ export async function startExtension(args: {
   const workspaceApi = new VsCodeWorkspaceApi();
   const editorStore = new KogitoEditorStore();
   const messageBroadcaster = new EnvelopeBusMessageBroadcaster();
+  const vsCodeNotificationsApi = new VsCodeNotificationsApi(workspaceApi, vsCodeI18n);
   const editorFactory = new KogitoEditorFactory(
     args.context,
     editorStore,
     args.editorEnvelopeLocator,
     messageBroadcaster,
     workspaceApi,
-    args.backendProxy
+    args.backendProxy,
+    vsCodeNotificationsApi
   );
 
   const editorWebviewProvider = new KogitoEditorWebviewProvider(
@@ -63,7 +66,8 @@ export async function startExtension(args: {
     args.viewType,
     editorStore,
     editorFactory,
-    vsCodeI18n
+    vsCodeI18n,
+    vsCodeNotificationsApi
   );
 
   args.context.subscriptions.push(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,25 +1279,25 @@
     eol "^0.9.1"
     glob "^7.1.6"
 
-"@kogito-tooling/bpmn-editor-unpacked@7.49.0-SNAPSHOT-20210126.222335":
-  version "7.49.0-SNAPSHOT-20210126.222335"
-  resolved "https://registry.yarnpkg.com/@kogito-tooling/bpmn-editor-unpacked/-/bpmn-editor-unpacked-7.49.0-SNAPSHOT-20210126.222335.tgz#98875b2dccd324ec268ec2d622e0fc8b7a66dccb"
-  integrity sha512-W/FPmRN1NdGHOGYqDEkzV8M+AEJ9oBaiLpMsSlknVBzliOlOMWSGIN6NJu5pRkP1noyV97Jbfg5LSITrWum5rQ==
+"@kogito-tooling/bpmn-editor-unpacked@7.50.0-SNAPSHOT-20210203.151532":
+  version "7.50.0-SNAPSHOT-20210203.151532"
+  resolved "https://registry.yarnpkg.com/@kogito-tooling/bpmn-editor-unpacked/-/bpmn-editor-unpacked-7.50.0-SNAPSHOT-20210203.151532.tgz#1032c78916e413034befc1c0461a4097a9cd823b"
+  integrity sha512-8h4DIlnhQlot8zvqLagPvISKNpjeDBrAAoEeayfe0MJNhdERAlykvgJoK2fxk28G3cNC7GxbPJQbKvJ9W8o8KQ==
 
-"@kogito-tooling/dmn-editor-unpacked@7.49.0-SNAPSHOT-20210126.222335":
-  version "7.49.0-SNAPSHOT-20210126.222335"
-  resolved "https://registry.yarnpkg.com/@kogito-tooling/dmn-editor-unpacked/-/dmn-editor-unpacked-7.49.0-SNAPSHOT-20210126.222335.tgz#1ee332a7d6aaf597eec04fc2df00ed9d1193e595"
-  integrity sha512-cLoICJpXP8WrLhEbBAbrNgB/HrwtquRFIdewyow1fBfPNXP6/daqcAVCFE9BJZ0v0PPrQdfYi7isnCXh6TwhFw==
+"@kogito-tooling/dmn-editor-unpacked@7.50.0-SNAPSHOT-20210203.151532":
+  version "7.50.0-SNAPSHOT-20210203.151532"
+  resolved "https://registry.yarnpkg.com/@kogito-tooling/dmn-editor-unpacked/-/dmn-editor-unpacked-7.50.0-SNAPSHOT-20210203.151532.tgz#ed6d5c7f486ca2daf3c48147190fc7d0dcdc2bb3"
+  integrity sha512-+qGx9LXxTDyrx/+Dz7OUzATXpQQvMLIGrhVfX6v2N8bjh+feHTP/X+EoaH4GT9uvkVNxYlcqtrM6d3X0Zpwutg==
 
 "@kogito-tooling/quarkus-runner-unpacked@0.7.0-SNAPSHOT":
   version "0.7.0-SNAPSHOT"
   resolved "https://registry.yarnpkg.com/@kogito-tooling/quarkus-runner-unpacked/-/quarkus-runner-unpacked-0.7.0-SNAPSHOT.tgz#5f84c2657347f82f1cab0f08cc9b430b32c9d222"
   integrity sha512-nlfngzKGZrI+P6+4dZr76FDGUoXuNsRWckNs7QS8iLTvEChi3azgFz4CBIqNB5sJjPUF4P+TAxsFlQMidIBzyA==
 
-"@kogito-tooling/scesim-editor-unpacked@7.49.0-SNAPSHOT-20210126.222335":
-  version "7.49.0-SNAPSHOT-20210126.222335"
-  resolved "https://registry.yarnpkg.com/@kogito-tooling/scesim-editor-unpacked/-/scesim-editor-unpacked-7.49.0-SNAPSHOT-20210126.222335.tgz#107db7d095b76acd3d4ff58fff6d28509efc4db4"
-  integrity sha512-uziDevpr9QPEq4XYsGnUW75R9smHYewttUUnqeYiRk4twEHmipEGN5Q614VoHjF8lQq/GeUiMziI6fD/ncVMJg==
+"@kogito-tooling/scesim-editor-unpacked@7.50.0-SNAPSHOT-20210203.151532":
+  version "7.50.0-SNAPSHOT-20210203.151532"
+  resolved "https://registry.yarnpkg.com/@kogito-tooling/scesim-editor-unpacked/-/scesim-editor-unpacked-7.50.0-SNAPSHOT-20210203.151532.tgz#f2d357ca4605f19d6371a0dd2823a30aaa508a2f"
+  integrity sha512-DTxgMOunZ0hJ+y13DYKprv+UIeCpxlo0g4Y6Wf5YKZM8A0JvTNxU3dMwnnUEWXTF564+kk5+M+0GgIlX0Vz78A==
 
 "@lerna/add@3.18.0":
   version "3.18.0"


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

https://issues.redhat.com/browse/KOGITO-3846

**referenced Pull Requests**: 

* https://github.com/kiegroup/appformer/pull/1092
* https://github.com/kiegroup/kie-wb-common/pull/3538
* https://github.com/kiegroup/kogito-tooling/pull/374

**Details:**

This PR adds the Notification API that let GWT send notifications to Channels. There are two main notifications: Alerts and Problems. 
* Alerts: ephemeral notification, i.e: Popup. If the notification contains a non empty path it will display a button to open that path. Alerts severity can be INFO, ERROR or WARNING.
* Problems: Notifications that needs to be informed to the users an keep persisted until the problem is fixed. i.e: Problems tab in VSCode. Problems severity can be INFO, ERROR, WARNING, HINT. The path is non empty it will open that location.

To use this notifications api users will need to inject `NotificationsApi class`.
There are 3 main methods:
* `send`: Send a single Alerts/Problem. For problems that notification will not disappear unless user removes it.
* `set` Send a list of Alerts/Problems. For problems, that list will replace the previous list, and for problems all the notification will be join in a single message.
* `remove`: Removes all the problems that belongs to a path. Alerts is not implemented since they are ephimeral.


@yesamer @romartin @karreiro 
