### PR TITLE
Improve pull request workflows with `ref` in `actions/checkout`

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.base_ref }}
 
       - name: "Setup Node"
         uses: actions/setup-node@v1

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.base_ref }}
 
       - name: "Setup Node"
         uses: actions/setup-node@v1


### PR DESCRIPTION
With the `ref` arg pointing to the target branch, the `actions/checkout` is able to checkout the target branch with the latest updates. This is useful, for example, when there's a need to re-run workflows of a PR after the integration of new changes in the target branch.

Please note that PRs open before the integration of this PR will still need a rebase.