### PR TITLE
KOGITO-2313: Do not check for number of properties

### DIFF
--- a/packages/kie-editors-standalone/it-tests/cypress/integration/bpmn-workitem.spec.ts
+++ b/packages/kie-editors-standalone/it-tests/cypress/integration/bpmn-workitem.spec.ts
@@ -99,7 +99,6 @@ describe("Bpmn Workitem E2E Test.", () => {
             .find("[id='mainContainer']")
             .should("be.visible")
             .children(".row")
-            .should("have.length", 11)
             .then(($items) => {
               propertyItems = $items;
             });


### PR DESCRIPTION
This check is too strict and destabilizes the test suite
@jstastny-cz quick fix for KOGITO-2313 that adds metadata attributes to all activities.