### PR TITLE
Minor infrastructure improvements

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: always() && !cancelled()
         with:
           name: artifacts-${{ matrix.os }}
           if-no-files-found: warn
@@ -101,7 +101,7 @@ jobs:
 
       - name: "Upload IT Tests artifacts"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: always() && !cancelled()
         with:
           name: it-tests-artifacts-${{ matrix.os }}
           if-no-files-found: warn

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: always() && !cancelled()
         with:
           name: artifacts-${{ matrix.os }}
           if-no-files-found: warn
@@ -95,7 +95,7 @@ jobs:
 
       - name: "Upload IT Tests artifacts"
         uses: actions/upload-artifact@v2
-        if: always()
+        if: always() && !cancelled()
         with:
           name: it-tests-artifacts-${{ matrix.os }}
           if-no-files-found: warn

--- a/.github/workflows/publish_daily_dev_version.yml
+++ b/.github/workflows/publish_daily_dev_version.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build kogito-tooling
         env:
-          COMPATIBLE_VERSION: "0.12.0"
+          COMPATIBLE_VERSION: "0.12.1"
           WEBPACK__minimize: "true"
           WEBPACK__tsLoaderTranspileOnly: "false"
           CHROME_EXTENSION__routerTargetOrigin: "https://kiegroup.github.io"

--- a/.github/workflows/publish_daily_dev_version.yml
+++ b/.github/workflows/publish_daily_dev_version.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Build kogito-tooling
         env:
+          COMPATIBLE_VERSION: "0.12.0"
           WEBPACK__minimize: "true"
           WEBPACK__tsLoaderTranspileOnly: "false"
           CHROME_EXTENSION__routerTargetOrigin: "https://kiegroup.github.io"
@@ -68,10 +69,10 @@ jobs:
           ONLINE_EDITOR__downloadHubUrlLinux: "https://kiegroup.github.io/kogito-online/dev/hub_download_unsupported.txt"
           ONLINE_EDITOR__downloadHubUrlMacOs: "https://kiegroup.github.io/kogito-online/dev/hub_download_unsupported.txt"
           ONLINE_EDITOR__downloadHubUrlWindows: "https://kiegroup.github.io/kogito-online/dev/hub_download_unsupported.txt"
-          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlLinux: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ steps.release_json.outputs.tag }}/kie_tooling_extended_services_linux_${{ steps.release_json.outputs.tag }}.tar.gz"
-          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlMacOs: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ steps.release_json.outputs.tag }}/kie_tooling_extended_services_macos_${{ steps.release_json.outputs.tag }}.dmg"
-          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlWindows: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ steps.release_json.outputs.tag }}/kie_tooling_extended_services_windows_${{ steps.release_json.outputs.tag }}.exe"
-          ONLINE_EDITOR__kieToolingExtendedServicesCompatibleVersion: "${{ steps.release_json.outputs.tag }}"
+          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlLinux: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ env.COMPATIBLE_VERSION }}/kie_tooling_extended_services_linux_${{ env.COMPATIBLE_VERSION }}.tar.gz"
+          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlMacOs: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ env.COMPATIBLE_VERSION }}/kie_tooling_extended_services_macos_${{ env.COMPATIBLE_VERSION }}.dmg"
+          ONLINE_EDITOR__kieToolingExtendedServicesDownloadUrlWindows: "https://github.com/kiegroup/kogito-tooling-go/releases/download/${{ env.COMPATIBLE_VERSION }}/kie_tooling_extended_services_windows_${{ env.COMPATIBLE_VERSION }}.exe"
+          ONLINE_EDITOR__kieToolingExtendedServicesCompatibleVersion: "${{ env.COMPATIBLE_VERSION }}"
           ONLINE_EDITOR__buildInfo: "${{ steps.version.outputs.version }} (daily-dev) @ ${{ github.sha }}"
           DISPLAY: ":99.0"
         run: |

--- a/packages/backend-extended-services/package.json
+++ b/packages/backend-extended-services/package.json
@@ -18,9 +18,9 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
     "install:mvnw": "mvn -N io.takari:maven:wrapper -f kogito-extended-services-quarkus",
