### PR TITLE
KOGITO-4219: [Chrome Extension] "Copy link to Online editor" button doesn't work on private repositories

### DIFF
--- a/packages/online-editor/src/common/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/common/i18n/OnlineI18n.ts
@@ -170,6 +170,20 @@ interface OnlineDictionary extends ReferenceDictionary<OnlineDictionary> {
       finish: string;
     };
   };
+  alerts: {
+    gistError: string;
+    goToHomePage: string;
+    errorDetails: string;
+    responseError: {
+      title: string;
+    };
+    fetchError: {
+      title: string;
+      possibleCauses: string;
+      missingGitHubToken: string;
+      cors: string;
+    };
+  };
 }
 
 export interface OnlineI18n extends OnlineDictionary, CommonI18n {}

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -173,5 +173,19 @@ export const en: OnlineI18n = {
       kogitoDoc: `${en_common.names.kogito} documentation`,
       finish: "Finish the Tour"
     }
+  },
+  alerts: {
+    gistError: `Not able to open this Gist. If you have updated your Gist filename it can take a few seconds until the URL is available to be used.`,
+    goToHomePage: "Go to Home Page",
+    errorDetails: "Error details:",
+    responseError: {
+      title: "An error happened while fetching your file"
+    },
+    fetchError: {
+      title: "An unexpected error happened while trying to fetch your file",
+      possibleCauses: "Possible causes:",
+      missingGitHubToken: `If you're trying to open a private file, make sure to set your GitHub token before. To do it use one of the Editor pages and open the "Set your GitHub token" modal under the Share dropdown.`,
+      cors: "The URL to your file must allow CORS in its response, which should contain the following header:"
+    }
   }
 };

--- a/packages/online-editor/src/index.tsx
+++ b/packages/online-editor/src/index.tsx
@@ -27,7 +27,7 @@ import {
   removeFileExtension
 } from "./common/utils";
 import { GithubService } from "./common/GithubService";
-import { Alert, AlertActionLink, AlertVariant } from "@patternfly/react-core";
+import { Alert, AlertActionLink, AlertActionCloseButton, AlertVariant, List, ListItem } from "@patternfly/react-core";
 import { EditorEnvelopeLocator } from "@kogito-tooling/editor/dist/api";
 import "../static/resources/style.css";
 
