### PR TITLE
FAI-519: Score Cards: Renaming a DataField does not update Attributes' predicates

### DIFF
--- a/packages/pmml-editor/src/__tests__/editor/paths/PathBuilders.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/paths/PathBuilders.test.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Builder } from "../../../editor/paths";
+
+describe("PathBuilders::Basic tests", () => {
+  test("Header", () => {
+    expect(Builder().forHeader().build().path).toBe("Header");
+  });
+
+  test("DataDictionary", () => {
+    expect(Builder().forDataDictionary().build().path).toBe("DataDictionary");
+  });
+
+  test("DataField", () => {
+    expect(Builder().forDataDictionary().forDataField().build().path).toBe("DataDictionary.DataField");
+  });
+
+  test("DataField::Indexed", () => {
+    expect(Builder().forDataDictionary().forDataField(0).build().path).toBe("DataDictionary.DataField[0]");
+  });
+
+  test("Interval", () => {
+    expect(Builder().forDataDictionary().forDataField(0).forInterval().build().path).toBe(
+      "DataDictionary.DataField[0].Interval"
+    );
+  });
+
+  test("Interval::Indexed", () => {
+    expect(Builder().forDataDictionary().forDataField(0).forInterval(1).build().path).toBe(
+      "DataDictionary.DataField[0].Interval[1]"
+    );
+  });
+
+  test("Value", () => {
+    expect(Builder().forDataDictionary().forDataField(0).forValue().build().path).toBe(
+      "DataDictionary.DataField[0].Value"
+    );
+  });
+
+  test("Value::Indexed", () => {
+    expect(Builder().forDataDictionary().forDataField(0).forValue(1).build().path).toBe(
+      "DataDictionary.DataField[0].Value[1]"
+    );
+  });
+
+  test("Model", () => {
+    expect(Builder().forModel().build().path).toBe("models");
+  });
+
+  test("Model::Indexed", () => {
+    expect(Builder().forModel(0).build().path).toBe("models[0]");
+  });
+
+  test("Model::baselineScore", () => {
+    expect(Builder().forModel(0).forBaselineScore().build().path).toBe("models[0].baselineScore");
+  });
+
+  test("Model::useReasonCodes", () => {
+    expect(Builder().forModel(0).forUseReasonCodes().build().path).toBe("models[0].useReasonCodes");
+  });
+
+  test("MiningSchema", () => {
+    expect(Builder().forModel(0).forMiningSchema().build().path).toBe("models[0].MiningSchema");
+  });
+
+  test("MiningField", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField().build().path).toBe(
+      "models[0].MiningSchema.MiningField"
+    );
+  });
+
+  test("MiningField::Indexed", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).build().path).toBe(
+      "models[0].MiningSchema.MiningField[1]"
+    );
+  });
+
+  test("MiningField::importance", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forImportance().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].importance"
+    );
+  });
+
+  test("MiningField::highValue", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forHighValue().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].highValue"
+    );
+  });
+
+  test("MiningField::lowValue", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forLowValue().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].lowValue"
+    );
+  });
+
+  test("MiningField::invalidValueReplacement", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forInvalidValueReplacement().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].invalidValueReplacement"
+    );
+  });
+
+  test("MiningField::missingValueReplacement", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forMissingValueReplacement().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].missingValueReplacement"
+    );
+  });
+
+  test("MiningField::lowValue", () => {
+    expect(Builder().forModel(0).forMiningSchema().forMiningField(1).forDataFieldMissing().build().path).toBe(
+      "models[0].MiningSchema.MiningField[1].dataFieldMissing"
+    );
+  });
+
+  test("Characteristics", () => {
+    expect(Builder().forModel(0).forCharacteristics().build().path).toBe("models[0].Characteristics");
+  });
+
+  test("Characteristic", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic().build().path).toBe(
+      "models[0].Characteristics.Characteristic"
+    );
+  });
+
+  test("Characteristic::Indexed", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic(1).build().path).toBe(
+      "models[0].Characteristics.Characteristic[1]"
+    );
+  });
+
+  test("Characteristic::baselineScore", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic(1).forBaselineScore().build().path).toBe(
+      "models[0].Characteristics.Characteristic[1].baselineScore"
+    );
+  });
+
+  test("Characteristic::reasonCode", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic(1).forReasonCode().build().path).toBe(
+      "models[0].Characteristics.Characteristic[1].reasonCode"
+    );
+  });
+
+  test("Attribute", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute().build().path).toBe(
+      "models[0].Characteristics.Characteristic[1].Attribute"
+    );
+  });
+
+  test("Attribute::Indexed", () => {
+    expect(Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute(2).build().path).toBe(
+      "models[0].Characteristics.Characteristic[1].Attribute[2]"
+    );
+  });
+
+  test("Attribute::reasonCode", () => {
+    expect(
+      Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute(2).forReasonCode().build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].reasonCode");
+  });
+
+  test("Attribute::partialScore", () => {
+    expect(
+      Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute(2).forPartialScore().build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].partialScore");
+  });
+
+  test("Predicate", () => {
+    expect(
+      Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute(2).forPredicate().build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].predicate");
+  });
+
+  test("Predicate::fieldName", () => {
+    expect(
+      Builder()
+        .forModel(0)
+        .forCharacteristics()
+        .forCharacteristic(1)
+        .forAttribute(2)
+        .forPredicate()
+        .forFieldName()
+        .build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].predicate.fieldName");
+  });
+
+  test("Predicates", () => {
+    expect(
+      Builder().forModel(0).forCharacteristics().forCharacteristic(1).forAttribute(2).forPredicate(3).build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].predicates[3]");
+  });
+
+  test("Predicates::fieldName", () => {
+    expect(
+      Builder()
+        .forModel(0)
+        .forCharacteristics()
+        .forCharacteristic(1)
+        .forAttribute(2)
+        .forPredicate(3)
+        .forFieldName()
+        .build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].predicates[3].fieldName");
+  });
+
+  test("CompositePredicates", () => {
+    expect(
+      Builder()
+        .forModel(0)
+        .forCharacteristics()
+        .forCharacteristic(1)
+        .forAttribute(2)
+        .forPredicate(3)
+        .forPredicate(4)
+        .build().path
+    ).toBe("models[0].Characteristics.Characteristic[1].Attribute[2].predicates[3].predicates[4]");
+  });
+
+  test("Output", () => {
+    expect(Builder().forModel(0).forOutput().build().path).toBe("models[0].Output");
+  });
+
+  test("OutputField", () => {
+    expect(Builder().forModel(0).forOutput().forOutputField().build().path).toBe("models[0].Output.OutputField");
+  });
+
+  test("OutputField::Indexed", () => {
+    expect(Builder().forModel(0).forOutput().forOutputField(1).build().path).toBe("models[0].Output.OutputField[1]");
+  });
+
+  test("OutputField::targetField", () => {
+    expect(Builder().forModel(0).forOutput().forOutputField(1).forTargetField().build().path).toBe(
+      "models[0].Output.OutputField[1].targetField"
+    );
+  });
+});

