### PR TITLE
KOGITO-4130: Add workflow to publish snapshot version of Editors to NPM

### DIFF
--- a/.github/supporting-files/publish_maven_editors_snapshot_version/bpmn-editor-unpacked/package.json
+++ b/.github/supporting-files/publish_maven_editors_snapshot_version/bpmn-editor-unpacked/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@kogito-tooling/bpmn-editor-unpacked",
+  "description": "",
+  "license": "Apache-2.0",
+  "files": [
+    "target/bpmn"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kiegroup/kie-wb-common.git"
+  }
+}

--- a/.github/supporting-files/publish_maven_editors_snapshot_version/dmn-editor-unpacked/package.json
+++ b/.github/supporting-files/publish_maven_editors_snapshot_version/dmn-editor-unpacked/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@kogito-tooling/dmn-editor-unpacked",
+  "description": "",
+  "license": "Apache-2.0",
+  "files": [
+    "target/dmn"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kiegroup/kie-wb-common.git"
+  }
+}

--- a/.github/supporting-files/publish_maven_editors_snapshot_version/scesim-editor-unpacked/package.json
+++ b/.github/supporting-files/publish_maven_editors_snapshot_version/scesim-editor-unpacked/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@kogito-tooling/scesim-editor-unpacked",
+  "description": "",
+  "license": "Apache-2.0",
+  "files": [
+    "target/scesim"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kiegroup/kie-wb-common.git"
+  }
+}

--- a/.github/workflows/publish_maven_editors_snapshot_version.yml
+++ b/.github/workflows/publish_maven_editors_snapshot_version.yml
@@ -156,11 +156,11 @@ jobs:
           yarn run init
           #
           yarn add -W @kogito-tooling/bpmn-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
