### PR TITLE
BAQE-1828: Modify npm scripts to use settings.xml with maven builds

### DIFF
--- a/packages/backend-extended-services/package.json
+++ b/packages/backend-extended-services/package.json
@@ -18,9 +18,9 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "lint": "echo 'Linting'",
     "install:mvnw": "mvn -N io.takari:maven:wrapper -f kogito-extended-services-quarkus",
-    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not)",
-    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not)",
+    "build:dev": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -s $(build-env global.mavenSettings)",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) -s $(build-env global.mavenSettings)",
+    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not) -s $(build-env global.mavenSettings)",
     "build:prod": "yarn lint && run-script-os"
   }
 }

--- a/packages/build-env/index.js
+++ b/packages/build-env/index.js
@@ -15,6 +15,7 @@
  */
 
 const version = require("./package.json").version;
+const os = require("os");
 
 const str2bool = (str) => str === "true";
 
@@ -163,11 +164,17 @@ const ENV_VARS = {
     default: "1.10.0.Final",
     description: "",
   },
+  MAVEN_SETTINGS_XML: {
+    name: "MAVEN_SETTINGS_XML",
+    default: os.homedir() + "/.m2/settings.xml",
+    description: "Path to the settings.xml to use with Maven",
+  },
 };
 
 module.exports = {
   global: {
     version: version,
+    mavenSettings: getOrDefault(ENV_VARS.MAVEN_SETTINGS_XML),
     build: {
       lint: str2bool(getOrDefault(ENV_VARS.KOGITO_TOOLING_BUILD_lint)),
       test: str2bool(getOrDefault(ENV_VARS.KOGITO_TOOLING_BUILD_test)),

--- a/packages/dmn-json-schema-generator/package.json
+++ b/packages/dmn-json-schema-generator/package.json
@@ -17,11 +17,11 @@
     "install:mvnw": "run-script-os",
     "install:mvnw:win32": "yarn powershell mvn -N io.takari:maven:wrapper `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
     "install:mvnw:darwin:linux": "mvn -N io.takari:maven:wrapper -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
-    "build:dev:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
-    "build:dev:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:dev:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) `-s $(build-env global.mavenSettings)",
+    "build:dev:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) -s $(build-env global.mavenSettings)",
     "build:dev": "run-script-os",
-    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
-    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version)",
+    "build:prod:win32": "yarn install:mvnw && yarn powershell mvn clean install -B -ntp `-DskipTests=$(build-env global.build.test --not) `-DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) `-s $(build-env global.mavenSettings)",
+    "build:prod:darwin:linux": "yarn install:mvnw && mvn clean install -B -ntp -DskipTests=$(build-env global.build.test --not) -DKOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) -s $(build-env global.mavenSettings)",
     "build:prod": "yarn lint && run-script-os"
   }
 }


### PR DESCRIPTION
Adds new variable that can be set during builds, defaults to settings in .m2 directory of user's home. 

NOTE
This does not set the repository URL or version that wrapper will be using as having a correct settings.xml overrides following properties.
These can be set by using `-Dmaven=3.8.2` to set correct maven and if we use `export MVNW_REPOURL=path` the correct repo will be used.
One culprit for Jenkins is that `maven` is a ENV variable there already but has `maven-3.8.2` value.