### PR TITLE
FAI-622: ScoreCard: MiningField validation

### DIFF
--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
@@ -13,10 +13,10 @@ import MiningSchemaPropertiesEdit from "../MiningSchemaPropertiesEdit/MiningSche
 import "./MiningSchemaContainer.scss";
 
 import { DataDictionary, FieldName, MiningField, MiningSchema } from "@kogito-tooling/pmml-editor-marshaller";
-import NoMiningSchemaFieldsOptions from "../NoMiningSchemaFieldsOptions/NoMiningSchemaFieldsOptions";
 import { useValidationRegistry } from "../../../validation";
 import { Builder } from "../../../paths";
 import { Interaction } from "../../../types";
+import NoMiningSchemaFieldsOptions from "../NoMiningSchemaFieldsOptions/NoMiningSchemaFieldsOptions";
 
 interface MiningSchemaContainerProps {
   modelIndex: number;
@@ -149,33 +149,33 @@ const MiningSchemaContainer = (props: MiningSchemaContainerProps) => {
                   )}
                   <StackItem className="mining-schema__fields">
                     <section>
-                      {fields.length === 0 && (
-                        <Bullseye style={{ height: "40vh" }}>
-                          <NoMiningSchemaFieldsOptions />
-                        </Bullseye>
-                      )}
-                      {fields.length > 0 && (
-                        <>
-                          {miningSchema === undefined ||
-                            (miningSchema?.MiningField.length === 0 && (
+                      {miningSchema === undefined ||
+                        (miningSchema?.MiningField.length === 0 && (
+                          <>
+                            {fields.length === 0 && (
+                              <Bullseye style={{ height: "40vh" }}>
+                                <NoMiningSchemaFieldsOptions />
+                              </Bullseye>
+                            )}{" "}
+                            {fields.length > 0 && (
                               <Bullseye style={{ height: "40vh" }}>
                                 <EmptyMiningSchema />
                               </Bullseye>
-                            ))}
-                          {miningSchema && miningSchema.MiningField.length > 0 && (
-                            <>
-                              <MiningSchemaFields
-                                modelIndex={modelIndex}
-                                dataDictionary={dataDictionary}
-                                fields={miningSchema?.MiningField}
-                                onAddProperties={goToProperties}
-                                onDelete={handleDeleteField}
-                                onPropertyDelete={handlePropertyDelete}
-                                onEdit={handleEditField}
-                                onCancel={handleCancelEditing}
-                              />
-                            </>
-                          )}
+                            )}
+                          </>
+                        ))}
+                      {miningSchema && miningSchema.MiningField.length > 0 && (
+                        <>
+                          <MiningSchemaFields
+                            modelIndex={modelIndex}
+                            dataDictionary={dataDictionary}
+                            fields={miningSchema?.MiningField}
+                            onAddProperties={goToProperties}
+                            onDelete={handleDeleteField}
+                            onPropertyDelete={handlePropertyDelete}
+                            onEdit={handleEditField}
+                            onCancel={handleCancelEditing}
+                          />
                         </>
                       )}
                     </section>

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
@@ -149,21 +149,20 @@ const MiningSchemaContainer = (props: MiningSchemaContainerProps) => {
                   )}
                   <StackItem className="mining-schema__fields">
                     <section>
-                      {miningSchema === undefined ||
-                        (miningSchema?.MiningField.length === 0 && (
-                          <>
-                            {fields.length === 0 && (
-                              <Bullseye style={{ height: "40vh" }}>
-                                <NoMiningSchemaFieldsOptions />
-                              </Bullseye>
-                            )}{" "}
-                            {fields.length > 0 && (
-                              <Bullseye style={{ height: "40vh" }}>
-                                <EmptyMiningSchema />
-                              </Bullseye>
-                            )}
-                          </>
-                        ))}
+                      {(miningSchema === undefined || miningSchema?.MiningField.length === 0) && (
+                        <>
+                          {fields.length === 0 && (
+                            <Bullseye style={{ height: "40vh" }}>
+                              <NoMiningSchemaFieldsOptions />
+                            </Bullseye>
+                          )}{" "}
+                          {fields.length > 0 && (
+                            <Bullseye style={{ height: "40vh" }}>
+                              <EmptyMiningSchema />
+                            </Bullseye>
+                          )}
+                        </>
+                      )}
                       {miningSchema && miningSchema.MiningField.length > 0 && (
                         <>
                           <MiningSchemaFields

--- a/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.test.tsx
@@ -76,6 +76,26 @@ describe("MiningSchemaContainer", () => {
     expect(getByTestId("mining-schema-field-n1")).not.toBeUndefined();
   });
 
+  test("MiningField:Render::WithNoDataFields", () => {
+    const { getByTestId } = render(
+      <MiningSchemaContext.Provider value={-1}>
+        <MiningSchemaContainer
+          modelIndex={0}
+          dataDictionary={{ DataField: [] }}
+          miningSchema={{ MiningField: miningFields }}
+          onAddField={onAddField}
+          onDeleteField={onDeleteField}
+          onUpdateField={onUpdateField}
+        />
+      </MiningSchemaContext.Provider>
+    );
+    const container = getByTestId("mining-schema-container");
+    expect(container).toMatchSnapshot();
+
+    expect(getByTestId("mining-schema-field-n0")).not.toBeUndefined();
+    expect(getByTestId("mining-schema-field-n1")).not.toBeUndefined();
+  });
+
   test("MiningField:DeleteWithIconClick", () => {
     const onDeleteFieldImpl = jest.fn((index) => {
       miningFields = miningFields.slice(index, 1);

--- a/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/__snapshots__/MiningSchemaContainer.test.tsx.snap
+++ b/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/__snapshots__/MiningSchemaContainer.test.tsx.snap
@@ -234,3 +234,242 @@ exports[`MiningSchemaContainer MiningField:Render 1`] = `
   </div>
 </section>
 `;
+
+exports[`MiningSchemaContainer MiningField:Render::WithNoDataFields 1`] = `
+<section
+  class="mining-schema"
+  data-testid="mining-schema-container"
+>
+  <div
+    class="pf-l-stack pf-m-gutter mining-schema__overview"
+  >
+    <div
+      class="pf-l-stack__item"
+    >
+      <h4
+        class="pf-c-title pf-m-xl"
+      >
+        Add Fields
+      </h4>
+    </div>
+    <div
+      class="pf-l-stack__item"
+    >
+      <section
+        data-ouia-component-id="mining-toolbar"
+      >
+        <div
+          class="pf-l-split pf-m-gutter"
+        >
+          <div
+            class="pf-l-split__item pf-m-fill"
+          >
+            <div
+              class="pf-c-select"
+              data-ouia-component-id="select-mining-field"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <div
+                class="pf-c-select__toggle pf-m-disabled pf-m-typeahead"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <input
+                    aria-invalid="false"
+                    aria-label="Select fields"
+                    autocomplete="off"
+                    class="pf-c-form-control pf-c-select__toggle-typeahead"
+                    disabled=""
+                    id="pf-select-toggle-id-7-select-multi-typeahead-typeahead"
+                    placeholder="Select fields"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-label="Options menu"
+                  aria-labelledby="Select fields to add pf-select-toggle-id-7"
+                  class="pf-c-button pf-c-select__toggle-button pf-m-plain"
+                  disabled=""
+                  id="pf-select-toggle-id-7"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-c-select__toggle-arrow"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="pf-l-split__item"
+          >
+            <button
+              aria-disabled="true"
+              class="pf-c-button pf-m-primary pf-m-disabled"
+              data-ouia-component-id="add-mining-field"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              Add Field(s)
+            </button>
+          </div>
+          <div
+            class="pf-l-split__item"
+          >
+            <button
+              aria-disabled="true"
+              class="pf-c-button pf-m-secondary pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              disabled=""
+              type="button"
+            >
+              Add All Fields
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div
+      class="pf-l-stack__item mining-schema__fields"
+    >
+      <section>
+        <ul
+          class="mining-schema-list"
+        >
+          <li
+            class="editable-item "
+            data-testid="mining-schema-field-n0"
+            id="mining-schema-field-n0"
+            tabindex="0"
+          >
+            <section
+              class="editable-item__inner"
+            >
+              <div
+                class="pf-l-split pf-m-gutter"
+              >
+                <div
+                  class="pf-l-split__item"
+                >
+                  <span
+                    class="mining-schema-list__item__name"
+                  >
+                    field1
+                  </span>
+                </div>
+                <div
+                  class="pf-l-split__item pf-m-fill"
+                />
+                <div
+                  class="pf-l-split__item"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-plain editable-item__delete"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    data-testid="mining-schema-field-n0__delete"
+                    id="mining-schema-field-n0__delete"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+          </li>
+          <li
+            class="editable-item "
+            data-testid="mining-schema-field-n1"
+            id="mining-schema-field-n1"
+            tabindex="0"
+          >
+            <section
+              class="editable-item__inner"
+            >
+              <div
+                class="pf-l-split pf-m-gutter"
+              >
+                <div
+                  class="pf-l-split__item"
+                >
+                  <span
+                    class="mining-schema-list__item__name"
+                  >
+                    field2
+                  </span>
+                </div>
+                <div
+                  class="pf-l-split__item pf-m-fill"
+                />
+                <div
+                  class="pf-l-split__item"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-plain editable-item__delete"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    data-testid="mining-schema-field-n1__delete"
+                    id="mining-schema-field-n1__delete"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</section>
+`;


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-622

The `MiningField`'s were not being rendered if there was no `DataField`'s.

They are now rendered regardless and appropriate validation messages shown on each row if no corresponding `DataField` exists.