### PR TITLE
FAI-384: Score Cards: Move validation to post-commit update

### DIFF
--- a/packages/pmml-editor/src/__tests__/editor/history/HistoryProvider.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/history/HistoryProvider.test.ts
@@ -106,4 +106,21 @@ describe("HistoryProvider", () => {
     const updated4: PMML = service.redo(updated3);
     expect(updated4).toStrictEqual(updated1);
   });
+
+  test("Validation", () => {
+    const validator = jest.fn();
+    service.batch(
+      pmml,
+      null,
+      draft => {
+        draft.Header = header1;
+      },
+      validator
+    );
+
+    const updated: PMML = service.commit(pmml) as PMML;
+    expect(updated).not.toStrictEqual(pmml);
+
+    expect(validator).toBeCalled();
+  });
 });

--- a/packages/pmml-editor/src/editor/PMMLModelHelper.ts
+++ b/packages/pmml-editor/src/editor/PMMLModelHelper.ts
@@ -19,14 +19,20 @@ import {
   AssociationModel,
   BaselineModel,
   BayesianNetworkModel,
+  Characteristics,
   ClusteringModel,
+  DataDictionary,
   GaussianProcessModel,
   GeneralRegressionModel,
+  MiningField,
   MiningModel,
+  MiningSchema,
   Model,
   NaiveBayesModel,
   NearestNeighborModel,
   NeuralNetwork,
+  Output,
+  PMML,
   RegressionModel,
   RuleSetModel,
   Scorecard,
@@ -36,7 +42,8 @@ import {
   TimeSeriesModel,
   TreeModel
 } from "@kogito-tooling/pmml-editor-marshaller";
-import get = Reflect.get;
+import { Builder } from "./paths";
+import { get } from "lodash";
 
 const ICON_BASE: string = "images/";
 const ICON_DEFAULT: string = "card-icon-default.svg";
@@ -274,4 +281,74 @@ export const findIncrementalName = (name: string, existingNames: string[], start
     counter++;
   } while (newName.length === 0);
   return newName;
+};
+
+export const getDataDictionary = (pmml: PMML): DataDictionary | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forDataDictionary()
+      .build().path
+  );
+};
+
+export const getMiningSchema = (pmml: PMML, modelIndex: number): MiningSchema | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forMiningSchema()
+      .build().path
+  );
+};
+
+export const getMiningField = (pmml: PMML, modelIndex: number, miningFieldIndex: number): MiningField | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forMiningSchema()
+      .forMiningField(miningFieldIndex)
+      .build().path
+  );
+};
+
+export const getOutputs = (pmml: PMML, modelIndex: number): Output | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forOutput()
+      .build().path
+  );
+};
+
+export const getCharacteristics = (pmml: PMML, modelIndex: number): Characteristics | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forCharacteristics()
+      .build().path
+  );
+};
+
+export const getBaselineScore = (pmml: PMML, modelIndex: number): number | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forBaselineScore()
+      .build().path
+  );
+};
+
+export const getUseReasonCodes = (pmml: PMML, modelIndex: number): boolean | undefined => {
+  return get(
+    pmml,
+    Builder()
+      .forModel(modelIndex)
+      .forUseReasonCodes()
+      .build().path
+  );
 };

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
@@ -92,7 +92,7 @@ const MiningSchemaContainer = (props: MiningSchemaContainerProps) => {
           .forMiningSchema()
           .build()
       ),
