### PR TITLE
publish prod script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "update-version-to": "node ./scripts/update_version.js",
     "locktt": "locktt",
     "npm-tt": "npm-tt",
-    "publish:productization": "lerna exec --scope @kogito-tooling/kie-editors-standalone -- npm publish --access public",
+    "publish:productization": "lerna run publish:prod --scope @kogito-tooling/kie-editors-standalone --include-filtered-dependencies  --stream",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky install",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/build-env/package.json
+++ b/packages/build-env/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "print-build-env": "rimraf dist && build-env --print-cli-tools-check && build-env --print-env && build-env --print-config && build-env --build-graph",
     "build:dev": "yarn print-build-env",
-    "build:prod": "yarn print-build-env"
+    "build:prod": "yarn print-build-env",
+    "publish:prod": "npm publish --access public"
   }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -34,7 +34,8 @@
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "copy:css": "copyfiles -u 1 src/**/*.{sass,scss,css} dist/",
     "build:dev": "rimraf dist && yarn copy:css && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/envelope-bus/package.json
+++ b/packages/envelope-bus/package.json
@@ -17,7 +17,8 @@
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:tests": "rimraf dist-tests && tsc -p tsconfig.tests.json",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json && yarn build:tests",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn build:tests && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn build:tests && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/packages/envelope/package.json
+++ b/packages/envelope/package.json
@@ -25,7 +25,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/guided-tour/package.json
+++ b/packages/guided-tour/package.json
@@ -13,7 +13,8 @@
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "copy:css": "copyfiles -u 1 src/**/*.{sass,scss,css} dist/",
     "build:dev": "rimraf dist && yarn copy:css && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "dependencies": {
     "@kie-tooling-core/envelope-bus": "0.0.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -15,7 +15,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -24,7 +24,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/kie-bc-editors/package.json
+++ b/packages/kie-bc-editors/package.json
@@ -24,7 +24,8 @@
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "copy:css": "copyfiles -u 1 src/**/*.{sass,scss,css} dist/",
     "build:dev": "rimraf dist && yarn copy:css && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && yarn copy:css && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/kie-editors-standalone/package.json
+++ b/packages/kie-editors-standalone/package.json
@@ -24,6 +24,7 @@
     "build:preprocessor": "node dist/preprocessor/preprocessor.js",
     "build:dev": "rimraf dist && webpack --env dev --config webpack.build-resources.config.js && yarn run build:preprocessor && webpack --env dev --config webpack.package-resources.config.js",
     "build:prod": "yarn lint && yarn test && rimraf dist && webpack --config webpack.build-resources.config.js && yarn run build:preprocessor && webpack --config webpack.package-resources.config.js && yarn test:it",
+    "publish:prod": "npm publish --access public",
     "build:productization": "yarn run build:prod",
     "start": "webpack serve --host 0.0.0.0 --config webpack.package-resources.config.js",
     "cy:run": "yarn cypress run -b chrome --project it-tests",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -15,7 +15,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "dependencies": {
     "@kie-tooling-core/i18n": "0.0.0",

--- a/packages/operating-system/package.json
+++ b/packages/operating-system/package.json
@@ -17,7 +17,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "devDependencies": {
     "@kogito-tooling/build-env": "0.0.0"

--- a/packages/pmml-editor-marshaller/package.json
+++ b/packages/pmml-editor-marshaller/package.json
@@ -23,7 +23,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "babel": {
     "presets": [

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -15,7 +15,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "build:dev": "rimraf dist && tsc -p tsconfig.dev.json",
-    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test"
+    "build:prod": "yarn lint && rimraf dist && tsc -p tsconfig.prod.json && yarn test",
+    "publish:prod": "npm publish --access public"
   },
   "dependencies": {
     "@kie-tooling-core/operating-system": "0.0.0"


### PR DESCRIPTION
in case we follow `--scope @kogito-tooling/kie-editors-standalone --include-filtered-dependencies -- npm publish` at `publish:productization` script we have a discrepancy between what's produced (14 packages)
```
@kogito-tooling/kie-editors-standalone
@kie-tooling-core/editor
@kogito-tooling/build-env
@kogito-tooling/kie-bc-editors
@kie-tooling-core/backend
@kie-tooling-core/envelope
@kie-tooling-core/envelope-bus
@kie-tooling-core/guided-tour
@kie-tooling-core/i18n
@kie-tooling-core/keyboard-shortcuts
@kie-tooling-core/notifications
@kie-tooling-core/workspace
@kogito-tooling/pmml-editor-marshaller
@kie-tooling-core/operating-system
```
and what's built (16 packages)
```
(14 produced packages list)
@kogito-tooling/external-assets-base
@kie-tooling-core/patternfly-base
```
`--include-filtered-dependencies` will override `--ignore` flag https://www.npmjs.com/package/@lerna/filter-options/v/3.6.0#--include-filtered-dependencies so the best option I've found is to maintain a new `publish:prod` script together with the already existing `build:prod` as we do for the `build:productization`script (at root package.json)

wdyt @tiagobento @ederign ?
