### PR TITLE
Fix imports and PMML Editor package

### DIFF
--- a/packages/pmml-editor/README.md
+++ b/packages/pmml-editor/README.md
@@ -10,6 +10,4 @@ Nothing should be considered concrete at this point.
 
 In order to run:
 
-`yarn run build:showcase`
-
 `yarn run start`

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/editor/index.d.ts",
   "homepage": "https://manstis.github.io/kogito-tooling",
   "files": [
-    "dist"
+    "dist/editor"
   ],
   "repository": {
     "type": "git",

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -3,8 +3,8 @@
   "version": "0.8.5",
   "description": "",
   "license": "Apache-2.0",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/editor/index.js",
+  "types": "./dist/editor/index.d.ts",
   "homepage": "https://manstis.github.io/kogito-tooling",
   "files": [
     "dist"
@@ -42,8 +42,7 @@
     "test:watch": "jest --watch",
     "build:fast": "rm -rf dist && webpack",
     "build": "yarn run lint && yarn test && yarn run build:fast",
-    "build:prod": "yarn run build --mode production",
-    "build:showcase": "yarn run build:fast --mode development",
+    "build:prod": "yarn run build --mode production --devtool none",
     "start": "webpack-dev-server -d --host 0.0.0.0 --mode development",
     "deploy": "gh-pages -d dist"
   },

--- a/packages/pmml-editor/tsconfig.json
+++ b/packages/pmml-editor/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/packages/pmml-editor/webpack.config.js
+++ b/packages/pmml-editor/webpack.config.js
@@ -22,66 +22,59 @@ const common = require("../../webpack.common.config");
 const pfWebpackOptions = require("@kogito-tooling/patternfly-base/patternflyWebpackOptions");
 const nodeExternals = require("webpack-node-externals");
 
-let config = merge(common, {
-  entry: {
-    index: "./src/editor/index.ts"
-  },
-  plugins: [
-    new CopyPlugin([
-      {
-        from: "./static/images",
-        to: "./images"
-      }
-    ]),
-    new MonacoWebpackPlugin()
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.ttf$/,
-        use: ["file-loader"]
-      },
-      ...pfWebpackOptions.patternflyRules
-    ]
-  }
-});
-
-module.exports = (env, argv) => {
-  if (argv.mode === "production") {
-    config = merge(config, {
-      mode: "production",
-      devtool: "none",
-      externals: [nodeExternals({ modulesDir: "../../node_modules" })]
-    });
-  }
-
-  if (argv.mode === "development") {
-    config = merge(config, {
-      entry: {
-        index: "./src/showcase/index.tsx"
-      },
-      plugins: [
-        new CopyPlugin([
-          { from: "./src/showcase/static/resources", to: "./resources" },
-          { from: "./src/showcase/static/index.html", to: "./index.html" },
-          { from: "./src/showcase/static/favicon.ico", to: "./favicon.ico" },
-          { from: "./static/images", to: "./images" }
-        ])
-      ],
-      devServer: {
-        historyApiFallback: true,
-        disableHostCheck: true,
-        watchContentBase: true,
-        contentBase: path.join(__dirname),
-        compress: true,
-        port: 9001,
-        open: true,
-        inline: true,
-        hot: true,
-        overlay: true
-      }
-    });
-  }
-
-  return config;
-};
+module.exports = [
+  merge(common, {
+    entry: {
+      "editor/index": "./src/editor/index.ts"
+    },
+    output: {
+      libraryTarget: "commonjs2"
+    },
+    externals: [nodeExternals({ modulesDir: "../../node_modules" })],
+    plugins: [new CopyPlugin([{ from: "./static/images", to: "./images" }]), new MonacoWebpackPlugin()],
+    module: {
+      rules: [
+        {
+          test: /\.ttf$/,
+          use: ["file-loader"]
+        },
+        ...pfWebpackOptions.patternflyRules
+      ]
+    }
+  }),
+  merge(common, {
+    entry: {
+      index: "./src/showcase/index.tsx"
+    },
+    plugins: [
+      new MonacoWebpackPlugin(),
+      new CopyPlugin([
+        { from: "./src/showcase/static/resources", to: "./resources" },
+        { from: "./src/showcase/static/index.html", to: "./index.html" },
+        { from: "./src/showcase/static/favicon.ico", to: "./favicon.ico" },
+        { from: "./static/images", to: "./images" }
+      ])
+    ],
+    module: {
+      rules: [
+        {
+          test: /\.ttf$/,
+          use: ["file-loader"]
+        },
+        ...pfWebpackOptions.patternflyRules
+      ]
+    },
+    devServer: {
+      historyApiFallback: true,
+      disableHostCheck: true,
+      watchContentBase: true,
+      contentBase: path.join(__dirname),
+      compress: true,
+      port: 9001,
+      open: true,
+      inline: true,
+      hot: true,
+      overlay: true
+    }
+  })
+];

