### PR TITLE
KOGITO-4153: Fix extension clash in uitests and cleanup .vscode files

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/.vscode/launch.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
 	"version": "0.2.0",
-	"configurations": [{
+	"configurations": [
+		{
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
@@ -12,16 +13,6 @@
 				"${workspaceFolder}/dist/*/.js"
 			],
 			"preLaunchTask": "npm: watch"
-		},
-		{
-			"name": "Integration Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/tests-it/out/suite"
-			]
 		}
 	]
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -110,7 +110,7 @@
     "compile": "webpack",
     "watch": "webpack",
     "test": "echo 'No tests to run.'",
-    "ui-test": "yarn run compile && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
+    "ui-test": "yarn run compile && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -u -e ./test-resources -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run build:fast",
     "build:prod:linux:darwin": "yarn run build --mode production --devtool none && yarn run test && yarn run ui-test && yarn run package:prod",


### PR DESCRIPTION
Specifies -u to uninstall kogito extension after testing
Specifies -e ./test-resources to use specific folder for management
of extensions. This should fix the clash with RHBA extensions if it
is installed in developers vscode instance on local environment.
Remove integration tests config from launch.json