### PR TITLE
[backport][tests] KOGITO-4830: BPMN Read-only Mode E2E Coverage for standalone editors

### DIFF
--- a/packages/kie-editors-standalone/it-tests/cypress/fixtures/process-string.bpmn
+++ b/packages/kie-editors-standalone/it-tests/cypress/fixtures/process-string.bpmn
@@ -1,7 +1,14 @@
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_kGuj4BujEDmrLJYIynz9hA" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_wfZckHQ-EDmoD5SBglSh9A" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_string_inputItem" structureRef="String"/>
-  <bpmn2:error id="_74956D6C-C3B3-49FD-80D4-CCA6367DB98A"/>
-  <bpmn2:process id="default" drools:packageName="com.example" drools:version="1.0" drools:adHoc="false" name="Process string" isExecutable="true" processType="Public">
+  <bpmn2:error id="_953AB2AE-F7D2-4511-8E3E-1A80C1F76EEE"/>
+  <bpmn2:process id="defaultProcessId" drools:packageName="com.example" drools:version="1.0" drools:adHoc="false" name="Process string" isExecutable="true" processType="Public">
+    <bpmn2:documentation><![CDATA[Documentation]]></bpmn2:documentation>
+    <bpmn2:extensionElements>
+      <drools:global identifier="is_processing" type="Boolean"/>
+      <drools:metaData name="perf_indicator">
+        <drools:metaValue><![CDATA[good_performance]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
     <bpmn2:property id="string_input" itemSubjectRef="_string_inputItem" name="string_input"/>
     <bpmn2:sequenceFlow id="_228E7366-9427-450F-8B8A-67A52AE699AD" sourceRef="_B52EFB79-8087-4681-AC3B-6E4939AEF31D" targetRef="_30E7BBB3-352E-42DD-A5E4-88BDEF37BAC1">
       <bpmn2:extensionElements>
@@ -32,7 +39,7 @@
     <bpmn2:sequenceFlow id="_448A379A-CB17-4D92-B2B7-7EEB6D277896" sourceRef="_B542F26C-CEA8-4CC3-94C4-0F38867CFEF8" targetRef="_3B8CF7BA-6AFC-42DF-8E21-262FEB4657D8"/>
     <bpmn2:endEvent id="_30E7BBB3-352E-42DD-A5E4-88BDEF37BAC1">
       <bpmn2:incoming>_228E7366-9427-450F-8B8A-67A52AE699AD</bpmn2:incoming>
-      <bpmn2:errorEventDefinition errorRef="_74956D6C-C3B3-49FD-80D4-CCA6367DB98A"/>
+      <bpmn2:errorEventDefinition errorRef="_953AB2AE-F7D2-4511-8E3E-1A80C1F76EEE"/>
     </bpmn2:endEvent>
     <bpmn2:endEvent id="_814933F7-55AF-4EEE-B8A1-AA6777A1F555">
       <bpmn2:incoming>_D0DD8211-3377-4D40-B4B7-CA89C5292181</bpmn2:incoming>
@@ -65,7 +72,7 @@
     </bpmn2:startEvent>
   </bpmn2:process>
   <bpmndi:BPMNDiagram>
-    <bpmndi:BPMNPlane bpmnElement="default">
+    <bpmndi:BPMNPlane bpmnElement="defaultProcessId">
       <bpmndi:BPMNShape id="shape__B542F26C-CEA8-4CC3-94C4-0F38867CFEF8" bpmnElement="_B542F26C-CEA8-4CC3-94C4-0F38867CFEF8">
         <dc:Bounds height="56" width="56" x="137" y="187"/>
       </bpmndi:BPMNShape>
@@ -161,7 +168,7 @@
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_kGuj4BujEDmrLJYIynz9hA</bpmn2:source>
-    <bpmn2:target>_kGuj4BujEDmrLJYIynz9hA</bpmn2:target>
+    <bpmn2:source>_wfZckHQ-EDmoD5SBglSh9A</bpmn2:source>
+    <bpmn2:target>_wfZckHQ-EDmoD5SBglSh9A</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/packages/kie-editors-standalone/it-tests/cypress/integration/bpmn-read-only.spec.ts
+++ b/packages/kie-editors-standalone/it-tests/cypress/integration/bpmn-read-only.spec.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Bpmn Read Only.", () => {
+    before("Visit page", () => {
+      cy.visit("localhost:9001/bpmn-read-only");
+      cy.loadEditor("bpmn-read-only");
+    });
+
+    describe("Loads empty editor in read only mode", () => {
+      it("Editor palette is not visible", () => {
+        cy.editor("bpmn-read-only")
+          .find("[data-field='palettePanel']")
+          .should("not.be.visible");
+      })
+  
+      it("Editor properties bar is visible", () => {
+        cy.editor("bpmn-read-only")
+          .ouiaId("collapsed-docks-bar", "collapsed-docks-bar-E", { timeout: 10000 })
+          .should("be.visible");
+      });
+    });
+
+    describe("Loads non-empty editor in read only mode", () => {
+      it("Loads non-empty editor without palette", () => {
+        cy.uploadFile("process-string.bpmn");
+        cy.viewFile("process-string.bpmn");
+
+        cy.editor("bpmn-read-only")
+           .find("[data-field='palettePanel']")
+           .should("not.be.visible");
+      });
+
+      it("Loads non-empty editor with properties bar visible", () => {
+        cy.editor("bpmn-read-only")
+          .ouiaId("collapsed-docks-bar", "collapsed-docks-bar-E", { timeout: 10000 })
+          .should("be.visible");
+      });
+  
+      it("Editor properties bar can be openned", () => {
+        cy.editor("bpmn-read-only")
+          .ouiaId("docks-item", "docks-item-DiagramEditorPropertiesScreen")
+          .find("button")
+          .first()
+          .should("be.visible")
+          .click(); // open Properties
+        cy.editor("bpmn-read-only")
+          .ouiaId("expanded-docks-bar", "expanded-docks-bar-E")
+          .should("be.visible");
+      });
+
+      describe("Editor properties are displayed as read-only", () => {
+        let propertyItems: JQuery<HTMLElement>
+
+        it("Properties have expected length", () => {
+          cy.editor("bpmn-read-only")
+            .ouiaId("expanded-docks-bar", "expanded-docks-bar-E")
+            .within($properties => {
+              cy.wrap($properties)
+                .find("[id='mainContainer']")
+                .should("be.visible")
+                .children(".row")
+                .should("have.length", 17)
+                .then($items => {
+                        propertyItems = $items;
+                });
+            });
+        });
+        
+
+        it("Process name property is read only", () => {
+          cy.wrap(propertyItems)
+            .find("input[name*='diagramSet.name']")
+            .should("have.value", "Process string")
+            .should("not.have.class", "editable");
+        });
+    
+        it("Process documentation property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("textarea[name*='diagramSet.documentation']")
+              .should("have.value", "Documentation")
+              .should("not.have.class", "editable");
+        });
+    
+        it("Process ID property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.id']")
+              .should("not.have.class", "editable")
+              .should("have.value", "defaultProcessId");
+        });
+    
+        it("Process package property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.packageProperty']")
+              .should("not.have.class", "editable")
+              .should("have.value", "com.example");
+        });
+    
+        it("Process type property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("select[name*='diagramSet.processType']")
+              .should("not.have.class", "editable")
+              .should("have.value", "Public");
+        });
+    
+        it("Process version property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.version']")
+              .should("not.have.class", "editable")
+              .should("have.value", "1.0");
+        });
+
+        it("Process ad-hoc property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.adHoc']")
+              .should("be.disabled")
+              .should("not.be.checked");
+        });
+
+        it("Process instance description property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.processInstanceDescription']")
+              .should("not.have.class", "editable")
+              .should("have.value", "");
+        });
+
+        it("Process imports property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[id='importsTextBox']")
+              .should("have.value", "No imports")
+              .should("not.have.class", "editable");
+        });
+    
+        it.skip("Process imports buttons is read only", () => {
+            cy.wrap(propertyItems)
+              .find("button[id='importsButton']")
+              .should("be.disabled");
+        });
+    
+        it("Process executable property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.executable']")
+              .should("be.checked")
+              .should("be.disabled");
+        });
+
+        it("Process SLA due date property is read only", () => {
+            cy.wrap(propertyItems)
+              .find("input[name*='diagramSet.slaDueDate']")
+              .should("have.value", "")
+              .should("have.attr", "disabled");
+        });
+    
+        it("Process variables (Process Data section) section is not disabled", () => {
+            cy.wrap(propertyItems)
+              .find("a")
+              .contains("Process Data")
+              .should("not.be.disabled")
+              .click()
+              .scrollIntoView();
+        });
+    
+        it("Process variables add button is read only", () => {
+            cy.wrap(propertyItems)
+              .find("button[data-field='addVarButton']")
+              .should("be.disabled");
+        });
+  
+        describe("Process variables are displayed as read only", () => {
+          let processVariables: JQuery<HTMLElement>
+
+          it("Process Variables have expected length", () => {
+            cy.wrap(propertyItems)
+              .contains("Process Variables")
+              .siblings()
+              .first()
+              .should("not.be.disabled")
+              .should("be.visible")
+              .then($processVariablesContainer => {
+                    processVariables = $processVariablesContainer; 
+                    cy.wrap($processVariablesContainer)
+                      .find("#variableRow")
+                      .siblings()
+                      .should("have.length", "0");
+              });
+          });
+
+          it("Process variable name is read only", () => {
+            cy.wrap(processVariables)
+              .find("input[data-field='name']")
+              .should("not.have.class", "editable")
+              .should("have.value", "string_input");
+          });
+      
+          it("Process variable data type is read only", () => {
+              cy.wrap(processVariables)
+                .find("select[data-field='dataType']")
+                .should("not.have.class", "editable")
+                .should("have.value", "String");
+          });
+      
+          it.skip("Process variable TAG handle is read only", () => {
+              cy.wrap(processVariables)
+                .find("a[data-field='variable-tags-settings']")
+                .should("be.disabled");
+          });
+      
+          it("Process variable delete button is read only", () => {
+              cy.wrap(processVariables)
+                .find("button[data-field='deleteButton']")
+                .should("not.have.class", "editable");
+          });
+        });
+
+        it("Process advanced (Advanced section) section is not disabled", () => {
+          cy.wrap(propertyItems)
+            .find("a")
+            .contains("Advanced")
+            .should("not.be.disabled")
+            .click()
+            .scrollIntoView();
+        });
+
+        describe("Process metadata attributes rows are displayed as read only", () => {
+          let metadataAtttributes: JQuery<HTMLElement>
+
+          it("Metadata attributes list have expected size", () => {
+            cy.wrap(propertyItems)
+              .contains("Metadata Attributes")
+              .siblings()
+              .first()
+              .should("not.be.disabled")
+              .should("be.visible")
+              .then($metadataAtributesContainer => {
+                    metadataAtttributes = $metadataAtributesContainer; 
+                    cy.wrap($metadataAtributesContainer)
+                      .find("#metaDataRow")
+                      .siblings()
+                      .should("have.length", "0");
+              });
+          });        
+
+          it("Process metadata attribute name is read only", ()=> {
+            cy.wrap(metadataAtttributes)
+              .find("input[data-field='attribute']")
+              .should("not.have.class", "editable")
+              .should("have.value", "perf_indicator");
+          });
+      
+          it("Process metadata attribute value is read only", ()=> {
+              cy.wrap(metadataAtttributes)
+                .find("input[data-field='value']")
+                .should("not.have.class", "editable")
+                .should("have.value", "good_performance");
+          });
+      
+          it("Process metadata attribute delete button is read only", ()=> {
+              cy.wrap(metadataAtttributes)
+                .find("button[data-field='deleteButton']")
+                .should("be.disabled");
+          });
+        });
+
+        describe("Process global variables rows are displayed as read only", () => {
+          let globalVariables: JQuery<HTMLElement>
+
+          it("Global variables list have expected length", () => {
+            cy.wrap(propertyItems)
+              .contains("Global Variables")
+              .siblings()
+              .first()
+              .scrollIntoView()
+              .should("not.be.disabled")
+              .should("be.visible")
+              .then($globalVariablesContainer => {
+                    globalVariables = $globalVariablesContainer; 
+                    cy.wrap($globalVariablesContainer)
+                      .find("#variableRow")
+                      .siblings()
+                      .should("have.length", "0");
+              });
+          });          
+
+          it("Process global variable name is read only", () => {
+            cy.wrap(globalVariables)
+              .find("input[data-field='name']")
+              .should("not.have.class", "editable")
+              .should("have.value", "is_processing");
+          });
+      
+          it("Process global variable typeis read only", () => {
+              cy.wrap(globalVariables)
+                .find("select[data-field='dataType']")
+                .should("not.have.class", "editable")
+                .should("have.value", "Boolean");
+          });
+      
+          it("Process metadata attribute delete button is read only", () => {
+              cy.wrap(globalVariables)
+                .find("button[data-field='deleteButton']")
+                .should("be.disabled");
+          });
+        });
+      });    
+    });    
+});

--- a/packages/kie-editors-standalone/it-tests/src/pages/page.tsx
+++ b/packages/kie-editors-standalone/it-tests/src/pages/page.tsx
@@ -36,6 +36,9 @@ export const EditorPage: React.FC<{}> = () => {
             <Link to="/bpmn-editable">BPMN Editable</Link>
           </li>
           <li>
+            <Link to="/bpmn-read-only">BPMN Read Only</Link>
+          </li>
+          <li>
             <Link to="/bpmn-workitem">BPMN Workitem</Link>
           </li>
           <li>
@@ -75,6 +78,18 @@ export const EditorPage: React.FC<{}> = () => {
                 key="bpmn-editable"
                 id="bpmn-editable"
                 readOnly={false}
+                initialContent={Promise.resolve("")}
+              />
+            )}
+          />
+          <Route
+            exact={true}
+            path="/bpmn-read-only"
+            render={() => (
+              <BpmnEditorComponent
+                key="bpmn-read-only"
+                id="bpmn-read-only"
+                readOnly={true}
                 initialContent={Promise.resolve("")}
               />
             )}


### PR DESCRIPTION
Cherry-picks #466 to 0.9.0-prerelease.