### PR TITLE
Ignore NPM package publication if the version already exists

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -621,7 +621,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.kiegroup_npm_token }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          lerna exec 'npm publish --access public' --stream --no-private
+          lerna exec 'PKG_NAME=$(jq -r ".name" package.json); NPM_PKG_INFO=$(npm view $PKG_NAME@${{ inputs.tag }} name || echo ""); if [ -z $NPM_PKG_INFO ]; then npm publish --access public; fi' --stream --no-private
 
   standalone_editors_cdn:
     if: ${{ always() && needs.extract_runners.outputs.standalone_editors_cdn == 'true' && (needs.chrome_extension.result == 'success' || needs.chrome_extension.result == 'skipped') }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -29,7 +29,7 @@ on:
         default: '{"dmn_dev_sandbox_image":"false","online_editor":"false","chrome_extension":"false","vscode_extensions_dev":"false","vscode_extensions_prod":"false","desktop":"false","hub":"false","npm_packages":"false","standalone_editors_cdn":"false","extended_services":"false","dashbuilder":"false","dashbuilder_images":"false"}'
     secrets:
       kogito_tooling_bot_token:
-        required: true
+        required: false
       github_token:
         required: false
       quay_registry_password:
@@ -247,6 +247,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Checkout kogito-online"
+        if: ${{ !inputs.dry_run }}
         uses: actions/checkout@v2
         with:
           path: ${{ github.workspace }}/kogito-online
@@ -328,6 +329,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Checkout kogito-online"
+        if: ${{ !inputs.dry_run }}
         uses: actions/checkout@v2
         with:
           path: ${{ github.workspace }}/kogito-online
@@ -636,6 +638,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Checkout kogito-online"
+        if: ${{ !inputs.dry_run }}
         uses: actions/checkout@v2
         with:
           path: ${{ github.workspace }}/kogito-online

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -3,7 +3,7 @@ name: "Release :: Dry Run"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 17 * * *" # 5pm UTC everyday
+    - cron: "0 11 * * *" # 11am UTC everyday
   pull_request:
     branches: "**"
     paths:
@@ -16,5 +16,3 @@ jobs:
     with:
       dry_run: true
       runners: '{"dmn_dev_sandbox_image":"true","online_editor":"true","chrome_extension":"true","vscode_extensions_dev":"true","vscode_extensions_prod":"true","desktop":"true","hub":"true","npm_packages":"true","standalone_editors_cdn":"true","extended_services":"true","dashbuilder":"true","dashbuilder_images":"true"}'
-    secrets:
-      kogito_tooling_bot_token: ${{ secrets.KOGITO_TOOLING_BOT_TOKEN }}

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -25,7 +25,7 @@ on:
         default: ""
     secrets:
       kogito_tooling_bot_token:
-        required: true
+        required: false
       github_token:
         required: false
       quay_registry_password:
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Checkout kogito-online-staging"
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/checkout@v2
         with:
           path: ${{ github.workspace }}/kogito-online-staging

--- a/.github/workflows/staging_dry_run.yml
+++ b/.github/workflows/staging_dry_run.yml
@@ -3,7 +3,7 @@ name: "Staging :: Dry Run"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 15 * * *" # 3pm UTC everyday
+    - cron: "0 10 * * *" # 10am UTC everyday
   pull_request:
     branches: "**"
     paths:
@@ -15,5 +15,3 @@ jobs:
     uses: kiegroup/kogito-tooling/.github/workflows/staging_build.yml@main
     with:
       dry_run: true
-    secrets:
-      kogito_tooling_bot_token: ${{ secrets.KOGITO_TOOLING_BOT_TOKEN }}


### PR DESCRIPTION
- Ignore NPM package publication if the version already exists
- Skip checkout kogito-online for dry runs
- Change dry run schedules to an early time