### PR TITLE
KOGITO-5756: Minor improvements for the outdated icon

### DIFF
--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -474,7 +474,7 @@ export const en: OnlineI18n = {
       tooltip: {
         connected: (port: string) => `${en_common.names.kieToolingExtendedServices} is connected to port ${port}.`,
         install: `Setup ${en_common.names.kieToolingExtendedServices} to use this feature. Click to install.`,
-        outdated: `${en_common.names.kieToolingExtendedServices} is outdated.`,
+        outdated: `${en_common.names.kieToolingExtendedServices} is outdated. Click to update.`,
         disconnected: `${en_common.names.kieToolingExtendedServices} is disconnected.`,
       },
     },

--- a/packages/online-editor/src/editor/KieToolingExtendedServices/KieToolingExtendedServicesButtons.tsx
+++ b/packages/online-editor/src/editor/KieToolingExtendedServices/KieToolingExtendedServicesButtons.tsx
@@ -42,6 +42,13 @@ export function KieToolingExtendedServicesButtons() {
     [kieToolingExtendedServices.status]
   );
 
+  const onToggleKieToolingExtendedServices = useCallback(() => {
+    if (!kieToolingExtendedServices.outdated) {
+      return;
+    }
+    kieToolingExtendedServices.setModalOpen(true);
+  }, [kieToolingExtendedServices]);
+
   const onToggleDmnRunner = useCallback(() => {
     kieToolingExtendedServices.closeDmnTour();
     if (isKieToolingExtendedServicesRunning) {
@@ -78,7 +85,7 @@ export function KieToolingExtendedServicesButtons() {
           >
             <ExclamationTriangleIcon
               data-testid="outdated-icon"
-              className="static-opacity"
+              className="kogito--editor__kie-tooling-extended-services-dropdown-icon-outdated static-opacity"
               id="kie-tooling-extended-services-outdated-icon"
             />
           </Tooltip>
@@ -128,6 +135,7 @@ export function KieToolingExtendedServicesButtons() {
           <DropdownToggle
             id="kie-tooling-extended-services-button"
             toggleIndicator={null}
+            onToggle={onToggleKieToolingExtendedServices}
             className="kogito--kie-tooling-extended-services-button"
             data-testid="kie-tooling-extended-services-button"
           >

--- a/packages/online-editor/src/editor/KieToolingExtendedServices/KieToolingExtendedServicesContextProvider.tsx
+++ b/packages/online-editor/src/editor/KieToolingExtendedServices/KieToolingExtendedServicesContextProvider.tsx
@@ -86,12 +86,12 @@ export function KieToolingExtendedServicesContextProvider(props: Props) {
       bridge
         .check()
         .then(() => {
-          // Check the running version of the KieToolingExtendedServices, if outdated cancel polling and change status.
+          // Check the running version of the KieToolingExtendedServices, cancel polling if up-to-date.
           bridge.version().then((kieToolingExtendedServicesVersion) => {
-            window.clearInterval(detectKieToolingExtendedServices);
             if (kieToolingExtendedServicesVersion !== version) {
               setOutdated(true);
             } else {
+              window.clearInterval(detectKieToolingExtendedServices);
               setOutdated(false);
               setStatus(KieToolingExtendedServicesStatus.RUNNING);
             }

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -520,6 +520,14 @@
   }
 }
 
+.kogito--editor__kie-tooling-extended-services-dropdown-icon-outdated {
+  color: var(--pf-global--warning-color--100);
+}
+
+.kogito--editor__kie-tooling-extended-services-dropdown-icon-outdated:focus {
+  outline: none;
+}
+
 .kogito--editor__kie-tooling-extended-services-dropdown-icon-connected {
   color: var(--pf-global--palette--green-300);
 }


### PR DESCRIPTION
As per feedback, this PR includes:

- Outdated icon is now yellow gold.
![outdated](https://user-images.githubusercontent.com/638737/130794997-0c1b0773-198b-448e-a252-5914f01e37d0.png)

- Outdated icon is now clickable. This opens the Setup modal.