### PR TITLE
KOGITO-5012: VSCode IT tests are not showing test ouput in console

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
@@ -1,6 +1,4 @@
 {
-  "retries": 1,
-  "reporter": "xunit",
   "reporterOptions": {
     "output": "./it-tests/results/junit.xml"
   }


### PR DESCRIPTION
@tiagobento I think we misunderstood each other last time we were discussing this. So I am removing the retries and reporter to show the logs in console. The output is still generated even without reporter specified. Default one is used :) 