### PR TITLE
KOGITO-4892: Fix the separator replace code

### DIFF
--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -61,7 +61,7 @@ export class KogitoEditableDocument implements CustomDocument {
   get relativePath() {
     // For some reason, `asRelativePath` always returns paths with the '/' separator,
     // so on Windows, we need to replace it to the correct one, which is '\'.
-    return vscode.workspace.asRelativePath(this.uri).replace("/", nodePath.sep);
+    return vscode.workspace.asRelativePath(this.uri).replace(/\//g, nodePath.sep);
   }
 
   get fileExtension() {


### PR DESCRIPTION
This PR fixes a bug where custom tasks cannot be found from a WID in a BPMN file (VS Code - Windows OS only).
See [KOGITO-4892](https://issues.redhat.com/browse/KOGITO-4892)

This code only replaces the first separator:
```js
"test/foo/bar/see/the/separators".replace("/", "\\")
```
See:
![separators](https://user-images.githubusercontent.com/638737/114407907-470b3200-9b7f-11eb-93b5-7a6b0f6f548f.png)

According to the documentation:
![replace](https://user-images.githubusercontent.com/638737/114409425-d49b5180-9b80-11eb-8641-d8ab3c370a14.png)

Thus, we need to use a regex to make it work properly.
