### PR TITLE
 kie-editors-standalone README: remove origin parameter from the DmnEditor example

### DIFF
--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -27,7 +27,6 @@ const editor = DmnEditor.open({
   container: document.getElementById("dmn-editor-container"),
   initialContent: Promise.resolve(""),
   readOnly: false,
-  origin: "",
   resources: new Map([
     [
       "MyIncludedModel.dmn",

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -39,7 +39,7 @@ const editor = DmnEditor.open({
 });
 ```
 
-Parameters description:
+Available parameters:
 
 - `container`: HTML element in which the Editor will be appended to.
 - `initialContent`: Promise to a DMN model content. Can be empty. Examples:


### PR DESCRIPTION
Using the `origin: ''` parameter doesn't work. The default works most of the time.

This should prevent users from encountering issue like #425