### PR TITLE
Helpers should wait for elements before finding them

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/src/ui-test/helpers/PmmlEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/ui-test/helpers/PmmlEditorTestHelper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { By, WebElement, WebView } from "vscode-extension-tester";
+import { By, WebElement, WebView, until } from "vscode-extension-tester";
 import { assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
 
 export class Modal {
@@ -66,6 +66,9 @@ export default class PmmlEditorTestHelper {
    * @returns Promise<WebElement> promise that resolves to PMML Data Dictionary button.
    */
   private getDataDictionaryButton = async (): Promise<WebElement> => {
+    this.webview.getDriver().wait(
+      until.elementLocated(By.xpath("//button[@data-title='DataDictionary']"))
+    )
     this.dataDictionaryButton = await this.webview.findWebElement(By.xpath("//button[@data-title='DataDictionary']"));
     return this.dataDictionaryButton;
   };


### PR DESCRIPTION
Uses drivers wait() function and until object to wait for elements in test helper methods.

WIP