### PR TITLE
Fix Cypress performance issues by downgrading the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "copy-webpack-plugin": "5.1.0",
     "cross-var": "1.1.0",
     "css-loader": "3.2.0",
-    "cypress": "^6.7.1",
+    "cypress": "6.6.0",
     "cypress-file-upload": "^5.0.2",
     "cypress-iframe": "^1.0.1",
     "decompress": "^4.2.1",

--- a/packages/kie-editors-standalone/it-tests/cypress.json
+++ b/packages/kie-editors-standalone/it-tests/cypress.json
@@ -13,5 +13,6 @@
     "suiteTitleSeparatedBy": ".",
     "useFullSuiteTitle":true,
     "rootSuiteTitle": "@kogito-tooling/kie-editors-standalone"
-  }
+  },
+  "video": false
 }

--- a/packages/online-editor/it-tests/cypress.json
+++ b/packages/online-editor/it-tests/cypress.json
@@ -6,5 +6,6 @@
   "videosFolder": "videos",
   "supportFile": "support/index.ts",
   "baseUrl": "http://localhost:9001",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "video": false
 }

--- a/packages/pmml-editor/it-tests/cypress.json
+++ b/packages/pmml-editor/it-tests/cypress.json
@@ -6,5 +6,6 @@
   "videosFolder": "videos",
   "supportFile": "support/index.ts",
   "baseUrl": "http://localhost:8080",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "video": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5907,10 +5907,10 @@ cypress-iframe@^1.0.1:
   resolved "https://registry.yarnpkg.com/cypress-iframe/-/cypress-iframe-1.0.1.tgz#2a286cfd47a240aa9af0ad9f339f4c6f942089f8"
   integrity sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==
 
-cypress@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.7.1.tgz#6b8e1ba9badbded284ddc8575873b64211250ea6"
-  integrity sha512-MC9yt1GqpL4WVDQ0STI89K+PdLeC3T3NuAb2N61d6vYGR9pJy8w3Fqe0OWZwaRTJtg9eAyHXPGmFsyKeNQ3tmg==
+cypress@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.6.0.tgz#659c64cdb06e51b6be18fdac39d8f192deb54fa0"
+  integrity sha512-+Xx3Zn653LJHUsCb9h1Keql2jlazbr1ROmbY6DFJMmXKLgXP4ez9cE403W93JNGRbZK0Tng3R/oP8mvd9XAPVg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4906

If https://github.com/kiegroup/kogito-tooling/pull/474 is merged sooner. This PR needs to be updated.