--- a/packages/pmml-editor/src/__tests__/editor/reducers/ScorecardReducer.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/reducers/ScorecardReducer.test.ts
@@ -1,0 +1,582 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CompoundPredicate,
+  FieldName,
+  Model,
+  PMML,
+  Predicate,
+  Scorecard,
+  SimplePredicate,
+} from "@kogito-tooling/pmml-editor-marshaller";
+import { Actions, AllActions, ScorecardReducer } from "../../../editor/reducers";
+import { Reducer } from "react";
+import { HistoryService } from "../../../editor/history";
+import { ValidationRegistry } from "../../../editor/validation";
+
+const historyService = new HistoryService([]);
+const validationRegistry = new ValidationRegistry();
+const reducer: Reducer<Scorecard, AllActions> = ScorecardReducer(historyService, validationRegistry);
+
+describe("ScorecardReducer::Valid actions", () => {
+  test("Actions.Scorecard_SetModelName", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: { Characteristic: [] },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_SetModelName,
+      payload: {
+        modelIndex: 0,
+        modelName: "modelName",
+      },
+    });
+    const models = historyService.commit(pmml)?.models as Model[];
+    const updated = models[0] as Scorecard;
+
+    expect(updated.modelName).toBe("modelName");
+  });
+
+  test("Actions.Scorecard_SetCoreProperties", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: { Characteristic: [] },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_SetCoreProperties,
+      payload: {
+        modelIndex: 0,
+        algorithmName: "algorithmName",
+        functionName: "regression",
+        baselineMethod: "min",
+        initialScore: 1.0,
+        baselineScore: 2.0,
+        isScorable: true,
+        reasonCodeAlgorithm: "pointsAbove",
+        useReasonCodes: true,
+      },
+    });
+    const models = historyService.commit(pmml)?.models as Model[];
+    const updated = models[0] as Scorecard;
+
+    expect(updated.algorithmName).toBe("algorithmName");
+    expect(updated.functionName).toBe("regression");
+    expect(updated.baselineMethod).toBe("min");
+    expect(updated.initialScore).toBe(1.0);
+    expect(updated.baselineScore).toBe(2.0);
+    expect(updated.isScorable).toBeTruthy();
+    expect(updated.reasonCodeAlgorithm).toBe("pointsAbove");
+    expect(updated.useReasonCodes).toBeTruthy();
+  });
+
+  test("Actions.Scorecard_SetCoreProperties::clearReasonCodesWhenUseReasonCodesIsFalse", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            Attribute: [{ reasonCode: "AttributeReasonCode" }],
+            reasonCode: "CharacteristicReasonCode",
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_SetCoreProperties,
+      payload: {
+        modelIndex: 0,
+        algorithmName: "algorithmName",
+        functionName: "regression",
+        baselineMethod: "min",
+        initialScore: 1.0,
+        baselineScore: 2.0,
+        isScorable: true,
+        reasonCodeAlgorithm: "pointsAbove",
+        useReasonCodes: false,
+      },
+    });
+
+    expect(scorecard.Characteristics.Characteristic[0].reasonCode).toBe("CharacteristicReasonCode");
+    expect(scorecard.Characteristics.Characteristic[0].Attribute[0].reasonCode).toBe("AttributeReasonCode");
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    const updated = models[0] as Scorecard;
+
+    expect(updated.Characteristics.Characteristic[0].reasonCode).toBeUndefined();
+    expect(updated.Characteristics.Characteristic[0].Attribute[0].reasonCode).toBeUndefined();
+  });
+
+  test("Actions.Scorecard_SetCoreProperties::clearBaselineScoresWhenBaselineScoreExists", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            Attribute: [],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_SetCoreProperties,
+      payload: {
+        modelIndex: 0,
+        algorithmName: "algorithmName",
+        functionName: "regression",
+        baselineMethod: "min",
+        initialScore: 1.0,
+        baselineScore: 2.0,
+        isScorable: true,
+        reasonCodeAlgorithm: "pointsAbove",
+        useReasonCodes: false,
+      },
+    });
+
+    expect(scorecard.Characteristics.Characteristic[0].baselineScore).toBe(1.0);
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    const updated = models[0] as Scorecard;
+
+    expect(updated.Characteristics.Characteristic[0].baselineScore).toBeUndefined();
+  });
+
+  test("Actions.Scorecard_AddCharacteristic", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: { Characteristic: [] },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_AddCharacteristic,
+      payload: {
+        modelIndex: 0,
+        name: "characteristicName",
+        baselineScore: 1.0,
+        reasonCode: "characteristicReasonCode",
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(0);
+  });
+
+  test("Actions.Scorecard_DeleteCharacteristic", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_DeleteCharacteristic,
+      payload: {
+        modelIndex: 0,
+        characteristicIndex: 0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+  });
+
+  test("Actions.Scorecard_UpdateCharacteristic", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_UpdateCharacteristic,
+      payload: {
+        modelIndex: 0,
+        characteristicIndex: 0,
+        name: "updatedCharacteristicName",
+        reasonCode: "updatedCharacteristicReasonCode",
+        baselineScore: 2.0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+  });
+
+  test("Actions.Scorecard_AddAttribute", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [{ reasonCode: "attributeReasonCode", partialScore: 1.0, predicate: {} }],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_AddAttribute,
+      payload: {
+        modelIndex: 0,
+        characteristicIndex: 0,
+        partialScore: 1.0,
+        reasonCode: "attributeReasonCode",
+        predicate: {},
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(1);
+  });
+
+  test("Actions.Scorecard_DeleteAttribute", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [{ reasonCode: "attributeReasonCode", partialScore: 1.0, predicate: {} }],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_DeleteAttribute,
+      payload: {
+        modelIndex: 0,
+        characteristicIndex: 0,
+        attributeIndex: 0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(1);
+  });
+
+  test("Actions.AddMiningSchemaFields", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.AddMiningSchemaFields,
+      payload: {
+        modelIndex: 0,
+        names: ["miningSchemaField1" as FieldName],
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(0);
+  });
+
+  test("Actions.DeleteMiningSchemaField", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [{ name: "miningSchemaField" as FieldName }] },
+      Characteristics: {
+        Characteristic: [],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.DeleteMiningSchemaField,
+      payload: {
+        modelIndex: 0,
+        miningSchemaIndex: 0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.MiningSchema.MiningField.length).toBe(1);
+  });
+
+  test("Actions.Scorecard_UpdateAttribute", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [{ reasonCode: "attributeReasonCode", partialScore: 1.0, predicate: {} }],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml = { version: "1.0", DataDictionary: { DataField: [] }, Header: {}, models: [scorecard] };
+
+    reducer(scorecard, {
+      type: Actions.Scorecard_UpdateAttribute,
+      payload: {
+        modelIndex: 0,
+        characteristicIndex: 0,
+        attributeIndex: 0,
+        reasonCode: "updatedAttributeReasonCode",
+        partialScore: 2.0,
+        predicate: new SimplePredicate({ field: "field" as FieldName, operator: "equal", value: 100 }),
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    //ScorecardReducer only validates Characteristics for this action
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(1);
+  });
+
+  test("Actions.UpdateDataDictionaryField::SimplePredicate", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [
+              {
+                reasonCode: "attributeReasonCode",
+                partialScore: 1.0,
+                predicate: new SimplePredicate({
+                  field: "dataField" as FieldName,
+                  operator: "equal",
+                  value: 100,
+                }),
+              },
+            ],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml: PMML = {
+      version: "1.0",
+      DataDictionary: { DataField: [{ name: "dataField" as FieldName, dataType: "string", optype: "categorical" }] },
+      Header: {},
+      models: [scorecard],
+    };
+
+    reducer(scorecard, {
+      type: Actions.UpdateDataDictionaryField,
+      payload: {
+        modelIndex: 0,
+        dataField: { name: "updatedDataField" as FieldName, dataType: "string", optype: "categorical" },
+        originalName: "dataField" as FieldName,
+        dataDictionaryIndex: 0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute[0].predicate).toBeInstanceOf(SimplePredicate);
+
+    const predicate: SimplePredicate = updated.Characteristics.Characteristic[0].Attribute[0]
+      .predicate as SimplePredicate;
+    expect(predicate.field as string).toBe("updatedDataField");
+  });
+
+  test("Actions.UpdateDataDictionaryField::CompoundPredicate", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: {
+        Characteristic: [
+          {
+            name: "characteristic1",
+            baselineScore: 1.0,
+            reasonCode: "characteristicReasonCode",
+            Attribute: [
+              {
+                reasonCode: "attributeReasonCode",
+                partialScore: 1.0,
+                predicate: new CompoundPredicate({
+                  predicates: [
+                    new SimplePredicate({
+                      field: "dataField" as FieldName,
+                      operator: "greaterThan",
+                      value: 100,
+                    }),
+                    new SimplePredicate({
+                      field: "dataField" as FieldName,
+                      operator: "lessOrEqual",
+                      value: 200,
+                    }),
+                  ],
+                  booleanOperator: "and",
+                }),
+              },
+            ],
+          },
+        ],
+      },
+      functionName: "regression",
+    };
+    const pmml: PMML = {
+      version: "1.0",
+      DataDictionary: { DataField: [{ name: "dataField" as FieldName, dataType: "string", optype: "categorical" }] },
+      Header: {},
+      models: [scorecard],
+    };
+
+    reducer(scorecard, {
+      type: Actions.UpdateDataDictionaryField,
+      payload: {
+        modelIndex: 0,
+        dataField: { name: "updatedDataField" as FieldName, dataType: "string", optype: "categorical" },
+        originalName: "dataField" as FieldName,
+        dataDictionaryIndex: 0,
+      },
+    });
+
+    const models = historyService.commit(pmml)?.models as Model[];
+    expect(models).not.toBeUndefined();
+    const updated = models[0] as Scorecard;
+
+    expect(updated.Characteristics.Characteristic.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute.length).toBe(1);
+    expect(updated.Characteristics.Characteristic[0].Attribute[0].predicate).toBeInstanceOf(CompoundPredicate);
+
+    const compoundPredicate: CompoundPredicate = updated.Characteristics.Characteristic[0].Attribute[0]
+      .predicate as CompoundPredicate;
+    expect(compoundPredicate.predicates).not.toBeUndefined();
+    const predicates: Predicate[] = compoundPredicate.predicates as Predicate[];
+    expect(predicates.length).toBe(2);
+    expect(predicates[0]).toBeInstanceOf(SimplePredicate);
+    expect(predicates[1]).toBeInstanceOf(SimplePredicate);
+    const simplePredicate0: SimplePredicate = predicates[0] as SimplePredicate;
+    expect(simplePredicate0.field as string).toBe("updatedDataField");
+    const simplePredicate1: SimplePredicate = predicates[1] as SimplePredicate;
+    expect(simplePredicate1.field as string).toBe("updatedDataField");
+  });
+});
+
+describe("ScorecardReducer::Invalid actions", () => {
+  test("Actions.SetHeaderDescription", () => {
+    const scorecard: Scorecard = {
+      MiningSchema: { MiningField: [] },
+      Characteristics: { Characteristic: [] },
+      functionName: "regression",
+    };
+
+    const updated: Scorecard = reducer(scorecard, {
+      type: Actions.SetHeaderDescription,
+      payload: {
+        description: "description",
+      },
+    });
+
+    expect(updated).toEqual(scorecard);
+  });
+});