@@ -149,7 +149,8 @@ function showResponseError(statusCode: number, description: string) {
       <Alert
         variant={AlertVariant.danger}
         title="An error happened while fetching your file"
-        actionClose={<AlertActionLink onClick={goToHomePage}>Go to Home Page</AlertActionLink>}
+        actionLinks={<AlertActionLink onClick={goToHomePage}>Go to Home Page</AlertActionLink>}
+        actionClose={<AlertActionCloseButton onClose={goToHomePage} />}
       >
         <br />
         <b>Error details: </b>
@@ -168,17 +169,25 @@ function showFetchError(description: string) {
       <Alert
         variant={AlertVariant.danger}
         title="An unexpected error happened while trying to fetch your file"
-        actionClose={<AlertActionLink onClick={goToHomePage} children={"Go to Home Page"} />}
+        actionLinks={<AlertActionLink onClick={goToHomePage}>Go to Home Page</AlertActionLink>}
+        actionClose={<AlertActionCloseButton onClose={goToHomePage} />}
       >
         <br />
         <b>Error details: </b>
         {description}
         <br />
         <br />
-        <b>Possible cause: </b>
-        The URL to your file must allow CORS in its response, which should contain the following header:
-        <br />
-        <pre>Access-Control-Allow-Origin: *</pre>
+        <b>Possible causes: </b>
+        <List>
+          <ListItem>
+            If you're trying to open a private file, make sure to set your GitHub token before. To do it use one of the
+            Editor pages and open the "Set your GitHub token" modal under the Share dropdown.
+          </ListItem>
+          <ListItem>
+            The URL to your file must allow CORS in its response, which should contain the following header:
+            <pre>Access-Control-Allow-Origin: *</pre>
+          </ListItem>
+        </List>
       </Alert>
     </div>,
     document.getElementById("app")!

--- a/packages/online-editor/src/index.tsx
+++ b/packages/online-editor/src/index.tsx
@@ -30,9 +30,13 @@ import { GithubService } from "./common/GithubService";
 import { Alert, AlertActionLink, AlertActionCloseButton, AlertVariant, List, ListItem } from "@patternfly/react-core";
 import { EditorEnvelopeLocator } from "@kogito-tooling/editor/dist/api";
 import "../static/resources/style.css";
+import { I18n } from "@kogito-tooling/i18n/dist/core";
+import { OnlineI18n, onlineI18nDefaults, onlineI18nDictionaries } from "./common/i18n";
 
 const urlParams = new URLSearchParams(window.location.search);
 const githubService = new GithubService();
+const onlineI18n = new I18n<OnlineI18n>(onlineI18nDefaults, onlineI18nDictionaries, "en");
+
 const editorEnvelopeLocator: EditorEnvelopeLocator = {
   targetOrigin: window.location.origin,
   mapping: new Map([
@@ -86,6 +90,7 @@ function waitForEventWithFileData() {
 }
 
 function openFileByUrl() {
+  const i18n = onlineI18n.getCurrent();
   const filePath = urlParams
     .get("file")!
     .split("?")
@@ -96,9 +101,7 @@ function openFileByUrl() {
       .fetchGistFile(filePath)
       .then(content => openFile(filePath, Promise.resolve(content)))
       .catch(error => {
-        showFetchError(
-          `Not able to open this Gist. If you have updated your Gist filename it can take a few seconds until the URL is available to be used.`
-        );
+        showFetchError(i18n.alerts.gistError);
       });
   } else if (githubService.isGithub(filePath) || githubService.isGithubRaw(filePath)) {
     githubService
@@ -144,16 +147,17 @@ function openFile(filePath: string, getFileContent: Promise<string>) {
 }
 
 function showResponseError(statusCode: number, description: string) {
+  const i18n = onlineI18n.getCurrent();
   ReactDOM.render(
     <div className={"kogito--alert-container"}>
       <Alert
         variant={AlertVariant.danger}
-        title="An error happened while fetching your file"
-        actionLinks={<AlertActionLink onClick={goToHomePage}>Go to Home Page</AlertActionLink>}
+        title={i18n.alerts.responseError.title}
+        actionLinks={<AlertActionLink onClick={goToHomePage}>{i18n.alerts.goToHomePage}</AlertActionLink>}
         actionClose={<AlertActionCloseButton onClose={goToHomePage} />}
       >
         <br />
-        <b>Error details: </b>
+        <b>{i18n.alerts.errorDetails}</b>
         {statusCode}
         {statusCode && description && " - "}
         {description}
@@ -164,27 +168,25 @@ function showResponseError(statusCode: number, description: string) {
 }
 
 function showFetchError(description: string) {
+  const i18n = onlineI18n.getCurrent();
   ReactDOM.render(
     <div className={"kogito--alert-container"}>
       <Alert
         variant={AlertVariant.danger}
-        title="An unexpected error happened while trying to fetch your file"
-        actionLinks={<AlertActionLink onClick={goToHomePage}>Go to Home Page</AlertActionLink>}
+        title={i18n.alerts.fetchError.title}
+        actionLinks={<AlertActionLink onClick={goToHomePage}>{i18n.alerts.goToHomePage}</AlertActionLink>}
         actionClose={<AlertActionCloseButton onClose={goToHomePage} />}
       >
         <br />
-        <b>Error details: </b>
+        <b>{i18n.alerts.errorDetails} </b>
         {description}
         <br />
         <br />
-        <b>Possible causes: </b>
+        <b>{i18n.alerts.fetchError.possibleCauses} </b>
         <List>
+          <ListItem>{i18n.alerts.fetchError.missingGitHubToken}</ListItem>
           <ListItem>
-            If you're trying to open a private file, make sure to set your GitHub token before. To do it use one of the
-            Editor pages and open the "Set your GitHub token" modal under the Share dropdown.
-          </ListItem>
-          <ListItem>
-            The URL to your file must allow CORS in its response, which should contain the following header:
+            {i18n.alerts.fetchError.cors}
             <pre>Access-Control-Allow-Origin: *</pre>
           </ListItem>
         </List>

--- a/packages/online-editor/src/index.tsx
+++ b/packages/online-editor/src/index.tsx
@@ -86,7 +86,11 @@ function waitForEventWithFileData() {
 }
 
 function openFileByUrl() {
-  const filePath = urlParams.get("file")!;
+  const filePath = urlParams
+    .get("file")!
+    .split("?")
+    .shift()!;
+
   if (githubService.isGist(filePath)) {
     githubService
       .fetchGistFile(filePath)
@@ -96,7 +100,7 @@ function openFileByUrl() {
           `Not able to open this Gist. If you have updated your Gist filename it can take a few seconds until the URL is available to be used.`
         );
       });
-  } else if (githubService.isGithub(filePath)) {
+  } else if (githubService.isGithub(filePath) || githubService.isGithubRaw(filePath)) {
     githubService
       .fetchGithubFile(filePath)
       .then(response => {

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -87,7 +87,6 @@
   justify-content: center;
   align-items: center;
   padding: 1em;
-  pointer-events: none;
 }
 
 .kogito--alert {


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-4219
https://issues.redhat.com/browse/KOGITO-4220

## Demo
https://user-images.githubusercontent.com/24302289/105213365-602ab680-5b2d-11eb-80f5-c1ba1969ae01.mp4

