### PR TITLE
FAI-503: Score Cards: Support use of underscore ("_") in predicate field names

### DIFF
--- a/packages/pmml-editor/src/__tests__/editor/components/EditorScorecard/organisms/PredicateConverter.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/components/EditorScorecard/organisms/PredicateConverter.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CompoundPredicate,
+  CompoundPredicateBooleanOperator,
+  False,
+  Predicate,
+  SimplePredicate,
+  SimplePredicateOperator,
+  True,
+} from "@kogito-tooling/pmml-editor-marshaller";
+import { fromText } from "../../../../../editor/components/EditorScorecard/organisms";
+
+describe("PredicateConverter", () => {
+  test("fromText::undefined", () => {
+    const result = fromText(undefined);
+
+    expect(result).toBeUndefined();
+  });
+
+  test("fromText::True", () => {
+    assertTrue(fromText("True"));
+  });
+
+  test("fromText::true", () => {
+    assertTrue(fromText("true"));
+  });
+
+  const assertTrue = (predicate: Predicate | undefined) => {
+    expect(predicate).toBeInstanceOf(True);
+  };
+
+  test("fromText::False", () => {
+    assertFalse(fromText("False"));
+  });
+
+  test("fromText::false", () => {
+    assertFalse(fromText("false"));
+  });
+
+  const assertFalse = (predicate: Predicate | undefined) => {
+    expect(predicate).toBeInstanceOf(False);
+  };
+
+  test("fromText::UnaryOperator::isMissing", () => {
+    assertSimplePredicate(fromText("field1 isMissing"), "isMissing");
+  });
+
+  test("fromText::UnaryOperator::isNotMissing", () => {
+    assertSimplePredicate(fromText("field1 isNotMissing"), "isNotMissing");
+  });
+
+  test("fromText::BinaryOperator::equal", () => {
+    assertSimplePredicate(fromText("field1 = 100"), "equal", "100");
+  });
+
+  test("fromText::BinaryOperator::notEqual", () => {
+    assertSimplePredicate(fromText("field1 <> 100"), "notEqual", "100");
+  });
+
+  test("fromText::BinaryOperator::greaterThan", () => {
+    assertSimplePredicate(fromText("field1 > 100"), "greaterThan", "100");
+  });
+
+  test("fromText::BinaryOperator::greaterOrEqual", () => {
+    assertSimplePredicate(fromText("field1 >= 100"), "greaterOrEqual", "100");
+  });
+
+  test("fromText::BinaryOperator::lessThan", () => {
+    assertSimplePredicate(fromText("field1 < 100"), "lessThan", "100");
+  });
+
+  test("fromText::BinaryOperator::lessOrEqual", () => {
+    assertSimplePredicate(fromText("field1 <= 100"), "lessOrEqual", "100");
+  });
+
+  const assertSimplePredicate = (
+    predicate: Predicate | undefined,
+    operator: SimplePredicateOperator,
+    value?: string
+  ) => {
+    expect(predicate).toBeInstanceOf(SimplePredicate);
+
+    const sp = predicate as SimplePredicate;
+    expect(sp.field).toBe("field1");
+    expect(sp.operator).toBe(operator);
+    value ? expect(sp.value).toBe(value) : expect(sp.value).toBeUndefined();
+  };
+
+  test("fromText::CompoundPredicate::or", () => {
+    assertCompoundPredicate(fromText("field1 = 10 or field2 = 20"), "or");
+  });
+
+  test("fromText::CompoundPredicate::and", () => {
+    assertCompoundPredicate(fromText("field1 = 10 and field2 = 20"), "and");
+  });
+
+  test("fromText::CompoundPredicate::xor", () => {
+    assertCompoundPredicate(fromText("field1 = 10 xor field2 = 20"), "xor");
+  });
+
+  const assertCompoundPredicate = (
+    predicate: Predicate | undefined,
+    operator: CompoundPredicateBooleanOperator,
+    value?: string
+  ) => {
+    expect(predicate).toBeInstanceOf(CompoundPredicate);
+
+    const cp = predicate as CompoundPredicate;
+    expect(cp.booleanOperator).toBe(operator);
+    expect(cp.predicates?.length).toBe(2);
+
+    const cpp1 = cp.predicates ? cp.predicates[0] : undefined;
+    const cpp2 = cp.predicates ? cp.predicates[1] : undefined;
+    expect(cpp1).toBeInstanceOf(SimplePredicate);
+    const sp1 = cpp1 as SimplePredicate;
+    expect(sp1.field).toBe("field1");
+    expect(sp1.operator).toBe("equal");
+    expect(sp1.value).toBe("10");
+
+    expect(cpp2).toBeInstanceOf(SimplePredicate);
+    const sp2 = cpp2 as SimplePredicate;
+    expect(sp2.field).toBe("field2");
+    expect(sp2.operator).toBe("equal");
+    expect(sp2.value).toBe("20");
+  };
+
+  test("fromText::fieldName::underscore", () => {
+    assertFieldName(fromText("field_1 isMissing"), "field_1");
+    assertFieldName(fromText("fi__eld_1 isMissing"), "fi__eld_1");
+    assertFieldName(fromText("field_1 = 100"), "field_1");
+    assertFieldName(fromText("fi__eld_1 = 100"), "fi__eld_1");
+  });
+
+  test("fromText::fieldName::hyphen", () => {
+    assertFieldName(fromText("field-1 isMissing"), "field-1");
+    assertFieldName(fromText("fi--eld-1 isMissing"), "fi--eld-1");
+    assertFieldName(fromText("field-1 = 100"), "field-1");
+    assertFieldName(fromText("fi--eld-1 = 100"), "fi--eld-1");
+  });
+
+  const assertFieldName = (predicate: Predicate | undefined, fieldName: string) => {
+    expect(predicate).toBeInstanceOf(SimplePredicate);
+
+    const sp = predicate as SimplePredicate;
+    expect(sp.field).toBe(fieldName);
+  };
+});

