### PR TITLE
KOGITO-2099: Generate a SVG diagram automatically on each BPMN/DMN diagrams save

### DIFF
--- a/examples/base64png-editor-vscode-extension/src/extension.ts
+++ b/examples/base64png-editor-vscode-extension/src/extension.ts
@@ -44,7 +44,8 @@ export function activate(context: vscode.ExtensionContext) {
     extensionName: "kogito-tooling-examples.base64png-editor-vscode-extension",
     context: context,
     viewType: "kieKogitoWebviewBase64PNGEditor",
-    getPreviewCommandId: "extension.kogito.getPreviewSvg",
+    generateSvgCommandId: "extension.kogito.getPreviewSvg",
+    silentlyGenerateSvgCommandId: "",
     editorEnvelopeLocator: {
       targetOrigin: "vscode",
       mapping: new Map([

--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -57,6 +57,18 @@
         ]
       }
     ],
+    "configuration": {
+      "title": "BPMN",
+      "properties": {
+        "kogito.bpmn.runOnSave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Execute a command on each save operation of the BPMN file."
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.kogito.getPreviewSvgBpmn",
@@ -65,6 +77,10 @@
           "light": "./static/svg-icon-light.png",
           "dark": "./static/svg-icon-dark.png"
         }
+      },
+      {
+        "command": "extension.kogito.silentlyGenerateSvgBpmn",
+        "title": "Generate SVG without any notification"
       }
     ],
     "menus": {

--- a/packages/vscode-extension-bpmn-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-bpmn-editor/src/extension/extension.ts
@@ -32,7 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-bpmn-editor",
     context: context,
     viewType: "kieKogitoWebviewEditorsBpmn",
-    getPreviewCommandId: "extension.kogito.getPreviewSvgBpmn",
+    generateSvgCommandId: "extension.kogito.getPreviewSvgBpmn",
+    silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvgBpmn",
     editorEnvelopeLocator: {
       targetOrigin: "vscode",
       mapping: new Map([

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -58,6 +58,18 @@
         ]
       }
     ],
+    "configuration": {
+      "title": "DMN",
+      "properties": {
+        "kogito.dmn.runOnSave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Execute a command on each save operation of the DMN file."
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.kogito.getPreviewSvgDmn",
@@ -66,6 +78,10 @@
           "light": "./static/svg-icon-light.png",
           "dark": "./static/svg-icon-dark.png"
         }
+      },
+      {
+        "command": "extension.kogito.silentlyGenerateSvgDmn",
+        "title": "Generate SVG without any notification"
       }
     ],
     "menus": {

--- a/packages/vscode-extension-dmn-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-dmn-editor/src/extension/extension.ts
@@ -32,7 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-dmn-editor",
     context: context,
     viewType: "kieKogitoWebviewEditorsDmn",
-    getPreviewCommandId: "extension.kogito.getPreviewSvgDmn",
+    generateSvgCommandId: "extension.kogito.getPreviewSvgDmn",
+    silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvgDmn",
     editorEnvelopeLocator: {
       targetOrigin: "vscode",
       mapping: new Map([

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -28,6 +28,27 @@
     }
   },
   "contributes": {
+    "configuration": {
+      "title": "BPMN/DMN Test Configuration",
+      "properties": {
+        "kogito.bpmn.runOnSave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "extension.kogito.silentlyGenerateSvg",
+          "description": "Execute a command on each save operation of the BPMN file."
+        },
+        "kogito.dmn.runOnSave": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "extension.kogito.silentlyGenerateSvg",
+          "description": "Execute a command on each save operation of the BPMN file"
+        }
+      }
+    },
     "customEditors": [
       {
         "viewType": "kieKogitoWebviewEditors",
@@ -51,6 +72,10 @@
       {
         "command": "extension.kogito.runTest",
         "title": "Run"
+      },
+      {
+        "command": "extension.kogito.silentlyGenerateSvg",
+        "title": "Generate SVG without any notification"
       }
     ],
     "menus": {

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -45,7 +45,7 @@
             "null"
           ],
           "default": "extension.kogito.silentlyGenerateSvg",
-          "description": "Execute a command on each save operation of the BPMN file"
+          "description": "Execute a command on each save operation of the DMN file"
         }
       }
     },

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
@@ -47,7 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-pack-kogito-kie-editors",
     context: context,
     viewType: "kieKogitoWebviewEditors",
