### PR TITLE
Fix "Save & Download" button when clicked very fast after renaming file

### DIFF
--- a/packages/envelope-bus/src/channel/EnvelopeServer.ts
+++ b/packages/envelope-bus/src/channel/EnvelopeServer.ts
@@ -52,6 +52,11 @@ export class EnvelopeServer<
   }
 
   public startInitPolling() {
+
+    // We can't wait for the setInterval to run, because messages can be sent during the current event-loop pass,
+    // making the Envelope reply a message to an old EnvelopeServer instance.
+    this.pollInit(this).then(() => this.stopInitPolling());
+
     this.initPolling = setInterval(() => {
       this.pollInit(this).then(() => this.stopInitPolling());
     }, EnvelopeServer.INIT_POLLING_INTERVAL_IN_MS);

--- a/packages/envelope-bus/src/channel/EnvelopeServer.ts
+++ b/packages/envelope-bus/src/channel/EnvelopeServer.ts
@@ -52,7 +52,6 @@ export class EnvelopeServer<
   }
 
   public startInitPolling() {
-
     // We can't wait for the setInterval to run, because messages can be sent during the current event-loop pass,
     // making the Envelope reply a message to an old EnvelopeServer instance.
     this.pollInit(this).then(() => this.stopInitPolling());


### PR DESCRIPTION
This fix improves the stability of the Online Editor integration tests. The "Upload file tests" were failing sometimes because Cypress changes the name of the file and immediately clicks on "Save & download".

Changing the name causes a new `EnvelopeServer` instance to be created, meaning that the `useConnectedEnvelopeServer` hook will run again to refresh the event listeners and communicate the `Envelope` that it changed. Because we were using a setInterval macro-task to run the `pollInit` method, it was delayed until the end of the event-loop, leaving room for requests to be sent to the `Envelope` without first communicating it that its `EnvelopeServer` changed.

By immediately calling `pollInit`, we know for sure that it is the first message that the `Envelope` will process, causing it to update its `associatedEnvelopeServerId` and replying subsequent requests to the new `EnvelopeServer`.