--- a/packages/pmml-editor/webpack.config.js
+++ b/packages/pmml-editor/webpack.config.js
@@ -31,15 +31,9 @@ module.exports = [
       libraryTarget: "commonjs2"
     },
     externals: [nodeExternals({ modulesDir: "../../node_modules" })],
-    plugins: [new CopyPlugin([{ from: "./static/images", to: "./images" }]), new MonacoWebpackPlugin()],
+    plugins: [new MonacoWebpackPlugin()],
     module: {
-      rules: [
-        {
-          test: /\.ttf$/,
-          use: ["file-loader"]
-        },
-        ...pfWebpackOptions.patternflyRules
-      ]
+      rules: [...pfWebpackOptions.patternflyRules]
     }
   }),
   merge(common, {

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/webview/PMMLEditorEnvelopeApp.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/webview/PMMLEditorEnvelopeApp.ts
@@ -16,7 +16,7 @@
 
 import * as EditorEnvelope from "@kogito-tooling/editor/dist/envelope";
 import { ChannelType, getOperatingSystem } from "@kogito-tooling/channel-common-api";
-import { PMMLEditorFactory } from "@kogito-tooling/pmml-editor/src/editor";
+import { PMMLEditorFactory } from "@kogito-tooling/pmml-editor";
 
 EditorEnvelope.init({
   container: document.getElementById("envelope-app")!,

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -16,7 +16,7 @@
 
 import { KogitoEdit } from "@kogito-tooling/channel-common-api";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
-import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/dist/vscode";
 import * as vscode from "vscode";
 import {
   CancellationToken,

--- a/packages/vscode-extension/src/KogitoEditorWebviewProvider.ts
+++ b/packages/vscode-extension/src/KogitoEditorWebviewProvider.ts
@@ -31,7 +31,7 @@ import { KogitoEditorStore } from "./KogitoEditorStore";
 import { KogitoEditableDocument } from "./KogitoEditableDocument";
 import { VsCodeI18n } from "./i18n";
 import { I18n } from "@kogito-tooling/i18n/dist/core";
-import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/dist/vscode";
 
 export class KogitoEditorWebviewProvider implements CustomEditorProvider<KogitoEditableDocument> {
   private readonly _onDidChangeCustomDocument = new EventEmitter<CustomDocumentEditEvent<KogitoEditableDocument>>();

--- a/packages/vscode-extension/src/index.ts
+++ b/packages/vscode-extension/src/index.ts
@@ -25,7 +25,7 @@ import { vsCodeI18nDefaults, vsCodeI18nDictionaries } from "./i18n";
 import { KogitoEditorFactory } from "./KogitoEditorFactory";
 import { KogitoEditorStore } from "./KogitoEditorStore";
 import { KogitoEditorWebviewProvider } from "./KogitoEditorWebviewProvider";
-import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/src/vscode/VsCodeNotificationsApi";
+import { VsCodeNotificationsApi } from "@kogito-tooling/notifications/dist/vscode";
 
 /**
  * Starts a Kogito extension.


### PR DESCRIPTION
After releasing 0.8.4 and trying to use its packages to update `kie-tooling-store`, I faced issues with the way the some classes were being imported.  I also noticed that the imports for the PMML Editor wouldn't work, since they faced the same issue. This PR fixes these problems.

Tested `yarn start` without building the showcase first and it works, so I removed this script.

Also tested the VS Code Extension and it worked normally on both `yarn build:fast` and `yarn build:prod`.