### PR TITLE
Update Patternfly - Add script to help on future updates

### DIFF
--- a/packages/desktop/src/__tests__/webview/__snapshots__/App.test.tsx.snap
+++ b/packages/desktop/src/__tests__/webview/__snapshots__/App.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`invalid file type alert alert is closed after 3000ms 1`] = `
       </div>
     </header>
     <div
+      aria-hidden="true"
       class="pf-c-page__sidebar pf-m-collapsed"
       id="page-sidebar"
     >
@@ -143,6 +144,7 @@ exports[`invalid file type alert alert is closed after 3000ms 1`] = `
               <a
                 aria-current="page"
                 class="pf-c-nav__link pf-m-current"
+                tabindex="-1"
               >
                 Files
               </a>
@@ -155,6 +157,7 @@ exports[`invalid file type alert alert is closed after 3000ms 1`] = `
             >
               <a
                 class="pf-c-nav__link"
+                tabindex="-1"
               >
                 Learn more
               </a>
@@ -639,6 +642,7 @@ exports[`invalid file type alert alert is closed immediately after leaving the h
       </div>
     </header>
     <div
+      aria-hidden="true"
       class="pf-c-page__sidebar pf-m-collapsed"
       id="page-sidebar"
     >
@@ -664,6 +668,7 @@ exports[`invalid file type alert alert is closed immediately after leaving the h
               <a
                 aria-current="page"
                 class="pf-c-nav__link pf-m-current"
+                tabindex="-1"
               >
                 Files
               </a>
@@ -676,6 +681,7 @@ exports[`invalid file type alert alert is closed immediately after leaving the h
             >
               <a
                 class="pf-c-nav__link"
+                tabindex="-1"
               >
                 Learn more
               </a>
@@ -1085,7 +1091,6 @@ exports[`invalid file type alert alert is closed immediately after leaving the h
                   data-testid="toolbar-title"
                 >
                   <h3
-                    aria-describedby="pf-tooltip-2"
                     class="pf-c-title pf-m-xl"
                   >
                     a.dmn

--- a/packages/desktop/src/__tests__/webview/editor/__snapshots__/EditorToolbar.test.tsx.snap
+++ b/packages/desktop/src/__tests__/webview/editor/__snapshots__/EditorToolbar.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`EditorToolbar isDirty indicator should show the isDirty indicator when 
   data-testid="toolbar-title"
 >
   <h3
-    aria-describedby="pf-tooltip-1"
     class="pf-c-title pf-m-xl"
   >
     test.dmn
@@ -26,7 +25,6 @@ exports[`EditorToolbar isDirty indicator shouldn't show the isDirty indicator wh
   data-testid="toolbar-title"
 >
   <h3
-    aria-describedby="pf-tooltip-2"
     class="pf-c-title pf-m-xl"
   >
     test.dmn

--- a/packages/desktop/src/__tests__/webview/home/__snapshots__/FilesPage.test.tsx.snap
+++ b/packages/desktop/src/__tests__/webview/home/__snapshots__/FilesPage.test.tsx.snap
@@ -703,7 +703,6 @@ exports[`FilesPage three recent files in different directories listed ordered al
       class="pf-l-gallery pf-m-gutter kogito-desktop__file-gallery"
     >
       <article
-        aria-describedby="pf-tooltip-7"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-20"
         data-ouia-component-type="PF4/Card"
@@ -733,7 +732,6 @@ exports[`FilesPage three recent files in different directories listed ordered al
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-8"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-19"
         data-ouia-component-type="PF4/Card"
@@ -763,7 +761,6 @@ exports[`FilesPage three recent files in different directories listed ordered al
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-9"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-21"
         data-ouia-component-type="PF4/Card"
@@ -1146,7 +1143,6 @@ exports[`FilesPage three recent files in the same directory listed ordered alpha
       class="pf-l-gallery pf-m-gutter kogito-desktop__file-gallery"
     >
       <article
-        aria-describedby="pf-tooltip-14"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-27"
         data-ouia-component-type="PF4/Card"
@@ -1176,7 +1172,6 @@ exports[`FilesPage three recent files in the same directory listed ordered alpha
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-15"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-29"
         data-ouia-component-type="PF4/Card"
@@ -1206,7 +1201,6 @@ exports[`FilesPage three recent files in the same directory listed ordered alpha
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-16"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-28"
         data-ouia-component-type="PF4/Card"
@@ -1236,7 +1230,6 @@ exports[`FilesPage three recent files in the same directory listed ordered alpha
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-17"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-30"
         data-ouia-component-type="PF4/Card"
@@ -1619,7 +1612,6 @@ exports[`FilesPage three recent files listed 1`] = `
       class="pf-l-gallery pf-m-gutter kogito-desktop__file-gallery"
     >
       <article
-        aria-describedby="pf-tooltip-1"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-11"
         data-ouia-component-type="PF4/Card"
@@ -1649,7 +1641,6 @@ exports[`FilesPage three recent files listed 1`] = `
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-2"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-12"
         data-ouia-component-type="PF4/Card"
@@ -1679,7 +1670,6 @@ exports[`FilesPage three recent files listed 1`] = `
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-3"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-13"
         data-ouia-component-type="PF4/Card"
@@ -2062,7 +2052,6 @@ exports[`FilesPage three recent files listed ordered by access time 1`] = `
       class="pf-l-gallery pf-m-gutter kogito-desktop__file-gallery"
     >
       <article
-        aria-describedby="pf-tooltip-24"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-36"
         data-ouia-component-type="PF4/Card"
@@ -2092,7 +2081,6 @@ exports[`FilesPage three recent files listed ordered by access time 1`] = `
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-25"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-37"
         data-ouia-component-type="PF4/Card"
@@ -2122,7 +2110,6 @@ exports[`FilesPage three recent files listed ordered by access time 1`] = `
         </div>
       </article>
       <article
-        aria-describedby="pf-tooltip-26"
         class="pf-c-card pf-m-compact kogito--desktop__files-card"
         data-ouia-component-id="OUIA-Generated-Card-38"
         data-ouia-component-type="PF4/Card"

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -17,6 +17,6 @@
     "@patternfly/react-icons": "^4.9.5"
   },
   "scripts": {
-    "upgrade:patternfly": "node upgrade_patternfly.js"
+    "update": "node update_patternfly.js"
   }
 }

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -11,9 +11,12 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.70.2",
-    "@patternfly/react-charts": "6.12.12",
-    "@patternfly/react-core": "4.84.4",
-    "@patternfly/react-icons": "4.7.22"
+    "@patternfly/patternfly": "^4.87.3",
+    "@patternfly/react-charts": "^6.14.2",
+    "@patternfly/react-core": "^4.97.2",
+    "@patternfly/react-icons": "^4.9.2"
+  },
+  "scripts": {
+    "upgrade:patternfly": "node upgrade_patternfly.js"
   }
 }

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -17,6 +17,8 @@
     "@patternfly/react-icons": "^4.9.5"
   },
   "scripts": {
-    "update": "node update_patternfly.js"
+    "update": "node update_patternfly.js",
+    "update:deps": "node update_patternfly.js -d",
+    "update:snaps": "node update_patternfly.js -s"
   }
 }

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^4.87.3",
-    "@patternfly/react-charts": "^6.14.2",
-    "@patternfly/react-core": "^4.97.2",
-    "@patternfly/react-icons": "^4.9.2"
+    "@patternfly/patternfly": "^4.90.5",
+    "@patternfly/react-charts": "^6.14.6",
+    "@patternfly/react-core": "^4.101.3",
+    "@patternfly/react-icons": "^4.9.5"
   },
   "scripts": {
     "upgrade:patternfly": "node upgrade_patternfly.js"

--- a/packages/patternfly-base/update_patternfly.js
+++ b/packages/patternfly-base/update_patternfly.js
@@ -35,8 +35,8 @@ function updateSnapshots() {
 function usageExample() {
   console.log("Usage yarn update [options]");
   console.log("Options:");
-  console.log("-d, --dependencies           Update Patternfly dependencies");
-  console.log("-s, --snapshots              Update project test snapshots");
+  console.log("-d, --dependencies-only    Update Patternfly dependencies");
+  console.log("-s, --test-snapshots-only  Update project test snapshots");
 }
 
 function start() {
@@ -51,14 +51,14 @@ function start() {
   console.log("Updating...");
   switch (argument) {
     case "-d":
-    case "--dependencies": {
+    case "--dependencies-only": {
       updateDependencies()
         .then(() => console.log("Success"))
         .catch(err => console.error("Error", err));
       break;
     }
     case "-s":
-    case "--snapshots": {
+    case "--test-snapshots-only": {
       updateSnapshots()
         .then(() => console.log("Success"))
         .catch(err => console.error("Error", err));

--- a/packages/patternfly-base/update_patternfly.js
+++ b/packages/patternfly-base/update_patternfly.js
@@ -22,18 +22,18 @@ async function executeCommand(command) {
   });
 }
 
-function upgradeDependencies() {
+function updateDependencies() {
   return executeCommand(UPDATE_PATTERNFLY_COMMAND)
     .then(() => executeCommand(LINK_DEPENDENCIES_COMMAND))
     .then(() => executeCommand(BUILD_PROJECT_COMMAND));
 }
 
-function upgradeSnapshot() {
+function updateSnapshots() {
   return executeCommand(UPDATE_SNAPSHOTS_COMMAND);
 }
 
 function usageExample() {
-  console.log("Usage yarn upgrade:patternfly [options]");
+  console.log("Usage yarn update [options]");
   console.log("Options:");
   console.log("-d, --dependencies           Update Patternfly dependencies");
   console.log("-s, --snapshots              Update project test snapshots");
@@ -52,21 +52,21 @@ function start() {
   switch (argument) {
     case "-d":
     case "--dependencies": {
-      upgradeDependencies()
+      updateDependencies()
         .then(() => console.log("Success"))
         .catch(err => console.error("Error", err));
       break;
     }
     case "-s":
     case "--snapshots": {
-      upgradeSnapshot()
+      updateSnapshots()
         .then(() => console.log("Success"))
         .catch(err => console.error("Error", err));
       break;
     }
     case undefined: {
-      upgradeDependencies()
-        .then(() => upgradeSnapshot())
+      updateDependencies()
+        .then(() => updateSnapshots())
         .then(() => console.log("Success"))
         .catch(err => console.error("Error", err));
       break;

--- a/packages/patternfly-base/upgrade_patternfly.js
+++ b/packages/patternfly-base/upgrade_patternfly.js
@@ -7,17 +7,18 @@ const BUILD_PROJECT_COMMAND = "(cd ../../; npx lerna run build:fast)";
 const UPDATE_SNAPSHOTS_COMMAND = "(cd ../../; npx lerna run test --stream -- -u)";
 
 async function executeCommand(command) {
-  const execution = exec(command);
+  return new Promise((resolve, reject) => {
+    const execution = exec(command);
 
-  execution.stdout.pipe(process.stdout);
-  execution.stderr.pipe(process.stderr);
+    execution.stdout.pipe(process.stdout);
+    execution.stderr.pipe(process.stderr);
 
-  execution.on("close", code => {
-    if (code !== 0) {
+    execution.on("close", code => {
+      if (code === 0) {
+        resolve();
+      }
       reject(`child process exited with code ${code}`);
-    } else {
-      resolve();
-    }
+    });
   });
 }
 

--- a/packages/patternfly-base/upgrade_patternfly.js
+++ b/packages/patternfly-base/upgrade_patternfly.js
@@ -1,0 +1,80 @@
+const exec = require("child_process").exec;
+
+const UPDATE_PATTERNFLY_COMMAND =
+  "yarn add @patternfly/patternfly @patternfly/react-charts @patternfly/react-core @patternfly/react-icons";
+const LINK_DEPENDENCIES_COMMAND = "(cd ../../; npx lerna run init)";
+const BUILD_PROJECT_COMMAND = "(cd ../../; npx lerna run build:fast)";
+const UPDATE_SNAPSHOTS_COMMAND = "(cd ../../; npx lerna run test --stream -- -u)";
+
+async function executeCommand(command) {
+  const execution = exec(command);
+
+  execution.stdout.pipe(process.stdout);
+  execution.stderr.pipe(process.stderr);
+
+  execution.on("close", code => {
+    if (code !== 0) {
+      reject(`child process exited with code ${code}`);
+    } else {
+      resolve();
+    }
+  });
+}
+
+function upgradeDependencies() {
+  return executeCommand(UPDATE_PATTERNFLY_COMMAND)
+    .then(() => executeCommand(LINK_DEPENDENCIES_COMMAND))
+    .then(() => executeCommand(BUILD_PROJECT_COMMAND));
+}
+
+function upgradeSnapshot() {
+  return executeCommand(UPDATE_SNAPSHOTS_COMMAND);
+}
+
+function usageExample() {
+  console.log("Usage yarn upgrade:patternfly [options]");
+  console.log("Options:");
+  console.log("-d, --dependencies           Update Patternfly dependencies");
+  console.log("-s, --snapshots              Update project test snapshots");
+}
+
+function start() {
+  if (process.argv.length > 3) {
+    console.log("Can't handle more than one argument.");
+    usageExample();
+    return;
+  }
+
+  const [, , argument] = process.argv;
+
+  console.log("Updating...");
+  switch (argument) {
+    case "-d":
+    case "--dependencies": {
+      upgradeDependencies()
+        .then(() => console.log("Success"))
+        .catch(err => console.error("Error", err));
+      break;
+    }
+    case "-s":
+    case "--snapshots": {
+      upgradeSnapshot()
+        .then(() => console.log("Success"))
+        .catch(err => console.error("Error", err));
+      break;
+    }
+    case undefined: {
+      upgradeDependencies()
+        .then(() => upgradeSnapshot())
+        .then(() => console.log("Success"))
+        .catch(err => console.error("Error", err));
+      break;
+    }
+    default: {
+      console.log("Invalid argument.");
+      usageExample();
+    }
+  }
+}
+
+start();

--- a/packages/pmml-editor/src/__tests__/editor/components/LandingPage/molecules/__snapshots__/ModelCard.test.tsx.snap
+++ b/packages/pmml-editor/src/__tests__/editor/components/LandingPage/molecules/__snapshots__/ModelCard.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`ModelCard render::Basics 1`] = `
     </div>
   </div>
   <div
-    aria-describedby="pf-tooltip-1"
     class="pf-c-card__title model-card__title"
   >
     <span

--- a/packages/pmml-editor/src/__tests__/editor/components/LandingPage/templates/__snapshots__/LandingPage.test.tsx.snap
+++ b/packages/pmml-editor/src/__tests__/editor/components/LandingPage/templates/__snapshots__/LandingPage.test.tsx.snap
@@ -324,7 +324,6 @@ exports[`LandingPage render::With Supported Model 1`] = `
               </div>
             </div>
             <div
-              aria-describedby="pf-tooltip-1"
               class="pf-c-card__title model-card__title"
             >
               <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,37 +2163,37 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@patternfly/patternfly@4.70.2":
-  version "4.70.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.70.2.tgz#94b733f68f4f63040ab142eb2fa3c3ac5d08f2ae"
-  integrity sha512-XKCHnOjx1JThY3s98AJhsApSsGHPvEdlY7r+b18OecqUnmThVGw3nslzYYrwfCGlJ/xQtV5so29SduH2/uhHzA==
+"@patternfly/patternfly@4.87.3", "@patternfly/patternfly@^4.87.3":
+  version "4.87.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.87.3.tgz#eb2e9b22aa8f6f106580e7451bf204a06cb9949e"
+  integrity sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA==
 
-"@patternfly/react-charts@6.12.12":
-  version "6.12.12"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.12.12.tgz#15afe292724a06f11a4cfd979059957b5ac42234"
-  integrity sha512-2tCCR2FvbwObw9uw3sHIvIu7IeP1s+R0ANHyRTHmakie7GcfzAiVv3KbDgrOn7iKtEpIOdee3EH4PWhLlLkxtQ==
+"@patternfly/react-charts@^6.14.2":
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.14.2.tgz#20d5b98af4504c2e2e38e4836088dfa54fb324cf"
+  integrity sha512-QfO+wJRCj6Wof/18KWpY0XmZKXhv4y2QsmLtjMoGtZbbjHtEUwXA+lYc4agj9k+CEpm+3xXR2GOoNSwaSZN3RA==
   dependencies:
-    "@patternfly/patternfly" "4.70.2"
-    "@patternfly/react-styles" "^4.7.22"
-    "@patternfly/react-tokens" "^4.9.22"
+    "@patternfly/patternfly" "4.87.3"
+    "@patternfly/react-styles" "^4.8.2"
+    "@patternfly/react-tokens" "^4.10.2"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "1.13.0"
-    victory-area "^35.3.5"
-    victory-axis "^35.3.5"
-    victory-bar "^35.3.5"
-    victory-chart "^35.3.5"
-    victory-core "^35.3.5"
-    victory-create-container "^35.3.5"
-    victory-group "^35.3.5"
-    victory-legend "^35.3.5"
-    victory-line "^35.3.5"
-    victory-pie "^35.3.5"
-    victory-scatter "^35.3.5"
-    victory-stack "^35.3.5"
-    victory-tooltip "^35.3.5"
-    victory-voronoi-container "^35.3.5"
-    victory-zoom-container "^35.3.5"
+    victory-area "^35.4.4"
+    victory-axis "^35.4.4"
+    victory-bar "^35.4.4"
+    victory-chart "^35.4.4"
+    victory-core "^35.4.4"
+    victory-create-container "^35.4.4"
+    victory-group "^35.4.4"
+    victory-legend "^35.4.4"
+    victory-line "^35.4.4"
+    victory-pie "^35.4.4"
+    victory-scatter "^35.4.4"
+    victory-stack "^35.4.4"
+    victory-tooltip "^35.4.4"
+    victory-voronoi-container "^35.4.4"
+    victory-zoom-container "^35.4.4"
 
 "@patternfly/react-core@4.84.4":
   version "4.84.4"
@@ -2208,15 +2208,43 @@
     tippy.js "5.1.2"
     tslib "1.13.0"
 
+"@patternfly/react-core@^4.97.2":
+  version "4.97.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.2.tgz#a389f6984d03ed730506fa3cdccb1355f37b04fc"
+  integrity sha512-Xl/l/+OjWVtWnbb9Kw//1bn+6KEM9aOc1nk+Vm6D8wlbuuz+RAFBc0rZjPWuq00YYnVA+sExESe0W2d3wdn/SQ==
+  dependencies:
+    "@patternfly/react-icons" "^4.9.2"
+    "@patternfly/react-styles" "^4.8.2"
+    "@patternfly/react-tokens" "^4.10.2"
+    focus-trap "6.2.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "1.13.0"
+
 "@patternfly/react-icons@4.7.22", "@patternfly/react-icons@^4.7.22":
   version "4.7.22"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.22.tgz#ee8c4f66020abf200cbdd233fba27d004dea562f"
   integrity sha512-JDsnebr9CNIyrv9yjaGFQ56OChbV6KcxMYBIpNc8/sZdU4TXHWNC7P7rlUM/BuGpbWvyaOJtscRuf5uteIKX3A==
 
+"@patternfly/react-icons@^4.9.2":
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.2.tgz#dcb2efa9727de97d5aa5d6be47a75daee49addb8"
+  integrity sha512-3PY81A9mj9YyUpznSWhcWMKHRyGWNgZ1IDYqbMva7Q8wgd0fjsiTJ+5zAp4YQLo1mA8KwYX9v5s37hK8XiTbAA==
+
 "@patternfly/react-styles@^4.7.22":
   version "4.7.22"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.22.tgz#fda249c5ee03db965cad648da92aa1caa7eff02f"
   integrity sha512-ojNuSNJx6CkNtsSFseZ2SJEVyzPMFYh0jOs204ICzYM1+fn9acsIi3Co0bcskFRzw8F6e2/x+8uVNx6QI8elxg==
+
+"@patternfly/react-styles@^4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
+  integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
+
+"@patternfly/react-tokens@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
+  integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
 
 "@patternfly/react-tokens@^4.9.22":
   version "4.9.22"
@@ -15052,62 +15080,62 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-victory-area@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.4.6.tgz#0c67a0338487fbba16b35c2dd7032642de2d7140"
-  integrity sha512-J/SxkHAT1ygwjAHjSy92RtAyT6ZtH0cqh4721MSkfr8fdzI45420e/J7mG7JGN2XeYulD9N+VSiy/a/ExbOrEQ==
+victory-area@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.4.11.tgz#482d69455574e20ba8b1b7e2b2d79166ae8c3d1e"
+  integrity sha512-5HHJhSe8sRUfvfGIC6U9UsbL9mkWCtbCCBjLFLkCb0STmLcaVd2hsahX7TqEIxvsRKgflGwRfd6MPKi64LYJrg==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-axis@^35.3.5, victory-axis@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.4.6.tgz#0ab5d97adf94f731ec9f03cf2c874e52f61f3aa5"
-  integrity sha512-ULMgAue4+XM2xzOEjG7PWVtBl1FZjMLvTUoQQr5+AUV1HtIVg9IAD+bfgLzBR3VWb9w8Qmo6rYiy1oWebv7qMQ==
+victory-axis@^35.4.11, victory-axis@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.4.11.tgz#07d9fbcf0b4aaf3479313f26de60308060e046e2"
+  integrity sha512-qrBWFXGCg3Nip0zZZxqjkPcrYSuIO44agXymNpLYey3XsNPSiQ/iwx6pcF6E34uENaB0wfDomQZgXIdGr8H6Qw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-bar@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.4.6.tgz#b428a345280aecaa62b8dc7f26d1c0f90552a62a"
-  integrity sha512-YaliTB1FpYqWCj6Pd27XfLnM3pzkSw9AL1dSXPK1pj+404Yl5ImHbaU1gz7xq7o2EvWi6JIlgr2Ck5OtPdCFZg==
+victory-bar@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.4.11.tgz#402cf0571656f808e22a135c23fcb11a4098e441"
+  integrity sha512-/btO14sBFJjhqqi2f+MJ2nol4U272QanRPT6yAd9NGtIEeNXsxbjo6pD6se/fzX3BLMjeTP8Euif1xS0bmMjUA==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-brush-container@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.4.6.tgz#76579d20e268d3a6a74096bf6ac1b5d40e00b3e3"
-  integrity sha512-0Fh/e4xVCrxvn1G2Bmos5JC+/C3Kp97T4KecIBhIRiyXXX3XZH3qNe5KbCQD2wmTARZVggo5uCrI+uW6cBBaFQ==
+victory-brush-container@^35.4.11:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.4.11.tgz#ec37ab020412e6ef94a76c471b25d776e3dcd9c2"
+  integrity sha512-eG1i58ddXRhCv4tibT+1p55aJs7f1RE4QyaAuYRNoIGtOAHc4tC5uImrU667N+q4KSUYreuKwC7r8sHxobGJNg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-chart@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.4.6.tgz#7b1635a804abf8998ac4f5fa4a9911c8fe8ec287"
-  integrity sha512-lU78SkBo27nGRG4wmL6YzoAAZ1skpbkY9G2RgYfUK5uGfgvFCM0b/8LNcXi8cL3b9D5bJwoAkqud5YUtiWC8dQ==
+victory-chart@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.4.11.tgz#604de7a357741769972e6a3c084004d4a4846695"
+  integrity sha512-LPdoVX8LVzmHjE6mQQMWNFfqy8WnuN5UnBiWiKhQB1HNiCwL2JPWsSqaDIdV8flGBKSZzKDgsLmMABxGjwfBcg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^35.4.6"
-    victory-core "^35.4.6"
-    victory-polar-axis "^35.4.6"
-    victory-shared-events "^35.4.6"
+    victory-axis "^35.4.11"
+    victory-core "^35.4.11"
+    victory-polar-axis "^35.4.11"
+    victory-shared-events "^35.4.11"
 
-victory-core@^35.3.5, victory-core@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.4.6.tgz#fd104798f7dcaabae9cafa365fefaa9e13a6c542"
-  integrity sha512-aEq3QxqVihVoIDUyOs01P140e9VUjPqKabWPo9wxvxodAbeENMHafhPOSwogB0HEyNCV2J6nXCUPjghZoGSuKw==
+victory-core@^35.4.11, victory-core@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.4.11.tgz#61d6ee1e5f99655905a213e83b63cab1ac02a663"
+  integrity sha512-vXcX9pgZqUN7FLFn1Z2SfzBBBu3PyyN46kfKaNjcJbVnhdxtnmN8MfYtXx3eJGIJlv0FsTrPY8fpBYQpYHho4w==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
@@ -15118,146 +15146,146 @@ victory-core@^35.3.5, victory-core@^35.4.6:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.4.6.tgz#cf488a7e06978afabbfe041e39000699a5b325e8"
-  integrity sha512-0/kGdW+8/TXCL9u7HKyYm4Cc4ZXKH4AmuGu9NMtAAiWHhWBuN/r+ppInQwxgjWZ4uZMH9yzPz/E1ajvn5uYJ3w==
+victory-create-container@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.4.11.tgz#b013e02133f53568d22031e0ad61dd8aada6ad7e"
+  integrity sha512-v0CHqIvxupH76hBAcBe6nSwhqKOdnF7A94sLB0MCByeLI6ayWQ/PWRegjzYwYak2LjHvd9PvyChQkQhVstLGZw==
   dependencies:
     lodash "^4.17.19"
-    victory-brush-container "^35.4.6"
-    victory-core "^35.4.6"
-    victory-cursor-container "^35.4.6"
-    victory-selection-container "^35.4.6"
-    victory-voronoi-container "^35.4.6"
-    victory-zoom-container "^35.4.6"
+    victory-brush-container "^35.4.11"
+    victory-core "^35.4.11"
+    victory-cursor-container "^35.4.11"
+    victory-selection-container "^35.4.11"
+    victory-voronoi-container "^35.4.11"
+    victory-zoom-container "^35.4.11"
 
-victory-cursor-container@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.4.6.tgz#fe41b01013dc5ff2295c283ad96138d0c02d8255"
-  integrity sha512-LoiCnevAqKmXYFfpsKfP3Qp9ujCie0vG5/ooWsC4dV6FZNhGDD3JXffgejhqnHDla/Zp7jlM+7ajif5e/kTrdA==
+victory-cursor-container@^35.4.11:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.4.11.tgz#e250c7d7faf8a92aa53813ab9b9cea179bae11a8"
+  integrity sha512-UUKzKUUAaiSqMgVQbY5Z/X4vwRMi3m6WVIhT+1NIv8q9SrLBY5qXb21WcuF2u5rKeq1hcyioC7ZiGG3j9ZkgOQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-group@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.4.6.tgz#03d436611299b070bb033b37da6e903e5de97e40"
-  integrity sha512-kfAYrbY8wRfJaygNyNKfzAc9KhZmBAJztc9uUZfrB0c7Q0tgovAe3nmS558zx64QkIKGqsMU6ohcOFRvYRpyVA==
+victory-group@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.4.11.tgz#f5742fade75a6bbea977643b4dc8613612411918"
+  integrity sha512-pqb4n77MvopvCrLY8twjoFk6ariJD8nFG08uTLA83Phqo28J2TfWZBGzGES4/uLL/FIms4h7gtGcq5qgwlaLTQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.4.6"
-    victory-shared-events "^35.4.6"
+    victory-core "^35.4.11"
+    victory-shared-events "^35.4.11"
 
-victory-legend@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.4.6.tgz#5a094d38b117d12bd6322e6908353bb8ffe7082f"
-  integrity sha512-TmOJzv/qhKR7u0XixVsGI4I3Wjr1WflTVQfNYDOqDDixU5lBYL0XcTCVL+Ri4BOEfCkJIj1+4I2GXuyOsu/K+g==
+victory-legend@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.4.11.tgz#8d004e22e4d02f9e658f921b756839c98d9d1061"
+  integrity sha512-3E5DKYrkrqtC1YeqNHixRpfXYHo9qumBjLnfaP6IF/06R5sn5o5LdYHT0yz8ATXDL0AxZqRM2q6Au9Mwvcq2xg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-line@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.4.6.tgz#0d57b96e3ea6ead156e653717957da509de5102b"
-  integrity sha512-VU4fSMycsIOafj5sTKuUj7SK6Eua9QT85YCk9UA4yXny0lbLGTgNptz00KFYwjinPhxV1pkJnIqruSH4WAW4oQ==
+victory-line@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.4.11.tgz#67a9d26e0c06d125ac65a293c345410f2cca91ef"
+  integrity sha512-LmkvY1wMvXhBYvnafaZbSS7JiOgGEJ0+qy3HuTtT66THOKBuxAo0T66BsURFTN7LpFvjBz2QRehrtJ/KWfOz9A==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-pie@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.4.6.tgz#9883415db8a38cd8bd2141242e07414949445ce8"
-  integrity sha512-yqb6VCi4H05MTxaWcfQ06zG3XRjiqQMbHWFvve27oT+HKb5Iz6CsSBRqvaUm2Bii2n8IBd5+0izhmMLFjzJcKw==
+victory-pie@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.4.11.tgz#228b7d17c9e172122f93bc79cacfd144b24a32b6"
+  integrity sha512-AAfm3oUQRTOMfMMWQh5spMq0YdnY+DU9V8NbU/TBmBmgvVwWcZQOZqHlYb4rd21HL26VwcHeRe+EfXdLLV7vHg==
   dependencies:
     d3-shape "^1.0.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-polar-axis@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.4.6.tgz#c7aa9b0be35dced1e2f835e7e327e28c377f20a7"
-  integrity sha512-NtnjPJ2zvB4BoR9LY4wJydx0ZocZkv1367WA8J1Co5cx2jGnZFD0rrFxlQ3OWQxZ6/Dk+LrryjE64bPq81m0qw==
+victory-polar-axis@^35.4.11:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.4.11.tgz#e2fdd84d45abc318ba29e452382635094f88dbab"
+  integrity sha512-yLrZ/PfcCRvw98zUBPB+LK9EoiYLBjellnILI3nAT5vCvKg1AnmBdF0lLuz0tM9jfcFdCL+1o2IO+r+OHKWTnw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-scatter@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.4.6.tgz#ca612c9109d9eb92c0ff199d9456c64383e7e0f1"
-  integrity sha512-4qWNnKhI0gCxKAX2cW6L0aGnHd9Y5OUeJezQSL4JWvW+tNBDPhB/AXOgTTMqD/0NGwKvRIFgStN9k2DdgYu44A==
+victory-scatter@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.4.11.tgz#ad60e4c08f0ddd6699ab95f94279bf678d626eeb"
+  integrity sha512-IKcYa9tYwO2OIn12AotySRzpQ+tWAy71i/sdckw3lh3FBWDk6Zq+PVlICYDgKLuTsV2bUDQixYZGDQ5lcNIcmw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-selection-container@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.4.6.tgz#58b2332f7c5f564fb457fe785b0fee812e5bdaa5"
-  integrity sha512-mkxY10Vcy3kAtJ/dOFORnKdFNRdZv3OWDSazX0AHSfgZnXYIpYByolfYx/bqckbhge3kZzt5COzpJDG9kBDFMA==
+victory-selection-container@^35.4.11:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.4.11.tgz#205b249d4685882b96e7c8646f9edc30179e9308"
+  integrity sha512-+yuUd+Clt+BFD+moFgPCuU1pbiJrHwzncovUEnfKO668HKgEr1HbR67sd2ZDLVULhfG1JRwGnbzWAYnQBcjEoA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-shared-events@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.4.6.tgz#37932f620929b909cc8cf58b5ed86a1b63cac78d"
-  integrity sha512-fiKfxxRqQMsmCU5K/E0xaqiwAHOGSyzN4+sbuya0AuEq1sZEWUlFrhsEesUyqViEIqslLPfRsCrYgw/EA1I4WA==
+victory-shared-events@^35.4.11:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.4.11.tgz#28843d3c6d2165d15ee61ea5c70e0bc6a68c8229"
+  integrity sha512-OjoqLfIHX82iThVbZmytMDddzIKLTkIhfB2+qptGA7/2VKInmdQXi5IUjp904YJZls7oLLRMwXsGEwKKvZLLBw==
   dependencies:
     json-stringify-safe "^5.0.1"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-stack@^35.3.5:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.4.6.tgz#ebdc58922035b9d71d79e23b71d481c40f7dda5b"
-  integrity sha512-1+C7OSwlnEi4agfpY3HjFtVsbyUt+Q2nbU7SuNJ6BrNz7BDbTtazzrFi9nL9jAS56iJJA7Z6O3J7zOE3fj22Ug==
+victory-stack@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.4.11.tgz#e7b2626313e7090566ba2e77ba673563d64e5af6"
+  integrity sha512-NVVe1CI+BsKinJEFIfinOFex3cESI/NbeVG6lSJmxHkmh56B3ICYJvXbgLSTS5WKcExbSe6bkB3mMJrEZf1+eA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.4.6"
-    victory-shared-events "^35.4.6"
+    victory-core "^35.4.11"
+    victory-shared-events "^35.4.11"
 
-victory-tooltip@^35.3.5, victory-tooltip@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.4.6.tgz#377622c54fe6dc62bf224d8ef1bf9315507ed6ad"
-  integrity sha512-XEi/s4yvi4a+6m+VJWOp9biS/hy0x4cfY4qWQW3Xn/3NhxWY2TNhr3aQOsqKBkJhS59eo5KwzyQ9phEyT4i5rg==
+victory-tooltip@^35.4.11, victory-tooltip@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.4.11.tgz#c4291b0517010f09bac7bda89d482ad690cf8f63"
+  integrity sha512-nyhENyuy5/7Swl3H/q9T9g04TniPyE6vNvN+xkJw+KIHL8FivajjY7xtZhcUoid6ZUKWjcaYI1wu/TUpX9uMCg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
-victory-voronoi-container@^35.3.5, victory-voronoi-container@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.4.6.tgz#c1c03b0a09bfb639a9bb268f2853534646c2d7c2"
-  integrity sha512-lhXOGPZ4uEyfamp/l62/HJ5d/GDxmMD7Xagh+4TfIg6bWYBd3+BVG65bvO17yc+kkW2PWqzFIYtSpbFxEam9Ng==
+victory-voronoi-container@^35.4.11, victory-voronoi-container@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.4.11.tgz#d7c03f997de8e0129fbab38dbdb1dbca83647217"
+  integrity sha512-3KL5pN46+S0N1GSnNaTILgSXrmW/8Y6WryWhxlv/dgcDGd9j9V5gNF1OVBjqPeCYyu1jlszXB+PxMcE1CaCYEQ==
   dependencies:
     delaunay-find "0.0.5"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.4.6"
-    victory-tooltip "^35.4.6"
+    victory-core "^35.4.11"
+    victory-tooltip "^35.4.11"
 
-victory-zoom-container@^35.3.5, victory-zoom-container@^35.4.6:
-  version "35.4.6"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.4.6.tgz#161cfb70cfec14599fb2547d8b9c19c152b9e261"
-  integrity sha512-DbNkI3eyyIzz1ntw15yVTSW+b6vGS96JYYf7O8NNct8rzPIYTF0e4oNROPRLLGEJnm2XiBhSiR8/aWeOCcJMag==
+victory-zoom-container@^35.4.11, victory-zoom-container@^35.4.4:
+  version "35.4.11"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.4.11.tgz#42851b23e8d266a1d8a811f6382212b6eaef2816"
+  integrity sha512-iCbBU2enQLAkFmOC2rqV1xh8voC+kgDoaxjlXsh39dkK7bjkzGHS7N4zFcIN31tJtulSzR1w3X/owjK3dTzHkQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.4.6"
+    victory-core "^35.4.11"
 
 vm-browserify@^1.0.1:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,19 +2163,18 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@patternfly/patternfly@4.87.3", "@patternfly/patternfly@^4.87.3":
-  version "4.87.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.87.3.tgz#eb2e9b22aa8f6f106580e7451bf204a06cb9949e"
-  integrity sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA==
+"@patternfly/patternfly@^4.90.5":
+  version "4.90.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.90.5.tgz#49aca1c49837e5bf877cdb9ffe454d97bf48e587"
+  integrity sha512-Fe0C8UkzSjtacQ+fHXlFB/LHzrv/c2K4z479C6dboOgkGQE1FyB0wt1NBfxij0D++rhOy04OOYdE+Tr0JSlZKw==
 
-"@patternfly/react-charts@^6.14.2":
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.14.2.tgz#20d5b98af4504c2e2e38e4836088dfa54fb324cf"
-  integrity sha512-QfO+wJRCj6Wof/18KWpY0XmZKXhv4y2QsmLtjMoGtZbbjHtEUwXA+lYc4agj9k+CEpm+3xXR2GOoNSwaSZN3RA==
+"@patternfly/react-charts@^6.14.6":
+  version "6.14.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.14.6.tgz#2702d45cf7461c8381ece9ca7e397a086dff193a"
+  integrity sha512-k+360HSlpBzA93QDmvqwUOL49kEtLLFxVIRZoYBKFjRXaVuuzajZB4b8kGckxumrq9PHkRbsN/XTn6FPXoqSCQ==
   dependencies:
-    "@patternfly/patternfly" "4.87.3"
-    "@patternfly/react-styles" "^4.8.2"
-    "@patternfly/react-tokens" "^4.10.2"
+    "@patternfly/react-styles" "^4.8.5"
+    "@patternfly/react-tokens" "^4.10.5"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "1.13.0"
@@ -2208,14 +2207,14 @@
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-core@^4.97.2":
-  version "4.97.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.2.tgz#a389f6984d03ed730506fa3cdccb1355f37b04fc"
-  integrity sha512-Xl/l/+OjWVtWnbb9Kw//1bn+6KEM9aOc1nk+Vm6D8wlbuuz+RAFBc0rZjPWuq00YYnVA+sExESe0W2d3wdn/SQ==
+"@patternfly/react-core@^4.101.3":
+  version "4.101.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.101.3.tgz#aecf6c0e05f4e4811e5d1d55cae9725d51440026"
+  integrity sha512-xmBzwtpTHjykwahWVEc+xlqEJ7k+g90EYlLDSIFhNylnoq6iAka8cWbiRWuxOzAIwmk4UrKy2lOYP/Ff5A8ZCw==
   dependencies:
-    "@patternfly/react-icons" "^4.9.2"
-    "@patternfly/react-styles" "^4.8.2"
-    "@patternfly/react-tokens" "^4.10.2"
+    "@patternfly/react-icons" "^4.9.5"
+    "@patternfly/react-styles" "^4.8.5"
+    "@patternfly/react-tokens" "^4.10.5"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
@@ -2226,25 +2225,25 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.22.tgz#ee8c4f66020abf200cbdd233fba27d004dea562f"
   integrity sha512-JDsnebr9CNIyrv9yjaGFQ56OChbV6KcxMYBIpNc8/sZdU4TXHWNC7P7rlUM/BuGpbWvyaOJtscRuf5uteIKX3A==
 
-"@patternfly/react-icons@^4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.2.tgz#dcb2efa9727de97d5aa5d6be47a75daee49addb8"
-  integrity sha512-3PY81A9mj9YyUpznSWhcWMKHRyGWNgZ1IDYqbMva7Q8wgd0fjsiTJ+5zAp4YQLo1mA8KwYX9v5s37hK8XiTbAA==
+"@patternfly/react-icons@^4.9.5":
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.5.tgz#4f727ed1c161ba6932abd3fa7bddb0e03bca5ec1"
+  integrity sha512-5M6yBW2v0d7WDuW7AyR//84iFxz7CBp5clGReYS/2SNwBGX+TwWoedS8EM06xtLSKCMrTQG1lqeyZASn6KyoMA==
 
 "@patternfly/react-styles@^4.7.22":
   version "4.7.22"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.22.tgz#fda249c5ee03db965cad648da92aa1caa7eff02f"
   integrity sha512-ojNuSNJx6CkNtsSFseZ2SJEVyzPMFYh0jOs204ICzYM1+fn9acsIi3Co0bcskFRzw8F6e2/x+8uVNx6QI8elxg==
 
-"@patternfly/react-styles@^4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
-  integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
+"@patternfly/react-styles@^4.8.5":
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.5.tgz#2e7579768d1b1e5d244ee9af6fd78524fc1e3e22"
+  integrity sha512-ANJoOJpcO0R7DY0CsTHMWaZfiLoMfMKu36ctnVnheJ3YfZievCo6O8mztNBB6QLhJvF/PrirJ8yffyVxOopT5w==
 
-"@patternfly/react-tokens@^4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
-  integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
+"@patternfly/react-tokens@^4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.5.tgz#be8cccc1d350e0583a28b65914aefcfddfc8197c"
+  integrity sha512-/lJRrC1asoaMSJVt1e5eZNn+y87x0q9WzeKx+aMi44RmJLwRLSNYGe8CxZiOUP1gw45jpzjRAbLihU+AGESckg==
 
 "@patternfly/react-tokens@^4.9.22":
   version "4.9.22"


### PR DESCRIPTION
This PR adds new scripts to make it easier to update the Patternfly version.

The `package.json` has three new scripts:
 - `update` - Update Patternfly version, link dependencies, build and update snapshots;
 - `update:deps` - Update Patternfly version, link dependencies, and build;
 - `update:snaps` - Update snapshots;

The snapshots update should be used with **_caution_**. It is meant to help with minor changes, such as changes that don't affect the UI and don't remove the necessity to manually check for any breaking change on the Channels.