### PR TITLE
Fix timeout on `yarn run init`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup Yarn
-        run: npm install -g yarn@${{ matrix.yarn }}
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -24,7 +24,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup Yarn
-        run: npm install -g yarn@${{ matrix.yarn }}
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -83,7 +83,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup Yarn
-        run: npm install -g yarn@${{ matrix.yarn }}
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -30,7 +30,9 @@ jobs:
           node-version: 12.16.3
 
       - name: Setup Yarn
-        run: npm install -g yarn@1.19.1
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb
         run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/publish_daily_dev_version.yml
+++ b/.github/workflows/publish_daily_dev_version.yml
@@ -41,7 +41,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup Yarn
-        run: npm install -g yarn@${{ matrix.yarn }}
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish_maven_editors_snapshot_version.yml
+++ b/.github/workflows/publish_maven_editors_snapshot_version.yml
@@ -148,7 +148,9 @@ jobs:
 
       - name: Setup Yarn
         if: github.event.inputs.kogitoToolingBranchToUpdate && github.event.inputs.kogitoToolingForkToUpdate
-        run: npm install -g yarn@1.19.1
+        run: |
+          npm install -g yarn@1.19.1
+          yarn config set network-timeout 1000000
 
       - name: Update kogito-tooling PR branch
         timeout-minutes: 10

--- a/.github/workflows/pull_request_full_downstream_ci.yml
+++ b/.github/workflows/pull_request_full_downstream_ci.yml
@@ -254,7 +254,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Setup Yarn
-        run: npm install -g yarn@${{ matrix.yarn }}
+        run: |
+          npm install -g yarn@${{ matrix.yarn }}
+          yarn config set network-timeout 1000000
 
       - name: Start Xvfb
         run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,6 @@
     "packages/*"
   ],
   "npmClient": "yarn",
+  "npmClientArgs": ["--network-timeout 1000000"],
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,5 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "npmClientArgs": ["--network-timeout 1000000"],
   "useWorkspaces": true
 }


### PR DESCRIPTION
According to https://github.community/t/yarn-esockettimedout-on-windows/118776 and https://github.com/lerna/lerna/tree/main/commands/bootstrap, that's the way to fix it at the moment. I'll keep this issue open and run it 10 times, if I don't observe it anymore, then I think it's reasonable to accept it as a solution.