### PR TITLE
Bump `chromedriver` version to `96.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@vscode/test-web": "^0.0.15",
     "babel-loader": "^8.2.2",
     "chai": "^4.3.4",
-    "chromedriver": "^94.0.0",
+    "chromedriver": "^96.0.0",
     "circular-dependency-plugin": "^5.2.2",
     "compressing": "^1.5.1",
     "copy-webpack-plugin": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5881,10 +5881,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^94.0.0:
-  version "94.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-94.0.0.tgz#f6a3533976ba72413a01672954040c3544ea9d30"
-  integrity sha512-x4hK7R7iOyAhdLHJEcOyGBW/oa2kno6AqpHVLd+n3G7c2Vk9XcAXMz84XhNItqykJvTc6E3z/JRIT1eHYH//Eg==
+chromedriver@^96.0.0:
+  version "96.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
+  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"


### PR DESCRIPTION
ChromeDriver has just been updated in the Ubuntu image
See: https://github.com/actions/virtual-environments/pull/4554