### PR TITLE
Fix PMML CSS inside the editor package.

### DIFF
--- a/packages/pmml-editor/README.md
+++ b/packages/pmml-editor/README.md
@@ -11,3 +11,4 @@ Nothing should be considered concrete at this point.
 In order to run:
 
 `yarn run start`
+

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/patternfly.css";
-
 .attributes {
 
   &__header {

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/patternfly.css";
-
 .outputs {
 
   &__header {

--- a/packages/pmml-editor/src/editor/index.ts
+++ b/packages/pmml-editor/src/editor/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import "@patternfly/patternfly/base/patternfly-variables.css";
 import "@patternfly/patternfly/patternfly.scss";
 
 export * from "./PMMLEditor";

--- a/packages/pmml-editor/src/editor/index.ts
+++ b/packages/pmml-editor/src/editor/index.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import "@patternfly/patternfly/patternfly.css";
+import "@patternfly/patternfly/base/patternfly-variables.css";
+import "@patternfly/patternfly/patternfly.scss";
 
 export * from "./PMMLEditor";
 export * from "./PMMLEditorFactory";


### PR DESCRIPTION
@tiagobento @kelvah I propose this PR in preference of #457

This keeps the changes "inside the editor". The conclusion being: import the same packages as used by the container (envelope).