### PR TITLE
Remove `ref` from `actions/checkout`

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.base_ref }}
 
       - name: "Setup Node"
         uses: actions/setup-node@v1

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.base_ref }}
 
       - name: "Setup Node"
         uses: actions/setup-node@v1


### PR DESCRIPTION
Reverts kiegroup/kogito-tooling#568

`ref` does not work well with our build dependencies approach.