### PR TITLE
KOGITO-5791: Get the Route URL through the REST API

### DIFF
--- a/packages/online-editor/src/__tests__/editor/DmnDevSandbox/DmnDevSandboxService.test.tsx
+++ b/packages/online-editor/src/__tests__/editor/DmnDevSandbox/DmnDevSandboxService.test.tsx
@@ -22,7 +22,7 @@ import { CreateDeployment, Deployment, ListDeployments } from "../../../editor/D
 import { CreateImageStream } from "../../../editor/DmnDevSandbox/resources/ImageStream";
 import { GetProject } from "../../../editor/DmnDevSandbox/resources/Project";
 import { ResourceFetch } from "../../../editor/DmnDevSandbox/resources/Resource";
-import { CreateRoute } from "../../../editor/DmnDevSandbox/resources/Route";
+import { CreateRoute, ListRoutes, Route } from "../../../editor/DmnDevSandbox/resources/Route";
 import { CreateService } from "../../../editor/DmnDevSandbox/resources/Service";
 
 describe("DmnDevSandboxService", () => {
@@ -66,6 +66,21 @@ describe("DmnDevSandboxService", () => {
     };
   }
 
+  function createRoute(id: string): Route {
+    return {
+      metadata: {
+        uid: `uid-${id}`,
+        name: `deployment-${id}`,
+        labels: {},
+        annotations: {},
+        creationTimestamp: new Date().toISOString(),
+      },
+      spec: {
+        host: "test-host",
+      },
+    };
+  }
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -88,6 +103,10 @@ describe("DmnDevSandboxService", () => {
     when(fetchResourceFn)
       .calledWith(expect.any(CreateBuildConfig), expect.anything())
       .mockReturnValueOnce(Promise.resolve({ metadata: { uid: "uid" } }));
+
+    when(fetchResourceFn)
+      .calledWith(expect.any(CreateRoute), expect.anything())
+      .mockReturnValueOnce(Promise.resolve({ metadata: { uid: "uid" }, spec: { host: "host" } }));
 
     await service.deploy("myModel.dmn", "diagramContent", config);
 
@@ -131,6 +150,15 @@ describe("DmnDevSandboxService", () => {
       createBuild("6"),
     ];
 
+    const routes = [
+      createRoute("1"),
+      createRoute("2"),
+      createRoute("3"),
+      createRoute("4"),
+      createRoute("5"),
+      createRoute("6"),
+    ];
+
     when(fetchResourceFn)
       .calledWith(expect.any(ListDeployments))
       .mockReturnValueOnce(
@@ -144,6 +172,14 @@ describe("DmnDevSandboxService", () => {
       .mockReturnValueOnce(
         Promise.resolve({
           items: builds,
+        })
+      );
+
+    when(fetchResourceFn)
+      .calledWith(expect.any(ListRoutes))
+      .mockReturnValueOnce(
+        Promise.resolve({
+          items: routes,
         })
       );
 

--- a/packages/online-editor/src/common/i18n/locales/en.ts
+++ b/packages/online-editor/src/common/i18n/locales/en.ts
@@ -99,10 +99,9 @@ export const en: OnlineI18n = {
       noDeployments: "Your deployments show up here",
       setupFor: (username: string) => `Setup for ${username}`,
       item: {
-        upTooltip: "This deployment is up and running. Click to see more details in your instance.",
-        downTooltip: "This deployment is not running. Click to see more details in your instance.",
-        inProgressTooltip:
-          "This deployment is in progress and it will be available shortly. Click to see more details in your instance.",
+        upTooltip: "This deployment is up and running.",
+        downTooltip: "This deployment is not running.",
+        inProgressTooltip: "This deployment is in progress and it will be available shortly.",
         createdAt: (date: string) => `Created at ${date}`,
       },
     },

--- a/packages/online-editor/src/editor/DmnDevSandbox/DeployedModel.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DeployedModel.tsx
@@ -26,7 +26,6 @@ export interface DeployedModel {
   filename: string;
   urls: {
     index: string;
-    console: string;
     swaggerUI: string;
   };
   creationTimestamp: Date;

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
@@ -53,7 +53,7 @@ enum AlertTypes {
 
 export function DmnDevSandboxContextProvider(props: Props) {
   const KOGITO_ONLINE_EDITOR = "online-editor";
-  const LOAD_DEPLOYMENTS_POLLING_TIME = 1000;
+  const LOAD_DEPLOYMENTS_POLLING_TIME = 2500;
 
   const { i18n } = useOnlineI18n();
   const globalContext = useContext(GlobalContext);

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
@@ -32,14 +32,6 @@ interface Props {
 export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
   const { i18n } = useOnlineI18n();
 
-  const onConfigure = useCallback(
-    (e: React.MouseEvent) => {
-      window.open(props.deployment.urls.console, "_blank");
-      e.stopPropagation();
-    },
-    [props.deployment.urls.console]
-  );
-
   const filename = useMemo(() => {
     const maxSize = 25;
     const originalFilename = props.deployment.filename;
@@ -60,7 +52,6 @@ export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
           <CheckCircleIcon
             id="dmn-dev-sandbox-deployment-item-up-icon"
             className="kogito--editor__dmn-dev-sandbox-dropdown-item-status success-icon"
-            onClick={onConfigure}
           />
         </Tooltip>
       );
@@ -79,7 +70,6 @@ export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
           <SyncAltIcon
             id="dmn-dev-sandbox-deployment-item-in-progress-icon"
             className="kogito--editor__dmn-dev-sandbox-dropdown-item-status in-progress-icon rotating"
-            onClick={onConfigure}
           />
         </Tooltip>
       );
@@ -94,11 +84,10 @@ export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
         <ExclamationTriangleIcon
           id="dmn-dev-sandbox-deployment-item-down-icon"
           className="kogito--editor__dmn-dev-sandbox-dropdown-item-status warning-icon"
-          onClick={onConfigure}
         />
       </Tooltip>
     );
-  }, [i18n, onConfigure, props.deployment.state, props.id]);
+  }, [i18n, props.deployment.state, props.id]);
 
   const onItemClicked = useCallback(() => {
     window.open(props.deployment.urls.index, "_blank");

--- a/packages/online-editor/src/editor/DmnDevSandbox/resources/Route.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/resources/Route.tsx
@@ -14,9 +14,18 @@
  * limitations under the License.
  */
 
-import { HttpMethod, JAVA_RUNTIME_VERSION, ResourceFetch } from "./Resource";
+import { HttpMethod, JAVA_RUNTIME_VERSION, Resource, ResourceFetch } from "./Resource";
 
 const API_ENDPOINT = "apis/route.openshift.io/v1";
+
+export interface Route extends Resource {
+  spec: {
+    host: string;
+  };
+}
+export interface Routes {
+  items: Route[];
+}
 
 export class CreateRoute extends ResourceFetch {
   protected method(): HttpMethod {


### PR DESCRIPTION
In this PR:
- Fetch the Route API to build the base URL instead of manually composing it.
- Removed the click action from the deployment status icon so that other clusters are fully supported.