### PR TITLE
 kie-editors-standalone README: update the setContent signature

### DIFF
--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -55,7 +55,7 @@ Available parameters:
 The returned object will contain the methods needed to manipulate the Editor:
 
 - `getContent(): Promise<string>`: Returns a Promise containing the Editor content.
-- `setContent(content: string): Promise<void>`: Sets the content of the Editor. The returning Promise will be rejected if setting the content fails.
+- `setContent(path: string, content: string): Promise<void>`: Sets the content of the Editor. The returning Promise will be rejected if setting the content fails.
 - `getPreview(): Promise<string>`: Returns a Promise containing the SVG string of the current diagram.
 - `subscribeToContentChanges(callback: (isDirty: boolean) => void): (isDirty: boolean) => void`: Setup a callback to be called on every content change in the Editor. Returns the same callback to be used for unsubscription.
 - `unsubscribeToContentChanges(callback: (isDirty: boolean) => void): void`: Unsubscribes the passed callback from content changes.


### PR DESCRIPTION
The `setContent` has 2 parameters as of v0.9.1. So add the new `path` parameter in the README to avoid misleading users.

**Notes**
This breaking changes was marked as a fix in the 0.9.1 release notes (https://github.com/kiegroup/kogito-tooling/releases/tag/0.9.1, _KOGITO-4915 - Standalone editors setContent implementation should receive path and content_), so it was quite hard to notice.
At least, I didn't notice it could break the usage of the method after quickly checking the release notes, especially in a patch version. I was implicitly assuming that `kie-editors-standalone` was following semantic versioning.

I have been fooled myself in the past (https://github.com/process-analytics/bpmn-visualization-examples/issues/217#issuecomment-942061749), so this doc update should help others to not loose time.
If you can make such changes more visible in the future, this will be nice 😸 


