### PR TITLE
FAI-431: Score Cards: Validation of partial scores inside Characteristics' Attributes not behaving correctly

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/AttributeLabels.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/atoms/AttributeLabels.tsx
@@ -23,6 +23,7 @@ import { Builder } from "../../../paths";
 
 interface AttributeLabelsProps {
   modelIndex: number;
+  characteristic: Characteristic;
   characteristicIndex: number;
   activeAttributeIndex: number;
   activeAttribute: Attribute;
@@ -34,6 +35,7 @@ interface AttributeLabelsProps {
 export const AttributeLabels = (props: AttributeLabelsProps) => {
   const {
     modelIndex,
+    characteristic,
     characteristicIndex,
     activeAttributeIndex,
     activeAttribute,
@@ -74,7 +76,7 @@ export const AttributeLabels = (props: AttributeLabelsProps) => {
           .forPartialScore()
           .build()
       ),
-    [modelIndex, characteristicIndex, activeAttribute, activeAttributeIndex]
+    [modelIndex, characteristicIndex, characteristic, activeAttribute, activeAttributeIndex]
   );
 
   return (

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributesTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/AttributesTableRow.tsx
@@ -27,6 +27,7 @@ import { toText } from "../organisms";
 interface AttributesTableRowProps {
   modelIndex: number;
   characteristicIndex: number;
+  characteristic: Characteristic;
   attributeIndex: number;
   attribute: Attribute;
   areReasonCodesUsed: boolean;
@@ -42,6 +43,7 @@ export const AttributesTableRow = (props: AttributesTableRowProps) => {
   const {
     modelIndex,
     characteristicIndex,
+    characteristic,
     attributeIndex,
     attribute,
     areReasonCodesUsed,
@@ -116,6 +118,7 @@ export const AttributesTableRow = (props: AttributesTableRowProps) => {
           <AttributeLabels
             modelIndex={modelIndex}
             characteristicIndex={characteristicIndex}
+            characteristic={characteristic}
             activeAttributeIndex={attributeIndex}
             activeAttribute={attribute}
             areReasonCodesUsed={areReasonCodesUsed}

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
@@ -127,6 +127,7 @@ const CharacteristicAttributesList = (props: CharacteristicAttributesListProps) 
           <AttributeLabels
             modelIndex={modelIndex}
             characteristicIndex={characteristicIndex}
+            characteristic={characteristic}
             activeAttributeIndex={index}
             activeAttribute={item}
             areReasonCodesUsed={areReasonCodesUsed}

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.tsx
@@ -82,6 +82,7 @@ export const AttributesTable = (props: AttributesTableProps) => {
             key={index}
             modelIndex={modelIndex}
             characteristicIndex={characteristicIndex}
+            characteristic={characteristic}
             attributeIndex={index}
             attribute={attribute}
             areReasonCodesUsed={areReasonCodesUsed}


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/FAI-431

The validation of partial scores is not updated after undo/redo actions.

The rule is that if a baseline score is provided for one of the attributes, all the attributes of the same characteristic must have a baseline score too.

An example of the issue:
<img src="https://user-images.githubusercontent.com/1220606/112510497-c3d19a00-8d91-11eb-912f-ab410c420c5c.png?raw=true" width="500" />