-    [miningSchema]
+    [dataDictionary, miningSchema]
   );
 
   return (
@@ -142,6 +142,7 @@ const MiningSchemaContainer = (props: MiningSchemaContainerProps) => {
                             <>
                               <MiningSchemaFields
                                 modelIndex={modelIndex}
+                                dataDictionary={dataDictionary}
                                 fields={miningSchema?.MiningField}
                                 onAddProperties={goToProperties}
                                 onDelete={handleDeleteField}

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useContext, useMemo } from "react";
 import { Button, Flex, FlexItem, Split, SplitItem } from "@patternfly/react-core";
 import { TrashIcon } from "@patternfly/react-icons";
-import { MiningField } from "@kogito-tooling/pmml-editor-marshaller";
+import { DataDictionary, MiningField } from "@kogito-tooling/pmml-editor-marshaller";
 import { MiningSchemaContext } from "../MiningSchemaContainer/MiningSchemaContainer";
 import useOnclickOutside from "react-cool-onclickoutside";
 import MiningSchemaFieldLabels from "../MiningSchemaFieldLabels/MiningSchemaFieldLabels";
@@ -13,6 +13,7 @@ import { ValidationIndicator } from "../../EditorCore/atoms";
 
 interface MiningSchemaFieldsProps {
   modelIndex: number;
+  dataDictionary?: DataDictionary;
   fields: MiningField[] | undefined;
   onAddProperties: (index: number) => void;
   onDelete: (index: number, name: string) => void;
@@ -22,13 +23,14 @@ interface MiningSchemaFieldsProps {
 }
 
 const MiningSchemaFields = (props: MiningSchemaFieldsProps) => {
-  const { fields, modelIndex, onAddProperties, onDelete, onPropertyDelete, onEdit, onCancel } = props;
+  const { dataDictionary, fields, modelIndex, onAddProperties, onDelete, onPropertyDelete, onEdit, onCancel } = props;
   return (
     <ul className="mining-schema-list">
       {fields?.map((field, index) => {
         return (
           <MiningSchemaItem
             key={field.name as string}
+            dataDictionary={dataDictionary}
             field={field}
             index={index}
             modelIndex={modelIndex}
@@ -49,6 +51,7 @@ export default MiningSchemaFields;
 interface MiningSchemaFieldProps {
   index: number;
   modelIndex: number;
+  dataDictionary?: DataDictionary;
   field: MiningField;
   onAddProperties: (index: number) => void;
   onDelete: (index: number, name: string) => void;
@@ -58,7 +61,17 @@ interface MiningSchemaFieldProps {
 }
 
 const MiningSchemaItem = (props: MiningSchemaFieldProps) => {
-  const { index, modelIndex, field, onAddProperties, onDelete, onPropertyDelete, onEdit, onCancel } = props;
+  const {
+    index,
+    modelIndex,
+    dataDictionary,
+    field,
+    onAddProperties,
+    onDelete,
+    onPropertyDelete,
+    onEdit,
+    onCancel
+  } = props;
   const editing = useContext(MiningSchemaContext);
 
   const ref = useOnclickOutside(
@@ -99,7 +112,7 @@ const MiningSchemaItem = (props: MiningSchemaFieldProps) => {
           .forMiningField(index)
           .build()
       ),
-    [index, modelIndex, field]
+    [index, modelIndex, dataDictionary, field]
   );
 
   return (

--- a/packages/pmml-editor/src/editor/paths/PathBuilders.ts
+++ b/packages/pmml-editor/src/editor/paths/PathBuilders.ts
@@ -77,6 +77,10 @@ class ModelBuilder extends BaseBuilder {
     return new BaselineScoreBuilder(this.builders);
   };
 
+  public forUseReasonCodes = () => {
+    return new UseReasonCodesBuilder(this.builders);
+  };
+
   public forCharacteristics = () => {
     return new CharacteristicsBuilder(this.builders);
   };
@@ -218,6 +222,17 @@ class BaselineScoreBuilder extends BaseBuilder {
 
   protected segment(): string {
     return `baselineScore`;
+  }
+}
+
+class UseReasonCodesBuilder extends BaseBuilder {
+  constructor(protected builders: Builders) {
+    super(builders);
+    this.builders.add(this);
+  }
+
+  protected segment(): string {
+    return `useReasonCodes`;
   }
 }
 

--- a/packages/pmml-editor/src/editor/reducers/AttributesReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/AttributesReducer.ts
@@ -18,7 +18,6 @@ import { HistoryAwareReducer, HistoryService } from "../history";
 import { Attribute, CompoundPredicate, Predicate, SimplePredicate } from "@kogito-tooling/pmml-editor-marshaller";
 import { Reducer } from "react";
 import { immerable } from "immer";
-import { ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
 
 // @ts-ignore

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
@@ -26,6 +26,7 @@ import {
   ValidationRegistry
 } from "../validation";
 import { Builder } from "../paths";
+import { getMiningSchema } from "../PMMLModelHelper";
 
 interface DataDictionaryFieldPayload {
   [Actions.UpdateDataDictionaryField]: {
@@ -94,6 +95,8 @@ export const DataDictionaryFieldReducer: HistoryAwareValidatingReducer<DataField
 
               draft[dataDictionaryIndex] = dataField;
             }
+          },
+          pmml => {
             validationRegistry.clear(
               Builder()
                 .forDataDictionary()

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
@@ -26,7 +26,6 @@ import {
   ValidationRegistry
 } from "../validation";
 import { Builder } from "../paths";
-import { getMiningSchema } from "../PMMLModelHelper";
 
 interface DataDictionaryFieldPayload {
   [Actions.UpdateDataDictionaryField]: {
@@ -96,7 +95,7 @@ export const DataDictionaryFieldReducer: HistoryAwareValidatingReducer<DataField
               draft[dataDictionaryIndex] = dataField;
             }
           },
-          pmml => {
+          () => {
             validationRegistry.clear(
               Builder()
                 .forDataDictionary()

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
@@ -22,6 +22,7 @@ import { Builder } from "../paths";
 
 interface DataDictionaryPayload {
   [Actions.AddDataDictionaryField]: {
+    readonly modelIndex?: number;
     readonly name?: string;
     readonly type: DataType;
     readonly optype: OpType;

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
@@ -32,6 +32,7 @@ interface DataDictionaryPayload {
     readonly index: number;
   };
   [Actions.AddBatchDataDictionaryFields]: {
+    readonly modelIndex?: number;
     readonly dataDictionaryFields: FieldName[];
   };
   [Actions.ReorderDataDictionaryFields]: {

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
@@ -27,6 +27,7 @@ interface DataDictionaryPayload {
     readonly optype: OpType;
   };
   [Actions.DeleteDataDictionaryField]: {
+    readonly modelIndex?: number;
     readonly index: number;
   };
   [Actions.AddBatchDataDictionaryFields]: {
@@ -73,12 +74,14 @@ export const DataDictionaryReducer: HistoryAwareValidatingReducer<DataDictionary
             if (index >= 0 && index < draft.DataField.length) {
               draft.DataField.splice(index, 1);
             }
+          },
+          pmml => {
             validationRegistry.clear(
               Builder()
                 .forDataDictionary()
                 .build()
             );
-            validateDataFields(draft.DataField, validationRegistry);
+            validateDataFields(pmml.DataDictionary.DataField, validationRegistry);
           }
         );
         break;
@@ -92,12 +95,14 @@ export const DataDictionaryReducer: HistoryAwareValidatingReducer<DataDictionary
           draft => {
             const [removed] = draft.DataField.splice(action.payload.oldIndex, 1);
             draft.DataField.splice(action.payload.newIndex, 0, removed);
+          },
+          pmml => {
             validationRegistry.clear(
               Builder()
                 .forDataDictionary()
                 .build()
             );
-            validateDataFields(draft.DataField, validationRegistry);
+            validateDataFields(pmml.DataDictionary.DataField, validationRegistry);
           }
         );
         break;

--- a/packages/pmml-editor/src/editor/reducers/MiningSchemaFieldReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/MiningSchemaFieldReducer.ts
@@ -166,6 +166,7 @@ export const MiningSchemaFieldReducer: HistoryAwareValidatingReducer<MiningField
       //Note no break here, since we want the validation below to apply.
       case Actions.AddDataDictionaryField:
       case Actions.DeleteDataDictionaryField:
+      case Actions.AddBatchDataDictionaryFields:
         historyService.batch(
           state,
           Builder()

--- a/packages/pmml-editor/src/editor/reducers/MiningSchemaReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/MiningSchemaReducer.ts
@@ -20,6 +20,7 @@ import { FieldName, MiningSchema } from "@kogito-tooling/pmml-editor-marshaller"
 import { ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
 import { validateMiningFields } from "../validation/MiningSchema";
+import { getMiningSchema } from "../PMMLModelHelper";
 
 interface MiningSchemaPayload {
   [Actions.AddMiningSchemaFields]: {
@@ -70,13 +71,19 @@ export const MiningSchemaReducer: HistoryAwareValidatingReducer<MiningSchema, Al
             if (miningSchemaIndex >= 0 && miningSchemaIndex < draft.MiningField.length) {
               draft.MiningField.splice(miningSchemaIndex, 1);
             }
-            validationRegistry.clear(
-              Builder()
-                .forModel(action.payload.modelIndex)
-                .forMiningSchema()
-                .build()
-            );
-            validateMiningFields(action.payload.modelIndex, draft.MiningField, validationRegistry);
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            if (miningSchema !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forMiningSchema()
+                  .build()
+              );
+              validateMiningFields(modelIndex, miningSchema.MiningField, validationRegistry);
+            }
           }
         );
     }

--- a/packages/pmml-editor/src/editor/reducers/ModelReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/ModelReducer.ts
@@ -45,7 +45,9 @@ export const ModelReducer: HistoryAwareValidatingReducer<Model[], AllActions> = 
     MiningSchema: mergeReducers(MiningSchemaReducer(historyService, validationRegistry), {
       MiningField: MiningSchemaFieldReducer(historyService, validationRegistry)
     }),
-    Output: mergeReducers(OutputReducer(historyService), { OutputField: OutputFieldReducer(historyService) }),
+    Output: mergeReducers(OutputReducer(historyService, validationRegistry), {
+      OutputField: OutputFieldReducer(historyService, validationRegistry)
+    }),
     Characteristics: mergeReducers(CharacteristicsReducer(historyService), {
       Characteristic: CharacteristicReducer(historyService)
     })

--- a/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
@@ -194,6 +194,7 @@ export const OutputReducer: HistoryAwareValidatingReducer<Output, AllActions> = 
             state,
             Builder()
               .forModel(modelIndex)
+              .forOutput()
               .build(),
             draft => {
               state.OutputField.forEach((outputField, outputFieldIndex) => {
@@ -229,6 +230,7 @@ export const OutputReducer: HistoryAwareValidatingReducer<Output, AllActions> = 
             state,
             Builder()
               .forModel(modelIndex)
+              .forOutput()
               .build(),
             draft => {
               if (action.payload.usageType !== "target") {

--- a/packages/pmml-editor/src/editor/reducers/PMMLReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/PMMLReducer.ts
@@ -15,12 +15,12 @@
  */
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
-import { MiningSchema, PMML } from "@kogito-tooling/pmml-editor-marshaller";
+import { PMML } from "@kogito-tooling/pmml-editor-marshaller";
 import { Reducer } from "react";
 import { ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
 import { validateMiningFieldsDataFieldReference } from "../validation/MiningSchema";
-import get = Reflect.get;
+import { getMiningSchema } from "../PMMLModelHelper";
 
 interface PMMLPayload {
   [Actions.Refresh]: {
@@ -68,7 +68,7 @@ export const PMMLReducer: HistoryAwareValidatingReducer<PMML, AllActions> = (
         const dataFields = state.DataDictionary.DataField;
         const models = state.models ?? [];
         models.forEach((model, modelIndex) => {
-          const miningSchema = get(model, "MiningSchema");
+          const miningSchema = getMiningSchema(state, modelIndex);
           if (miningSchema !== undefined) {
             validationRegistry.clear(
               Builder()
@@ -79,7 +79,7 @@ export const PMMLReducer: HistoryAwareValidatingReducer<PMML, AllActions> = (
             validateMiningFieldsDataFieldReference(
               modelIndex,
               dataFields,
-              (miningSchema as MiningSchema).MiningField,
+              miningSchema.MiningField,
               validationRegistry
             );
           }

--- a/packages/pmml-editor/src/editor/reducers/ScorecardReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/ScorecardReducer.ts
@@ -20,7 +20,6 @@ import {
   CompoundPredicate,
   False,
   FieldName,
-  MiningField,
   MiningFunction,
   Predicate,
   ReasonCodeAlgorithm,
@@ -34,11 +33,12 @@ import { immerable } from "immer";
 import { CharacteristicsActions } from "./CharacteristicsReducer";
 import { CharacteristicActions } from "./CharacteristicReducer";
 import { AttributesActions } from "./AttributesReducer";
-import { isOutputsTargetFieldRequired, validateOutput, validateOutputs } from "../validation/Outputs";
-import { ValidationEntry, ValidationLevel, ValidationRegistry } from "../validation";
+import { validateOutputs } from "../validation/Outputs";
+import { ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
 import { validateCharacteristic, validateCharacteristics } from "../validation/Characteristics";
 import { validateBaselineScore } from "../validation/ModelCoreProperties";
+import { getBaselineScore, getCharacteristics, getMiningSchema, getUseReasonCodes } from "../PMMLModelHelper";
 
 // @ts-ignore
 Scorecard[immerable] = true;
@@ -72,130 +72,6 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
 ): Reducer<Scorecard, AllActions> => {
   return (state: Scorecard, action: AllActions) => {
     switch (action.type) {
-      case Actions.AddMiningSchemaFields:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forCharacteristics()
-            .build()
-        );
-        validateCharacteristics(
-          action.payload.modelIndex,
-          { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-          state.Characteristics.Characteristic,
-          state.MiningSchema.MiningField.concat(action.payload.names.map(n => new MiningField({ name: n }))),
-          validationRegistry
-        );
-
-        break;
-
-      case Actions.Scorecard_AddAttribute:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forCharacteristics()
-            .forCharacteristic(action.payload.characteristicIndex)
-            .build()
-        );
-        validateCharacteristic(
-          action.payload.modelIndex,
-          { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-          action.payload.characteristicIndex,
-          {
-            ...state.Characteristics.Characteristic[action.payload.characteristicIndex],
-            Attribute: [
-              ...state.Characteristics.Characteristic[action.payload.characteristicIndex].Attribute,
-              {
-                predicate: action.payload.predicate,
-                partialScore: action.payload.partialScore,
-                reasonCode: action.payload.reasonCode
-              }
-            ]
-          },
-          state.MiningSchema.MiningField,
-          validationRegistry
-        );
-        break;
-
-      case Actions.Scorecard_DeleteAttribute:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forCharacteristics()
-            .forCharacteristic(action.payload.characteristicIndex)
-            .build()
-        );
-        validateCharacteristic(
-          action.payload.modelIndex,
-          { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-          action.payload.characteristicIndex,
-          {
-            ...state.Characteristics.Characteristic[action.payload.characteristicIndex],
-            Attribute: state.Characteristics.Characteristic[action.payload.characteristicIndex].Attribute.filter(
-              (attribute, attributeIndex) => attributeIndex !== action.payload.attributeIndex
-            )
-          },
-          state.MiningSchema.MiningField,
-          validationRegistry
-        );
-        break;
-
-      case Actions.Scorecard_UpdateAttribute:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forCharacteristics()
-            .build()
-        );
-        validateCharacteristics(
-          action.payload.modelIndex,
-          { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-          state.Characteristics.Characteristic.map((characteristic, characteristicIndex) => {
-            if (characteristicIndex === action.payload.characteristicIndex) {
-              const attributes = characteristic.Attribute.map((attribute, attributeIndex) => {
-                if (attributeIndex === action.payload.attributeIndex) {
-                  return {
-                    ...attribute,
-                    predicate: action.payload.predicate,
-                    reasonCode: action.payload.reasonCode,
-                    partialScore: action.payload.partialScore
-                  };
-                }
-                return attribute;
-              });
-              return {
-                ...characteristic,
-                Attribute: attributes
-              };
-            }
-            return characteristic;
-          }),
-          state.MiningSchema.MiningField,
-          validationRegistry
-        );
-
-        break;
-
-      case Actions.UpdateDataDictionaryField:
-        if (action.payload.modelIndex !== undefined) {
-          const modelIndex = action.payload.modelIndex;
-          state.Characteristics.Characteristic.forEach((characteristic, characteristicIndex) => {
-            characteristic.Attribute.forEach((attribute, attributeIndex) => {
-              updatePredicateFieldName(
-                modelIndex,
-                characteristicIndex,
-                attributeIndex,
-                attribute.predicate,
-                action.payload.dataField.name,
-                action.payload.originalName,
-                historyService
-              );
-            });
-          });
-        }
-
-        break;
-
       case Actions.Scorecard_SetModelName:
         historyService.batch(
           state,
@@ -234,349 +110,301 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
                 characteristic.baselineScore = undefined;
               });
             }
-            validationRegistry.clear(
-              Builder()
-                .forModel(action.payload.modelIndex)
-                .forBaselineScore()
-                .build()
-            );
-            validateBaselineScore(
-              action.payload.modelIndex,
-              action.payload.useReasonCodes,
-              action.payload.baselineScore,
-              state.Characteristics.Characteristic,
-              validationRegistry
-            );
-            validationRegistry.clear(
-              Builder()
-                .forModel(action.payload.modelIndex)
-                .forCharacteristics()
-                .build()
-            );
-            validateCharacteristics(
-              action.payload.modelIndex,
-              {
-                baselineScore: action.payload.baselineScore,
-                useReasonCodes: action.payload.useReasonCodes
-              },
-              state.Characteristics.Characteristic,
-              state.MiningSchema.MiningField,
-              validationRegistry
-            );
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (miningSchema !== undefined && characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forBaselineScore()
+                  .build()
+              );
+              validateBaselineScore(
+                modelIndex,
+                useReasonCodes,
+                baselineScore,
+                characteristics.Characteristic,
+                validationRegistry
+              );
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forCharacteristics()
+                  .build()
+              );
+              validateCharacteristics(
+                modelIndex,
+                {
+                  baselineScore: baselineScore,
+                  useReasonCodes: useReasonCodes
+                },
+                characteristics.Characteristic,
+                miningSchema.MiningField,
+                validationRegistry
+              );
+            }
+          }
+        );
+        break;
+
+      case Actions.Scorecard_AddCharacteristic:
+        historyService.batch(
+          state,
+          Builder()
+            .forModel(action.payload.modelIndex)
+            .build(),
+          () => {
+            // No changes to model. Only validation is required.
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (miningSchema !== undefined && characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(action.payload.modelIndex)
+                  .forBaselineScore()
+                  .build()
+              );
+              validateBaselineScore(
+                modelIndex,
+                useReasonCodes,
+                baselineScore,
+                characteristics.Characteristic,
+                validationRegistry
+              );
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forCharacteristics()
+                  .build()
+              );
+              validateCharacteristics(
+                modelIndex,
+                { baselineScore: baselineScore, useReasonCodes: useReasonCodes },
+                characteristics.Characteristic,
+                miningSchema.MiningField,
+                validationRegistry
+              );
+            }
+          }
+        );
+        break;
+
+      case Actions.Scorecard_DeleteCharacteristic:
+        historyService.batch(
+          state,
+          Builder()
+            .forModel(action.payload.modelIndex)
+            .build(),
+          () => {
+            // No changes to model. Only validation is required.
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forBaselineScore()
+                  .build()
+              );
+              validateBaselineScore(
+                modelIndex,
+                useReasonCodes,
+                baselineScore,
+                characteristics.Characteristic,
+                validationRegistry
+              );
+            }
+          }
+        );
+        break;
+
+      case Actions.Scorecard_UpdateCharacteristic:
+        historyService.batch(
+          state,
+          Builder()
+            .forModel(action.payload.modelIndex)
+            .build(),
+          () => {
+            // No changes to model. Only validation is required.
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (miningSchema !== undefined && characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forBaselineScore()
+                  .build()
+              );
+              validateBaselineScore(
+                modelIndex,
+                useReasonCodes,
+                baselineScore,
+                characteristics.Characteristic,
+                validationRegistry
+              );
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forCharacteristics()
+                  .build()
+              );
+              validateCharacteristics(
+                modelIndex,
+                { baselineScore: baselineScore, useReasonCodes: useReasonCodes },
+                characteristics.Characteristic,
+                miningSchema.MiningField,
+                validationRegistry
+              );
+            }
+          }
+        );
+        break;
+
+      case Actions.Scorecard_AddAttribute:
+      case Actions.Scorecard_DeleteAttribute:
+        historyService.batch(
+          state,
+          Builder()
+            .forModel(action.payload.modelIndex)
+            .build(),
+          () => {
+            // No changes to model. Only validation is required.
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const characteristicIndex = action.payload.characteristicIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (miningSchema !== undefined && characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forCharacteristics()
+                  .forCharacteristic(characteristicIndex)
+                  .build()
+              );
+              validateCharacteristic(
+                modelIndex,
+                { baselineScore: baselineScore, useReasonCodes: useReasonCodes },
+                characteristicIndex,
+                characteristics.Characteristic[characteristicIndex],
+                miningSchema.MiningField,
+                validationRegistry
+              );
+            }
+          }
+        );
+        break;
+
+      case Actions.UpdateDataDictionaryField:
+        if (action.payload.modelIndex !== undefined) {
+          const modelIndex = action.payload.modelIndex;
+          const dataFieldName = action.payload.dataField.name;
+          const originalDataFieldName = action.payload.originalName;
+          state.Characteristics.Characteristic.forEach((characteristic, characteristicIndex) => {
+            characteristic.Attribute.forEach((attribute, attributeIndex) => {
+              updatePredicateFieldName(
+                modelIndex,
+                characteristicIndex,
+                attributeIndex,
+                attribute.predicate,
+                dataFieldName,
+                originalDataFieldName,
+                historyService
+              );
+            });
+          });
+        }
+        break;
+
+      case Actions.AddMiningSchemaFields:
+      case Actions.Scorecard_UpdateAttribute:
+        historyService.batch(
+          state,
+          Builder()
+            .forModel(action.payload.modelIndex)
+            .build(),
+          () => {
+            // No changes to model. Only validation is required.
+          },
+          pmml => {
+            const modelIndex = action.payload.modelIndex;
+            const miningSchema = getMiningSchema(pmml, modelIndex);
+            const characteristics = getCharacteristics(pmml, modelIndex);
+            const baselineScore = getBaselineScore(pmml, modelIndex);
+            const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+            if (miningSchema !== undefined && characteristics !== undefined) {
+              validationRegistry.clear(
+                Builder()
+                  .forModel(modelIndex)
+                  .forCharacteristics()
+                  .build()
+              );
+              validateCharacteristics(
+                action.payload.modelIndex,
+                { baselineScore: baselineScore, useReasonCodes: useReasonCodes },
+                characteristics.Characteristic,
+                miningSchema.MiningField,
+                validationRegistry
+              );
+            }
           }
         );
         break;
 
       case Actions.DeleteMiningSchemaField:
-        if (state.MiningSchema.MiningField.length && state.Output?.OutputField.length) {
-          validationRegistry.clear(
+        if (state.MiningSchema.MiningField.length > 0) {
+          const modelIndex = action.payload.modelIndex;
+          historyService.batch(
+            state,
             Builder()
-              .forModel(action.payload.modelIndex)
-              .forOutput()
-              .build()
-          );
-          state.Output.OutputField.forEach((outputField, outputFieldIndex) => {
-            if (outputField.targetField === action.payload.name) {
-              historyService.batch(
-                state,
-                Builder()
-                  .forModel(action.payload.modelIndex)
-                  .build(),
-                draft => {
-                  draft!.Output!.OutputField[outputFieldIndex] = {
-                    ...draft!.Output!.OutputField[outputFieldIndex],
-                    targetField: undefined
-                  };
-                  validateOutput(
-                    action.payload.modelIndex,
-                    { ...state.Output!.OutputField[outputFieldIndex], targetField: undefined },
-                    outputFieldIndex,
-                    state.MiningSchema.MiningField.filter(
-                      (miningField, miningFieldIndex) => miningFieldIndex !== action.payload.miningSchemaIndex
-                    ),
-                    validationRegistry
-                  );
-                }
-              );
-            }
-          });
-          validateOutputs(
-            action.payload.modelIndex,
-            state.Output?.OutputField,
-            state.MiningSchema.MiningField.filter((field, index) => index !== action.payload.miningSchemaIndex),
-            validationRegistry
-          );
-        }
-
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forCharacteristics()
-            .build()
-        );
-        validateCharacteristics(
-          action.payload.modelIndex,
-          { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-          state.Characteristics.Characteristic,
-          state.MiningSchema.MiningField.filter(mf => mf.name !== action.payload.name),
-          validationRegistry
-        );
-
-        break;
-
-      case Actions.UpdateMiningSchemaField:
-        if (state.MiningSchema.MiningField.length && state.Output?.OutputField.length) {
-          validationRegistry.clear(
-            Builder()
-              .forModel(action.payload.modelIndex)
-              .forOutput()
-              .build()
-          );
-          if (action.payload.usageType !== "target") {
-            state.Output.OutputField.forEach((outputField, outputFieldIndex) => {
-              if (outputField.targetField === action.payload.name) {
-                historyService.batch(
-                  state,
+              .forModel(modelIndex)
+              .build(),
+            draft => {
+              // No changes to model. Only validation is required.
+            },
+            pmml => {
+              const miningSchema = getMiningSchema(pmml, modelIndex);
+              const characteristics = getCharacteristics(pmml, modelIndex);
+              const baselineScore = getBaselineScore(pmml, modelIndex);
+              const useReasonCodes = getUseReasonCodes(pmml, modelIndex);
+              if (miningSchema !== undefined && characteristics !== undefined) {
+                validationRegistry.clear(
                   Builder()
-                    .forModel(action.payload.modelIndex)
-                    .build(),
-                  draft => {
-                    draft!.Output!.OutputField[outputFieldIndex] = {
-                      ...draft!.Output!.OutputField[outputFieldIndex],
-                      targetField: undefined
-                    };
-                    validateOutput(
-                      action.payload.modelIndex,
-                      { ...state.Output!.OutputField[outputFieldIndex], targetField: undefined },
-                      outputFieldIndex,
-                      state.MiningSchema.MiningField.map((miningField, miningFieldIndex) => {
-                        if (miningFieldIndex === action.payload.miningSchemaIndex) {
-                          miningField = { ...miningField, usageType: action.payload.usageType };
-                        }
-                        return miningField;
-                      }),
-                      validationRegistry
-                    );
-                  }
+                    .forModel(modelIndex)
+                    .forCharacteristics()
+                    .build()
+                );
+                validateCharacteristics(
+                  modelIndex,
+                  { baselineScore: baselineScore, useReasonCodes: useReasonCodes },
+                  characteristics.Characteristic,
+                  miningSchema.MiningField,
+                  validationRegistry
                 );
               }
-            });
-          }
-          validateOutputs(
-            action.payload.modelIndex,
-            state.Output?.OutputField,
-            state.MiningSchema.MiningField.map((item, index) => {
-              if (index === action.payload.miningSchemaIndex) {
-                item = { ...item, usageType: action.payload.usageType };
-              }
-              return item;
-            }),
-            validationRegistry
-          );
-        }
-        break;
-
-      case Actions.UpdateOutput:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forOutput()
-            .forOutputField(action.payload.outputIndex)
-            .forTargetField()
-            .build()
-        );
-        validateOutput(
-          action.payload.modelIndex,
-          action.payload.outputField,
-          action.payload.outputIndex,
-          state.MiningSchema.MiningField,
-          validationRegistry
-        );
-        break;
-
-      case Actions.AddBatchOutputs:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forOutput()
-            .build()
-        );
-        if (state.Output && state.Output?.OutputField.length > 0) {
-          validateOutputs(
-            action.payload.modelIndex,
-            state.Output?.OutputField,
-            state.MiningSchema.MiningField,
-            validationRegistry
-          );
-        }
-        if (isOutputsTargetFieldRequired(state.MiningSchema.MiningField)) {
-          const startIndex = state.Output?.OutputField.length ?? 0;
-          action.payload.outputFields.forEach((name, index) => {
-            validationRegistry.set(
-              Builder()
-                .forModel(action.payload.modelIndex)
-                .forOutput()
-                .forOutputField(startIndex + index)
-                .forTargetField()
-                .build(),
-              new ValidationEntry(
-                ValidationLevel.WARNING,
-                `"${name}" output field, target field is required if Mining Schema has multiple target fields.`
-              )
-            );
-          });
-        }
-        break;
-
-      case Actions.AddOutput:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forOutput()
-            .build()
-        );
-        if (state.Output && state.Output?.OutputField.length > 0) {
-          validateOutputs(
-            action.payload.modelIndex,
-            state.Output?.OutputField,
-            state.MiningSchema.MiningField,
-            validationRegistry
-          );
-        }
-        if (isOutputsTargetFieldRequired(state.MiningSchema.MiningField)) {
-          const outputFieldIndex = state.Output?.OutputField.length ?? 0;
-          validationRegistry.set(
-            Builder()
-              .forModel(action.payload.modelIndex)
-              .forOutput()
-              .forOutputField(outputFieldIndex)
-              .forTargetField()
-              .build(),
-            new ValidationEntry(
-              ValidationLevel.WARNING,
-              `"${action.payload.outputField.name}" output field, target field is required if Mining Schema has multiple target fields.`
-            )
-          );
-        }
-        break;
-
-      case Actions.DeleteOutput:
-        validationRegistry.clear(
-          Builder()
-            .forModel(action.payload.modelIndex)
-            .forOutput()
-            .build()
-        );
-        validateOutputs(
-          action.payload.modelIndex,
-          state.Output?.OutputField.filter((field, index) => index !== action.payload.outputIndex) ?? [],
-          state.MiningSchema.MiningField,
-          validationRegistry
-        );
-        break;
-
-      case Actions.Scorecard_AddCharacteristic:
-        if (action.payload.modelIndex !== undefined) {
-          const modelIndex = action.payload.modelIndex;
-          const characteristicsPlusAdded = [
-            ...state.Characteristics.Characteristic,
-            {
-              name: action.payload.name,
-              reasonCode: action.payload.reasonCode,
-              baselineScore: action.payload.baselineScore,
-              Attribute: []
             }
-          ];
-          validationRegistry.clear(
-            Builder()
-              .forModel(modelIndex)
-              .forCharacteristics()
-              .build()
-          );
-          validateCharacteristics(
-            modelIndex,
-            { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-            characteristicsPlusAdded,
-            state.MiningSchema.MiningField,
-            validationRegistry
-          );
-          validationRegistry.clear(
-            Builder()
-              .forModel(action.payload.modelIndex)
-              .forBaselineScore()
-              .build()
-          );
-          validateBaselineScore(
-            action.payload.modelIndex,
-            state.useReasonCodes,
-            state.baselineScore,
-            characteristicsPlusAdded,
-            validationRegistry
-          );
-        }
-        break;
-
-      case Actions.Scorecard_DeleteCharacteristic:
-        if (action.payload.modelIndex !== undefined) {
-          validationRegistry.clear(
-            Builder()
-              .forModel(action.payload.modelIndex)
-              .forBaselineScore()
-              .build()
-          );
-          validateBaselineScore(
-            action.payload.modelIndex,
-            state.useReasonCodes,
-            state.baselineScore,
-            state.Characteristics.Characteristic.filter(
-              (characteristic, characteristicIndex) => characteristicIndex !== action.payload.characteristicIndex
-            ),
-            validationRegistry
-          );
-        }
-        break;
-
-      case Actions.Scorecard_UpdateCharacteristic:
-        if (action.payload.modelIndex !== undefined) {
-          const modelIndex = action.payload.modelIndex;
-          const updatedCharacteristics = state.Characteristics.Characteristic.map(
-            (characteristic, characteristicIndex) => {
-              if (characteristicIndex === action.payload.characteristicIndex) {
-                characteristic = {
-                  ...characteristic,
-                  name: action.payload.name,
-                  reasonCode: action.payload.reasonCode,
-                  baselineScore: action.payload.baselineScore
-                };
-              }
-              return characteristic;
-            }
-          );
-          validationRegistry.clear(
-            Builder()
-              .forModel(modelIndex)
-              .forCharacteristics()
-              .build()
-          );
-          validateCharacteristics(
-            modelIndex,
-            { baselineScore: state.baselineScore, useReasonCodes: state.useReasonCodes },
-            updatedCharacteristics,
-            state.MiningSchema.MiningField,
-            validationRegistry
-          );
-          validationRegistry.clear(
-            Builder()
-              .forModel(action.payload.modelIndex)
-              .forBaselineScore()
-              .build()
-          );
-          validateBaselineScore(
-            modelIndex,
-            state.useReasonCodes,
-            state.baselineScore,
-            updatedCharacteristics,
-            validationRegistry
           );
         }
         break;
@@ -586,7 +414,20 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
           const modelIndex = action.payload.modelIndex;
           validationRegistry.clear(
             Builder()
-              .forModel(action.payload.modelIndex)
+              .forModel(modelIndex)
+              .forOutput()
+              .build()
+          );
+          validateOutputs(
+            modelIndex,
+            state.Output?.OutputField ?? [],
+            state.MiningSchema.MiningField,
+            validationRegistry
+          );
+
+          validationRegistry.clear(
+            Builder()
+              .forModel(modelIndex)
               .forBaselineScore()
               .build()
           );
@@ -595,19 +436,6 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
             state.useReasonCodes,
             state.baselineScore,
             state.Characteristics.Characteristic,
-            validationRegistry
-          );
-
-          validationRegistry.clear(
-            Builder()
-              .forModel(modelIndex)
-              .forOutput()
-              .build()
-          );
-          validateOutputs(
-            action.payload.modelIndex,
-            state.Output?.OutputField ?? [],
-            state.MiningSchema.MiningField,
             validationRegistry
           );
 
@@ -625,7 +453,6 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
             validationRegistry
           );
         }
-        break;
     }
 
     return state;

--- a/packages/pmml-editor/src/editor/validation/MiningSchema.ts
+++ b/packages/pmml-editor/src/editor/validation/MiningSchema.ts
@@ -168,11 +168,28 @@ export const validateMiningFieldsDataFieldReference = (
 ): void => {
   const dataFieldNames = dataFields.map(dataField => dataField.name);
   miningFields.forEach((miningField, miningFieldIndex) =>
-    validateMiningFieldDataFieldReference(modelIndex, dataFieldNames, miningFieldIndex, miningField, validationRegistry)
+    _validateMiningFieldDataFieldReference(
+      modelIndex,
+      dataFieldNames,
+      miningFieldIndex,
+      miningField,
+      validationRegistry
+    )
   );
 };
 
-const validateMiningFieldDataFieldReference = (
+export const validateMiningFieldDataFieldReference = (
+  modelIndex: number,
+  dataFields: DataField[],
+  miningFieldIndex: number,
+  miningField: MiningField,
+  validationRegistry: ValidationRegistry
+): void => {
+  const dataFieldNames = dataFields.map(dataField => dataField.name);
+  _validateMiningFieldDataFieldReference(modelIndex, dataFieldNames, miningFieldIndex, miningField, validationRegistry);
+};
+
+const _validateMiningFieldDataFieldReference = (
   modelIndex: number,
   dataFieldNames: FieldName[],
   miningFieldIndex: number,

--- a/packages/pmml-editor/src/editor/validation/MiningSchema.ts
+++ b/packages/pmml-editor/src/editor/validation/MiningSchema.ts
@@ -15,7 +15,6 @@
  */
 import {
   DataField,
-  FieldName,
   InvalidValueTreatmentMethod,
   MiningField,
   MissingValueTreatmentMethod,
@@ -166,15 +165,8 @@ export const validateMiningFieldsDataFieldReference = (
   miningFields: MiningField[],
   validationRegistry: ValidationRegistry
 ): void => {
-  const dataFieldNames = dataFields.map(dataField => dataField.name);
   miningFields.forEach((miningField, miningFieldIndex) =>
-    _validateMiningFieldDataFieldReference(
-      modelIndex,
-      dataFieldNames,
-      miningFieldIndex,
-      miningField,
-      validationRegistry
-    )
+    validateMiningFieldDataFieldReference(modelIndex, dataFields, miningFieldIndex, miningField, validationRegistry)
   );
 };
 
@@ -185,18 +177,7 @@ export const validateMiningFieldDataFieldReference = (
   miningField: MiningField,
   validationRegistry: ValidationRegistry
 ): void => {
-  const dataFieldNames = dataFields.map(dataField => dataField.name);
-  _validateMiningFieldDataFieldReference(modelIndex, dataFieldNames, miningFieldIndex, miningField, validationRegistry);
-};
-
-const _validateMiningFieldDataFieldReference = (
-  modelIndex: number,
-  dataFieldNames: FieldName[],
-  miningFieldIndex: number,
-  miningField: MiningField,
-  validationRegistry: ValidationRegistry
-): void => {
-  if (dataFieldNames.filter(dataFieldName => dataFieldName === miningField.name).length === 0) {
+  if (dataFields.filter(dataField => dataField.name === miningField.name).length === 0) {
     validationRegistry.set(
       Builder()
         .forModel(modelIndex)


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-384

This is an exciting PR :1st_place_medal: 

It refactors the entire validation sub-system to perform validation after all of the batch commits have completed.

Previously we were validating sub-trees after the sub-tree had been updated. However this was problematic when one sub-tree depended on the state/update made to another since the dependent sub-tree only had access to the stale/prior state and had to re-apply the change to the sub-tree it could access to mimic the complete batch. The JIRA may explain it better (of course it may not).

Sadly, with regard to testing, every RESOLVED child JIRA under https://issues.redhat.com/browse/FAI-333 should be revisited.