### PR TITLE
KOGITO-5721: Parse date objects on formInputs

### DIFF
--- a/packages/online-editor/src/__tests__/common/utils.test.ts
+++ b/packages/online-editor/src/__tests__/common/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { extractEditorFileExtensionFromUrl } from "../../common/utils";
+import { extractEditorFileExtensionFromUrl, jsonParseWithDate } from "../../common/utils";
 
 const supportedFileExtensions = ["bpmn", "dmn", "bpmn2", "myext"];
 
@@ -69,5 +69,30 @@ describe("utils::extractEditorFileExtensionFromUrl", () => {
   test("should be undefined when empty", () => {
     setWindowLocationHref("");
     expect(extractEditorFileExtensionFromUrl(supportedFileExtensions)).toBeUndefined();
+  });
+});
+
+describe("utils::jsonParseWithDate", () => {
+  it("should parse JSON strings with dates properly", () => {
+    const myObject = {
+      myNumber: 1,
+      myString: "myValue",
+      myBoolean: false,
+      myUndefined: undefined,
+      myObject: {
+        myNumber: 2,
+        myDate: Date.now(),
+      },
+      myDateOne: Date.now(),
+      myDateTwo: new Date(Date.UTC(2021, 8, 18, 7, 59, 0, 0)),
+      myDateThree: new Date(),
+      myDateFour: new Date("August 18, 2021 07:59:00"),
+      myDateFive: new Date("2021-08-18T07:59:00"),
+      myDateSix: new Date(2021, 8, 18),
+      myDateSeven: new Date(2021, 8, 18, 7, 59, 0),
+    };
+    const json = JSON.stringify(myObject);
+    expect(JSON.parse(json)).not.toEqual(myObject);
+    expect(jsonParseWithDate(json)).toEqual(myObject);
   });
 });

--- a/packages/online-editor/src/common/utils.ts
+++ b/packages/online-editor/src/common/utils.ts
@@ -96,3 +96,10 @@ export function flatten(obj: object): object {
     return { ...acc, [`${key}`]: value };
   }, {});
 }
+
+export function jsonParseWithDate(json: string): any {
+  return JSON.parse(json, (_key: string, value: any) => {
+    const regexISO = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+    return typeof value === "string" && regexISO.test(value) ? new Date(value) : value;
+  });
+}

--- a/packages/online-editor/src/editor/DmnRunner/DmnRunnerContext.tsx
+++ b/packages/online-editor/src/editor/DmnRunner/DmnRunnerContext.tsx
@@ -17,6 +17,7 @@
 import { DmnFormSchema } from "@kogito-tooling/form/dist/dmn";
 import * as React from "react";
 import { useContext } from "react";
+import { jsonParseWithDate } from "../../common/utils";
 import { DmnRunnerService } from "./DmnRunnerService";
 import { DmnRunnerStatus } from "./DmnRunnerStatus";
 
@@ -47,7 +48,7 @@ export function extractFormInputsFromUrlParams(): any {
   const urlParams = new URLSearchParams(window.location.search);
   if (urlParams.has("formInputs")) {
     try {
-      return JSON.parse(decodeURIComponent(urlParams.get("formInputs")!));
+      return jsonParseWithDate(decodeURIComponent(urlParams.get("formInputs")!));
     } catch (e) {
       console.error("Cannot parse formInputs", e);
     }


### PR DESCRIPTION
See [KOGITO-5721](https://issues.redhat.com/browse/KOGITO-5721)

The form only accepts `date-time` as objects, not strings.
Since `JSON.parse` does not transform date strings to date objects, we need to provide a function that does such a thing.

Keep in mind that, the "time" part is still not being filled up in the form, but this is probably related to [KOGITO-5722](https://issues.redhat.com/browse/KOGITO-5722).

### Before:
![KOGITO-5721-before](https://user-images.githubusercontent.com/638737/130244907-02ca02f0-a94a-47a2-8797-c2bfd54214c4.png)

### After:
![KOGITO-5721](https://user-images.githubusercontent.com/638737/130244940-95c7135e-ce0c-4711-b926-683838407330.gif)
