### PR TITLE
FAI-357: [Scorecard Editor] Model Setup and Characteristics panels restyle

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabel.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabel.tsx
@@ -15,7 +15,6 @@
  */
 import * as React from "react";
 import { Label, Tooltip, TooltipPosition } from "@patternfly/react-core";
-
 import "./CharacteristicLabel.scss";
 
 export const CharacteristicLabel = (name: string, value: any, tooltip?: string) => {
@@ -46,19 +45,28 @@ export const CharacteristicLabel = (name: string, value: any, tooltip?: string) 
   );
 };
 
-export const CharacteristicLabelAttribute = (name: string, value: any, tooltip: string) => {
+export const CharacteristicPredicateLabel = (value: string) => {
+  const truncatedText = value.length > 32 ? value.slice(0, 29) + "..." : value;
+
   return (
-    <Tooltip
-      position={TooltipPosition.top}
-      isContentLeftAligned={true}
-      maxWidth={"100em"}
-      content={<pre>{tooltip}</pre>}
-    >
-      <Label tabIndex={0} color="blue" className="characteristic-list__item__label">
-        <strong>{name}:</strong>
-        &nbsp;
-        <pre>{value}</pre>
-      </Label>
-    </Tooltip>
+    <>
+      {value.length > truncatedText.length && (
+        <Tooltip
+          position={TooltipPosition.top}
+          isContentLeftAligned={true}
+          maxWidth={"100em"}
+          content={<pre>{value}</pre>}
+        >
+          <Label tabIndex={0} color="blue" className="characteristic-list__item__label">
+            <pre>{truncatedText}</pre>
+          </Label>
+        </Tooltip>
+      )}
+      {value.length === truncatedText.length && (
+        <Label tabIndex={0} color="blue" className="characteristic-list__item__label">
+          <pre>{value}</pre>
+        </Label>
+      )}
+    </>
   );
 };

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabels.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabels.tsx
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { Characteristic, DataField } from "@kogito-tooling/pmml-editor-marshaller";
+import { Characteristic } from "@kogito-tooling/pmml-editor-marshaller";
 import { CharacteristicLabel } from "./CharacteristicLabel";
 
 interface CharacteristicLabelsProps {
   activeCharacteristic: Characteristic;
   areReasonCodesUsed: boolean;
   isBaselineScoreRequired: boolean;
-  dataFields: DataField[];
 }
 
 export const CharacteristicLabels = (props: CharacteristicLabelsProps) => {
-  const { activeCharacteristic, areReasonCodesUsed, isBaselineScoreRequired, dataFields } = props;
+  const { activeCharacteristic, areReasonCodesUsed, isBaselineScoreRequired } = props;
 
   return (
     <>
-      {activeCharacteristic.baselineScore !== undefined && isBaselineScoreRequired &&
-
-      CharacteristicLabel("Baseline score", activeCharacteristic.baselineScore)}
-      {activeCharacteristic.reasonCode !== undefined && areReasonCodesUsed &&
+      {activeCharacteristic.baselineScore !== undefined &&
+        isBaselineScoreRequired &&
+        CharacteristicLabel("Baseline score", activeCharacteristic.baselineScore)}
+      {activeCharacteristic.reasonCode !== undefined &&
+        areReasonCodesUsed &&
         CharacteristicLabel("Reason code", activeCharacteristic.reasonCode)}
     </>
   );

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabels.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/CharacteristicLabels.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { Attribute, Characteristic, DataField } from "@kogito-tooling/pmml-editor-marshaller";
-import { CharacteristicLabel, CharacteristicLabelAttribute } from "./CharacteristicLabel";
-import { toText } from "../../../reducers";
+import { Characteristic, DataField } from "@kogito-tooling/pmml-editor-marshaller";
+import { CharacteristicLabel } from "./CharacteristicLabel";
 
 interface CharacteristicLabelsProps {
   activeCharacteristic: Characteristic;
@@ -30,39 +29,11 @@ export const CharacteristicLabels = (props: CharacteristicLabelsProps) => {
 
   return (
     <>
-      {activeCharacteristic.Attribute.length > 0 &&
-        CharacteristicLabelAttribute(
-          "Attributes",
-          attributesToTruncatedText(activeCharacteristic.Attribute, dataFields),
-          attributesToFullText(activeCharacteristic.Attribute, dataFields)
-        )}
-      {activeCharacteristic.reasonCode !== undefined &&
-        areReasonCodesUsed &&
+      {activeCharacteristic.baselineScore !== undefined && isBaselineScoreRequired &&
+
+      CharacteristicLabel("Baseline score", activeCharacteristic.baselineScore)}
+      {activeCharacteristic.reasonCode !== undefined && areReasonCodesUsed &&
         CharacteristicLabel("Reason code", activeCharacteristic.reasonCode)}
-      {activeCharacteristic.baselineScore !== undefined &&
-        isBaselineScoreRequired &&
-        CharacteristicLabel("Baseline score", activeCharacteristic.baselineScore)}
     </>
   );
-};
-
-const attributesToTruncatedText = (attributes: Attribute[], fields: DataField[]): string => {
-  const text: string[] = [];
-  attributes.forEach(attribute => {
-    let line: string = toText(attribute.predicate, fields);
-    if (line.length > 32) {
-      line = line.slice(0, 29) + "...";
-    }
-    text.push(line);
-  });
-  return text.join(" ");
-};
-
-const attributesToFullText = (attributes: Attribute[], fields: DataField[]): string => {
-  const text: string[] = [];
-  attributes.forEach(attribute => {
-    const line: string = toText(attribute.predicate, fields);
-    text.push(line);
-  });
-  return text.join("\n");
 };

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributeToolbar.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributeToolbar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { Button, Split, SplitItem, TextContent, Title, Toolbar, ToolbarContent } from "@patternfly/react-core";
+import { Button, Split, SplitItem, Title } from "@patternfly/react-core";
 import { ArrowAltCircleLeftIcon } from "@patternfly/react-icons";
 
 interface AttributeToolbarProps {
@@ -25,39 +25,33 @@ export const AttributeToolbar = (props: AttributeToolbarProps) => {
   const { viewOverview } = props;
 
   return (
-    <Toolbar id="attribute-toolbar" data-testid="attribute-toolbar">
-      <ToolbarContent>
-        <Split hasGutter={true} style={{ width: "100%" }}>
-          <SplitItem isFilled={true}>
-            <TextContent>
-              <Title size="lg" headingLevel="h1">
-                <a
-                  onClick={e => {
-                    e.preventDefault();
-                    viewOverview();
-                  }}
-                >
-                  Characteristics
-                </a>
-                &nbsp;/&nbsp;Attribute
-              </Title>
-            </TextContent>
-          </SplitItem>
-          <SplitItem>
-            <Button
-              variant="primary"
-              onClick={e => {
-                e.preventDefault();
-                viewOverview();
-              }}
-              icon={<ArrowAltCircleLeftIcon />}
-              iconPosition="left"
-            >
-              Done
-            </Button>
-          </SplitItem>
-        </Split>
-      </ToolbarContent>
-    </Toolbar>
+    <Split>
+      <SplitItem isFilled={true}>
+        <Title size="lg" headingLevel="h1">
+          <a
+            onClick={e => {
+              e.preventDefault();
+              viewOverview();
+            }}
+          >
+            Characteristics
+          </a>
+          &nbsp;/&nbsp;Attribute
+        </Title>
+      </SplitItem>
+      <SplitItem>
+        <Button
+          variant="primary"
+          onClick={e => {
+            e.preventDefault();
+            viewOverview();
+          }}
+          icon={<ArrowAltCircleLeftIcon />}
+          iconPosition="left"
+        >
+          Done
+        </Button>
+      </SplitItem>
+    </Split>
   );
 };

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributesTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributesTableRow.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { Split, SplitItem } from "@patternfly/react-core";
+import { Label, Split, SplitItem } from "@patternfly/react-core";
 import { Attribute, DataField } from "@kogito-tooling/pmml-editor-marshaller";
 import "./AttributesTableRow.scss";
 import { AttributeLabels, AttributesTableAction } from "../atoms";
@@ -36,7 +36,7 @@ export const AttributesTableRow = (props: AttributesTableRowProps) => {
     <article
       className={`attribute-item attribute-item-n${index} editable`}
       tabIndex={0}
-      onClick={e => onEdit()}
+      onClick={() => onEdit()}
       onKeyDown={e => {
         if (e.key === "Enter") {
           e.preventDefault();
@@ -47,7 +47,9 @@ export const AttributesTableRow = (props: AttributesTableRowProps) => {
     >
       <Split hasGutter={true} style={{ height: "100%" }}>
         <SplitItem>
-          <pre>{toText(attribute.predicate, dataFields)}</pre>
+          <Label tabIndex={0} color="blue">
+            <pre>{toText(attribute.predicate, dataFields)}</pre>
+          </Label>
         </SplitItem>
         <SplitItem isFilled={true}>
           <AttributeLabels activeAttribute={attribute} areReasonCodesUsed={areReasonCodesUsed} />

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
@@ -60,10 +60,12 @@ export const CharacteristicsTableRow = (props: CharacteristicsTableRowProps) => 
             activeCharacteristic={characteristic.characteristic}
             areReasonCodesUsed={areReasonCodesUsed}
             isBaselineScoreRequired={isBaselineScoreRequired}
+          />
+          <CharacteristicAttributesList
+            characteristic={characteristic.characteristic}
+            areReasonCodesUsed={areReasonCodesUsed}
             dataFields={dataFields}
           />
-          <br />
-          <CharacteristicAttributesList characteristic={characteristic.characteristic} dataFields={dataFields} />
         </SplitItem>
         <SplitItem>
           <CharacteristicsTableAction onDelete={onDelete} />
@@ -75,18 +77,19 @@ export const CharacteristicsTableRow = (props: CharacteristicsTableRowProps) => 
 
 interface CharacteristicAttributesListProps {
   characteristic: Characteristic;
+  areReasonCodesUsed: boolean;
   dataFields: DataField[];
 }
 
 const CharacteristicAttributesList = (props: CharacteristicAttributesListProps) => {
-  const { characteristic, dataFields } = props;
+  const { characteristic, areReasonCodesUsed, dataFields } = props;
 
   return (
     <ul>
       {characteristic.Attribute.map((item, index) => (
         <li key={index}>
           {CharacteristicPredicateLabel(toText(item.predicate, dataFields))}
-          <AttributeLabels activeAttribute={item} />
+          <AttributeLabels activeAttribute={item} areReasonCodesUsed={areReasonCodesUsed} />
         </li>
       ))}
     </ul>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
@@ -15,11 +15,16 @@
  */
 import * as React from "react";
 import { Split, SplitItem } from "@patternfly/react-core";
-import { CharacteristicLabels, CharacteristicsTableAction } from "../atoms";
+import {
+  AttributeLabels,
+  CharacteristicLabels,
+  CharacteristicPredicateLabel,
+  CharacteristicsTableAction
+} from "../atoms";
+import { Characteristic, DataField } from "@kogito-tooling/pmml-editor-marshaller";
 import { IndexedCharacteristic } from "../organisms";
+import { toText } from "../../../reducers";
 import "./CharacteristicsTableRow.scss";
-import "../../EditorScorecard/templates/ScorecardEditorPage.scss";
-import { DataField } from "@kogito-tooling/pmml-editor-marshaller";
 
 interface CharacteristicsTableRowProps {
   characteristic: IndexedCharacteristic;
@@ -57,11 +62,33 @@ export const CharacteristicsTableRow = (props: CharacteristicsTableRowProps) => 
             isBaselineScoreRequired={isBaselineScoreRequired}
             dataFields={dataFields}
           />
+          <br />
+          <CharacteristicAttributesList characteristic={characteristic.characteristic} dataFields={dataFields} />
         </SplitItem>
         <SplitItem>
           <CharacteristicsTableAction onDelete={onDelete} />
         </SplitItem>
       </Split>
     </article>
+  );
+};
+
+interface CharacteristicAttributesListProps {
+  characteristic: Characteristic;
+  dataFields: DataField[];
+}
+
+const CharacteristicAttributesList = (props: CharacteristicAttributesListProps) => {
+  const { characteristic, dataFields } = props;
+
+  return (
+    <ul>
+      {characteristic.Attribute.map((item, index) => (
+        <li key={index}>
+          {CharacteristicPredicateLabel(toText(item.predicate, dataFields))}
+          <AttributeLabels activeAttribute={item} />
+        </li>
+      ))}
+    </ul>
   );
 };

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.scss
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#characteristics-toolbar {
+  --pf-c-toolbar__content--PaddingLeft: 0;
+  --pf-c-toolbar__content--PaddingRight: 0;
+  --pf-c-toolbar--PaddingTop: 0;
+}

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.tsx
@@ -29,6 +29,7 @@ import {
   ToolbarItem
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
+import "./CharacteristicsToolbar.scss";
 
 interface CharacteristicsToolbarProps {
   onFilter: (filter: string) => void;
@@ -73,7 +74,7 @@ export const CharacteristicsToolbar = (props: CharacteristicsToolbarProps) => {
                       data-testid="characteristics-toolbar__submit"
                       variant={ButtonVariant.control}
                       aria-label="filter button for filter input"
-                      onClick={e => onFilter(filter)}
+                      onClick={() => onFilter(filter)}
                     >
                       <SearchIcon />
                     </Button>
@@ -88,7 +89,7 @@ export const CharacteristicsToolbar = (props: CharacteristicsToolbarProps) => {
                 id="add-characteristic-button"
                 data-testid="characteristics-toolbar__add-characteristic"
                 variant="primary"
-                onClick={e => onAddCharacteristic()}
+                onClick={() => onAddCharacteristic()}
               >
                 Add Characteristic
               </Button>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.scss
@@ -15,14 +15,13 @@
  */
 
 .characteristics-container {
-
   height: 100%;
 
   &__overview {
     overflow-y: auto;
     padding: 1em;
     background-color: var(--pf-global--BackgroundColor--200);
-    height: calc(100vh - 482px);
+    height: 100%;
 
     &-enter {
       opacity: 0;

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.scss
@@ -46,7 +46,7 @@
     overflow-y: auto;
     padding: 1em;
     background-color: var(--pf-global--BackgroundColor--200);
-    height: calc(100vh - 482px);
+    height: 100%;
 
     &-enter {
       transform: translateX(100px);

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
@@ -196,7 +196,7 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
           >
             <>
               {viewSection === "overview" && (
-                <Stack hasGutter={true}>
+                <Stack>
                   <StackItem>
                     <CharacteristicsToolbar onFilter={onFilter} onAddCharacteristic={onAddCharacteristic} />
                   </StackItem>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.scss
@@ -15,8 +15,10 @@
  */
 
 .core-properties {
-
-  &__container {
-    width: 100%;
+  &__label {
+    margin-right: var(--pf-global--spacer--sm);
+    &:last-of-type {
+      margin-right: 0;
+    }
   }
 }

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -77,7 +77,7 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
   const [baselineScore, setBaselineScore] = useState<number | undefined>();
   const [baselineMethod, setBaselineMethod] = useState<BaselineMethod | undefined>();
   const [initialScore, setInitialScore] = useState<number | undefined>();
-  const [areReasonCodesUsed, setAreReasonCodesUsed] = useState<boolean>(props.areReasonCodesUsed);
+  const [areReasonCodesUsed, setAreReasonCodesUsed] = useState<boolean | undefined>();
   const [reasonCodeAlgorithm, setReasonCodeAlgorithm] = useState<ReasonCodeAlgorithm | undefined>();
 
   useEffect(() => {
@@ -169,7 +169,8 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                   {functionName !== undefined && CorePropertyLabel("Function", functionName)}
                   {algorithmName !== undefined && CorePropertyLabel("Algorithm", algorithmName)}
                   {initialScore !== undefined && CorePropertyLabel("Initial Score", initialScore)}
-                  {useReasonCodes !== undefined && CorePropertyLabel("Use Reason Codes", toYesNo(useReasonCodes))}
+                  {areReasonCodesUsed !== undefined &&
+                    CorePropertyLabel("Use Reason Codes", toYesNo(areReasonCodesUsed))}
                   {reasonCodeAlgorithm !== undefined && CorePropertyLabel("Reason Code Algorithm", reasonCodeAlgorithm)}
                   {baselineScore !== undefined && CorePropertyLabel("Baseline Score", baselineScore)}
                   {baselineMethod !== undefined && CorePropertyLabel("Baseline Method", baselineMethod)}

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -323,7 +323,7 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
 
 const CorePropertyLabel = (name: string, value: any) => {
   return (
-    <Label color="purple" className="core-properties__label">
+    <Label color="orange" className="core-properties__label">
       <strong>{name}:</strong>
       &nbsp;
       <span>{value}</span>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -21,14 +21,16 @@ import {
   Bullseye,
   Form,
   FormGroup,
+  Label,
   Level,
   LevelItem,
   PageSection,
   PageSectionVariants,
+  Split,
+  SplitItem,
   Stack,
   StackItem,
   Switch,
-  TextContent,
   TextInput,
   Title
 } from "@patternfly/react-core";
@@ -42,14 +44,14 @@ import get = Reflect.get;
 
 interface CoreProperties {
   modelIndex: number;
-  isScorable: boolean;
-  functionName: MiningFunction;
-  algorithmName: string;
+  isScorable: boolean | undefined;
+  functionName: MiningFunction | undefined;
+  algorithmName: string | undefined;
   baselineScore: number | undefined;
-  baselineMethod: BaselineMethod;
+  baselineMethod: BaselineMethod | undefined;
   initialScore: number | undefined;
   areReasonCodesUsed: boolean;
-  reasonCodeAlgorithm: ReasonCodeAlgorithm;
+  reasonCodeAlgorithm: ReasonCodeAlgorithm | undefined;
 }
 
 interface CorePropertiesTableProps extends CoreProperties {
@@ -75,7 +77,7 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
   const [algorithmName, setAlgorithmName] = useState<string | undefined>();
   const [baselineScore, setBaselineScore] = useState<number | undefined>();
   const [baselineMethod, setBaselineMethod] = useState<BaselineMethod | undefined>();
-  const [initialScore, setInitialScore] = useState<number | undefined>(props.initialScore);
+  const [initialScore, setInitialScore] = useState<number | undefined>();
   const [areReasonCodesUsed, setAreReasonCodesUsed] = useState<boolean>(props.areReasonCodesUsed);
   const [reasonCodeAlgorithm, setReasonCodeAlgorithm] = useState<ReasonCodeAlgorithm | undefined>();
 
@@ -90,14 +92,10 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
     setReasonCodeAlgorithm(props.reasonCodeAlgorithm);
   }, [props]);
 
-  const ref = useOnclickOutside(event => onCommitAndClose(), {
+  const ref = useOnclickOutside(() => onCommitAndClose(), {
     disabled: activeOperation !== Operation.UPDATE_CORE,
     eventTypes: ["click"]
   });
-
-  const value = (_value: any | undefined) => {
-    return _value ? <span>{_value}</span> : <span>&nbsp;</span>;
-  };
 
   const toNumber = (_value: string): number | undefined => {
     if (_value === "") {
@@ -160,26 +158,39 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
       <PageSection variant={PageSectionVariants.light}>
         <Stack hasGutter={true}>
           <StackItem>
-            <TextContent>
-              <Title size="lg" headingLevel="h1">
-                Model setup
-              </Title>
-            </TextContent>
+            <Split hasGutter={true}>
+              <SplitItem>
+                <Title size="lg" headingLevel="h1">
+                  Model Setup
+                </Title>
+              </SplitItem>
+              {!isEditModeEnabled && (
+                <SplitItem>
+                  {isScorable !== undefined && CorePropertyLabel("Is Scorable", toYesNo(isScorable))}
+                  {functionName !== undefined && CorePropertyLabel("Function", functionName)}
+                  {algorithmName !== undefined && CorePropertyLabel("Algorithm", algorithmName)}
+                  {initialScore !== undefined && CorePropertyLabel("Initial Score", initialScore)}
+                  {useReasonCodes !== undefined && CorePropertyLabel("Use Reason Codes", toYesNo(useReasonCodes))}
+                  {reasonCodeAlgorithm !== undefined && CorePropertyLabel("Reason Code Algorithm", reasonCodeAlgorithm)}
+                  {baselineScore !== undefined && CorePropertyLabel("Baseline Score", baselineScore)}
+                  {baselineMethod !== undefined && CorePropertyLabel("Baseline Method", baselineMethod)}
+                </SplitItem>
+              )}
+            </Split>
           </StackItem>
-          <StackItem>
-            <Bullseye>
-              <Form
-                onSubmit={e => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                }}
-                className="core-properties__container"
-              >
-                <Level hasGutter={true}>
-                  <LevelItem>
-                    <FormGroup label="Scorable?" fieldId="core-isScorable">
-                      {!isEditModeEnabled && value(toYesNo(isScorable))}
-                      {isEditModeEnabled && (
+          {isEditModeEnabled && (
+            <StackItem>
+              <Bullseye>
+                <Form
+                  onSubmit={e => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
+                  className="core-properties__container"
+                >
+                  <Level hasGutter={true}>
+                    <LevelItem>
+                      <FormGroup label="Is Scorable" fieldId="core-isScorable">
                         <Switch
                           id="core-isScorable"
                           isChecked={isScorable}
@@ -188,14 +199,11 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                             onCommit({ isScorable: checked });
                           }}
                         />
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Function" fieldId="core-functionName" required={true}>
-                      {!isEditModeEnabled && value(functionName)}
-                      {isEditModeEnabled &&
-                        GenericSelectorEditor(
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Function" fieldId="core-functionName" required={true}>
+                        {GenericSelectorEditor(
                           "core-functionName",
                           [
                             "associationRules",
@@ -215,12 +223,10 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           // See http://dmg.org/pmml/v4-4/Scorecard.html
                           true
                         )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Algorithm" fieldId="core-algorithmName">
-                      {!isEditModeEnabled && value(algorithmName)}
-                      {isEditModeEnabled && (
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Algorithm" fieldId="core-algorithmName">
                         <TextInput
                           type="text"
                           id="core-algorithmName"
@@ -228,17 +234,14 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           aria-describedby="core-algorithmName"
                           value={algorithmName}
                           onChange={e => setAlgorithmName(e)}
-                          onBlur={e => {
+                          onBlur={() => {
                             onCommit({ algorithmName: algorithmName });
                           }}
                         />
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Initial score" fieldId="core-initialScore">
-                      {!isEditModeEnabled && value(initialScore)}
-                      {isEditModeEnabled && (
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Initial score" fieldId="core-initialScore">
                         <TextInput
                           id="core-initialScore"
                           value={initialScore}
@@ -248,13 +251,10 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           }}
                           type="number"
                         />
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
-                      {!isEditModeEnabled && value(toYesNo(areReasonCodesUsed))}
-                      {isEditModeEnabled && (
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
                         <Switch
                           id="core-useReasonCodes"
                           isChecked={areReasonCodesUsed}
@@ -263,14 +263,11 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                             onCommit({ areReasonCodesUsed: checked });
                           }}
                         />
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
-                      {!isEditModeEnabled && value(reasonCodeAlgorithm)}
-                      {isEditModeEnabled &&
-                        GenericSelectorEditor(
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
+                        {GenericSelectorEditor(
                           "core-reasonCodeAlgorithm",
                           ["pointsAbove", "pointsBelow"],
                           reasonCodeAlgorithm,
@@ -282,12 +279,10 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           // See http://dmg.org/pmml/v4-4/Scorecard.html
                           !areReasonCodesUsed
                         )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Baseline score" fieldId="core-baselineScore">
-                      {!isEditModeEnabled && value(baselineScore)}
-                      {isEditModeEnabled && (
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Baseline score" fieldId="core-baselineScore">
                         <TextInput
                           id="core-baselineScore"
                           value={baselineScore}
@@ -300,14 +295,11 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           // See http://dmg.org/pmml/v4-4/Scorecard.html
                           isDisabled={!areReasonCodesUsed}
                         />
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Baseline method" fieldId="core-baselineMethod">
-                      {!isEditModeEnabled && value(baselineMethod)}
-                      {isEditModeEnabled &&
-                        GenericSelectorEditor(
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Baseline method" fieldId="core-baselineMethod">
+                        {GenericSelectorEditor(
                           "core-baselineMethod",
                           ["max", "min", "mean", "neutral", "other"],
                           baselineMethod,
@@ -319,14 +311,25 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           // See http://dmg.org/pmml/v4-4/Scorecard.html
                           !areReasonCodesUsed
                         )}
-                    </FormGroup>
-                  </LevelItem>
-                </Level>
-              </Form>
-            </Bullseye>
-          </StackItem>
+                      </FormGroup>
+                    </LevelItem>
+                  </Level>
+                </Form>
+              </Bullseye>
+            </StackItem>
+          )}
         </Stack>
       </PageSection>
     </div>
+  );
+};
+
+const CorePropertyLabel = (name: string, value: any) => {
+  return (
+    <Label color="purple" className="core-properties__label">
+      <strong>{name}:</strong>
+      &nbsp;
+      <span>{value}</span>
+    </Label>
   );
 };

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -18,7 +18,6 @@ import { useEffect, useMemo, useState } from "react";
 import { GenericSelector } from "../atoms";
 import { BaselineMethod, MiningFunction, ReasonCodeAlgorithm } from "@kogito-tooling/pmml-editor-marshaller";
 import {
-  Bullseye,
   Form,
   FormGroup,
   Label,
@@ -180,142 +179,140 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
           </StackItem>
           {isEditModeEnabled && (
             <StackItem>
-              <Bullseye>
-                <Form
-                  onSubmit={e => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                  }}
-                  className="core-properties__container"
-                >
-                  <Level hasGutter={true}>
-                    <LevelItem>
-                      <FormGroup label="Is Scorable" fieldId="core-isScorable">
-                        <Switch
-                          id="core-isScorable"
-                          isChecked={isScorable}
-                          onChange={checked => {
-                            setScorable(checked);
-                            onCommit({ isScorable: checked });
-                          }}
-                        />
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Function" fieldId="core-functionName" required={true}>
-                        {GenericSelectorEditor(
-                          "core-functionName",
-                          [
-                            "associationRules",
-                            "sequences",
-                            "classification",
-                            "regression",
-                            "clustering",
-                            "timeSeries",
-                            "mixed"
-                          ],
-                          functionName,
-                          _selection => {
-                            setFunctionName(_selection as MiningFunction);
-                            onCommit({ functionName: _selection as MiningFunction });
-                          },
-                          // TODO {manstis] Scorecards are ALWAYS regression. We probably don't need this field.
-                          // See http://dmg.org/pmml/v4-4/Scorecard.html
-                          true
-                        )}
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Algorithm" fieldId="core-algorithmName">
-                        <TextInput
-                          type="text"
-                          id="core-algorithmName"
-                          name="core-algorithmName"
-                          aria-describedby="core-algorithmName"
-                          value={algorithmName}
-                          onChange={e => setAlgorithmName(e)}
-                          onBlur={() => {
-                            onCommit({ algorithmName: algorithmName });
-                          }}
-                        />
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Initial score" fieldId="core-initialScore">
-                        <TextInput
-                          id="core-initialScore"
-                          value={initialScore}
-                          onChange={e => setInitialScore(toNumber(e))}
-                          onBlur={() => {
-                            onCommit({ initialScore: initialScore });
-                          }}
-                          type="number"
-                        />
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
-                        <Switch
-                          id="core-useReasonCodes"
-                          isChecked={areReasonCodesUsed}
-                          onChange={checked => {
-                            setAreReasonCodesUsed(checked);
-                            onCommit({ areReasonCodesUsed: checked });
-                          }}
-                        />
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
-                        {GenericSelectorEditor(
-                          "core-reasonCodeAlgorithm",
-                          ["pointsAbove", "pointsBelow"],
-                          reasonCodeAlgorithm,
-                          _selection => {
-                            setReasonCodeAlgorithm(_selection as ReasonCodeAlgorithm);
-                            onCommit({ reasonCodeAlgorithm: _selection as ReasonCodeAlgorithm });
-                          },
-                          // Reason Code Algorithm is only required when Reason Codes are enabled.
-                          // See http://dmg.org/pmml/v4-4/Scorecard.html
-                          !areReasonCodesUsed
-                        )}
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Baseline score" fieldId="core-baselineScore">
-                        <TextInput
-                          id="core-baselineScore"
-                          value={baselineScore}
-                          onChange={e => setBaselineScore(toNumber(e))}
-                          onBlur={() => {
-                            onCommit({ baselineScore: baselineScore });
-                          }}
-                          type="number"
-                          // Baseline Score is only required when Reason Codes are enabled.
-                          // See http://dmg.org/pmml/v4-4/Scorecard.html
-                          isDisabled={!areReasonCodesUsed}
-                        />
-                      </FormGroup>
-                    </LevelItem>
-                    <LevelItem>
-                      <FormGroup label="Baseline method" fieldId="core-baselineMethod">
-                        {GenericSelectorEditor(
-                          "core-baselineMethod",
-                          ["max", "min", "mean", "neutral", "other"],
-                          baselineMethod,
-                          _selection => {
-                            setBaselineMethod(_selection as BaselineMethod);
-                            onCommit({ baselineMethod: _selection as BaselineMethod });
-                          },
-                          // Baseline Method is only required when Reason Codes are enabled.
-                          // See http://dmg.org/pmml/v4-4/Scorecard.html
-                          !areReasonCodesUsed
-                        )}
-                      </FormGroup>
-                    </LevelItem>
-                  </Level>
-                </Form>
-              </Bullseye>
+              <Form
+                onSubmit={e => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+                className="core-properties__container"
+              >
+                <Level hasGutter={true}>
+                  <LevelItem>
+                    <FormGroup label="Is Scorable" fieldId="core-isScorable">
+                      <Switch
+                        id="core-isScorable"
+                        isChecked={isScorable === true}
+                        onChange={checked => {
+                          setScorable(checked);
+                          onCommit({ isScorable: checked });
+                        }}
+                      />
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Function" fieldId="core-functionName" required={true}>
+                      {GenericSelectorEditor(
+                        "core-functionName",
+                        [
+                          "associationRules",
+                          "sequences",
+                          "classification",
+                          "regression",
+                          "clustering",
+                          "timeSeries",
+                          "mixed"
+                        ],
+                        functionName,
+                        _selection => {
+                          setFunctionName(_selection as MiningFunction);
+                          onCommit({ functionName: _selection as MiningFunction });
+                        },
+                        // TODO {manstis] Scorecards are ALWAYS regression. We probably don't need this field.
+                        // See http://dmg.org/pmml/v4-4/Scorecard.html
+                        true
+                      )}
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Algorithm" fieldId="core-algorithmName">
+                      <TextInput
+                        type="text"
+                        id="core-algorithmName"
+                        name="core-algorithmName"
+                        aria-describedby="core-algorithmName"
+                        value={algorithmName}
+                        onChange={e => setAlgorithmName(e)}
+                        onBlur={() => {
+                          onCommit({ algorithmName: algorithmName });
+                        }}
+                      />
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Initial score" fieldId="core-initialScore">
+                      <TextInput
+                        id="core-initialScore"
+                        value={initialScore}
+                        onChange={e => setInitialScore(toNumber(e))}
+                        onBlur={() => {
+                          onCommit({ initialScore: initialScore });
+                        }}
+                        type="number"
+                      />
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
+                      <Switch
+                        id="core-useReasonCodes"
+                        isChecked={areReasonCodesUsed}
+                        onChange={checked => {
+                          setAreReasonCodesUsed(checked);
+                          onCommit({ areReasonCodesUsed: checked });
+                        }}
+                      />
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
+                      {GenericSelectorEditor(
+                        "core-reasonCodeAlgorithm",
+                        ["pointsAbove", "pointsBelow"],
+                        reasonCodeAlgorithm,
+                        _selection => {
+                          setReasonCodeAlgorithm(_selection as ReasonCodeAlgorithm);
+                          onCommit({ reasonCodeAlgorithm: _selection as ReasonCodeAlgorithm });
+                        },
+                        // Reason Code Algorithm is only required when Reason Codes are enabled.
+                        // See http://dmg.org/pmml/v4-4/Scorecard.html
+                        !areReasonCodesUsed
+                      )}
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Baseline score" fieldId="core-baselineScore">
+                      <TextInput
+                        id="core-baselineScore"
+                        value={baselineScore}
+                        onChange={e => setBaselineScore(toNumber(e))}
+                        onBlur={() => {
+                          onCommit({ baselineScore: baselineScore });
+                        }}
+                        type="number"
+                        // Baseline Score is only required when Reason Codes are enabled.
+                        // See http://dmg.org/pmml/v4-4/Scorecard.html
+                        isDisabled={!areReasonCodesUsed}
+                      />
+                    </FormGroup>
+                  </LevelItem>
+                  <LevelItem>
+                    <FormGroup label="Baseline method" fieldId="core-baselineMethod">
+                      {GenericSelectorEditor(
+                        "core-baselineMethod",
+                        ["max", "min", "mean", "neutral", "other"],
+                        baselineMethod,
+                        _selection => {
+                          setBaselineMethod(_selection as BaselineMethod);
+                          onCommit({ baselineMethod: _selection as BaselineMethod });
+                        },
+                        // Baseline Method is only required when Reason Codes are enabled.
+                        // See http://dmg.org/pmml/v4-4/Scorecard.html
+                        !areReasonCodesUsed
+                      )}
+                    </FormGroup>
+                  </LevelItem>
+                </Level>
+              </Form>
             </StackItem>
           )}
         </Stack>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.scss
@@ -17,6 +17,9 @@
 .editor {
   position: relative;
   height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
 }
 
 .editable-item {

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
@@ -173,53 +173,51 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
           </PageSection>
 
           <PageSection isFilled={true} style={{ paddingTop: "0px" }}>
-            <PageSection variant={PageSectionVariants.light}>
-              <div>
-                <CharacteristicsContainer
-                  modelIndex={modelIndex}
-                  areReasonCodesUsed={model.useReasonCodes ?? true}
-                  isBaselineScoreRequired={(model.useReasonCodes ?? true) && model.baselineScore === undefined}
-                  characteristics={characteristics?.Characteristic ?? []}
-                  filteredCharacteristics={filteredCharacteristics}
-                  filter={filter}
-                  onFilter={setFilter}
-                  deleteCharacteristic={index => {
-                    if (window.confirm(`Delete Characteristic "${index}"?`)) {
-                      dispatch({
-                        type: Actions.Scorecard_DeleteCharacteristic,
-                        payload: {
-                          modelIndex: modelIndex,
-                          characteristicIndex: index
-                        }
-                      });
-                    }
-                  }}
-                  commit={(_index, _characteristic) => {
-                    if (_index === undefined) {
-                      dispatch({
-                        type: Actions.Scorecard_AddCharacteristic,
-                        payload: {
-                          modelIndex: modelIndex,
-                          name: _characteristic.name,
-                          reasonCode: _characteristic.reasonCode,
-                          baselineScore: _characteristic.baselineScore
-                        }
-                      });
-                    } else {
-                      dispatch({
-                        type: Actions.Scorecard_UpdateCharacteristic,
-                        payload: {
-                          modelIndex: modelIndex,
-                          characteristicIndex: _index,
-                          name: _characteristic.name,
-                          reasonCode: _characteristic.reasonCode,
-                          baselineScore: _characteristic.baselineScore
-                        }
-                      });
-                    }
-                  }}
-                />
-              </div>
+            <PageSection variant={PageSectionVariants.light} style={{ height: "100%" }}>
+              <CharacteristicsContainer
+                modelIndex={modelIndex}
+                areReasonCodesUsed={model.useReasonCodes ?? true}
+                isBaselineScoreRequired={(model.useReasonCodes ?? true) && model.baselineScore === undefined}
+                characteristics={characteristics?.Characteristic ?? []}
+                filteredCharacteristics={filteredCharacteristics}
+                filter={filter}
+                onFilter={setFilter}
+                deleteCharacteristic={index => {
+                  if (window.confirm(`Delete Characteristic "${index}"?`)) {
+                    dispatch({
+                      type: Actions.Scorecard_DeleteCharacteristic,
+                      payload: {
+                        modelIndex: modelIndex,
+                        characteristicIndex: index
+                      }
+                    });
+                  }
+                }}
+                commit={(_index, _characteristic) => {
+                  if (_index === undefined) {
+                    dispatch({
+                      type: Actions.Scorecard_AddCharacteristic,
+                      payload: {
+                        modelIndex: modelIndex,
+                        name: _characteristic.name,
+                        reasonCode: _characteristic.reasonCode,
+                        baselineScore: _characteristic.baselineScore
+                      }
+                    });
+                  } else {
+                    dispatch({
+                      type: Actions.Scorecard_UpdateCharacteristic,
+                      payload: {
+                        modelIndex: modelIndex,
+                        characteristicIndex: _index,
+                        name: _characteristic.name,
+                        reasonCode: _characteristic.reasonCode,
+                        baselineScore: _characteristic.baselineScore
+                      }
+                    });
+                  }
+                }}
+              />
             </PageSection>
           </PageSection>
         </>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
@@ -147,7 +147,7 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
               modelIndex={modelIndex}
               isScorable={model.isScorable ?? true}
               functionName={model.functionName}
-              algorithmName={model.algorithmName ?? ""}
+              algorithmName={model.algorithmName}
               baselineScore={model.baselineScore}
               baselineMethod={model.baselineMethod ?? "other"}
               initialScore={model.initialScore}


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/FAI-357

This PR changes Model Setup and Characteristics panels style in the Scorecard home screen, reducing the space taken by Model Setup and displaying a list of attributes predicates for each Characteristic.

@manstis I left the labels color as orange for now. Let's discuss their color system again and eventually change them across the whole editor.