### PR TITLE
KOGITO-4346: Move VSCode UI test execution into it-tests github workflow

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -124,7 +124,7 @@ jobs:
           name: kie-editors-standalone-it-tests-videos-${{ matrix.os }}
           path: packages/kie-editors-standalone/it-tests/cypress/videos
 
-  kie-editors-vscode-tests-it:
+  vscode-extension-tests-it:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -123,3 +123,46 @@ jobs:
         with:
           name: kie-editors-standalone-it-tests-videos-${{ matrix.os }}
           path: packages/kie-editors-standalone/it-tests/cypress/videos
+
+  kie-editors-vscode-tests-it:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [12.16.3]
+        yarn: [1.19.1]
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup Yarn
+        run: npm install -g yarn@${{ matrix.yarn }}
+
+      - name: Start Xvfb (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
+      - name: Download dependencies
+        run: yarn run init
+
+      - name: Build repository
+        run: npx lerna run build:prod --scope 'vscode-extension-pack-kogito-kie-editors' --include-dependencies
+
+      - name: Run tests
+        run: npx lerna run test:it --scope 'vscode-extension-pack-kogito-kie-editors'
+        env:
+          DISPLAY: ":99.0"
+
+      - name: Archive test results
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: junit-kie-editors-vscode-${{ matrix.os }}.xml
+          path: "packages/vscode-extension-pack-kogito-kie-editors/it-tests/results/junit.xml"

--- a/packages/vscode-extension-pack-kogito-kie-editors/.gitignore
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 *.dockerimage
 test-resources/
+it-tests/**/results

--- a/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
@@ -1,3 +1,7 @@
 {
-    "retries": 0
+    "retries": 1,
+    "reporter":  "xunit",
+    "reporterOptions": {
+        "output": "./it-tests/results/junit.xml"
+    }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -110,10 +110,10 @@
     "compile": "webpack",
     "watch": "webpack",
     "test": "echo 'No tests to run.'",
-    "ui-test": "yarn run compile && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -u -e ./test-resources -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
+    "test:it": "yarn run compile && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -u -e ./test-resources -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run build:fast",
-    "build:prod:linux:darwin": "yarn run build --mode production --devtool none && yarn run test && yarn run ui-test && yarn run package:prod",
+    "build:prod:linux:darwin": "yarn run build --mode production --devtool none && yarn run test && yarn run package:prod",
     "build:prod:windows": "yarn run build --mode production --devtool none && yarn run test && yarn run package:prod",
     "build:prod": "run-script-os"
   },


### PR DESCRIPTION
Add new job for vscode it tests
Move the tests execution from build:prod
Rename script name from ui-test to test:it
Add archiving of artifacts for it tests of vscode

cc @tiagobento @jstastny-cz 
Videos and screenshot are not possible as of now :) 