--- a/packages/pmml-editor/src/__tests__/editor/validation/Attributes.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/validation/Attributes.test.ts
@@ -178,7 +178,7 @@ describe("ValidateAttribute", () => {
     expect(registry.get(asPath("models[0]")).length).toBe(1);
     assertValidationEntry(
       "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.fieldName",
-      "cannot be not found"
+      "cannot be found"
     );
   });
 
@@ -216,12 +216,64 @@ describe("ValidateAttribute", () => {
     expect(registry.get(asPath("models[0]")).length).toBe(2);
     assertValidationEntry(
       "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.predicates[0].fieldName",
-      "cannot be not found"
+      "cannot be found"
     );
     assertValidationEntry(
       "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.predicates[1].fieldName",
-      "cannot be not found"
+      "cannot be found"
     );
+  });
+
+  test("ValidateAttribute::predicates::definedAndDoesExist::SimplePredicate", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+
+  test("ValidateAttribute::predicates::definedAndDoesExist::CompoundPredicate", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      {
+        predicate: new CompoundPredicate({
+          predicates: [
+            new SimplePredicate({
+              field: "field1" as FieldName,
+              operator: "greaterThan",
+              value: 100,
+            }),
+            new SimplePredicate({
+              field: "field1" as FieldName,
+              operator: "lessOrEqual",
+              value: 200,
+            }),
+          ],
+          booleanOperator: "and",
+        }),
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
   });
 });
 