-          while [ -z `git diff | grep bpmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          while [ -z `git diff | grep 'bpmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"'` ]; do !!; done # Retry until last command succeeds
           yarn add -W @kogito-tooling/dmn-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
-          while [ -z `git diff | grep dmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          while [ -z `git diff | grep 'dmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"'` ]; do !!; done # Retry until last command succeeds
           yarn add -W @kogito-tooling/scesim-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
-          while [ -z `git diff | grep scesim-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          while [ -z `git diff | grep 'scesim-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"'` ]; do !!; done # Retry until last command succeeds
           #
           git config --global user.email "kietooling@gmail.com"
           git config --global user.name "Kogito Tooling Bot (kiegroup)"

--- a/.github/workflows/publish_maven_editors_snapshot_version.yml
+++ b/.github/workflows/publish_maven_editors_snapshot_version.yml
@@ -1,0 +1,174 @@
+name: "Maven :: Publish Editors snapshot version to NPM"
+
+on:
+  workflow_dispatch:
+    inputs:
+      kogitoToolingForkToUpdate:
+        description: 'PR Fork to update (optional)'
+        required: false
+      kogitoToolingBranchToUpdate:
+        description: 'PR Branch to update (optional)'
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout droolsjbpm-build-bootstrap
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/droolsjbpm-build-bootstrap
+          repository: kiegroup/droolsjbpm-build-bootstrap
+          fetch-depth: 0
+
+      - name: Checkout kie-soup
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/kie-soup
+          repository: kiegroup/kie-soup
+          fetch-depth: 0
+
+      - name: Checkout appformer
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/appformer
+          repository: kiegroup/appformer
+          fetch-depth: 0
+
+      - name: Checkout kie-wb-common
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/kie-wb-common
+          repository: kiegroup/kie-wb-common
+          fetch-depth: 0
+      
+      - name: Checkout drools-wb
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/drools-wb
+          repository: kiegroup/drools-wb
+          fetch-depth: 0
+
+      - name: Checkout kogito-tooling
+        uses: actions/checkout@v2
+        if: github.event.inputs.kogitoToolingBranchToUpdate && github.event.inputs.kogitoToolingForkToUpdate
+        with:
+          token: ${{ secrets.KOGITO_TOOLING_BOT_TOKEN }}
+          path: ${{ github.workspace }}/kogito-tooling
+          repository: kiegroup/kogito-tooling
+          fetch-depth: 0
+
+      - name: Build droolsjbpm-build-bootstrap
+        run: |
+          mvn clean install -DskipTests -Dgwt.compiler.skip -Denforcer.skip -T 2 -B
+
+      - name: Build kie-soup
+        run: |
+          mvn clean install -DskipTests -Dgwt.compiler.skip -Denforcer.skip -T 2 -B
+
+      - name: Build appformer
+        run: |
+          mvn clean install -DskipTests -Dgwt.compiler.skip -Denforcer.skip -T 2 -B
+
+      - name: Build kie-wb-common
+        run: |
+          mvn clean install -DskipTests -Denforcer.skip -T 2 -B -am -pl kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime,kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime
+
+      - name: Build drools-wb
+        run: |
+          mvn clean install -DskipTests -Denforcer.skip -pl drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime -am -T 2 -B
+
+      - name: Upload DMN editor
+        uses: actions/upload-artifact@v1
+        with:
+          name: dmn-editor-fdb
+          path: ${{ github.workspace }}/kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/target/kie-wb-common-dmn-webapp-kogito-runtime
+
+      - name: Upload BPMN editor
+        uses: actions/upload-artifact@v1
+        with:
+          name: bpmn-editor-fdb
+          path: ${{ github.workspace }}/kie-wb-common/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/target/kie-wb-common-stunner-bpmn-kogito-runtime
+
+      - name: Upload SceSim editor
+        uses: actions/upload-artifact@v1
+        with:
+          name: scesim-editor-fdb
+          path: ${{ github.workspace }}/drools-wb/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/target/drools-wb-scenario-simulation-editor-kogito-runtime/
+
+      - name: Output new packages version on NPM
+        id: newEditorsVersionOnNpm
+        run: |
+          MVN_VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec -f ${{ github.workspace }}/kie-wb-common`
+          DATE=`date +"%Y%m%d"`
+          TIME=`date +"%H%M%S"`
+          NPM_VERSION=`echo $MVN_VERSION+$DATE.$TIME`
+          echo 'New version is $NPM_VERSION'
+          echo ::set-output name=version::$NPM_VERSION
+      
+      - name: Publish BPMN Editor
+        run: |
+          cd ${{ github.workspace }}/kie-wb-common/.github/supporting-files/publish_maven_editors_snapshot_version/bpmn-editor-unpacked
+          cp -r ${{ github.workspace }}/kie-wb-common/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/target/kie-wb-common-stunner-bpmn-kogito-runtime ./target/bpmn
+          ls -la .
+          npm version ${{ steps.newEditorsVersionOnNpm.outputs.version }}
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.KIEGROUP_NPM_TOKEN }}" > ~/.npmrc
+          npm publish --access public --tag snapshot
+          
+      - name: Publish DMN Editor
+        run: |
+          cd ${{ github.workspace }}/kie-wb-common/.github/supporting-files/publish_maven_editors_snapshot_version/dmn-editor-unpacked
+          cp -r ${{ github.workspace }}/kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/target/kie-wb-common-dmn-webapp-kogito-runtime ./target/dmn
+          ls -la .
+          npm version ${{ steps.newEditorsVersionOnNpm.outputs.version }}
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.KIEGROUP_NPM_TOKEN }}" > ~/.npmrc
+          npm publish --access public --tag snapshot
+          
+      - name: Publish SceSim Editor
+        run: |
+          cd ${{ github.workspace }}/kie-wb-common/.github/supporting-files/publish_maven_editors_snapshot_version/scesim-editor-unpacked
+          cp -r ${{ github.workspace }}/drools-wb/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/target/drools-wb-scenario-simulation-editor-kogito-runtime ./target/scesim
+          ls -la .
+          npm version ${{ steps.newEditorsVersionOnNpm.outputs.version }}
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.KIEGROUP_NPM_TOKEN }}" > ~/.npmrc
+          npm publish --access public --tag snapshot
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        if: github.event.inputs.kogitoToolingBranchToUpdate && github.event.inputs.kogitoToolingForkToUpdate
+        with:
+          node-version: 12.16.3
+
+      - name: Setup Yarn
+        if: github.event.inputs.kogitoToolingBranchToUpdate && github.event.inputs.kogitoToolingForkToUpdate
+        run: npm install -g yarn@1.19.1
+
+      - name: Update kogito-tooling PR branch
+        timeout-minutes: 10
+        if: github.event.inputs.kogitoToolingBranchToUpdate && github.event.inputs.kogitoToolingForkToUpdate
+        run: |
+          cd ${{ github.workspace }}/kogito-tooling
+          git remote add fork-to-update https://kogito-tooling-bot:${{ secrets.KOGITO_TOOLING_BOT_TOKEN }}@github.com/${{ github.event.inputs.kogitoToolingForkToUpdate }}/kogito-tooling.git
+          git fetch fork-to-update
+          git checkout ${{ github.event.inputs.kogitoToolingBranchToUpdate }}
+          yarn run init
+          #
+          yarn add -W @kogito-tooling/bpmn-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
+          while [ -z `git diff | grep bpmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          yarn add -W @kogito-tooling/dmn-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
+          while [ -z `git diff | grep dmn-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          yarn add -W @kogito-tooling/scesim-editor-unpacked@${{ steps.newEditorsVersionOnNpm.outputs.version }} --non-interactive || true
+          while [ -z `git diff | grep scesim-editor-unpacked": "${{ steps.newEditorsVersionOnNpm.outputs.version }}"` ]; do !!; done # Retry until last command succeeds
+          #
+          git config --global user.email "kietooling@gmail.com"
+          git config --global user.name "Kogito Tooling Bot (kiegroup)"
+          git add .
+          git commit -m "Update Editors to ${{ steps.newEditorsVersionOnNpm.outputs.version }}"
+          git push
+
+
+
+
+        


### PR DESCRIPTION
This workflow will build the Editors using the repositories default branches and publish a snapshot version to NPM. Version format is `[version]-SNAPSHOT+[date].[time]`. e.g. `7.49.0-SNAPSHOT+20210126.152301`.

You can also specify two inputs: Fork and Branch names of an open PR on kogito-tooling. This will make the workflow update your PR with the new Editors version.