### PR TITLE
Make `dashbuilder` private package

### DIFF
--- a/packages/dashbuilder/package.json
+++ b/packages/dashbuilder/package.json
@@ -2,6 +2,7 @@
   "name": "@kogito-tooling/dashbuilder",
   "version": "0.0.0",
   "description": "",
+  "private": true,
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Content is too large to publish to NPM.