### PR TITLE
FAI-558: Score Cards: Algorithm Name cannot be cleared

### DIFF
--- a/packages/pmml-editor/it-tests/integration/scorecard-model.ts
+++ b/packages/pmml-editor/it-tests/integration/scorecard-model.ts
@@ -340,18 +340,12 @@ describe("Scorecard Model Test", () => {
     cy.ouiaType("model-setup-overview")
       .find("[data-ouia-component-type=model-property]")
       .should(($label) => {
-        expect($label).to.have.length(6);
+        expect($label).to.have.length(5);
         expect($label[0]).to.have.text("Is Scorable:\u00A0Yes");
         expect($label[1]).to.have.text("Function:\u00A0regression");
-        /*
-         * This attribute is not required by PMML definition.
-         * If its value is the empty string then the particular label should be removed.
-         * TODO: reach an agreement about functionality.
-         */
-        expect($label[2]).to.have.text("Algorithm:\u00A0");
-        expect($label[3]).to.have.text("Use Reason Codes:\u00A0Yes");
-        expect($label[4]).to.have.text("Reason Code Algorithm:\u00A0pointsBelow");
-        expect($label[5]).to.have.text("Baseline Method:\u00A0other");
+        expect($label[2]).to.have.text("Use Reason Codes:\u00A0Yes");
+        expect($label[3]).to.have.text("Reason Code Algorithm:\u00A0pointsBelow");
+        expect($label[4]).to.have.text("Baseline Method:\u00A0other");
       });
 
     cy.ouiaType("model-setup-overview")

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/CorePropertiesTable.tsx
@@ -273,10 +273,13 @@ export const CorePropertiesTable = (props: CorePropertiesTableProps) => {
                           id="core-algorithmName"
                           name="core-algorithmName"
                           aria-describedby="core-algorithmName"
+                          data-testid="core-properties-table-algorithmName"
                           value={algorithmName ?? ""}
                           onChange={(e) => setAlgorithmName(e)}
                           onBlur={() => {
-                            onCommit({ algorithmName: algorithmName });
+                            onCommit({
+                              algorithmName: algorithmName === "" ? undefined : algorithmName,
+                            });
                           }}
                           data-ouia-component-id="algorithm"
                         />

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/CorePropertiesTable.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import { CoreProperties, CorePropertiesTable } from "../../../../../src/editor/components/EditorScorecard/organisms";
 import { Operation, OperationContext } from "../../../../../src/editor/components/EditorScorecard";
@@ -167,5 +167,47 @@ describe("CorePropertiesTable", () => {
     const args: CoreProperties[] = commit.mock.calls[0];
     expect(args.length).toEqual(1);
     expect(args[0].areReasonCodesUsed).toBeFalsy();
+  });
+
+  test("algorithmName::empty value", () => {
+    const component = (
+      <OperationContext.Provider
+        value={{
+          activeOperation: Operation.UPDATE_CORE,
+          setActiveOperation: (operation) => {
+            /*NOP*/
+          },
+        }}
+      >
+        <CorePropertiesTable
+          modelIndex={0}
+          isScorable={true}
+          functionName={"regression"}
+          algorithmName={"algorithmName"}
+          baselineScore={1}
+          isBaselineScoreDisabled={false}
+          baselineMethod={"other"}
+          initialScore={2}
+          areReasonCodesUsed={true}
+          reasonCodeAlgorithm={"pointsBelow"}
+          commit={commit}
+        />
+      </OperationContext.Provider>
+    );
+
+    const { getByTestId, rerender } = render(component);
+    const container = getByTestId("core-properties-table");
+
+    container.click();
+    rerender(component);
+
+    const algorithmName = getByTestId("core-properties-table-algorithmName");
+    fireEvent.change(algorithmName, { target: { value: "" } });
+    fireEvent.blur(algorithmName);
+
+    expect(commit).toBeCalledTimes(1);
+    const args: CoreProperties[] = commit.mock.calls[0];
+    expect(args.length).toEqual(1);
+    expect(args[0].algorithmName).toBeUndefined();
   });
 });

--- a/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
+++ b/packages/pmml-editor/tests/editor/components/EditorScorecard/organisms/__snapshots__/CorePropertiesTable.test.tsx.snap
@@ -372,6 +372,7 @@ exports[`CorePropertiesTable render::Editing 2`] = `
                     aria-invalid="false"
                     class="pf-c-form-control"
                     data-ouia-component-id="algorithm"
+                    data-testid="core-properties-table-algorithmName"
                     id="core-algorithmName"
                     name="core-algorithmName"
                     type="text"


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-558

"Algorithm Name" (on the core properties table) was the only place I could find the issue.

The fix uses the same approach as elsewhere for consistency (i.e. in the `blur` handling).