### PR TITLE
KOGITO-6144: DMN Editor missing xml-prolog for UTF-8 encoding

### DIFF
--- a/packages/online-editor/it-tests/integration/UploadFileTest.ts
+++ b/packages/online-editor/it-tests/integration/UploadFileTest.ts
@@ -81,6 +81,7 @@ describe("Upload file test", () => {
 
     // check process content
     cy.readFile("downloads/testProcess.bpmn").should(($text) => {
+      expect($text).match(/<\?xml version="1.0" encoding="UTF-8"\?>/);
       expect($text).match(/<bpmn2:endEvent id="[A-Z0-9_-]*" name="End test node">/);
       expect($text).match(/<bpmn2:startEvent id="[A-Z0-9_-]*" name="Start test node">/);
     });

--- a/packages/online-editor/it-tests/integration/UploadFileTest.ts
+++ b/packages/online-editor/it-tests/integration/UploadFileTest.ts
@@ -141,6 +141,7 @@ describe("Upload file test", () => {
 
     // check model content
     cy.readFile("downloads/testModel.dmn").should(($text) => {
+      expect($text).match(/<\?xml version="1.0" encoding="UTF-8"\?>/);
       expect($text).match(/<dmn:inputData id="[A-Z0-9_-]*" name="Test input data">/);
       expect($text).match(/<dmn:decision id="[A-Z0-9_-]*" name="Test decision node">/);
     });

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { By, SideBarView, WebView } from "vscode-extension-tester";
+import { By, EditorView, InputBox, SideBarView, TextEditor, WebView } from "vscode-extension-tester";
 import * as path from "path";
 import { h5ComponentWithText } from "./helpers/CommonLocators";
 import { EditorTabs } from "./helpers/EditorTabs";
@@ -32,11 +32,13 @@ import {
 } from "./helpers/bpmn/BpmnLocators";
 import DecisionNavigatorHelper from "./helpers/dmn/DecisionNavigatorHelper";
 import { PropertiesPanelSection } from "./helpers/bpmn/PropertiesPanelHelper";
+import { TextEdit } from "vscode";
 
 describe("Editors are loading properly", () => {
   const RESOURCES: string = path.resolve("it-tests-tmp", "resources");
   const DEMO_BPMN: string = "demo.bpmn";
   const DEMO_DMN: string = "demo.dmn";
+  const DEMO_DMN_SCESIM: string = "demo-dmn.scesim";
   const DEMO_SCESIM: string = "demo.scesim";
   const DEMO_PMML: string = "demo.pmml";
 
@@ -155,6 +157,34 @@ describe("Editors are loading properly", () => {
     await scesimEditorTester.openTestTools();
 
     await webview.switchBack();
+  });
+
+  /**
+   * As the openend scesim file is empty, a promtp to specify file under test should be shown
+   */
+  it("Opens demo-dmn.scesim file in SCESIM Editor", async function () {
+    this.timeout(20000);
+
+    webview = await testHelper.openFileFromSidebar(DEMO_DMN_SCESIM);
+    await testHelper.switchWebviewToFrame(webview);
+    const scesimEditorTester = new ScesimEditorTestHelper(webview);
+
+    await scesimEditorTester.specifyDmnOnLandingPage(DEMO_DMN);
+
+    await webview.switchBack();
+
+    // save file so we can check the plain text source
+    await testHelper.executeCommandFromPrompt("File: Save");
+
+    // check plain text source starts with <?xml?> prolog
+    await testHelper.executeCommandFromPrompt("View: Reopen Editor With...");
+    const input = await InputBox.create();
+    await input.selectQuickPick("Text Editor");
+
+    const xmlProlog = '<?xml version="1.0" encoding="UTF-8"?>';
+    const plainText = new TextEditor();
+    assert.equal(await plainText.getTextAtLine(1), xmlProlog, "First line should be an <?xml?> prolog");
+    assert.notEqual(await plainText.getTextAtLine(2), xmlProlog, "<?xml?> prolog should be there just once");
   });
 
   it("Opens demo.pmml file in PMML Editor", async function () {

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -160,7 +160,7 @@ describe("Editors are loading properly", () => {
   });
 
   /**
-   * As the openend scesim file is empty, a promtp to specify file under test should be shown
+   * As the opened sceism file is empty, a prompt to specify file under test should be shown
    */
   it("Opens demo-dmn.scesim file in SCESIM Editor", async function () {
     this.timeout(20000);

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/ScesimEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/ScesimEditorTestHelper.ts
@@ -121,8 +121,8 @@ export default class ScesimEditorTestHelper {
   };
 
   /**
-   * In case you open empty scesim file a landing page prompt you to specify a a file you want to test.
-   * This method set specified dmn file to be tested.
+   * In case you open empty scesim file a landing page prompts you to specify a file you want to test.
+   * This method sets specified dmn file to be tested.
    *
    * @param dmnFileName
    *

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/ScesimEditorTestHelper.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/helpers/ScesimEditorTestHelper.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { By, WebElement, WebView } from "vscode-extension-tester";
+import { By, until, WebElement, WebView } from "vscode-extension-tester";
 import { assertWebElementIsDisplayedEnabled } from "./CommonAsserts";
-import { expandedDocksBarE, h3ComponentWithText } from "./CommonLocators";
+import { expandedDocksBarE, h3ComponentWithText, spanComponentWithText } from "./CommonLocators";
 
 /**
  * Helper class to easen work with SCESIM editor inside of a webview.
@@ -118,5 +118,38 @@ export default class ScesimEditorTestHelper {
     );
     await assertWebElementIsDisplayedEnabled(expandedNavigatorPanel);
     return expandedNavigatorPanel;
+  };
+
+  /**
+   * In case you open empty scesim file a landing page prompt you to specify a a file you want to test.
+   * This method set specified dmn file to be tested.
+   *
+   * @param dmnFileName
+   *
+   */
+  public specifyDmnOnLandingPage = async (dmnFileName: String): Promise<void> => {
+    await (await this.webview.findWebElement(spanComponentWithText("DMN"))).click();
+
+    // wait until available DMNs appear
+    const availableDmns = await this.webview
+      .getDriver()
+      .wait(until.elementLocated(By.xpath("//div[@data-field='dmn-assets']")), 5000, "DMN Models not found");
+
+    // expand available DMNs
+    await (await availableDmns.findElement(By.xpath("//button[@title='Select']"))).click();
+    const options = await this.webview
+      .getDriver()
+      .wait(
+        until.elementLocated(By.xpath("//ul[@role='menu']")),
+        5000,
+        "DMN Models not not expanded after click on Select"
+      );
+
+    // select demanded DMN
+    await (await options.findElement(By.xpath(`//li/a/span[text()='${dmnFileName}']`))).click();
+
+    // finish landing page by click on Confirm button
+    await (await this.webview.findWebElement(By.xpath("//button[@data-field='ok-button']"))).click();
+    return;
   };
 }


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/KOGITO-6144

Ensemble together with:
- https://github.com/kiegroup/kogito-editors-java/pull/154