### PR TITLE
KOGITO-4442: Task Console Form breaks when task has no data assignments

### DIFF
--- a/packages/form-renderer/package.json
+++ b/packages/form-renderer/package.json
@@ -21,7 +21,9 @@
     "ajv": "6.12.2",
     "uniforms": "3.0.0",
     "uniforms-bridge-json-schema": "3.0.0",
-    "uniforms-patternfly": "4.1.2",
+    "uniforms-patternfly": "4.1.2"
+  },
+  "devDependencies": {
     "lodash": "^4.14.2"
   },
   "files": [

--- a/packages/form-renderer/package.json
+++ b/packages/form-renderer/package.json
@@ -21,7 +21,8 @@
     "ajv": "6.12.2",
     "uniforms": "3.0.0",
     "uniforms-bridge-json-schema": "3.0.0",
-    "uniforms-patternfly": "4.1.2"
+    "uniforms-patternfly": "4.1.2",
+    "lodash": "^4.14.2"
   },
   "files": [
     "dist"

--- a/packages/form-renderer/src/utils/ModelConversionTool.ts
+++ b/packages/form-renderer/src/utils/ModelConversionTool.ts
@@ -40,6 +40,10 @@ export class ModelConversionTool {
       return obj;
     }
 
+    if (!schema.properties) {
+      return obj;
+    }
+
     Object.keys(model).forEach(property => {
       const properties = schema.properties[property];
 

--- a/packages/form-renderer/src/utils/__tests__/ModelConversionTool.test.ts
+++ b/packages/form-renderer/src/utils/__tests__/ModelConversionTool.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { cloneDeep } from 'lodash';
 import { ModelConversionTool } from "../ModelConversionTool";
 
 const schema = {
@@ -107,15 +108,25 @@ function testModel(
 }
 
 describe("Model Conversion  tests", () => {
-  test("String to dates conversion", () => {
+  it("String to dates conversion", () => {
     testModel(currentStrDate, currentDate, (model, formSchema) =>
       ModelConversionTool.convertStringToDate(model, formSchema)
     );
   });
 
-  test("Dates to strings conversion", () => {
+  it("Dates to strings conversion", () => {
     testModel(currentDate, currentStrDate, (model, formSchema) =>
       ModelConversionTool.convertDateToString(model, formSchema)
     );
+  });
+
+  it('Empty schema conversion', () => {
+    const model = getModel(currentDate);
+    const formSchema = cloneDeep(schema);
+    delete formSchema.properties;
+
+    const result = ModelConversionTool.convertDateToString(model, formSchema);
+
+    expect(result).not.toBeNull();
   });
 });


### PR DESCRIPTION
This PR avoids breaking the FormRenderer when the form schema doesn't have properties. In runtimes this may happen if the task doesn't have data assignments.