### PR TITLE
Remove timeout from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     if: github.repository == 'kiegroup/kogito-tooling' || github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Since Yarn downloads can take a while, I'm removing this timeout to avoid unnecessary re-runs.