### PR TITLE
Add test for Undo command on VS Code extension

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -120,8 +120,11 @@ describe("Editors are loading properly", () => {
     await webview.switchToFrame();
     const dmnEditorTester = new DmnEditorTestHelper(webview);
 
-    await (await dmnEditorTester.openDecisionNavigator()).selectDiagramNode("?DemoDecision1");
-    await (await dmnEditorTester.openDiagramProperties()).changeProperty("Name", "Updated Name 1");
+    const decisionNavigator = await dmnEditorTester.openDecisionNavigator();
+    await decisionNavigator.selectDiagramNode("?DemoDecision1");
+    
+    const diagramProperties = await dmnEditorTester.openDiagramProperties();
+    await diagramProperties.changeProperty("Name", "Updated Name 1");
 
     const navigatorPanel: DecisionNavigatorHelper = await dmnEditorTester.openDecisionNavigator();
     await navigatorPanel.assertDiagramNodeIsPresent("Updated Name 1");

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -133,8 +133,8 @@ describe("Editors are loading properly", () => {
     await webview.switchBack();
 
     // changeProperty() is implemented as clear() and sendKeys(), that is why we need two undo operations
-    await testHelper.undo();
-    await testHelper.undo();
+    await testHelper.openCommandFromPrompt("Undo");
+    await testHelper.openCommandFromPrompt("Undo");
 
     await webview.switchToFrame();
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -133,8 +133,8 @@ describe("Editors are loading properly", () => {
     await webview.switchBack();
 
     // changeProperty() is implemented as clear() and sendKeys(), that is why we need two undo operations
-    await testHelper.openCommandFromPrompt("Undo");
-    await testHelper.openCommandFromPrompt("Undo");
+    await testHelper.executeCommandFromPrompt("Undo");
+    await testHelper.executeCommandFromPrompt("Undo");
 
     await webview.switchToFrame();
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -22,7 +22,7 @@ import { assertWebElementIsDisplayedEnabled, assertWebElementWithAtribute } from
 import VSCodeTestHelper from "./helpers/VSCodeTestHelper";
 import BpmnEditorTestHelper, { PaletteCategories } from "./helpers/BpmnEditorTestHelper";
 import ScesimEditorTestHelper from "./helpers/ScesimEditorTestHelper";
-import DmnEditorTestHelper from "./helpers/DmnEditorTestHelper";
+import DmnEditorTestHelper from "./helpers/dmn/DmnEditorTestHelper";
 import PmmlEditorTestHelper from "./helpers/PmmlEditorTestHelper";
 import { assert } from "chai";
 import {
@@ -31,6 +31,7 @@ import {
   palletteItemAnchor,
   assignmentsTextBoxInput,
 } from "./helpers/BpmnLocators";
+import DecisionNavigatorHelper from "./helpers/dmn/DecisionNavigatorHelper";
 
 describe("Editors are loading properly", () => {
   const RESOURCES: string = path.resolve("it-tests", "resources");
@@ -109,6 +110,33 @@ describe("Editors are loading properly", () => {
     // await dmnEditorTester.inspectIncludedModel("reusable-model", 2)
 
     await dmnEditorTester.switchEditorTab(EditorTabs.Editor);
+
+    await webview.switchBack();
+  });
+
+  it("Undo command in DMN Editor", async function () {
+    this.timeout(40000);
+    webview = await testHelper.openFileFromSidebar(DEMO_DMN);
+    await webview.switchToFrame();
+    const dmnEditorTester = new DmnEditorTestHelper(webview);
+
+    await (await dmnEditorTester.openDecisionNavigator()).selectDiagramNode("?DemoDecision1");
+    await (await dmnEditorTester.openDiagramProperties()).changeProperty("Name", "Updated Name 1");
+
+    const navigatorPanel: DecisionNavigatorHelper = await dmnEditorTester.openDecisionNavigator();
+    await navigatorPanel.assertDiagramNodeIsPresent("Updated Name 1");
+    await navigatorPanel.assertDiagramNodeIsPresent("?DecisionFinal1");
+
+    await webview.switchBack();
+
+    // changeProperty() is implemented as clear() and sendKeys(), that is why we need two undo operations
+    await testHelper.undo();
+    await testHelper.undo();
+
+    await webview.switchToFrame();
+
+    await navigatorPanel.assertDiagramNodeIsPresent("?DemoDecision1");
+    await navigatorPanel.assertDiagramNodeIsPresent("?DecisionFinal1");
 
     await webview.switchBack();
   });

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -122,7 +122,7 @@ describe("Editors are loading properly", () => {
 
     const decisionNavigator = await dmnEditorTester.openDecisionNavigator();
     await decisionNavigator.selectDiagramNode("?DemoDecision1");
-    
+
     const diagramProperties = await dmnEditorTester.openDiagramProperties();
     await diagramProperties.changeProperty("Name", "Updated Name 1");
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonAsserts.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonAsserts.ts
@@ -43,14 +43,12 @@ export const assertWebElementWithAtribute = async (
 
 /**
  * Asserts the provided variable is defined
- * 
+ *
  * @param value Variable to check
  * @param valueDescriptor Variable descriptor printed in case of assertion fail
  */
 export function assertIsDefined<T>(value: T, valueDescriptor?: String): asserts value is NonNullable<T> {
   if (value === undefined || value === null) {
-    throw new AssertionError(
-      `Expected ${valueDescriptor} to be defined, but received ${value}`
-    );
+    throw new AssertionError(`Expected ${valueDescriptor} to be defined, but received ${value}`);
   }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonAsserts.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonAsserts.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import { assert, AssertionError } from "chai";
 import { WebElement } from "vscode-extension-tester";
 
 /**
@@ -40,3 +40,17 @@ export const assertWebElementWithAtribute = async (
 ): Promise<void> => {
   assert.equal(await tested.getAttribute(attribute), attributeValue);
 };
+
+/**
+ * Asserts the provided variable is defined
+ * 
+ * @param value Variable to check
+ * @param valueDescriptor Variable descriptor printed in case of assertion fail
+ */
+export function assertIsDefined<T>(value: T, valueDescriptor?: String): asserts value is NonNullable<T> {
+  if (value === undefined || value === null) {
+    throw new AssertionError(
+      `Expected ${valueDescriptor} to be defined, but received ${value}`
+    );
+  }
+}

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonLocators.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/CommonLocators.ts
@@ -26,12 +26,20 @@ export const aComponentWithText = (text: string): By => {
 };
 
 /**
- * Creates a XPATH string that locates <span> element with specific text.
+ * Creates a XPATH locator that locates <span> element with specific text.
  *
  * @param text string to match
  */
 export const spanComponentWithText = (text: string): By => {
   return By.xpath(`//span[text() = '${text}']`);
+};
+
+/**
+ * Creates a XPATH locator that locates <input> element with specified label.
+ * @param label label of the input field
+ */
+export const labeledInputElementInPropertiesPanel = (label: string): By => {
+  return By.xpath(`//label[contains(.,\'${label}\')]/following-sibling::div[@data-field='fieldContainer']/input`);
 };
 
 /**

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
@@ -231,10 +231,10 @@ export default class VSCodeTestHelper {
   public undo = async (): Promise<void> => {
     const edit = await new TitleBar().getItem("Edit");
     assertIsDefined(edit, "Edit Menu Item");
-    
+
     const editContextMenu = await edit.select();
     assertWebElementIsDisplayedEnabled(editContextMenu);
-    
+
     const undo = await editContextMenu.getItem("Undo");
     assertIsDefined(undo, "Undo Menu Item");
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
@@ -226,19 +226,24 @@ export default class VSCodeTestHelper {
   };
 
   /**
-   * Invokes the Edit -> Undo from the VS Code Title Bar
+   * Opens commands prompt and select given command there
    */
-  public undo = async (): Promise<void> => {
-    const edit = await new TitleBar().getItem("Edit");
-    assertIsDefined(edit, "Edit Menu Item");
+  public openCommandFromPrompt = async (command: string): Promise<void> => {
+    const inputBox = (await this.workbench.openCommandPrompt()) as InputBox;
+    await inputBox.setText(`>${command}`);
 
-    const editContextMenu = await edit.select();
-    assertWebElementIsDisplayedEnabled(editContextMenu);
+    const qPicks = await inputBox.getQuickPicks();
 
-    const undo = await editContextMenu.getItem("Undo");
-    assertIsDefined(undo, "Undo Menu Item");
+    for (const qPick of qPicks) {
+      const label = await qPick.getLabel();
+      if (label === command) {
+        await qPick.select();
+        await sleep(1000);
+        return;
+      }
+    }
 
-    await undo.select();
+    throw new Error(`'${command}' not found in prompt`);
   };
 }
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { assert, AssertionError } from "chai";
+import { assert } from "chai";
 import {
   ActivityBar,
   By,
   InputBox,
   SideBarView,
   until,
-  TitleBar,
   ViewControl,
   ViewSection,
   VSBrowser,
@@ -30,7 +29,6 @@ import {
   Workbench,
 } from "vscode-extension-tester";
 import { kogitoLoadingSpinner } from "./CommonLocators";
-import { assertIsDefined, assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
 
 /**
  * Common test helper class for VSCode extension testing.
@@ -228,16 +226,16 @@ export default class VSCodeTestHelper {
   /**
    * Opens commands prompt and select given command there
    */
-  public openCommandFromPrompt = async (command: string): Promise<void> => {
+  public executeCommandFromPrompt = async (command: string): Promise<void> => {
     const inputBox = (await this.workbench.openCommandPrompt()) as InputBox;
     await inputBox.setText(`>${command}`);
 
-    const qPicks = await inputBox.getQuickPicks();
+    const quickPicks = await inputBox.getQuickPicks();
 
-    for (const qPick of qPicks) {
-      const label = await qPick.getLabel();
+    for (const quickPick of quickPicks) {
+      const label = await quickPick.getLabel();
       if (label === command) {
-        await qPick.select();
+        await quickPick.select();
         await sleep(1000);
         return;
       }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
@@ -21,6 +21,7 @@ import {
   InputBox,
   SideBarView,
   until,
+  TitleBar,
   ViewControl,
   ViewSection,
   VSBrowser,
@@ -29,6 +30,7 @@ import {
   Workbench,
 } from "vscode-extension-tester";
 import { kogitoLoadingSpinner } from "./CommonLocators";
+import { assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
 
 /**
  * Common test helper class for VSCode extension testing.
@@ -221,6 +223,21 @@ export default class VSCodeTestHelper {
     await sleep(2000);
 
     await driver.switchTo().frame(null);
+  };
+
+  /**
+   * Invokes the Edit -> Undo from the VS Code Title Bar
+   */
+  public undo = async (): Promise<void> => {
+    const edit = await new TitleBar().getItem("Edit");
+    if (typeof edit !== "undefined") {
+      const editContextMenu = await edit.select();
+      assertWebElementIsDisplayedEnabled(editContextMenu);
+      const undo = await editContextMenu.getItem("Undo");
+      if (typeof undo !== "undefined") {
+        await undo.select();
+      }
+    }
   };
 }
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/VSCodeTestHelper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
+import { assert, AssertionError } from "chai";
 import {
   ActivityBar,
   By,
@@ -30,7 +30,7 @@ import {
   Workbench,
 } from "vscode-extension-tester";
 import { kogitoLoadingSpinner } from "./CommonLocators";
-import { assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
+import { assertIsDefined, assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
 
 /**
  * Common test helper class for VSCode extension testing.
@@ -230,14 +230,15 @@ export default class VSCodeTestHelper {
    */
   public undo = async (): Promise<void> => {
     const edit = await new TitleBar().getItem("Edit");
-    if (typeof edit !== "undefined") {
-      const editContextMenu = await edit.select();
-      assertWebElementIsDisplayedEnabled(editContextMenu);
-      const undo = await editContextMenu.getItem("Undo");
-      if (typeof undo !== "undefined") {
-        await undo.select();
-      }
-    }
+    assertIsDefined(edit, "Edit Menu Item");
+    
+    const editContextMenu = await edit.select();
+    assertWebElementIsDisplayedEnabled(editContextMenu);
+    
+    const undo = await editContextMenu.getItem("Undo");
+    assertIsDefined(undo, "Undo Menu Item");
+
+    await undo.select();
   };
 }
 

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { until, WebElement } from "vscode-extension-tester";
+import { assertWebElementIsDisplayedEnabled } from "../CommonAsserts";
+import { spanComponentWithText } from "../CommonLocators";
+
+/**
+ * Class for accessing expanded DMN Decision Navigator panel
+ */
+export default class DecisionNavigatorHelper {
+  private root: WebElement;
+
+  constructor(root: WebElement) {
+    this.root = root;
+  }
+
+  /**
+   * Selects a DMN diagram node by click it the DMN Decision Navigator panel
+   * Do not use this method to select an expression like 'Decision Table', 'Literal Expression' ...
+   *
+   * @param nodeName node name to select
+   */
+  public selectDiagramNode = async (nodeName: string): Promise<DecisionNavigatorHelper> => {
+    const node: WebElement = await this.getDiagramNode(nodeName);
+    await node.click();
+
+    return this;
+  };
+
+  /**
+   * Check if a given node is present in the DMN Deciion Navigator panel
+   *
+   * @param nodeName node name that will be asserted
+   */
+  public assertDiagramNodeIsPresent = async (nodeName: string): Promise<void> => {
+    await assertWebElementIsDisplayedEnabled(await this.getDiagramNode(nodeName));
+  };
+
+  private getDiagramNode = async (nodeName: string): Promise<WebElement> => {
+    return this.root
+      .getDriver()
+      .wait(until.elementLocated(spanComponentWithText(nodeName)), 5000, `${nodeName} not found in 5 seconds`);
+  };
+}

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
@@ -35,7 +35,7 @@ export default class DecisionNavigatorHelper {
     await node.click();
 
     return this;
-  };
+  }
 
   /**
    * Check if a given node is present in the DMN Deciion Navigator panel
@@ -44,11 +44,11 @@ export default class DecisionNavigatorHelper {
    */
   public async assertDiagramNodeIsPresent(nodeName: string): Promise<void> {
     await assertWebElementIsDisplayedEnabled(await this.getDiagramNode(nodeName));
-  };
+  }
 
   private async getDiagramNode(nodeName: string): Promise<WebElement> {
     return this.root
       .getDriver()
       .wait(until.elementLocated(spanComponentWithText(nodeName)), 5000, `${nodeName} not found in 5 seconds`);
-  };
+  }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
@@ -22,11 +22,7 @@ import { spanComponentWithText } from "../CommonLocators";
  * Class for accessing expanded DMN Decision Navigator panel
  */
 export default class DecisionNavigatorHelper {
-  private root: WebElement;
-
-  constructor(root: WebElement) {
-    this.root = root;
-  }
+  constructor(private readonly root: WebElement) {}
 
   /**
    * Selects a DMN diagram node by click it the DMN Decision Navigator panel

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DecisionNavigatorHelper.ts
@@ -30,7 +30,7 @@ export default class DecisionNavigatorHelper {
    *
    * @param nodeName node name to select
    */
-  public selectDiagramNode = async (nodeName: string): Promise<DecisionNavigatorHelper> => {
+  public async selectDiagramNode(nodeName: string): Promise<DecisionNavigatorHelper> {
     const node: WebElement = await this.getDiagramNode(nodeName);
     await node.click();
 
@@ -42,11 +42,11 @@ export default class DecisionNavigatorHelper {
    *
    * @param nodeName node name that will be asserted
    */
-  public assertDiagramNodeIsPresent = async (nodeName: string): Promise<void> => {
+  public async assertDiagramNodeIsPresent(nodeName: string): Promise<void> {
     await assertWebElementIsDisplayedEnabled(await this.getDiagramNode(nodeName));
   };
 
-  private getDiagramNode = async (nodeName: string): Promise<WebElement> => {
+  private async getDiagramNode(nodeName: string): Promise<WebElement> {
     return this.root
       .getDriver()
       .wait(until.elementLocated(spanComponentWithText(nodeName)), 5000, `${nodeName} not found in 5 seconds`);

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
@@ -16,9 +16,11 @@
 
 import { expect } from "chai";
 import { By, until, WebElement, WebView } from "vscode-extension-tester";
-import { assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
-import { expandedDocksBarE, h3ComponentWithText, tabWithTitle } from "./CommonLocators";
-import { EditorTabs } from "./EditorTabs";
+import { assertWebElementIsDisplayedEnabled } from "../CommonAsserts";
+import { expandedDocksBarE, h3ComponentWithText, tabWithTitle } from "../CommonLocators";
+import { EditorTabs } from "../EditorTabs";
+import PropertiesPanelHelper from "./PropertiesPanelHelper";
+import DecisionNavigatorHelper from "./DecisionNavigatorHelper";
 
 /**
  * Helper class to easen work with DMN editor inside of a webview.
@@ -152,14 +154,14 @@ export default class DmnEditorTestHelper {
    *
    * @returns a promise resolving to WebElement of openned panel.
    */
-  public openDiagramProperties = async (): Promise<WebElement> => {
+  public openDiagramProperties = async (): Promise<PropertiesPanelHelper> => {
     const properties = await this.getDiagramProperties();
     await assertWebElementIsDisplayedEnabled(properties);
     await properties.click();
     const expandedPropertiesPanel = await this.webview.findWebElement(expandedDocksBarE());
     await assertWebElementIsDisplayedEnabled(await properties.findElement(By.xpath(h3ComponentWithText("Properties"))));
     await assertWebElementIsDisplayedEnabled(expandedPropertiesPanel);
-    return expandedPropertiesPanel;
+    return new PropertiesPanelHelper(expandedPropertiesPanel);
   };
 
   /**
@@ -192,7 +194,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns a promise resolving to WebElement of openned panel.
    */
-  public openDecisionNavigator = async (): Promise<WebElement> => {
+  public openDecisionNavigator = async (): Promise<DecisionNavigatorHelper> => {
     const navigator = await this.getDecisionNavigator();
     await assertWebElementIsDisplayedEnabled(navigator);
     await navigator.click();
@@ -201,6 +203,6 @@ export default class DmnEditorTestHelper {
       await navigator.findElement(By.xpath(h3ComponentWithText("Decision Navigator")))
     );
     await assertWebElementIsDisplayedEnabled(expandedNavigatorPanel);
-    return expandedNavigatorPanel;
+    return new DecisionNavigatorHelper(expandedNavigatorPanel);
   };
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
@@ -28,14 +28,12 @@ import DecisionNavigatorHelper from "./DecisionNavigatorHelper";
  * via contructor.
  */
 export default class DmnEditorTestHelper {
-  
   private decisionNavigator: WebElement;
   private diagramExplorer: WebElement;
   private properties: WebElement;
 
-
   /**
-   * 
+   *
    * @param webview WebView where the editor Iframe is located.
    */
   constructor(private readonly webview: WebView) {}
@@ -48,7 +46,7 @@ export default class DmnEditorTestHelper {
   public async getDiagramExplorer(): Promise<WebElement> {
     this.diagramExplorer = await this.webview.findWebElement(By.xpath("//button[@data-title='Explore diagram']"));
     return this.diagramExplorer;
-  };
+  }
 
   /**
    * Finds DMN diagram properties element.
@@ -58,7 +56,7 @@ export default class DmnEditorTestHelper {
   public async getDiagramProperties(): Promise<WebElement> {
     this.properties = await this.webview.findWebElement(By.className("docks-item-E-DiagramEditorPropertiesScreen"));
     return this.properties;
-  };
+  }
 
   /**
    * Finds DMN decision navigator element.
@@ -70,7 +68,7 @@ export default class DmnEditorTestHelper {
       By.className("docks-item-E-org.kie.dmn.decision.navigator")
     );
     return this.decisionNavigator;
-  };
+  }
 
   /**
    * Switch editor to other Tab
@@ -80,7 +78,7 @@ export default class DmnEditorTestHelper {
     const tabElement = await this.webview.findWebElement(tabWithTitle(editorTab));
     await assertWebElementIsDisplayedEnabled(tabElement);
     await tabElement.click();
-  };
+  }
 
   /**
    * Using 'EditorTabs.IncludedModels' tab new model is included
@@ -120,7 +118,7 @@ export default class DmnEditorTestHelper {
     const includeButton = await this.webview.findWebElement(By.xpath("//button[@data-field='include']"));
     await assertWebElementIsDisplayedEnabled(includeButton);
     await includeButton.click();
-  };
+  }
 
   /**
    * Assert included model details on the 'EditorTabs.IncludedModels'
@@ -141,7 +139,7 @@ export default class DmnEditorTestHelper {
 
     const includedNodes = await includeDetails.findElement(By.xpath("//span[@data-field='drg-elements-count']"));
     expect(await includedNodes.getText()).to.equal(`${nodesCount}`, "Included model nodes count was not as expected");
-  };
+  }
 
   /**
    * Opens diagram properties.
@@ -160,7 +158,7 @@ export default class DmnEditorTestHelper {
     await assertWebElementIsDisplayedEnabled(await properties.findElement(By.xpath(h3ComponentWithText("Properties"))));
     await assertWebElementIsDisplayedEnabled(expandedPropertiesPanel);
     return new PropertiesPanelHelper(expandedPropertiesPanel);
-  };
+  }
 
   /**
    * Opens diagram explorer.
@@ -181,7 +179,7 @@ export default class DmnEditorTestHelper {
     );
     await assertWebElementIsDisplayedEnabled(expandedExplorerPanel);
     return expandedExplorerPanel;
-  };
+  }
 
   /**
    * Opens decision navigator.
@@ -202,5 +200,5 @@ export default class DmnEditorTestHelper {
     );
     await assertWebElementIsDisplayedEnabled(expandedNavigatorPanel);
     return new DecisionNavigatorHelper(expandedNavigatorPanel);
-  };
+  }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/DmnEditorTestHelper.ts
@@ -28,26 +28,24 @@ import DecisionNavigatorHelper from "./DecisionNavigatorHelper";
  * via contructor.
  */
 export default class DmnEditorTestHelper {
-  /**
-   * WebView in whitch the editor Iframe is located.
-   * Initialize in constructor.
-   */
-  private webview: WebView;
-
+  
   private decisionNavigator: WebElement;
   private diagramExplorer: WebElement;
   private properties: WebElement;
 
-  constructor(webview: WebView) {
-    this.webview = webview;
-  }
+
+  /**
+   * 
+   * @param webview WebView where the editor Iframe is located.
+   */
+  constructor(private readonly webview: WebView) {}
 
   /**
    * Finds button that open DMN diagram explorer.
    *
    * @returns Promise<WebElement> promise that resolves to DMN diagram explorer button.
    */
-  public getDiagramExplorer = async (): Promise<WebElement> => {
+  public async getDiagramExplorer(): Promise<WebElement> {
     this.diagramExplorer = await this.webview.findWebElement(By.xpath("//button[@data-title='Explore diagram']"));
     return this.diagramExplorer;
   };
@@ -57,7 +55,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns Promise<WebElement> promise that resolves to DMN diagram properties element.
    */
-  public getDiagramProperties = async (): Promise<WebElement> => {
+  public async getDiagramProperties(): Promise<WebElement> {
     this.properties = await this.webview.findWebElement(By.className("docks-item-E-DiagramEditorPropertiesScreen"));
     return this.properties;
   };
@@ -67,7 +65,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns Promise<WebElement> promise that resolves to DMN decision navigator element.
    */
-  public getDecisionNavigator = async (): Promise<WebElement> => {
+  public async getDecisionNavigator(): Promise<WebElement> {
     this.decisionNavigator = await this.webview.findWebElement(
       By.className("docks-item-E-org.kie.dmn.decision.navigator")
     );
@@ -78,7 +76,7 @@ export default class DmnEditorTestHelper {
    * Switch editor to other Tab
    * @param editorTab Tab to be swithced on
    */
-  public switchEditorTab = async (editorTab: EditorTabs): Promise<void> => {
+  public async switchEditorTab(editorTab: EditorTabs): Promise<void> {
     const tabElement = await this.webview.findWebElement(tabWithTitle(editorTab));
     await assertWebElementIsDisplayedEnabled(tabElement);
     await tabElement.click();
@@ -88,7 +86,7 @@ export default class DmnEditorTestHelper {
    * Using 'EditorTabs.IncludedModels' tab new model is included
    * @param modelFileName file name in the same direcotry that will be included
    */
-  public includeModel = async (modelFileName: string, modelAlias: string): Promise<void> => {
+  public async includeModel(modelFileName: string, modelAlias: string): Promise<void> {
     // Invoke Include Model pop-up
     const includeModelButton = await this.webview.findWebElement(By.xpath("//button[@data-field='include-model']"));
     await assertWebElementIsDisplayedEnabled(includeModelButton);
@@ -129,7 +127,7 @@ export default class DmnEditorTestHelper {
    * @param modelAlias model to be asserted
    * @param nodesCount asserted model expected nodes count
    */
-  public inspectIncludedModel = async (modelAlias: string, nodesCount: number): Promise<void> => {
+  public async inspectIncludedModel(modelAlias: string, nodesCount: number): Promise<void> {
     // Wait until card with include details is shown
     const includeDetails = await this.webview
       .getDriver()
@@ -154,7 +152,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns a promise resolving to WebElement of openned panel.
    */
-  public openDiagramProperties = async (): Promise<PropertiesPanelHelper> => {
+  public async openDiagramProperties(): Promise<PropertiesPanelHelper> {
     const properties = await this.getDiagramProperties();
     await assertWebElementIsDisplayedEnabled(properties);
     await properties.click();
@@ -173,7 +171,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns a promise resolving to WebElement of openned panel.
    */
-  public openDiagramExplorer = async (): Promise<WebElement> => {
+  public async openDiagramExplorer(): Promise<WebElement> {
     const explorer = await this.getDiagramExplorer();
     await assertWebElementIsDisplayedEnabled(explorer);
     await explorer.click();
@@ -194,7 +192,7 @@ export default class DmnEditorTestHelper {
    *
    * @returns a promise resolving to WebElement of openned panel.
    */
-  public openDecisionNavigator = async (): Promise<DecisionNavigatorHelper> => {
+  public async openDecisionNavigator(): Promise<DecisionNavigatorHelper> {
     const navigator = await this.getDecisionNavigator();
     await assertWebElementIsDisplayedEnabled(navigator);
     await navigator.click();

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
@@ -21,11 +21,8 @@ import { labeledInputElementInPropertiesPanel } from "../CommonLocators";
  * Class for accessing expanded DMN Properties panel
  */
 export default class PropertiesPanelHelper {
-  private root: WebElement;
 
-  constructor(root: WebElement) {
-    this.root = root;
-  }
+  constructor(private readonly root: WebElement) {}
 
   /**
    * Change a property to a provided value. The Original value is replaced by the new value completely.
@@ -34,7 +31,7 @@ export default class PropertiesPanelHelper {
    * @param propertyName
    * @param propertyValue
    */
-  public changeProperty = async (propertyName: string, propertyValue: string): Promise<PropertiesPanelHelper> => {
+  public async changeProperty(propertyName: string, propertyValue: string): Promise<PropertiesPanelHelper> {
     const property = await this.root.findElement(labeledInputElementInPropertiesPanel(propertyName));
     await property.clear();
     await property.sendKeys(propertyValue);

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
@@ -21,7 +21,6 @@ import { labeledInputElementInPropertiesPanel } from "../CommonLocators";
  * Class for accessing expanded DMN Properties panel
  */
 export default class PropertiesPanelHelper {
-
   constructor(private readonly root: WebElement) {}
 
   /**
@@ -37,5 +36,5 @@ export default class PropertiesPanelHelper {
     await property.sendKeys(propertyValue);
 
     return this;
-  };
+  }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/dmn/PropertiesPanelHelper.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WebElement } from "vscode-extension-tester";
+import { labeledInputElementInPropertiesPanel } from "../CommonLocators";
+
+/**
+ * Class for accessing expanded DMN Properties panel
+ */
+export default class PropertiesPanelHelper {
+  private root: WebElement;
+
+  constructor(root: WebElement) {
+    this.root = root;
+  }
+
+  /**
+   * Change a property to a provided value. The Original value is replaced by the new value completely.
+   * Just visible properties are assumed. Accordion view hidden content can not be changed by this method.
+   *
+   * @param propertyName
+   * @param propertyValue
+   */
+  public changeProperty = async (propertyName: string, propertyValue: string): Promise<PropertiesPanelHelper> => {
+    const property = await this.root.findElement(labeledInputElementInPropertiesPanel(propertyName));
+    await property.clear();
+    await property.sendKeys(propertyValue);
+
+    return this;
+  };
+}


### PR DESCRIPTION
Motivation behind this PR is https://github.com/kiegroup/kie-wb-common/pull/3594 review. Especially the fact that undo command was affected by that PR. I found out we do not have tests for it in VS Code.

https://issues.redhat.com/browse/KOGITO-3192