### PR TITLE
KOGITO-4399: Validation errors does not affect save anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Develop
 > **Example:**
 >
 > $ export EXTERNAL_RESOURCE_PATH__bpmnEditor=/Users/tiago/redhat/kie-wb-common/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/target/kie-wb-common-stunner-bpmn-kogito-runtime
+> 
+> $ export EXTERNAL_RESOURCE_PATH__dmnEditor=/Users/tiago/redhat/kie-wb-common/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/target/kie-wb-common-dmn-webapp-kogito-runtime/
 >
 > $ yarn run init && yarn run build:prod
 >

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -73,12 +73,16 @@ export class KogitoEditableDocument implements CustomDocument {
     try {
       const editor = this.editorStore.get(this.uri);
       if (!editor) {
-        console.error(`Cannot save because there's no open Editor for ${this.uri.fsPath}`);
+        this.vsCodeLogger.error(`Cannot save because there's no open Editor for ${this.uri.fsPath}`);
         return;
       }
 
-      const notifications = await editor.validate();
-      this.vsCodeNotifications.setNotifications(destination.fsPath, notifications);
+      try {
+        const notifications = await editor.validate();
+        this.vsCodeNotifications.setNotifications(destination.fsPath, notifications);
+      } catch (e) {
+        this.vsCodeLogger.warn(`File was not validated: ${e}`);
+      }
 
       const content = await editor.getContent();
       if (cancellation.isCancellationRequested) {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-4399

A try/catch was added to the validation part not to break save.

* https://github.com/kiegroup/appformer/pull/1101
* https://github.com/kiegroup/kogito-tooling/pull/417