### PR TITLE
kie-editors-standalone: update options description in README

### DIFF
--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -47,8 +47,8 @@ Parameters description:
   - `Promise.resolve("")`
   - `Promise.resolve("<DIAGRAM_CONTENT_DIRECTLY_HERE>")`
   - `fetch("MyDmnModel.dmn").then(content => content.text())`
-- `readOnly` (optional, defaults to `false`): Use `false` to allow content edition, and `true` for read-only mode, in which the Editor will not allow changes. WARNING: Currently only the DMN Editor supports read-only mode.
-- `origin` (optional, defaults to `window.location.origin`): If for some reason your application needs to change this parameter, you can use it.
+- `readOnly` (optional, defaults to `false`): Use `false` to allow content edition, and `true` for read-only mode, in which the Editor will not allow changes.
+- `origin` (optional, defaults to `*` when accessing the application with the `file` protocol, `window.location.origin` otherwise): If for some reason your application needs to change this parameter, you can use it.
 - `onError` (optional, defaults to `() => {}`): If there's an error opening the Editor, this function will be called.
 
 * `resources` (optional, defaults to `[]`): Map of resources that will be provided for the Editor. This can be used, for instance, to provide included models for the DMN Editor or Work Item Definitions for the BPMN Editor. Each entry in the map has the resource name as its key and an object containing the `content-type` (`text` or `binary`) and the resource `content` (Promise similar to the `initialContent` parameter) as its value.


### PR DESCRIPTION
`origin`: add default when using the file protocol
`readOnly`: it is also available in the BPMN Editor

**Rationale**
- origin: [BPMN](https://github.com/kiegroup/kogito-tooling/blob/0.12.0/packages/kie-editors-standalone/src/bpmn/index.ts#L32) and [DMN](https://github.com/kiegroup/kogito-tooling/blob/0.12.0/packages/kie-editors-standalone/src/dmn/index.ts#L32)
- readOnly: [EnvelopeServer](https://github.com/kiegroup/kogito-tooling/blob/0.12.0/packages/kie-editors-standalone/src/bpmn/index.ts#L47) and [Channel](https://github.com/kiegroup/kogito-tooling/blob/0.12.0/packages/kie-editors-standalone/src/bpmn/index.ts#L84)