-    "build:dev": "yarn install:mvnw && mvn clean install -DskipTests",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install `-DskipTests=$(build-env global.build.test --not)",
-    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -DskipTests=$(build-env global.build.test --not)",
+    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not)",
+    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not)",
     "build:prod": "yarn lint && run-script-os"
   }
 }

--- a/packages/build-env/index.js
+++ b/packages/build-env/index.js
@@ -158,6 +158,11 @@ const ENV_VARS = {
     name: "WEBPACK__mode",
     description: "",
   },
+  KOGITO_RUNTIME_version: {
+    name: "KOGITO_RUNTIME_version",
+    default: "1.9.1.Final",
+    description: "",
+  },
 };
 
 module.exports = {
@@ -250,6 +255,11 @@ module.exports = {
       port: 9005,
     },
   },
+
+  kogitoRuntime: {
+    version: getOrDefault(ENV_VARS.KOGITO_RUNTIME_version),
+  },
+
   vars: () => ({
     ENV_VARS,
     getOrDefault: getOrDefault,

--- a/packages/build-env/index.js
+++ b/packages/build-env/index.js
@@ -160,7 +160,7 @@ const ENV_VARS = {
   },
   KOGITO_RUNTIME_version: {
     name: "KOGITO_RUNTIME_version",
-    default: "1.9.1.Final",
+    default: "1.10.0.Final",
     description: "",
   },
 };

--- a/packages/dmn-dev-sandbox-deployment-base-image/Dockerfile
+++ b/packages/dmn-dev-sandbox-deployment-base-image/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.1
 
-ARG KOGITO_RUNTIME_VERSION=1.7.0.Final
+ARG KOGITO_RUNTIME_VERSION
 
 RUN mkdir /tmp/kogito/
 

--- a/packages/dmn-dev-sandbox-deployment-base-image/Dockerfile
+++ b/packages/dmn-dev-sandbox-deployment-base-image/Dockerfile
@@ -24,7 +24,7 @@ COPY dist-dev/mvnw mvnw
 COPY dist-dev/.mvn/ .mvn
 COPY dist-dev/dmn-json-schema-generator.jar dmn-json-schema-generator.jar
 
-RUN ./mvnw archetype:generate -B \
+RUN ./mvnw archetype:generate -B -ntp \
         -DarchetypeGroupId=org.kie.kogito \
         -DarchetypeArtifactId=kogito-quarkus-archetype \
         -DarchetypeVersion=${KOGITO_RUNTIME_VERSION} \
@@ -38,7 +38,7 @@ RUN ./mvnw archetype:generate -B \
 COPY --chown=185:root dist-dev/dmn-dev-sandbox-form-webapp/ project/src/main/resources/META-INF/resources/
 
 RUN echo -e '\nquarkus.http.cors=true' >> project/src/main/resources/application.properties \
-    && ./mvnw clean package -f project/pom.xml \
+    && ./mvnw clean package -B -ntp -f project/pom.xml \
     && cp project/target/quarkus-app/*.jar /deployments/ \
     && cp -R project/target/quarkus-app/lib/ /deployments/ \
     && cp -R project/target/quarkus-app/app/ /deployments/ \

--- a/packages/dmn-dev-sandbox-deployment-base-image/package.json
+++ b/packages/dmn-dev-sandbox-deployment-base-image/package.json
@@ -12,7 +12,7 @@
     "cleanup": "rimraf dist-dev && mkdir dist-dev",
     "copy:assets": "cp ../dmn-json-schema-generator/target/dmn-json-schema-generator.jar ./dist-dev && cp -R ../dmn-dev-sandbox-form-webapp/dist ./dist-dev/dmn-dev-sandbox-form-webapp",
     "install:mvnw": "cd dist-dev/ && mvn -N io.takari:maven:wrapper",
-    "podman:build": "yarn run run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build $(echo $(build-env dmnDevSandbox.baseImage.buildTags) | xargs printf -- \"-t $(build-env dmnDevSandbox.baseImage.registry)/$(build-env dmnDevSandbox.baseImage.account)/$(build-env dmnDevSandbox.baseImage.name):%s\n\" | xargs echo) .\" --else \"echo Podman not found, skipping image build.\"",
+    "podman:build": "yarn run run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build $(echo $(build-env dmnDevSandbox.baseImage.buildTags) | xargs printf -- \"-t $(build-env dmnDevSandbox.baseImage.registry)/$(build-env dmnDevSandbox.baseImage.account)/$(build-env dmnDevSandbox.baseImage.name):%s\n\" | xargs echo) --build-arg KOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) .\" --else \"echo Podman not found, skipping image build.\"",
     "build:dev": "yarn cleanup && yarn install:mvnw && yarn copy:assets",
     "build:prod:win32": "echo \"Not supported\"",
     "build:prod:darwin:linux": "yarn run run-script-if --bool \"$(build-env global.build.docker)\" --then \"yarn podman:build\"",

--- a/packages/dmn-json-schema-generator/package.json
+++ b/packages/dmn-json-schema-generator/package.json
@@ -15,7 +15,7 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
     "install:mvnw": "run-script-os",
-    "install:mvnw:win32": "mvn -N io.takari:maven:wrapper `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "install:mvnw:win32": "yarn powershell mvn -N io.takari:maven:wrapper `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "install:mvnw:darwin:linux": "mvn -N io.takari:maven:wrapper -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",

