### PR TITLE
adapt publish:productization script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "update-version-to": "node ./scripts/update_version.js",
     "locktt": "locktt",
     "npm-tt": "npm-tt",
-    "publish:productization": "lerna exec --scope @kogito-tooling/* --ignore @kogito-tooling/online-editor --ignore @kogito-tooling/desktop --ignore @kogito-tooling/hub --ignore @kogito-tooling/pmml-editor -- npm publish --access public",
+    "publish:productization": "lerna exec --scope @kogito-tooling/kie-editors-standalone -- npm publish --access public",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky install",

--- a/packages/i18n-common-dictionary/package.json
+++ b/packages/i18n-common-dictionary/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kogito-tooling/i18n-common-dictionary",
   "version": "0.0.0",
+  "private": true,
   "description": "",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/i18n-common-dictionary/package.json
+++ b/packages/i18n-common-dictionary/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@kogito-tooling/i18n-common-dictionary",
   "version": "0.0.0",
-  "private": true,
   "description": "",
   "license": "Apache-2.0",
   "main": "./dist/index.js",


### PR DESCRIPTION
in order to publish it as a part of the `@kogito-tooling/kie-editors-standalone` nightly product otherwise
```
npm notice 📦  @kogito-tooling/i18n-common-dictionary@0.0.0-redhat-20210803
npm notice === Tarball Contents === 
npm notice 11.4kB LICENSE     
npm notice 0B     README.md   
npm notice 1.1kB  package.json
npm notice === Tarball Details === 
npm notice name:          @kogito-tooling/i18n-common-dictionary                          
npm notice version:       0.0.0-redhat-20210803                                           
npm notice filename:      @kogito-tooling/i18n-common-dictionary-0.0.0-redhat-20210803.tgz
npm notice package size:  4.6 kB                                                          
npm notice unpacked size: 12.5 kB                                                         
npm notice shasum:        d9c66eef04d40a3b9d112b8b2f90fc0acaf74c3c                        
npm notice integrity:     sha512-W5AKIkdsVWffY[...]tIzewzUuzFs/g==                        
npm notice total files:   3                                                               
npm notice 
+ @kogito-tooling/uniforms-bootstrap4-codegen@0.0.0-redhat-20210803
npm ERR! code EPRIVATE
npm ERR! This package has been marked as private
npm ERR! Remove the 'private' field from the package.json to publish it.
```