### PR TITLE
Improve VS Code Extension Integration Tests

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
@@ -1,1 +1,7 @@
-{}
+{
+    "retries": 1,
+    "reporter":  "xunit",
+    "reporterOptions": {
+        "output": "./it-tests/results/junit.xml"
+    }
+}

--- a/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
@@ -1,7 +1,1 @@
-{
-    "retries": 1,
-    "reporter":  "xunit",
-    "reporterOptions": {
-        "output": "./it-tests/results/junit.xml"
-    }
-}
+{}

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -110,7 +110,7 @@
     "compile": "webpack",
     "watch": "webpack",
     "test": "echo 'No tests to run.'",
-    "test:it": "yarn run compile && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -u -e ./test-resources -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
+    "test:it": "rm -rf ./test-resource && rm -rf ./out && tsc --skipLibCheck --sourceMap true && extest setup-and-run --yarn -u -e ./test-resources -o src/ui-test/settings.json \"out/ui-test/*.test.js\"",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run build:fast",
     "build:prod:linux:darwin": "yarn run build --mode production --devtool none && yarn run test && yarn run package:prod",


### PR DESCRIPTION
@domhanak While debugging the integration tests on #409, I found some points of improvement on the way we run our VS Code Extension IT tests. Can you please take a look? cc @caponetto 

What I did:
1. Removed the call to `yarn run compile`, since we only run the IT tests after running `build:prod`, which generates a `.vsix` file, that's used for executing the tests.
2. Added `rm -rf ./test-resource`. For some reason, when the tests failed, the existence of this file was blocking a re-run, so removing it before running fixes the problem
3. Removed the custom reporter on mocha configuration. I don't think we still need to report the errors on this JUnit format, right? So to make it easier to see the errors on our CI jobs, using the default reporter might save us some time!

**NOTE:** I noticed that some times the tests were haging before executing. This might be what's causing the flaky behaviour on our CI as well! What I noticed here locally is that the `before` part is executing before our extension is *active* on the testing VS Code window. Do you know if there's a way to wait for the extensions to be fully active before beginning the tests?