--- a/packages/dmn-json-schema-generator/package.json
+++ b/packages/dmn-json-schema-generator/package.json
@@ -14,9 +14,11 @@
   "scripts": {
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
-    "install:mvnw": "mvn -N io.takari:maven:wrapper -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "install:mvnw": "run-script-os",
+    "install:mvnw:win32": "mvn -N io.takari:maven:wrapper `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "install:mvnw:darwin:linux": "mvn -N io.takari:maven:wrapper -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:prod": "yarn lint && run-script-os"
   }

--- a/packages/dmn-json-schema-generator/package.json
+++ b/packages/dmn-json-schema-generator/package.json
@@ -15,9 +15,9 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
     "install:mvnw": "mvn -N io.takari:maven:wrapper",
-    "build:dev": "yarn install:mvnw && mvn clean install -DskipTests",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install `-DskipTests=$(build-env global.build.test --not)",
-    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -DskipTests=$(build-env global.build.test --not)",
+    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not)",
+    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not)",
     "build:prod": "yarn lint && run-script-os"
   }
 }

--- a/packages/dmn-json-schema-generator/package.json
+++ b/packages/dmn-json-schema-generator/package.json
@@ -14,10 +14,10 @@
   "scripts": {
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
-    "install:mvnw": "mvn -N io.takari:maven:wrapper",
-    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not)",
-    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not)",
+    "install:mvnw": "mvn -N io.takari:maven:wrapper -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "build:prod": "yarn lint && run-script-os"
   }
 }

--- a/packages/dmn-json-schema-generator/pom.xml
+++ b/packages/dmn-json-schema-generator/pom.xml
@@ -28,7 +28,7 @@
     <uberjar.name>dmn-json-schema-generator</uberjar.name>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <version.org.kie.kogito>1.7.0.Final</version.org.kie.kogito>
+    <version.org.kie.kogito>${KOGITO_RUNTIME_VERSION}</version.org.kie.kogito>
     <version.org.slf4j>1.7.30</version.org.slf4j>
     <version.jar.plugin>3.1.0</version.jar.plugin>
     <version.shade.plugin>3.2.4</version.shade.plugin>
@@ -39,7 +39,7 @@
     <dependencies>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-build-parent</artifactId>
+        <artifactId>kogito-kie7-bom</artifactId>
         <version>${version.org.kie.kogito}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/packages/online-editor/src/editor/DmnDevSandbox/resources/Build.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/resources/Build.tsx
@@ -105,10 +105,10 @@ export class CreateBuild extends ResourceFetch {
         source:
           dockerfile: |
             FROM ${this.BASE_IMAGE}
-            ENV MAVEN_OPTS="-Xmx256m -Xms128m" JAVA_OPTS="-Xmx256m -Xms128m"
+            ENV MAVEN_OPTS="-Xmx352m -Xms128m" JAVA_OPTS="-Xmx352m -Xms128m"
             RUN echo $'${this.args.model.content}' > '${diagramPath}' \
                 && java -jar ${this.FORM_SCHEMA_GENERATOR_PATH} '${diagramPath}' '${this.DATA_PATH}' '${this.args.urls.index}' '${this.args.urls.onlineEditor}' '${this.args.urls.swaggerUI}' \
-                && ${this.MVNW_PATH} clean package -f ${this.POM_PATH} \
+                && ${this.MVNW_PATH} clean package -B -ntp -f ${this.POM_PATH} \
                 && cp ${this.QUARKUS_APP_FOLDER}/*.jar ${this.DEPLOYMENTS_FOLDER} \
                 && cp -R ${this.QUARKUS_APP_FOLDER}/lib/ ${this.DEPLOYMENTS_FOLDER} \
                 && cp -R ${this.QUARKUS_APP_FOLDER}/app/ ${this.DEPLOYMENTS_FOLDER} \


### PR DESCRIPTION
Including in this PR:
- Add compatible version on `Publish Daily Dev Version` workflow (currently set to `0.12.1`).
- Introduce `KOGITO_RUNTIME_version` env var (currently set to `1.10.0.Final`).
- Hide transfer progress logs for maven with arg `-ntp`.
- Increase Xmx in the Build resource to avoid OutOfMemory errors.
- Monorepo CI should always upload artifacts, except when the job is cancelled.

⚠️  Please merge only after `0.12.0` release.

Related PRs:
https://github.com/kiegroup/kogito-tooling/pull/594
https://github.com/kiegroup/kogito-tooling-go/pull/19