### PR TITLE
Disable Workspace Trust on VS Code Extension IT tests

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/settings.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/settings.json
@@ -6,5 +6,6 @@
   "workbench.startupEditor": "none",
   "files.simpleDialog.enable": true,
   "window.dialogStyle": "custom",
-  "explorer.compactFolders": false
+  "explorer.compactFolders": false,
+  "security.workspace.trust.enabled": false
 }


### PR DESCRIPTION
VS Code 1.57.0 is out and the new Workspaces Trust feature opens a popup when VS Code opens a new workspace. This caused our IT tests to fail. Since we trust the folders we're opening during the VS Code Extensions IT tests, disabling Workspaces Trust is not a problem.