--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { BaseSyntheticEvent, useEffect, useMemo, useState } from "react";
 import useOnclickOutside from "react-cool-onclickoutside";
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
@@ -103,7 +103,9 @@ const DataTypeItem = (props: DataTypeItemProps) => {
     }
   };
 
-  const handleEditStatus = () => {
+  const handleEditStatus = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
     onEdit?.(index);
   };
 
@@ -309,12 +311,10 @@ const DataTypeItem = (props: DataTypeItemProps) => {
         <section
           className={"editable-item__inner"}
           tabIndex={0}
-          onClick={handleEditStatus}
+          onClick={(event) => handleEditStatus(event)}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
-              event.preventDefault();
-              event.stopPropagation();
-              handleEditStatus();
+              handleEditStatus(event);
             }
           }}
         >

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/PredicateConverter.ts
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/PredicateConverter.ts
@@ -141,11 +141,11 @@ export const fromText = (text: string | undefined): Predicate | undefined => {
   }
 
   //Quick RegEx based match for SimplePredicates.. Need a parser for ALL Predicates
-  const regTrue = /^True$/gm;
-  const regFalse = /^False$/gm;
-  const regUnaryOperator = /^([a-zA-Z]+[0-9]*)\s+(isMissing|isNotMissing)\s*$/gm;
-  const regBinaryOperator = /^([a-zA-Z]+[0-9]*)\s*(=|>|<|<=|>=|<>)\s*"?([a-zA-Z0-9]+)"?$/gm;
-  const regSimpleCompound = /^(.*)\s*(and|or|xor)\s*(.*)$/gm;
+  const regTrue = /^True$/gim;
+  const regFalse = /^False$/gim;
+  const regUnaryOperator = /^(\S+)\s+(isMissing|isNotMissing)\s*$/gm;
+  const regBinaryOperator = /^(\S+)\s*(=|>|<|<=|>=|<>)\s*"?(\S+)"?$/gm;
+  const regSimpleCompound = /^(.*)\s*(\band\b|\bxor\b|\bor\b)\s*(.*)$/gm;
 
   if (regTrue.test(text)) {
     return TruePredicate();

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useContext, useMemo } from "react";
+import { BaseSyntheticEvent, useContext, useMemo } from "react";
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
@@ -91,7 +91,9 @@ const MiningSchemaItem = (props: MiningSchemaFieldProps) => {
     onPropertyDelete(index, updatedField);
   };
 
-  const handleEdit = () => {
+  const handleEdit = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
     onEdit(index);
   };
 
@@ -105,14 +107,12 @@ const MiningSchemaItem = (props: MiningSchemaFieldProps) => {
     <li
       className={`editable-item ${editing === index ? "editable-item--editing" : ""}`}
       key={field.name.value}
-      onClick={handleEdit}
+      onClick={(event) => handleEdit(event)}
       ref={ref}
       tabIndex={0}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
-          event.preventDefault();
-          event.stopPropagation();
-          handleEdit();
+          handleEdit(event);
         }
         if (event.key === "Escape") {
           onCancel();

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useMemo } from "react";
+import { BaseSyntheticEvent, useMemo } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
@@ -85,16 +85,20 @@ const OutputFieldRow = (props: OutputFieldRowProps) => {
     [outputFieldIndex, modelIndex, outputField]
   );
 
+  const handleEdit = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onEditOutputField();
+  };
+
   return (
     <section
-      className={"editable-item__inner"}
-      onClick={onEditOutputField}
       tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          e.stopPropagation();
-          onEditOutputField();
+      className={"editable-item__inner"}
+      onClick={(event) => handleEdit(event)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          handleEdit(event);
         }
       }}
     >


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-503

I widened the regex to include all non-white space characters (as the PMML [specification](http://dmg.org/pmml/v4-4/GeneralStructure.html#xsdType_FIELD-NAME) supports _anything_).