### PR TITLE
BAQE-1821: Introduce mocha-multi-reporters to allow test management

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "minimatch": "^3.0.4",
     "mocha": "^8.3.2",
     "mocha-jenkins-reporter": "^0.4.5",
+    "mocha-multi-reporters": "1.5.1",
     "npm-run-all": "^4.1.5",
     "null-loader": "^4.0.1",
     "path-browserify": "^1.0.1",

--- a/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/.mocharc.json
@@ -1,5 +1,6 @@
 {
+  "reporter": "mocha-multi-reporters",
   "reporterOptions": {
-    "output": "./it-tests/results/junit.xml"
+    "configFile": "./mocha-reporter-config.json"
   }
 }

--- a/packages/vscode-extension-pack-kogito-kie-editors/mocha-reporter-config.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/mocha-reporter-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, xunit",
+  "xunitReporterOptions": {
+    "output": "./it-tests/results/junit-vscode-it-tests.xml"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11325,6 +11325,14 @@ mocha-jenkins-reporter@^0.4.5:
     mkdirp "^0.5.4"
     xml "^1.0.1"
 
+mocha-multi-reporters@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz#c73486bed5519e1d59c9ce39ac7a9792600e5676"
+  integrity sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==
+  dependencies:
+    debug "^4.1.1"
+    lodash "^4.17.15"
+
 mocha@^8.3.2:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.4.0.tgz#677be88bf15980a3cae03a73e10a0fc3997f0cff"


### PR DESCRIPTION
Adds mocha-multi-reportes devDependency of 1.5.1 version.
Configures xunit and spec reporters for vscode IT tests.
Xunit outputs results to XML file

Like this we will have console outputs and also XML report to consume.