### PR TITLE
FAI-398: [Scorecard Editor] Back button for Data Dictionary, Mining Schema and Outputs properties view

### DIFF
--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryPropertiesEdit/DataDictionaryPropertiesEdit.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryPropertiesEdit/DataDictionaryPropertiesEdit.tsx
@@ -31,7 +31,7 @@ import {
   TitleSizes,
   Tooltip
 } from "@patternfly/react-core";
-import { HelpIcon } from "@patternfly/react-icons";
+import { ArrowAltCircleLeftIcon, HelpIcon } from "@patternfly/react-icons";
 import { ConstraintType, DDDataField } from "../DataDictionaryContainer/DataDictionaryContainer";
 import ConstraintsEdit from "../ConstraintsEdit/ConstraintsEdit";
 import "./DataDictionaryPropertiesEdit.scss";
@@ -238,6 +238,11 @@ const DataDictionaryPropertiesEdit = (props: DataDictionaryPropertiesEditProps) 
             </SplitItem>
           </Split>
         </Form>
+      </StackItem>
+      <StackItem>
+        <Button variant="primary" onClick={onClose} icon={<ArrowAltCircleLeftIcon />} iconPosition="left">
+          Back
+        </Button>
       </StackItem>
     </Stack>
   );

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaPropertiesEdit/MiningSchemaPropertiesEdit.scss
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaPropertiesEdit/MiningSchemaPropertiesEdit.scss
@@ -6,12 +6,11 @@
     background-color: var(--pf-global--BackgroundColor--200);
 
     &__disabled {
-      background-color: var(--pf-global--BorderColor--100)
+      background-color: var(--pf-global--BorderColor--100);
     }
   }
 
   &__actions {
-    margin-top: var(--pf-global--spacer--lg);
+    margin-top: var(--pf-global--spacer--md);
   }
-
 }

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaPropertiesEdit/MiningSchemaPropertiesEdit.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaPropertiesEdit/MiningSchemaPropertiesEdit.tsx
@@ -455,7 +455,7 @@ const MiningSchemaPropertiesEdit = ({
         </section>
         <section className="mining-schema__edit__actions">
           <Button variant="primary" onClick={onClose} icon={<ArrowAltCircleLeftIcon />} iconPosition="left">
-            Done
+            Back
           </Button>
         </section>
       </StackItem>

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
@@ -213,7 +213,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
                     icon={<ArrowAltCircleLeftIcon />}
                     iconPosition="left"
                   >
-                    Done
+                    Back
                   </Button>
                 </StackItem>
               </Stack>


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/FAI-398

Reintroduced the button to go back from Data Dictionary properties view to the Data Dictionary overview.

All the back buttons in properties views (DD, MS, Outputs) have been renamed from "Done" to "Back".