--- a/packages/pmml-editor/src/__tests__/editor/validation/Attributes.test.ts
+++ b/packages/pmml-editor/src/__tests__/editor/validation/Attributes.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ValidationEntry, ValidationRegistry } from "../../../editor/validation";
+import { validateAttribute, validateAttributes } from "../../../editor/validation/Attributes";
+import { CompoundPredicate, FieldName, SimplePredicate } from "@kogito-tooling/pmml-editor-marshaller";
+
+let registry: ValidationRegistry;
+beforeEach(() => {
+  registry = new ValidationRegistry();
+});
+
+const asPath = (segment: string) => {
+  return { path: segment };
+};
+
+const assertValidationEntry = (path: string, snippet: string) => {
+  const validations: ValidationEntry[] = registry.get(asPath(path));
+  expect(validations.length).toBe(1);
+  expect(validations[0].message).toContain(snippet);
+};
+
+describe("ValidateAttribute", () => {
+  test("ValidateAttribute::reasonCode::requiredButNotDefined", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: true },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(1);
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[2].reasonCode",
+      "Reason code is required"
+    );
+  });
+
+  test("ValidateAttribute::reasonCode::requiredAndDefinedOnCharacteristic", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: true },
+      1,
+      {
+        reasonCode: "reasonCode",
+        Attribute: [],
+      },
+      false,
+      2,
+      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+
+  test("ValidateAttribute::reasonCode::requiredAndDefinedOnAttribute", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: true },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      {
+        reasonCode: "reasonCode",
+        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+
+  test("ValidateAttribute::partialScore::requiredButNotDefined", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      true,
+      2,
+      {
+        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(1);
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[2].partialScore",
+      "Partial score is required"
+    );
+  });
+
+  test("ValidateAttribute::partialScore::requiredAndPresent", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      true,
+      2,
+      {
+        partialScore: 2.0,
+        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+
+  test("ValidateAttribute::predicates::notDefined", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      {},
+      [],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(1);
+    assertValidationEntry("models[0].Characteristics.Characteristic[1].Attribute[2].predicate", "No predicate defined");
+  });
+
+  test("ValidateAttribute::predicates::definedButDoesNotExist::SimplePredicate", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+      [],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(1);
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.fieldName",
+      "cannot be not found"
+    );
+  });
+
+  test("ValidateAttribute::predicates::definedButDoesNotExist::CompoundPredicate", () => {
+    validateAttribute(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [],
+      },
+      false,
+      2,
+      {
+        predicate: new CompoundPredicate({
+          predicates: [
+            new SimplePredicate({
+              field: "field1" as FieldName,
+              operator: "greaterThan",
+              value: 100,
+            }),
+            new SimplePredicate({
+              field: "field1" as FieldName,
+              operator: "lessOrEqual",
+              value: 200,
+            }),
+          ],
+          booleanOperator: "and",
+        }),
+      },
+      [],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(2);
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.predicates[0].fieldName",
+      "cannot be not found"
+    );
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[2].predicate.predicates[1].fieldName",
+      "cannot be not found"
+    );
+  });
+});
+
+describe("ValidateAttributes", () => {
+  test("ValidateAttributes::partialScore::notRequired", () => {
+    validateAttributes(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [
+          {
+            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+          },
+          { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+        ],
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+
+  test("ValidateAttributes::partialScore::requiredButNotDefined", () => {
+    validateAttributes(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [
+          {
+            partialScore: 1.0,
+            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+          },
+          { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+        ],
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(1);
+    assertValidationEntry(
+      "models[0].Characteristics.Characteristic[1].Attribute[1].partialScore",
+      "Partial score is required"
+    );
+  });
+
+  test("ValidateAttributes::partialScore::requiredAndPresent", () => {
+    validateAttributes(
+      0,
+      { baselineScore: 0.0, useReasonCodes: false },
+      1,
+      {
+        Attribute: [
+          {
+            partialScore: 1.0,
+            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+          },
+          {
+            partialScore: 2.0,
+            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+          },
+        ],
+      },
+      [{ name: "field1" as FieldName }],
+      registry
+    );
+
+    expect(registry.get(asPath("models[0]")).length).toBe(0);
+  });
+});

--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataTypeItem/DataTypeItem.tsx
@@ -311,7 +311,7 @@ const DataTypeItem = (props: DataTypeItemProps) => {
         <section
           className={"editable-item__inner"}
           tabIndex={0}
-          onClick={(event) => handleEditStatus(event)}
+          onClick={handleEditStatus}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
               handleEditStatus(event);

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/molecules/CharacteristicsTableRow.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useCallback } from "react";
+import { BaseSyntheticEvent, useCallback } from "react";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import {
   AttributeLabels,
@@ -51,16 +51,20 @@ export const CharacteristicsTableRow = (props: CharacteristicsTableRowProps) => 
     onDelete,
   } = props;
 
+  const handleEdit = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onEdit();
+  };
+
   return (
     <article
       className={"editable-item__inner"}
       tabIndex={0}
-      onClick={onEdit}
+      onClick={handleEdit}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
-          e.preventDefault();
-          e.stopPropagation();
-          onEdit();
+          handleEdit(e);
         }
       }}
     >

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { BaseSyntheticEvent, useEffect, useMemo, useState } from "react";
 import { GenericSelector } from "../atoms";
 import { BaselineMethod, MiningFunction, ReasonCodeAlgorithm } from "@kogito-tooling/pmml-editor-marshaller";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
@@ -144,16 +144,20 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
     Builder().forModel(props.modelIndex).forBaselineScore().build()
   );
 
+  const handleEdit = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onEdit();
+  };
+
   return (
     <div
       ref={ref}
-      onClick={onEdit}
+      onClick={handleEdit}
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
-          e.preventDefault();
-          e.stopPropagation();
-          onEdit();
+          handleEdit(e);
         }
       }}
     >

