### PR TITLE
FAI-544: Score Cards: Model Setup switches not working

### DIFF
--- a/packages/pmml-editor/it-tests/cypress.json
+++ b/packages/pmml-editor/it-tests/cypress.json
@@ -6,5 +6,6 @@
   "videosFolder": "../dist-it-tests/videos",
   "supportFile": "support/index.ts",
   "chromeWebSecurity": false,
-  "video": true
+  "video": true,
+  "defaultCommandTimeout": 10000
 }

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -110,9 +110,12 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
     return _value ? "Yes" : "No";
   };
 
-  const onEdit = () => {
-    setEditing(true);
+  const onEdit = (event: BaseSyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     setActiveOperation(Operation.UPDATE_CORE);
+    setEditing(true);
   };
 
   const onCommitAndClose = () => {
@@ -144,225 +147,236 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
     Builder().forModel(props.modelIndex).forBaselineScore().build()
   );
 
-  const handleEdit = (event: BaseSyntheticEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    onEdit();
-  };
-
   return (
-    <div
-      ref={ref}
-      onClick={handleEdit}
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          handleEdit(e);
-        }
-      }}
-    >
-      <PageSection
-        variant={PageSectionVariants.light}
-        className={isEditModeEnabled ? "editable-item--editing" : "editable-item"}
-      >
-        <Stack hasGutter={true}>
-          <StackItem>
-            <Split hasGutter={true}>
-              <SplitItem>
-                <Title size="lg" headingLevel="h1">
-                  Model Setup
-                </Title>
-              </SplitItem>
-              {!isEditModeEnabled && (
-                <SplitItem>
-                  {isScorable !== undefined && CorePropertyLabel("Is Scorable", toYesNo(isScorable))}
-                  {functionName !== undefined && CorePropertyLabel("Function", functionName)}
-                  {algorithmName !== undefined && CorePropertyLabel("Algorithm", algorithmName)}
-                  {initialScore !== undefined && CorePropertyLabel("Initial Score", initialScore)}
-                  {areReasonCodesUsed !== undefined &&
-                    CorePropertyLabel("Use Reason Codes", toYesNo(areReasonCodesUsed))}
-                  {reasonCodeAlgorithm !== undefined && CorePropertyLabel("Reason Code Algorithm", reasonCodeAlgorithm)}
-                  {baselineScore !== undefined &&
-                    baselineScoreValidation.length === 0 &&
-                    CorePropertyLabel("Baseline Score", baselineScore)}
-                  {baselineScoreValidation.length > 0 && (
-                    <ValidationIndicatorLabel validations={baselineScoreValidation} cssClass="core-properties__label">
-                      <>
-                        <strong>Baseline score:</strong>&nbsp;
-                        <em>Missing</em>
-                      </>
-                    </ValidationIndicatorLabel>
-                  )}
-                  {baselineMethod !== undefined && CorePropertyLabel("Baseline Method", baselineMethod)}
-                </SplitItem>
-              )}
-            </Split>
-          </StackItem>
-          {isEditModeEnabled && (
-            <StackItem>
-              <Form
-                onSubmit={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                }}
-                className="core-properties__container"
-              >
-                <Level hasGutter={true}>
-                  <LevelItem>
-                    <FormGroup label="Is Scorable" fieldId="core-isScorable">
-                      <Switch
-                        id="core-isScorable"
-                        isChecked={isScorable === true}
-                        onChange={(checked) => {
-                          setScorable(checked);
-                          onCommit({ isScorable: checked });
-                        }}
-                      />
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Function" fieldId="core-functionName" required={true}>
-                      {GenericSelectorEditor(
-                        "core-functionName",
-                        [
-                          "associationRules",
-                          "sequences",
-                          "classification",
-                          "regression",
-                          "clustering",
-                          "timeSeries",
-                          "mixed",
-                        ],
-                        functionName,
-                        (_selection) => {
-                          setFunctionName(_selection as MiningFunction);
-                          onCommit({ functionName: _selection as MiningFunction });
-                        },
-                        // TODO {manstis] Scorecards are ALWAYS regression. We probably don't need this field.
-                        // See http://dmg.org/pmml/v4-4/Scorecard.html
-                        true
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Algorithm" fieldId="core-algorithmName">
-                      <TextInput
-                        type="text"
-                        id="core-algorithmName"
-                        name="core-algorithmName"
-                        aria-describedby="core-algorithmName"
-                        value={algorithmName ?? ""}
-                        onChange={(e) => setAlgorithmName(e)}
-                        onBlur={() => {
-                          onCommit({ algorithmName: algorithmName });
-                        }}
-                      />
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Initial score" fieldId="core-initialScore">
-                      <TextInput
-                        id="core-initialScore"
-                        value={initialScore}
-                        onChange={(e) => setInitialScore(toNumber(e))}
-                        onBlur={() => {
-                          onCommit({ initialScore: initialScore });
-                        }}
-                        type="number"
-                      />
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
-                      <Switch
-                        id="core-useReasonCodes"
-                        isChecked={areReasonCodesUsed}
-                        onChange={(checked) => {
-                          setAreReasonCodesUsed(checked);
-                          onCommit({ areReasonCodesUsed: checked });
-                        }}
-                      />
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
-                      {GenericSelectorEditor(
-                        "core-reasonCodeAlgorithm",
-                        ["pointsAbove", "pointsBelow"],
-                        reasonCodeAlgorithm,
-                        (_selection) => {
-                          setReasonCodeAlgorithm(_selection as ReasonCodeAlgorithm);
-                          onCommit({ reasonCodeAlgorithm: _selection as ReasonCodeAlgorithm });
-                        },
-                        // Reason Code Algorithm is only required when Reason Codes are enabled.
-                        // See http://dmg.org/pmml/v4-4/Scorecard.html
-                        !areReasonCodesUsed
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup
-                      label="Baseline score"
-                      fieldId="core-baselineScore"
-                      validated={baselineScoreValidation.length > 0 ? "warning" : "default"}
-                      helperText={baselineScoreValidation.length > 0 ? baselineScoreValidation[0].message : undefined}
-                      labelIcon={
-                        <Tooltip
-                          content={
-                            areReasonCodesUsed && props.isBaselineScoreDisabled
-                              ? `A Baseline score is already provided inside all Characteristics`
-                              : `
+    <>
+      {!isEditModeEnabled && (
+        <div
+          tabIndex={0}
+          onClick={onEdit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              onEdit(e);
+            }
+          }}
+          data-testid="core-properties-table"
+        >
+          <PageSection variant={PageSectionVariants.light} className="editable-item">
+            <Stack hasGutter={true}>
+              <StackItem>
+                <Split hasGutter={true}>
+                  <SplitItem>
+                    <Title size="lg" headingLevel="h1">
+                      Model Setup
+                    </Title>
+                  </SplitItem>
+                  <SplitItem>
+                    {isScorable !== undefined && CorePropertyLabel("Is Scorable", toYesNo(isScorable))}
+                    {functionName !== undefined && CorePropertyLabel("Function", functionName)}
+                    {algorithmName !== undefined && CorePropertyLabel("Algorithm", algorithmName)}
+                    {initialScore !== undefined && CorePropertyLabel("Initial Score", initialScore)}
+                    {areReasonCodesUsed !== undefined &&
+                      CorePropertyLabel("Use Reason Codes", toYesNo(areReasonCodesUsed))}
+                    {reasonCodeAlgorithm !== undefined &&
+                      CorePropertyLabel("Reason Code Algorithm", reasonCodeAlgorithm)}
+                    {baselineScore !== undefined &&
+                      baselineScoreValidation.length === 0 &&
+                      CorePropertyLabel("Baseline Score", baselineScore)}
+                    {baselineScoreValidation.length > 0 && (
+                      <ValidationIndicatorLabel validations={baselineScoreValidation} cssClass="core-properties__label">
+                        <>
+                          <strong>Baseline score:</strong>&nbsp;
+                          <em>Missing</em>
+                        </>
+                      </ValidationIndicatorLabel>
+                    )}
+                    {baselineMethod !== undefined && CorePropertyLabel("Baseline Method", baselineMethod)}
+                  </SplitItem>
+                </Split>
+              </StackItem>
+            </Stack>
+          </PageSection>
+        </div>
+      )}
+      {isEditModeEnabled && (
+        <div ref={ref} data-testid="core-properties-table">
+          <PageSection variant={PageSectionVariants.light} className="editable-item--editing">
+            <Stack hasGutter={true}>
+              <StackItem>
+                <Split hasGutter={true}>
+                  <SplitItem>
+                    <Title size="lg" headingLevel="h1">
+                      Model Setup
+                    </Title>
+                  </SplitItem>
+                </Split>
+              </StackItem>
+              <StackItem>
+                <Form
+                  onSubmit={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
+                  className="core-properties__container"
+                >
+                  <Level hasGutter={true}>
+                    <LevelItem>
+                      <FormGroup label="Is Scorable" fieldId="core-isScorable">
+                        <Switch
+                          id="core-isScorable"
+                          isChecked={isScorable === true}
+                          aria-label="Is scorable"
+                          onChange={(checked) => {
+                            setScorable(checked);
+                            onCommit({ isScorable: checked });
+                          }}
+                        />
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Function" fieldId="core-functionName" required={true}>
+                        {GenericSelectorEditor(
+                          "core-functionName",
+                          [
+                            "associationRules",
+                            "sequences",
+                            "classification",
+                            "regression",
+                            "clustering",
+                            "timeSeries",
+                            "mixed",
+                          ],
+                          functionName,
+                          (_selection) => {
+                            setFunctionName(_selection as MiningFunction);
+                            onCommit({ functionName: _selection as MiningFunction });
+                          },
+                          // TODO {manstis] Scorecards are ALWAYS regression. We probably don't need this field.
+                          // See http://dmg.org/pmml/v4-4/Scorecard.html
+                          true
+                        )}
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Algorithm" fieldId="core-algorithmName">
+                        <TextInput
+                          type="text"
+                          id="core-algorithmName"
+                          name="core-algorithmName"
+                          aria-describedby="core-algorithmName"
+                          value={algorithmName ?? ""}
+                          onChange={(e) => setAlgorithmName(e)}
+                          onBlur={() => {
+                            onCommit({ algorithmName: algorithmName });
+                          }}
+                        />
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Initial score" fieldId="core-initialScore">
+                        <TextInput
+                          id="core-initialScore"
+                          value={initialScore}
+                          onChange={(e) => setInitialScore(toNumber(e))}
+                          onBlur={() => {
+                            onCommit({ initialScore: initialScore });
+                          }}
+                          type="number"
+                        />
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Use reason codes?" fieldId="core-useReasonCodes">
+                        <Switch
+                          id="core-useReasonCodes"
+                          isChecked={areReasonCodesUsed}
+                          aria-label="Use reason codes"
+                          onChange={(checked) => {
+                            setAreReasonCodesUsed(checked);
+                            onCommit({ areReasonCodesUsed: checked });
+                          }}
+                        />
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Reason code algorithm" fieldId="core-reasonCodeAlgorithm">
+                        {GenericSelectorEditor(
+                          "core-reasonCodeAlgorithm",
+                          ["pointsAbove", "pointsBelow"],
+                          reasonCodeAlgorithm,
+                          (_selection) => {
+                            setReasonCodeAlgorithm(_selection as ReasonCodeAlgorithm);
+                            onCommit({ reasonCodeAlgorithm: _selection as ReasonCodeAlgorithm });
+                          },
+                          // Reason Code Algorithm is only required when Reason Codes are enabled.
+                          // See http://dmg.org/pmml/v4-4/Scorecard.html
+                          !areReasonCodesUsed
+                        )}
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup
+                        label="Baseline score"
+                        fieldId="core-baselineScore"
+                        validated={baselineScoreValidation.length > 0 ? "warning" : "default"}
+                        helperText={baselineScoreValidation.length > 0 ? baselineScoreValidation[0].message : undefined}
+                        labelIcon={
+                          <Tooltip
+                            content={
+                              areReasonCodesUsed && props.isBaselineScoreDisabled
+                                ? `A Baseline score is already provided inside all Characteristics`
+                                : `
                                 When Use Reason Codes is set to yes, a Baseline score value must be provided. \
                                 Alternatively you can provide a Baseline score for all the characteristics
                                 `
-                          }
-                        >
-                          <button
-                            aria-label="More information for Baseline score"
-                            onClick={(e) => e.preventDefault()}
-                            className="pf-c-form__group-label-help"
+                            }
                           >
-                            <HelpIcon style={{ color: "var(--pf-global--info-color--100)" }} />
-                          </button>
-                        </Tooltip>
-                      }
-                    >
-                      <TextInput
-                        id="core-baselineScore"
-                        value={baselineScore ?? ""}
-                        onChange={(e) => setBaselineScore(toNumber(e))}
-                        onBlur={() => {
-                          onCommit({ baselineScore: baselineScore });
-                        }}
-                        type="number"
-                        validated={baselineScoreValidation.length > 0 ? "warning" : "default"}
-                        isDisabled={props.isBaselineScoreDisabled}
-                      />
-                    </FormGroup>
-                  </LevelItem>
-                  <LevelItem>
-                    <FormGroup label="Baseline method" fieldId="core-baselineMethod">
-                      {GenericSelectorEditor(
-                        "core-baselineMethod",
-                        ["max", "min", "mean", "neutral", "other"],
-                        baselineMethod,
-                        (_selection) => {
-                          setBaselineMethod(_selection as BaselineMethod);
-                          onCommit({ baselineMethod: _selection as BaselineMethod });
-                        },
-                        // Baseline Method is only required when Reason Codes are enabled.
-                        // See http://dmg.org/pmml/v4-4/Scorecard.html
-                        !areReasonCodesUsed
-                      )}
-                    </FormGroup>
-                  </LevelItem>
-                </Level>
-              </Form>
-            </StackItem>
-          )}
-        </Stack>
-      </PageSection>
-    </div>
+                            <button
+                              aria-label="More information for Baseline score"
+                              onClick={(e) => e.preventDefault()}
+                              className="pf-c-form__group-label-help"
+                            >
+                              <HelpIcon style={{ color: "var(--pf-global--info-color--100)" }} />
+                            </button>
+                          </Tooltip>
+                        }
+                      >
+                        <TextInput
+                          id="core-baselineScore"
+                          value={baselineScore ?? ""}
+                          onChange={(e) => setBaselineScore(toNumber(e))}
+                          onBlur={() => {
+                            onCommit({ baselineScore: baselineScore });
+                          }}
+                          type="number"
+                          validated={baselineScoreValidation.length > 0 ? "warning" : "default"}
+                          isDisabled={props.isBaselineScoreDisabled}
+                        />
+                      </FormGroup>
+                    </LevelItem>
+                    <LevelItem>
+                      <FormGroup label="Baseline method" fieldId="core-baselineMethod">
+                        {GenericSelectorEditor(
+                          "core-baselineMethod",
+                          ["max", "min", "mean", "neutral", "other"],
+                          baselineMethod,
+                          (_selection) => {
+                            setBaselineMethod(_selection as BaselineMethod);
+                            onCommit({ baselineMethod: _selection as BaselineMethod });
+                          },
+                          // Baseline Method is only required when Reason Codes are enabled.
+                          // See http://dmg.org/pmml/v4-4/Scorecard.html
+                          !areReasonCodesUsed
+                        )}
+                      </FormGroup>
+                    </LevelItem>
+                  </Level>
+                </Form>
+              </StackItem>
+            </Stack>
+          </PageSection>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -39,7 +39,7 @@ import { ValidationIndicatorLabel } from "../../EditorCore/atoms";
 import set = Reflect.set;
 import get = Reflect.get;
 
-interface CoreProperties {
+export interface CoreProperties {
   modelIndex: number;
   isScorable: boolean | undefined;
   functionName: MiningFunction | undefined;
@@ -225,6 +225,7 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           id="core-isScorable"
                           isChecked={isScorable === true}
                           aria-label="Is scorable"
+                          data-testid="core-properties-table-isScorable"
                           onChange={(checked) => {
                             setScorable(checked);
                             onCommit({ isScorable: checked });
@@ -290,6 +291,7 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           id="core-useReasonCodes"
                           isChecked={areReasonCodesUsed}
                           aria-label="Use reason codes"
+                          data-testid="core-properties-table-useReasonCodes"
                           onChange={(checked) => {
                             setAreReasonCodesUsed(checked);
                             onCommit({ areReasonCodesUsed: checked });

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { CorePropertiesTable } from "../../../../../src/editor/components/EditorScorecard/organisms";
+import { Operation, OperationContext } from "../../../../../src/editor/components/EditorScorecard";
+
+const commit = jest.fn(() => {
+  /*NOP*/
+});
+
+describe("CorePropertiesTable", () => {
+  test("render::Editing", () => {
+    const component = (
+      <OperationContext.Provider
+        value={{
+          activeOperation: Operation.UPDATE_CORE,
+          setActiveOperation: (operation) => {
+            /*NOP*/
+          },
+        }}
+      >
+        <CorePropertiesTable
+          modelIndex={0}
+          isScorable={true}
+          functionName={"regression"}
+          algorithmName={"algorithmName"}
+          baselineScore={1}
+          isBaselineScoreDisabled={false}
+          baselineMethod={"other"}
+          initialScore={2}
+          areReasonCodesUsed={true}
+          reasonCodeAlgorithm={"pointsBelow"}
+          commit={commit}
+        />
+      </OperationContext.Provider>
+    );
+
+    const { getByTestId, rerender } = render(component);
+    const container = getByTestId("core-properties-table");
+    expect(container.children[0].className.toString()).toContain("editable-item");
+    expect(container).toMatchSnapshot();
+
+    container.click();
+    rerender(component);
+    const containerEditing = getByTestId("core-properties-table");
+    expect(containerEditing.children[0].className.toString()).toContain("editable-item--editing");
+    expect(containerEditing).toMatchSnapshot();
+  });
+
+  test("render::Not editing", async () => {
+    const component = (
+      <CorePropertiesTable
+        modelIndex={0}
+        isScorable={true}
+        functionName={"regression"}
+        algorithmName={"algorithmName"}
+        baselineScore={1}
+        isBaselineScoreDisabled={false}
+        baselineMethod={"other"}
+        initialScore={2}
+        areReasonCodesUsed={true}
+        reasonCodeAlgorithm={"pointsBelow"}
+        commit={commit}
+      />
+    );
+
+    const container = render(component).getByTestId("core-properties-table");
+    expect(container.children[0].className.toString()).toContain("editable-item");
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
@@ -15,11 +15,15 @@
  */
 import { render } from "@testing-library/react";
 import * as React from "react";
-import { CorePropertiesTable } from "../../../../../src/editor/components/EditorScorecard/organisms";
+import { CoreProperties, CorePropertiesTable } from "../../../../../src/editor/components/EditorScorecard/organisms";
 import { Operation, OperationContext } from "../../../../../src/editor/components/EditorScorecard";
 
 const commit = jest.fn(() => {
   /*NOP*/
+});
+
+beforeEach(() => {
+  commit.mockReset();
 });
 
 describe("CorePropertiesTable", () => {
@@ -81,5 +85,87 @@ describe("CorePropertiesTable", () => {
     const container = render(component).getByTestId("core-properties-table");
     expect(container.children[0].className.toString()).toContain("editable-item");
     expect(container).toMatchSnapshot();
+  });
+
+  test("isScorable::clickable", () => {
+    const component = (
+      <OperationContext.Provider
+        value={{
+          activeOperation: Operation.UPDATE_CORE,
+          setActiveOperation: (operation) => {
+            /*NOP*/
+          },
+        }}
+      >
+        <CorePropertiesTable
+          modelIndex={0}
+          isScorable={true}
+          functionName={"regression"}
+          algorithmName={"algorithmName"}
+          baselineScore={1}
+          isBaselineScoreDisabled={false}
+          baselineMethod={"other"}
+          initialScore={2}
+          areReasonCodesUsed={true}
+          reasonCodeAlgorithm={"pointsBelow"}
+          commit={commit}
+        />
+      </OperationContext.Provider>
+    );
+
+    const { getByTestId, rerender } = render(component);
+    const container = getByTestId("core-properties-table");
+
+    container.click();
+    rerender(component);
+
+    const isScorable = getByTestId("core-properties-table-isScorable");
+    isScorable.click();
+
+    expect(commit).toBeCalledTimes(1);
+    const args: CoreProperties[] = commit.mock.calls[0];
+    expect(args.length).toEqual(1);
+    expect(args[0].isScorable).toBeFalsy();
+  });
+
+  test("useReasonCodes::clickable", () => {
+    const component = (
+      <OperationContext.Provider
+        value={{
+          activeOperation: Operation.UPDATE_CORE,
+          setActiveOperation: (operation) => {
+            /*NOP*/
+          },
+        }}
+      >
+        <CorePropertiesTable
+          modelIndex={0}
+          isScorable={true}
+          functionName={"regression"}
+          algorithmName={"algorithmName"}
+          baselineScore={1}
+          isBaselineScoreDisabled={false}
+          baselineMethod={"other"}
+          initialScore={2}
+          areReasonCodesUsed={true}
+          reasonCodeAlgorithm={"pointsBelow"}
+          commit={commit}
+        />
+      </OperationContext.Provider>
+    );
+
+    const { getByTestId, rerender } = render(component);
+    const container = getByTestId("core-properties-table");
+
+    container.click();
+    rerender(component);
+
+    const useReasonCodes = getByTestId("core-properties-table-useReasonCodes");
+    useReasonCodes.click();
+
+    expect(commit).toBeCalledTimes(1);
+    const args: CoreProperties[] = commit.mock.calls[0];
+    expect(args.length).toEqual(1);
+    expect(args[0].areReasonCodesUsed).toBeFalsy();
   });
 });

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
@@ -235,6 +235,7 @@ exports[`CorePropertiesTable render::Editing 2`] = `
                       aria-label="Is scorable"
                       checked=""
                       class="pf-c-switch__input"
+                      data-testid="core-properties-table-isScorable"
                       id="core-isScorable"
                       type="checkbox"
                     />
@@ -435,6 +436,7 @@ exports[`CorePropertiesTable render::Editing 2`] = `
                       aria-label="Use reason codes"
                       checked=""
                       class="pf-c-switch__input"
+                      data-testid="core-properties-table-useReasonCodes"
                       id="core-useReasonCodes"
                       type="checkbox"
                     />

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
@@ -1,0 +1,824 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CorePropertiesTable render::Editing 1`] = `
+<div
+  data-testid="core-properties-table"
+  tabindex="0"
+>
+  <section
+    class="pf-c-page__main-section pf-m-light editable-item"
+  >
+    <div
+      class="pf-l-stack pf-m-gutter"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-l-split__item"
+          >
+            <h1
+              class="pf-c-title pf-m-lg"
+            >
+              Model Setup
+            </h1>
+          </div>
+          <div
+            class="pf-l-split__item"
+          >
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Is Scorable
+                  :
+                </strong>
+                 
+                <span>
+                  Yes
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Function
+                  :
+                </strong>
+                 
+                <span>
+                  regression
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Algorithm
+                  :
+                </strong>
+                 
+                <span>
+                  algorithmName
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Initial Score
+                  :
+                </strong>
+                 
+                <span>
+                  2
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Use Reason Codes
+                  :
+                </strong>
+                 
+                <span>
+                  Yes
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Reason Code Algorithm
+                  :
+                </strong>
+                 
+                <span>
+                  pointsBelow
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Baseline Score
+                  :
+                </strong>
+                 
+                <span>
+                  1
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Baseline Method
+                  :
+                </strong>
+                 
+                <span>
+                  other
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`CorePropertiesTable render::Editing 2`] = `
+<div
+  data-testid="core-properties-table"
+>
+  <section
+    class="pf-c-page__main-section pf-m-light editable-item--editing"
+  >
+    <div
+      class="pf-l-stack pf-m-gutter"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-l-split__item"
+          >
+            <h1
+              class="pf-c-title pf-m-lg"
+            >
+              Model Setup
+            </h1>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-l-stack__item"
+      >
+        <form
+          class="pf-c-form core-properties__container"
+          novalidate=""
+        >
+          <div
+            class="pf-l-level pf-m-gutter"
+          >
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-isScorable"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Is Scorable
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <label
+                    class="pf-c-switch"
+                    data-ouia-component-id="OUIA-Generated-Switch-1"
+                    data-ouia-component-type="PF4/Switch"
+                    data-ouia-safe="true"
+                    for="core-isScorable"
+                  >
+                    <input
+                      aria-label="Is scorable"
+                      checked=""
+                      class="pf-c-switch__input"
+                      id="core-isScorable"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-switch__toggle"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="pf-c-switch__toggle-icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </label>
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+                required=""
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-functionName"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Function
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <div
+                    class="pf-c-select generic-selector ignore-onclickoutside"
+                    data-ouia-component-id="OUIA-Generated-Select-single-1"
+                    data-ouia-component-type="PF4/Select"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-labelledby=" pf-select-toggle-id-6"
+                      class="pf-c-select__toggle pf-m-disabled"
+                      disabled=""
+                      id="pf-select-toggle-id-6"
+                      type="button"
+                    >
+                      <div
+                        class="pf-c-select__toggle-wrapper"
+                      >
+                        <span
+                          class="pf-c-select__toggle-text"
+                        >
+                          regression
+                        </span>
+                      </div>
+                      <span
+                        class="pf-c-select__toggle-arrow"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-algorithmName"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Algorithm
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <input
+                    aria-describedby="core-algorithmName"
+                    aria-invalid="false"
+                    class="pf-c-form-control"
+                    id="core-algorithmName"
+                    name="core-algorithmName"
+                    type="text"
+                    value="algorithmName"
+                  />
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-initialScore"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Initial score
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-c-form-control"
+                    id="core-initialScore"
+                    type="number"
+                    value="2"
+                  />
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-useReasonCodes"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Use reason codes?
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <label
+                    class="pf-c-switch"
+                    data-ouia-component-id="OUIA-Generated-Switch-2"
+                    data-ouia-component-type="PF4/Switch"
+                    data-ouia-safe="true"
+                    for="core-useReasonCodes"
+                  >
+                    <input
+                      aria-label="Use reason codes"
+                      checked=""
+                      class="pf-c-switch__input"
+                      id="core-useReasonCodes"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-switch__toggle"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="pf-c-switch__toggle-icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </label>
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-reasonCodeAlgorithm"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Reason code algorithm
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <div
+                    class="pf-c-select generic-selector ignore-onclickoutside"
+                    data-ouia-component-id="OUIA-Generated-Select-single-2"
+                    data-ouia-component-type="PF4/Select"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-labelledby=" pf-select-toggle-id-7"
+                      class="pf-c-select__toggle"
+                      id="pf-select-toggle-id-7"
+                      type="button"
+                    >
+                      <div
+                        class="pf-c-select__toggle-wrapper"
+                      >
+                        <span
+                          class="pf-c-select__toggle-text"
+                        >
+                          pointsBelow
+                        </span>
+                      </div>
+                      <span
+                        class="pf-c-select__toggle-arrow"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-baselineScore"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Baseline score
+                    </span>
+                  </label>
+                   
+                  <button
+                    aria-label="More information for Baseline score"
+                    class="pf-c-form__group-label-help"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-c-form-control"
+                    id="core-baselineScore"
+                    type="number"
+                    value="1"
+                  />
+                  
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-form__group"
+              >
+                <div
+                  class="pf-c-form__group-label"
+                >
+                  <label
+                    class="pf-c-form__label"
+                    for="core-baselineMethod"
+                  >
+                    <span
+                      class="pf-c-form__label-text"
+                    >
+                      Baseline method
+                    </span>
+                  </label>
+                   
+                </div>
+                <div
+                  class="pf-c-form__group-control"
+                >
+                  <div
+                    class="pf-c-select generic-selector ignore-onclickoutside"
+                    data-ouia-component-id="OUIA-Generated-Select-single-3"
+                    data-ouia-component-type="PF4/Select"
+                    data-ouia-safe="true"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-labelledby=" pf-select-toggle-id-8"
+                      class="pf-c-select__toggle"
+                      id="pf-select-toggle-id-8"
+                      type="button"
+                    >
+                      <div
+                        class="pf-c-select__toggle-wrapper"
+                      >
+                        <span
+                          class="pf-c-select__toggle-text"
+                        >
+                          other
+                        </span>
+                      </div>
+                      <span
+                        class="pf-c-select__toggle-arrow"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`CorePropertiesTable render::Not editing 1`] = `
+<div
+  data-testid="core-properties-table"
+  tabindex="0"
+>
+  <section
+    class="pf-c-page__main-section pf-m-light editable-item"
+  >
+    <div
+      class="pf-l-stack pf-m-gutter"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-l-split__item"
+          >
+            <h1
+              class="pf-c-title pf-m-lg"
+            >
+              Model Setup
+            </h1>
+          </div>
+          <div
+            class="pf-l-split__item"
+          >
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Is Scorable
+                  :
+                </strong>
+                 
+                <span>
+                  Yes
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Function
+                  :
+                </strong>
+                 
+                <span>
+                  regression
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Algorithm
+                  :
+                </strong>
+                 
+                <span>
+                  algorithmName
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Initial Score
+                  :
+                </strong>
+                 
+                <span>
+                  2
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Use Reason Codes
+                  :
+                </strong>
+                 
+                <span>
+                  Yes
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Reason Code Algorithm
+                  :
+                </strong>
+                 
+                <span>
+                  pointsBelow
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Baseline Score
+                  :
+                </strong>
+                 
+                <span>
+                  1
+                </span>
+              </span>
+            </span>
+            <span
+              class="pf-c-label pf-m-cyan core-properties__label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                <strong>
+                  Baseline Method
+                  :
+                </strong>
+                 
+                <span>
+                  other
+                </span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-544

The issue was:

1. The same `div` was [used](https://github.com/kiegroup/kogito-tooling/blob/main/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx#L155-L163) to wrap both the "read-only" and "editing" content. The `onClick` handler called `event.stopPropagation()` that prevented the `Switch` from receiving click events.

2. A further consequence of using the same `div` is that if I removed the call to `event.stopPropagation()` then the event first triggered the move to edit state but was also then received by child elements and, since they were not the `div` with the "Click Outside" registered handler the handler was invoked and cancelled the move to edit mode; thus rendering the whole table inoperable.

I have moved the `onClick` handler registration (to enter edit mode) to a `div` used for the "read only" view and the "Click Outside" callback to a different `div` used for edit mode. This is consistent with how our editable lists work - where we have one component for "read only" and another for "editing". 

All problems are resolved :1st_place_medal: 