### PR TITLE
KOGITO-3909: Activate the DMN dirty indicator test

### DIFF
--- a/packages/kie-editors-standalone/it-tests/cypress/integration/dmn-editable-data-type.ts
+++ b/packages/kie-editors-standalone/it-tests/cypress/integration/dmn-editable-data-type.ts
@@ -20,8 +20,7 @@ describe("Dmn Editable Data Type.", () => {
     cy.loadEditors(["dmn-editable"]);
   });
 
-  // Currently skipped due to https://issues.redhat.com/browse/KOGITO-3909
-  it.skip("Test Add New Data Type And Check Dirty Indicator", () => {
+  it("Test Add New Data Type And Check Dirty Indicator", () => {
     cy.editor("dmn-editable").find("[data-field='kie-palette']").should("be.visible");
 
     cy.editor("dmn-editable").ouiaId("editor-nav-tab", "Data Types", { timeout: 10000 }).should("be.visible").click();


### PR DESCRIPTION
As the PR https://github.com/kiegroup/kogito-editors-java/pull/99 fixes the https://issues.redhat.com/browse/KOGITO-3909 we can activate the previosuly prepared test for dirty indicator on a DMN Editor, once a DMN data type is added to the diagram.