-    getPreviewCommandId: "extension.kogito.getPreviewSvg",
+    generateSvgCommandId: "extension.kogito.getPreviewSvg",
+    silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvg",
     editorEnvelopeLocator: {
       targetOrigin: envelopeTargetOrigin,
       mapping: new Map([

--- a/packages/vscode-extension-pmml-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-pmml-editor/src/extension/extension.ts
@@ -32,7 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-pmml-editor",
     context: context,
     viewType: "kieKogitoWebviewEditorsPmml",
-    getPreviewCommandId: "",
+    generateSvgCommandId: "",
+    silentlyGenerateSvgCommandId: "",
     editorEnvelopeLocator: {
       targetOrigin: "vscode",
       mapping: new Map([

--- a/packages/vscode-extension/src/KogitoEditableDocument.ts
+++ b/packages/vscode-extension/src/KogitoEditableDocument.ts
@@ -91,9 +91,19 @@ export class KogitoEditableDocument implements CustomDocument {
       }
 
       await vscode.workspace.fs.writeFile(destination, this.encoder.encode(content));
+      this.executeOnSaveHook();
       vscode.window.setStatusBarMessage(i18n.savedSuccessfully, 3000);
     } catch (e) {
       this.vsCodeLogger.error(`Error saving. ${e}`);
+    }
+  }
+
+  private executeOnSaveHook() {
+    const hookId = `kogito.${this.fileExtension}.runOnSave`;
+    const hook = vscode.workspace.getConfiguration().get(hookId, "");
+
+    if (hook) {
+      vscode.commands.executeCommand(hook);
     }
   }
 

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -23,14 +23,15 @@ import { I18n } from "@kie-tooling-core/i18n/dist/core";
 
 const encoder = new TextEncoder();
 
-export async function generateSvg(
-  editorStore: KogitoEditorStore,
-  workspaceApi: WorkspaceApi,
-  vsCodeI18n: I18n<VsCodeI18n>
-) {
-  const i18n = vsCodeI18n.getCurrent();
+export async function generateSvg(args: {
+  editorStore: KogitoEditorStore;
+  workspaceApi: WorkspaceApi;
+  vsCodeI18n: I18n<VsCodeI18n>;
+  displayNotification: boolean;
+}) {
+  const i18n = args.vsCodeI18n.getCurrent();
 
-  const editor = editorStore.activeEditor;
+  const editor = args.editorStore.activeEditor;
   if (!editor) {
     console.info(`Unable to create SVG because there's no Editor open.`);
     return;
@@ -47,11 +48,13 @@ export async function generateSvg(
   const svgUri = editor.document.uri.with({ path: __path.join(parsedPath.dir, svgFileName) });
   await vscode.workspace.fs.writeFile(svgUri, encoder.encode(previewSvg));
 
-  vscode.window.showInformationMessage(i18n.savedSvg(svgFileName), i18n.openSvg).then((selection) => {
-    if (selection !== i18n.openSvg) {
-      return;
-    }
+  if (args.displayNotification) {
+    vscode.window.showInformationMessage(i18n.savedSvg(svgFileName), i18n.openSvg).then((selection) => {
+      if (selection !== i18n.openSvg) {
+        return;
+      }
 
-    workspaceApi.kogitoWorkspace_openFile(svgUri.fsPath);
-  });
+      args.workspaceApi.kogitoWorkspace_openFile(svgUri.fsPath);
+    });
+  }
 }

--- a/packages/vscode-extension/src/index.ts
+++ b/packages/vscode-extension/src/index.ts
@@ -40,7 +40,8 @@ export async function startExtension(args: {
   extensionName: string;
   context: vscode.ExtensionContext;
   viewType: string;
-  getPreviewCommandId: string;
+  generateSvgCommandId: string;
+  silentlyGenerateSvgCommandId: string;
   editorEnvelopeLocator: EditorEnvelopeLocator;
   backendProxy: VsCodeBackendProxy;
 }) {
@@ -79,6 +80,24 @@ export async function startExtension(args: {
   );
 
   args.context.subscriptions.push(
-    vscode.commands.registerCommand(args.getPreviewCommandId, () => generateSvg(editorStore, workspaceApi, vsCodeI18n))
+    vscode.commands.registerCommand(args.generateSvgCommandId, () =>
+      generateSvg({
+        editorStore: editorStore,
+        workspaceApi: workspaceApi,
+        vsCodeI18n: vsCodeI18n,
+        displayNotification: true,
+      })
+    )
+  );
+
+  args.context.subscriptions.push(
+    vscode.commands.registerCommand(args.silentlyGenerateSvgCommandId, () =>
+      generateSvg({
+        editorStore: editorStore,
+        workspaceApi: workspaceApi,
+        vsCodeI18n: vsCodeI18n,
+        displayNotification: false,
+      })
+    )
   );
 }


### PR DESCRIPTION
To make the use of VSCode more friendly for RHPAM users (especially on the integration with Kie Server), the idea is to provide a configurable way to generate the SVG on each save of the BPMN/DMN diagram and provide a similar capability of business central.

The following commands were added: 

<code>
"kogito.dmn.runOnSave": "extension.kogito.silentlyGenerateSvgDmn",

"kogito.bpmn.runOnSave": "extension.kogito.silentlyGenerateSvgBpmn"
</code>

Whenever the user config those commands, we will auto-generate (silently) the SVG for BPMN and DMN diagrams. (PMML extension was not affected).

For vscode-extension-pack-kogito-kie-editors, I've configured the respective parameters as default.

[Feature Video](https://p192.p3.n0.cdn.getcloudapp.com/items/GGupbBwl/f9ed294c-2eeb-4918-b3fc-f74f1b50fabf.gif?source=client&v=f1da3017eff42b749d56fdabbd208568)
