### PR TITLE
Add missing 'lint' script for vscode-extension-* modules

### DIFF
--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "scripts": {
+    "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && yarn pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
     "pack:prod": "vsce package --githubBranch main --yarn -o ./dist/vscode_extension_bpmn_editor_$npm_package_version.vsix",

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "scripts": {
+    "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && yarn pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
     "pack:prod": "vsce package --githubBranch main --yarn -o ./dist/vscode_extension_dmn_editor_$npm_package_version.vsix",

--- a/packages/vscode-extension-kogito-bundle/package.json
+++ b/packages/vscode-extension-kogito-bundle/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "scripts": {
+    "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && yarn pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
     "pack:prod": "vsce package --githubBranch main --yarn -o ./dist/vscode_extension_kogito_bundle_$npm_package_version.vsix",

--- a/packages/vscode-extension-pmml-editor/package.json
+++ b/packages/vscode-extension-pmml-editor/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "scripts": {
+    "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && yarn pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
     "pack:prod": "vsce package --githubBranch main --yarn -o ./dist/vscode_extension_pmml_editor_$npm_package_version.vsix",

--- a/packages/vscode-extension-red-hat-business-automation-bundle/package.json
+++ b/packages/vscode-extension-red-hat-business-automation-bundle/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/kiegroup/kogito-tooling.git"
   },
   "scripts": {
+    "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && yarn pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
     "pack:prod": "vsce package --githubBranch main --yarn -o ./dist/vscode_extension_red_hat_business_automation_bundle_$npm_package_version.vsix",


### PR DESCRIPTION
This is important, if we run top level `build:prod`, where `lerna` run also `lint` script for sub modules