### PR TITLE
Tweak Cypress reporters in kie-editors-standalone it-tests

### DIFF
--- a/packages/kie-editors-standalone/it-tests/cypress.json
+++ b/packages/kie-editors-standalone/it-tests/cypress.json
@@ -8,8 +8,9 @@
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "./results/junit-[hash].xml",
-    "jenkinsMode": true,
+    "testsuitesTitle": true,
     "testCaseSwitchClassnameAndName": true,
-    "reporterOptions.rootSuiteTitle": "@kogito-tooling/kie-editors-standalone"
+    "suiteTitleSeparatedBy": ".",
+    "rootSuiteTitle": "@kogito-tooling/kie-editors-standalone"
   }
 }

--- a/packages/kie-editors-standalone/it-tests/cypress.json
+++ b/packages/kie-editors-standalone/it-tests/cypress.json
@@ -8,9 +8,10 @@
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "./results/junit-[hash].xml",
-    "testsuitesTitle": true,
+    "testsuitesTitle": "@kogito-tooling",
     "testCaseSwitchClassnameAndName": true,
     "suiteTitleSeparatedBy": ".",
+    "useFullSuiteTitle":true,
     "rootSuiteTitle": "@kogito-tooling/kie-editors-standalone"
   }
 }

--- a/packages/kie-editors-standalone/it-tests/cypress.json
+++ b/packages/kie-editors-standalone/it-tests/cypress.json
@@ -7,6 +7,9 @@
   "supportFile": "./cypress/support/index.ts",
   "reporter": "junit",
   "reporterOptions": {
-    "mochaFile": "./results/junit-[hash].xml"
+    "mochaFile": "./results/junit-[hash].xml",
+    "jenkinsMode": true,
+    "testCaseSwitchClassnameAndName": true,
+    "reporterOptions.rootSuiteTitle": "@kogito-tooling/kie-editors-standalone"
   }
 }


### PR DESCRIPTION
By this change resulting junit.xml files follow format:
```
<testsuite name="@kogito-tooling/kie-editors-standalone.Bpmn Workitem." timestamp="2021-01-13T18:08:49" tests="1" time="22.8120" failures="0">
<testcase name="Test Open Editor With Custom Workitem" time="22.8120" classname="Bpmn Workitem. Test Open Editor With Custom Workitem"> </testcase>
...
</testsuite>
```
Which can then be more easily processed in jenkins.