### PR TITLE
Add `--concurrency 1` to the NPM Packages release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -578,7 +578,7 @@ jobs:
 
       - name: "Build"
         run: |
-          lerna run build:prod --stream --no-private
+          lerna run build:prod --stream --no-private --concurrency 1
 
       - name: "Publish packages to the NPM registry"
         env:


### PR DESCRIPTION
This prevents Maven from failing when running in parallel.