### PR TITLE
PMML Editor: Remove relative paths to node_modules on SCSS files

### DIFF
--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/sass-utilities/all";
-@import "../../../../../../../node_modules/@patternfly/patternfly/base/variables";
+@import "@patternfly/patternfly/sass-utilities/all";
+@import "@patternfly/patternfly/base/variables";
 
 .attributes {
   &__header {

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/AttributesTable.scss
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "@patternfly/patternfly/sass-utilities/all";
-@import "@patternfly/patternfly/base/variables";
+@import "~@patternfly/patternfly/sass-utilities/all";
+@import "~@patternfly/patternfly/base/variables";
 
 .attributes {
   &__header {

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "../../../../../../../node_modules/@patternfly/patternfly/sass-utilities/all";
-@import "../../../../../../../node_modules/@patternfly/patternfly/base/variables";
+@import "@patternfly/patternfly/sass-utilities/all";
+@import "@patternfly/patternfly/base/variables";
 
 .outputs {
   &__header {

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.scss
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import "@patternfly/patternfly/sass-utilities/all";
-@import "@patternfly/patternfly/base/variables";
+@import "~@patternfly/patternfly/sass-utilities/all";
+@import "~@patternfly/patternfly/base/variables";
 
 .outputs {
   &__header {


### PR DESCRIPTION
Relative paths break `kie-tooling-store`, as the dir structure is different.