### PR TITLE
Fix PMML Editor CSS

### DIFF
--- a/packages/editor/src/envelope/EditorEnvelopeView.tsx
+++ b/packages/editor/src/envelope/EditorEnvelopeView.tsx
@@ -17,9 +17,7 @@
 import * as React from "react";
 import { Editor } from "../api";
 import { LoadingScreen } from "./LoadingScreen";
-import "@patternfly/patternfly/base/patternfly-variables.css";
-import "@patternfly/patternfly/patternfly-addons.scss";
-import "@patternfly/patternfly/patternfly.scss";
+import "@patternfly/patternfly/patternfly.css";
 import { KeyBindingsHelpOverlay } from "./KeyBindingsHelpOverlay";
 import { useCallback, useImperativeHandle, useState } from "react";
 

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/patternfly.css";
+@import "../../../../../../../node_modules/@patternfly/patternfly/sass-utilities/all";
+@import "../../../../../../../node_modules/@patternfly/patternfly/base/variables";
 
 .attributes {
 

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/patternfly.css";
+@import "../../../../../../../node_modules/@patternfly/patternfly/sass-utilities/all";
+@import "../../../../../../../node_modules/@patternfly/patternfly/base/variables";
 
 .outputs {
 


### PR DESCRIPTION
I noticed that patternfly.css was loading one extra time when the extension was built with the fixed import, so I tracked it down to the envelope importing it as `.scss` and the PMML Editor importing it as `.css`. I figured webpack treated them as different modules, therefore, loaded it twice. This is all theoretical of course, but it worked :)

Also, I changed the imports on the custom `.scss` files to be the same as in `styles.scss` of the Envelope. Couldn't find anything broken after this change too.

Please take a look at the VS Code extension on the CI artifacts! If everything is okay, we can do a new release first thing next week.