--- a/packages/pmml-editor/src/editor/paths/PathBuilders.ts
+++ b/packages/pmml-editor/src/editor/paths/PathBuilders.ts
@@ -27,7 +27,13 @@ class Builders {
 }
 
 abstract class BaseBuilder {
-  constructor(protected readonly builders: Builders) {}
+  protected readonly builders: Builders;
+
+  constructor(builders: Builders) {
+    const clone: BaseBuilder[] = [];
+    builders.builders.forEach((builder) => clone.push(builder));
+    this.builders = new Builders(clone);
+  }
 
   protected abstract segment(): string;
 
@@ -68,9 +74,12 @@ class PMMLBuilder extends BaseBuilder {
 }
 
 class ModelBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly modelIndex?: number) {
+  private readonly modelIndex?: number;
+
+  constructor(builders: Builders, modelIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.modelIndex = modelIndex;
   }
 
   public forBaselineScore = () => {
@@ -99,7 +108,7 @@ class ModelBuilder extends BaseBuilder {
 }
 
 class HeaderBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -110,7 +119,7 @@ class HeaderBuilder extends BaseBuilder {
 }
 
 class DataDictionaryBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -125,9 +134,12 @@ class DataDictionaryBuilder extends BaseBuilder {
 }
 
 class DataFieldBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly dataFieldIndex?: number) {
+  private readonly dataFieldIndex?: number;
+
+  constructor(builders: Builders, dataFieldIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.dataFieldIndex = dataFieldIndex;
   }
 
   public forInterval = (intervalIndex?: number) => {
@@ -144,9 +156,12 @@ class DataFieldBuilder extends BaseBuilder {
 }
 
 class IntervalBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly intervalIndex?: number) {
+  private readonly intervalIndex?: number;
+
+  constructor(builders: Builders, intervalIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.intervalIndex = intervalIndex;
   }
 
   protected segment(): string {
@@ -155,9 +170,12 @@ class IntervalBuilder extends BaseBuilder {
 }
 
 class ValueBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly valueIndex?: number) {
+  private readonly valueIndex?: number;
+
+  constructor(builders: Builders, valueIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.valueIndex = valueIndex;
   }
 
   protected segment(): string {
@@ -166,7 +184,7 @@ class ValueBuilder extends BaseBuilder {
 }
 
 class CharacteristicsBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -181,9 +199,12 @@ class CharacteristicsBuilder extends BaseBuilder {
 }
 
 class CharacteristicBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly characteristicIndex?: number) {
+  private readonly characteristicIndex?: number;
+
+  constructor(builders: Builders, characteristicIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.characteristicIndex = characteristicIndex;
   }
 
   public forReasonCode = () => {
@@ -204,7 +225,7 @@ class CharacteristicBuilder extends BaseBuilder {
 }
 
 class ReasonCodeBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -215,7 +236,7 @@ class ReasonCodeBuilder extends BaseBuilder {
 }
 
 class BaselineScoreBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -226,7 +247,7 @@ class BaselineScoreBuilder extends BaseBuilder {
 }
 
 class UseReasonCodesBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -237,9 +258,12 @@ class UseReasonCodesBuilder extends BaseBuilder {
 }
 
 class AttributeBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly attributeIndex?: number) {
+  private readonly attributeIndex?: number;
+
+  constructor(builders: Builders, attributeIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.attributeIndex = attributeIndex;
   }
 
   public forPredicate = (predicateIndex?: number) => {
@@ -260,7 +284,7 @@ class AttributeBuilder extends BaseBuilder {
 }
 
 class PartialScoreBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -270,23 +294,30 @@ class PartialScoreBuilder extends BaseBuilder {
   }
 }
 
-class PredicateBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly predicateIndex?: number) {
+export class PredicateBuilder extends BaseBuilder {
+  private readonly predicateIndex?: number;
+
+  constructor(builders: Builders, predicateIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.predicateIndex = predicateIndex;
   }
 
   public forFieldName = () => {
     return new FieldNameBuilder(this.builders);
   };
 
+  public forPredicate = (predicateIndex?: number) => {
+    return new PredicateBuilder(this.builders, predicateIndex);
+  };
+
   protected segment(): string {
-    return this.predicateIndex !== undefined ? `predicate[${this.predicateIndex}]` : `predicate`;
+    return this.predicateIndex !== undefined ? `predicates[${this.predicateIndex}]` : `predicate`;
   }
 }
 
 class FieldNameBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -297,7 +328,7 @@ class FieldNameBuilder extends BaseBuilder {
 }
 
 class MiningSchemaBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -312,9 +343,12 @@ class MiningSchemaBuilder extends BaseBuilder {
 }
 
 class MiningFieldBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly miningFieldIndex?: number) {
+  private readonly miningFieldIndex?: number;
+
+  constructor(builders: Builders, miningFieldIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.miningFieldIndex = miningFieldIndex;
   }
 
   public forImportance = () => {
@@ -347,7 +381,7 @@ class MiningFieldBuilder extends BaseBuilder {
 }
 
 class MiningFieldImportanceBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -358,7 +392,7 @@ class MiningFieldImportanceBuilder extends BaseBuilder {
 }
 
 class MiningFieldLowValueBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -369,7 +403,7 @@ class MiningFieldLowValueBuilder extends BaseBuilder {
 }
 
 class MiningFieldHighValueBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -380,7 +414,7 @@ class MiningFieldHighValueBuilder extends BaseBuilder {
 }
 
 class MiningFieldMissingValueReplacementBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -391,7 +425,7 @@ class MiningFieldMissingValueReplacementBuilder extends BaseBuilder {
 }
 
 class MiningFieldInvalidValueReplacementBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -402,7 +436,7 @@ class MiningFieldInvalidValueReplacementBuilder extends BaseBuilder {
 }
 
 class MiningFieldDataFieldMissingBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -413,7 +447,7 @@ class MiningFieldDataFieldMissingBuilder extends BaseBuilder {
 }
 
 class OutputBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }
@@ -428,9 +462,12 @@ class OutputBuilder extends BaseBuilder {
 }
 
 class OutputFieldBuilder extends BaseBuilder {
-  constructor(protected builders: Builders, private readonly outputFieldIndex?: number) {
+  private readonly outputFieldIndex?: number;
+
+  constructor(builders: Builders, outputFieldIndex?: number) {
     super(builders);
     this.builders.add(this);
+    this.outputFieldIndex = outputFieldIndex;
   }
 
   public forTargetField = () => {
@@ -443,7 +480,7 @@ class OutputFieldBuilder extends BaseBuilder {
 }
 
 class OutputFieldTargetFieldBuilder extends BaseBuilder {
-  constructor(protected builders: Builders) {
+  constructor(builders: Builders) {
     super(builders);
     this.builders.add(this);
   }

--- a/packages/pmml-editor/src/editor/validation/Attributes.ts
+++ b/packages/pmml-editor/src/editor/validation/Attributes.ts
@@ -134,14 +134,14 @@ const validatePredicate = (
     if (fieldNames.filter((fieldName) => fieldName === predicate.field).length === 0) {
       validationRegistry.set(
         pathBuilder.forFieldName().build(),
-        new ValidationEntry(ValidationLevel.WARNING, `"${predicate.field}" cannot be not found in the Mining Schema.`)
+        new ValidationEntry(ValidationLevel.WARNING, `"${predicate.field}" cannot be found in the Mining Schema.`)
       );
     }
   } else if (predicate instanceof SimplePredicate) {
     if (fieldNames.filter((fieldName) => fieldName === predicate.field).length === 0) {
       validationRegistry.set(
         pathBuilder.forFieldName().build(),
-        new ValidationEntry(ValidationLevel.WARNING, `"${predicate.field}" cannot be not found in the Mining Schema.`)
+        new ValidationEntry(ValidationLevel.WARNING, `"${predicate.field}" cannot be found in the Mining Schema.`)
       );
     }
   } else if (predicate instanceof CompoundPredicate) {

--- a/packages/pmml-editor/src/editor/validation/MiningSchema.ts
+++ b/packages/pmml-editor/src/editor/validation/MiningSchema.ts
@@ -155,7 +155,7 @@ export const validateMiningFieldDataFieldReference = (
   if (dataFields.filter((dataField) => dataField.name === miningField.name).length === 0) {
     validationRegistry.set(
       Builder().forModel(modelIndex).forMiningSchema().forMiningField(miningFieldIndex).forDataFieldMissing().build(),
-      new ValidationEntry(ValidationLevel.WARNING, `"${miningField.name}" cannot be not found in the Data Dictionary.`)
+      new ValidationEntry(ValidationLevel.WARNING, `"${miningField.name}" cannot be found in the Data Dictionary.`)
     );
   }
 };


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-519

We were not cascading renames (and validation) into `CompoundPredicates` correctly.

Simple fix.. but I added some tests for areas previously not covered.