### PR TITLE
KOGITO-3718: Importing DMN as Included Model in VS Code on Windows

### DIFF
--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -28,6 +28,7 @@ import { KogitoEdit } from "@kogito-tooling/channel-common-api";
 import { KogitoEditor } from "./KogitoEditor";
 import { VsCodeI18n } from "./i18n";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
+import * as nodePath from "path";
 
 export class KogitoEditableDocument implements CustomDocument {
   private readonly encoder = new TextEncoder();
@@ -53,7 +54,9 @@ export class KogitoEditableDocument implements CustomDocument {
   }
 
   get relativePath() {
-    return vscode.workspace.asRelativePath(this.uri);
+    // For some reason, `asRelativePath` always returns paths with the '/' separator,
+    // so on Windows, we need to replace it to the correct one, which is '\'.
+    return vscode.workspace.asRelativePath(this.uri).replace("/", nodePath.sep);
   }
 
   get fileExtension() {


### PR DESCRIPTION
After analysing this issue more carefully, the issue was that, on Windows, the extension was not correctly identifying the current directory of the open file, and it was always falling back to the root of the Workspace.

A workaround for this issue is to always work on the root folder of the Workspace. Keep in mind that even after this fix, only DMNs on the same folder can be used as Included Models.