### PR TITLE
FAI-348: Score Cards: When characteristic filter matches no rows, filter text is cleared

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsToolbar.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useState } from "react";
 import {
   Button,
   ButtonVariant,
@@ -32,14 +31,14 @@ import { SearchIcon } from "@patternfly/react-icons";
 import "./CharacteristicsToolbar.scss";
 
 interface CharacteristicsToolbarProps {
-  onFilter: (filter: string) => void;
+  filter: string;
+  setFilter: (filter: string) => void;
+  onFilter: () => void;
   onAddCharacteristic: () => void;
 }
 
 export const CharacteristicsToolbar = (props: CharacteristicsToolbarProps) => {
-  const { onFilter, onAddCharacteristic } = props;
-
-  const [filter, setFilter] = useState("");
+  const { filter, setFilter, onFilter, onAddCharacteristic } = props;
 
   return (
     <Toolbar id="characteristics-toolbar" data-testid="characteristics-toolbar">
@@ -74,7 +73,7 @@ export const CharacteristicsToolbar = (props: CharacteristicsToolbarProps) => {
                       data-testid="characteristics-toolbar__submit"
                       variant={ButtonVariant.control}
                       aria-label="filter button for filter input"
-                      onClick={() => onFilter(filter)}
+                      onClick={() => onFilter()}
                     >
                       <SearchIcon />
                     </Button>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
@@ -43,7 +43,6 @@ interface CharacteristicsContainerProps {
   isBaselineScoreRequired: boolean;
   characteristics: Characteristic[];
   filteredCharacteristics: IndexedCharacteristic[];
-  filter: string;
   onFilter: (filter: string) => void;
   deleteCharacteristic: (index: number) => void;
   commit: (index: number | undefined, characteristic: Characteristic) => void;
@@ -58,7 +57,6 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
     isBaselineScoreRequired,
     characteristics,
     filteredCharacteristics,
-    filter,
     onFilter,
     deleteCharacteristic,
     commit
@@ -68,6 +66,7 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
   const { service, getCurrentState } = useHistoryService();
   const dispatch = useBatchDispatch(service, getCurrentState);
 
+  const [filter, setFilter] = useState("");
   const [selectedCharacteristicIndex, setSelectedCharacteristicIndex] = useState<number | undefined>(undefined);
   const [selectedAttributeIndex, setSelectedAttributeIndex] = useState<number | undefined>(undefined);
 
@@ -168,19 +167,24 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
   };
 
   const emptyStateProvider = useMemo(() => {
-    if (filter === "") {
+    if (characteristics.length === 0) {
       return <EmptyStateNoCharacteristics addCharacteristic={onAddCharacteristic} />;
     } else {
       return (
         <Stack hasGutter={true}>
           <StackItem>
-            <CharacteristicsToolbar onFilter={onFilter} onAddCharacteristic={onAddCharacteristic} />
+            <CharacteristicsToolbar
+              filter={filter}
+              setFilter={setFilter}
+              onFilter={() => onFilter(filter)}
+              onAddCharacteristic={onAddCharacteristic}
+            />
             <EmptyStateNoMatchingCharacteristics />
           </StackItem>
         </Stack>
       );
     }
-  }, [filter]);
+  }, [filter, characteristics]);
 
   return (
     <div className="characteristics-container">
@@ -199,7 +203,12 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
               {viewSection === "overview" && (
                 <Stack>
                   <StackItem>
-                    <CharacteristicsToolbar onFilter={onFilter} onAddCharacteristic={onAddCharacteristic} />
+                    <CharacteristicsToolbar
+                      filter={filter}
+                      setFilter={setFilter}
+                      onFilter={() => onFilter(filter)}
+                      onAddCharacteristic={onAddCharacteristic}
+                    />
                   </StackItem>
                   <StackItem className="characteristics-container__overview">
                     <CharacteristicsTable

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
@@ -68,13 +68,13 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
     return [];
   });
 
-  useEffect(() => onFilter(), [modelIndex, characteristics]);
+  useEffect(() => applyFilter(), [modelIndex, characteristics]);
 
-  const doSetFilter = (_filter: string) => {
+  const setLowercaseTrimmedFilter = (_filter: string) => {
     setFilter(_filter.toLowerCase().trim());
   };
 
-  const onFilter = () => {
+  const applyFilter = () => {
     const _filteredCharacteristics = characteristics
       ?.map<IndexedCharacteristic>(
         (_characteristic, index) => ({ index: index, characteristic: _characteristic } as IndexedCharacteristic)
@@ -141,7 +141,7 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
       setActiveOperation(Operation.UPDATE_CHARACTERISTIC);
 
       //Clear filter to ensure new Characteristic is visible
-      doSetFilter("");
+      setLowercaseTrimmedFilter("");
     }
   }, [characteristics]);
 
@@ -224,8 +224,8 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
           <StackItem>
             <CharacteristicsToolbar
               filter={filter}
-              setFilter={doSetFilter}
-              onFilter={() => onFilter()}
+              setFilter={setLowercaseTrimmedFilter}
+              onFilter={applyFilter}
               onAddCharacteristic={onAddCharacteristic}
             />
             <EmptyStateNoMatchingCharacteristics />
@@ -254,8 +254,8 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
                   <StackItem>
                     <CharacteristicsToolbar
                       filter={filter}
-                      setFilter={doSetFilter}
-                      onFilter={() => onFilter()}
+                      setFilter={setLowercaseTrimmedFilter}
+                      onFilter={applyFilter}
                       onAddCharacteristic={onAddCharacteristic}
                     />
                   </StackItem>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CharacteristicsContainer.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Stack, StackItem } from "@patternfly/react-core";
 import { Operation } from "../Operation";
 import { CharacteristicsTable, IndexedCharacteristic } from "./CharacteristicsTable";
@@ -28,12 +28,13 @@ import {
   EmptyStateNoCharacteristics,
   EmptyStateNoMatchingCharacteristics
 } from "../molecules";
-import { Characteristic } from "@kogito-tooling/pmml-editor-marshaller";
+import { Characteristic, Model, PMML, Scorecard } from "@kogito-tooling/pmml-editor-marshaller";
 import { isEqual } from "lodash";
 import { findIncrementalName } from "../../../PMMLModelHelper";
 import { useBatchDispatch, useHistoryService } from "../../../history";
 import { useOperation } from "../OperationContext";
 import { fromText } from "./PredicateConverter";
+import { useSelector } from "react-redux";
 import set = Reflect.set;
 import get = Reflect.get;
 
@@ -41,36 +42,50 @@ interface CharacteristicsContainerProps {
   modelIndex: number;
   areReasonCodesUsed: boolean;
   isBaselineScoreRequired: boolean;
-  characteristics: Characteristic[];
-  filteredCharacteristics: IndexedCharacteristic[];
-  onFilter: (filter: string) => void;
-  deleteCharacteristic: (index: number) => void;
-  commit: (index: number | undefined, characteristic: Characteristic) => void;
 }
 
 type CharacteristicsViewSection = "overview" | "attribute";
 
 export const CharacteristicsContainer = (props: CharacteristicsContainerProps) => {
-  const {
-    modelIndex,
-    areReasonCodesUsed,
-    isBaselineScoreRequired,
-    characteristics,
-    filteredCharacteristics,
-    onFilter,
-    deleteCharacteristic,
-    commit
-  } = props;
+  const { modelIndex, areReasonCodesUsed, isBaselineScoreRequired } = props;
 
   const { setActiveOperation } = useOperation();
   const { service, getCurrentState } = useHistoryService();
   const dispatch = useBatchDispatch(service, getCurrentState);
 
   const [filter, setFilter] = useState("");
+  const [filteredCharacteristics, setFilteredCharacteristics] = useState<IndexedCharacteristic[]>([]);
   const [selectedCharacteristicIndex, setSelectedCharacteristicIndex] = useState<number | undefined>(undefined);
   const [selectedAttributeIndex, setSelectedAttributeIndex] = useState<number | undefined>(undefined);
-
   const [viewSection, setViewSection] = useState<CharacteristicsViewSection>("overview");
+
+  const characteristics: Characteristic[] = useSelector<PMML, Characteristic[]>((state: PMML) => {
+    const _model: Model | undefined = state.models ? state.models[props.modelIndex] : undefined;
+    if (_model && _model instanceof Scorecard) {
+      const scorecard = _model as Scorecard;
+      return scorecard.Characteristics.Characteristic;
+    }
+    return [];
+  });
+
+  useEffect(() => onFilter(), [modelIndex, characteristics]);
+
+  const doSetFilter = (_filter: string) => {
+    setFilter(_filter.toLowerCase().trim());
+  };
+
+  const onFilter = () => {
+    const _filteredCharacteristics = characteristics
+      ?.map<IndexedCharacteristic>(
+        (_characteristic, index) => ({ index: index, characteristic: _characteristic } as IndexedCharacteristic)
+      )
+      .filter(ic => {
+        const _characteristicName = ic.characteristic.name;
+        return _characteristicName?.toLowerCase().includes(filter);
+      });
+    setFilteredCharacteristics(_filteredCharacteristics ?? []);
+  };
+
   const getTransition = (_viewSection: CharacteristicsViewSection) => {
     if (_viewSection === "overview") {
       return "characteristics-container__overview";
@@ -112,15 +127,38 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
       const existingNames: string[] = characteristics.map(c => c.name ?? "");
       const newCharacteristicName = findIncrementalName("New characteristic", existingNames, 1);
 
-      commit(undefined, {
-        name: newCharacteristicName,
-        baselineScore: 0,
-        reasonCode: undefined,
-        Attribute: []
+      dispatch({
+        type: Actions.Scorecard_AddCharacteristic,
+        payload: {
+          modelIndex: modelIndex,
+          name: newCharacteristicName,
+          baselineScore: 0,
+          reasonCode: undefined,
+          Attribute: []
+        }
       });
+
       setActiveOperation(Operation.UPDATE_CHARACTERISTIC);
+
+      //Clear filter to ensure new Characteristic is visible
+      doSetFilter("");
     }
   }, [characteristics]);
+
+  const deleteCharacteristic = useCallback(
+    (characteristicIndex: number) => {
+      if (window.confirm(`Delete Characteristic "${characteristics?.[characteristicIndex].name}"?`)) {
+        dispatch({
+          type: Actions.Scorecard_DeleteCharacteristic,
+          payload: {
+            modelIndex: modelIndex,
+            characteristicIndex: characteristicIndex
+          }
+        });
+      }
+    },
+    [characteristics]
+  );
 
   const onAddAttribute = useCallback(() => {
     if (selectedCharacteristicIndex === undefined) {
@@ -148,18 +186,29 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
     onCancel();
   };
 
-  const onCommit = (partial: Partial<Characteristic>) => {
-    if (selectedCharacteristicIndex === undefined) {
-      return;
-    }
-    const characteristic = characteristics[selectedCharacteristicIndex];
-    const existingPartial: Partial<Characteristic> = {};
-    Object.keys(partial).forEach(key => set(existingPartial, key, get(characteristic, key)));
+  const onCommit = useCallback(
+    (partial: Partial<Characteristic>) => {
+      if (selectedCharacteristicIndex === undefined) {
+        return;
+      }
+      const characteristic = characteristics[selectedCharacteristicIndex];
+      const existingPartial: Partial<Characteristic> = {};
+      Object.keys(partial).forEach(key => set(existingPartial, key, get(characteristic, key)));
 
-    if (!isEqual(partial, existingPartial)) {
-      commit(selectedCharacteristicIndex, { ...characteristic, ...partial });
-    }
-  };
+      if (!isEqual(partial, existingPartial)) {
+        dispatch({
+          type: Actions.Scorecard_UpdateCharacteristic,
+          payload: {
+            modelIndex: modelIndex,
+            characteristicIndex: selectedCharacteristicIndex,
+            ...characteristic,
+            ...partial
+          }
+        });
+      }
+    },
+    [characteristics]
+  );
 
   const onCancel = () => {
     setSelectedCharacteristicIndex(undefined);
@@ -175,8 +224,8 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
           <StackItem>
             <CharacteristicsToolbar
               filter={filter}
-              setFilter={setFilter}
-              onFilter={() => onFilter(filter)}
+              setFilter={doSetFilter}
+              onFilter={() => onFilter()}
               onAddCharacteristic={onAddCharacteristic}
             />
             <EmptyStateNoMatchingCharacteristics />
@@ -205,8 +254,8 @@ export const CharacteristicsContainer = (props: CharacteristicsContainerProps) =
                   <StackItem>
                     <CharacteristicsToolbar
                       filter={filter}
-                      setFilter={setFilter}
-                      onFilter={() => onFilter(filter)}
+                      setFilter={doSetFilter}
+                      onFilter={() => onFilter()}
                       onAddCharacteristic={onAddCharacteristic}
                     />
                   </StackItem>

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { PageSection, PageSectionVariants } from "@patternfly/react-core";
 import { EditorHeader } from "../../EditorCore/molecules";
-import {
-  Characteristics,
-  MiningSchema,
-  Model,
-  Output,
-  OutputField,
-  PMML,
-  Scorecard
-} from "@kogito-tooling/pmml-editor-marshaller";
-import { CharacteristicsContainer, CorePropertiesTable, IndexedCharacteristic } from "../organisms";
+import { MiningSchema, Model, Output, OutputField, PMML, Scorecard } from "@kogito-tooling/pmml-editor-marshaller";
+import { CharacteristicsContainer, CorePropertiesTable } from "../organisms";
 import { getModelName } from "../../..";
 import { Actions } from "../../../reducers";
 import { useSelector } from "react-redux";
@@ -45,8 +37,6 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
   const { service, getCurrentState } = useHistoryService();
   const dispatch = useBatchDispatch(service, getCurrentState);
 
-  const [filteredCharacteristics, setFilteredCharacteristics] = useState<IndexedCharacteristic[]>([]);
-
   const model: Scorecard | undefined = useSelector<PMML, Scorecard | undefined>((state: PMML) => {
     const _model: Model | undefined = state.models ? state.models[props.modelIndex] : undefined;
     if (_model && _model instanceof Scorecard) {
@@ -55,11 +45,8 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
     return undefined;
   });
 
-  const characteristics: Characteristics | undefined = useMemo(() => model?.Characteristics, [model]);
   const miningSchema: MiningSchema | undefined = useMemo(() => model?.MiningSchema, [model]);
   const output: Output | undefined = useMemo(() => model?.Output, [model]);
-
-  useEffect(() => onFilter(""), [modelIndex]);
 
   const validateOutputName = useCallback(
     (index: number | undefined, name: string): boolean => {
@@ -72,17 +59,6 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
     },
     [output]
   );
-
-  const onFilter = (filter: string) => {
-    const _lowerCaseFilter = filter.toLowerCase();
-    const _filteredCharacteristics = characteristics?.Characteristic.map<IndexedCharacteristic>(
-      (_characteristic, index) => ({ index: index, characteristic: _characteristic } as IndexedCharacteristic)
-    ).filter(ic => {
-      const _characteristicName = ic.characteristic.name;
-      return _characteristicName?.toLowerCase().includes(_lowerCaseFilter);
-    });
-    setFilteredCharacteristics(_filteredCharacteristics ?? []);
-  };
 
   return (
     <div data-testid="editor-page" className={"editor"}>
@@ -175,44 +151,6 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
                 modelIndex={modelIndex}
                 areReasonCodesUsed={model.useReasonCodes ?? true}
                 isBaselineScoreRequired={(model.useReasonCodes ?? true) && model.baselineScore === undefined}
-                characteristics={characteristics?.Characteristic ?? []}
-                filteredCharacteristics={filteredCharacteristics}
-                onFilter={onFilter}
-                deleteCharacteristic={index => {
-                  if (window.confirm(`Delete Characteristic "${characteristics?.Characteristic[index].name}"?`)) {
-                    dispatch({
-                      type: Actions.Scorecard_DeleteCharacteristic,
-                      payload: {
-                        modelIndex: modelIndex,
-                        characteristicIndex: index
-                      }
-                    });
-                  }
-                }}
-                commit={(_index, _characteristic) => {
-                  if (_index === undefined) {
-                    dispatch({
-                      type: Actions.Scorecard_AddCharacteristic,
-                      payload: {
-                        modelIndex: modelIndex,
-                        name: _characteristic.name,
-                        reasonCode: _characteristic.reasonCode,
-                        baselineScore: _characteristic.baselineScore
-                      }
-                    });
-                  } else {
-                    dispatch({
-                      type: Actions.Scorecard_UpdateCharacteristic,
-                      payload: {
-                        modelIndex: modelIndex,
-                        characteristicIndex: _index,
-                        name: _characteristic.name,
-                        reasonCode: _characteristic.reasonCode,
-                        baselineScore: _characteristic.baselineScore
-                      }
-                    });
-                  }
-                }}
               />
             </PageSection>
           </PageSection>


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-348

@sjamboro This can be tested as follows:-
- Open a Scorecard with Characteristics
- Enter a value in the Characteristics filter `TextBox` and press enter/click magnifying glass icon
- The view should show the filtered Characteristics. The Filter text remains as entered.
- Change the filter so that no Characteristics match
- The view should show some text about nothing matching. The Filter text remains as entered.

The last step was previously the bug. The Filter text would become empty.