### PR TITLE
KOGITO-6214: Settings for exporting SVG files in VSCode Extensions

### DIFF
--- a/packages/vscode-extension-bpmn-editor/README.md
+++ b/packages/vscode-extension-bpmn-editor/README.md
@@ -17,13 +17,13 @@ Create and edit BPMN and BPMN2 files.
 
 ### Settings
 
-| Setting                        | Description                                               | Default value                        |
-| ------------------------------ | --------------------------------------------------------- | ------------------------------------ |
-| `kogito.bpmn.runOnSave`        | Execute a command on each save operation of the BPMN file | _empty_                              |
-| `kogito.bpmn.filenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.bpmn.filePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
+| Setting                           | Description                                               | Default value                        |
+| --------------------------------- | --------------------------------------------------------- | ------------------------------------ |
+| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                              |
+| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
 
-The `kogito.bpmn.filenameTemplate` and `kogito.bpmn.filePath` settings accept the following variables as tokens:
+The `kogito.bpmn.svgFilenameTemplate` and `kogito.bpmn.svgFilePath` settings accept the following variables as tokens:
 
 | Variable                       | Example                                   |
 | ------------------------------ | ----------------------------------------- |

--- a/packages/vscode-extension-bpmn-editor/README.md
+++ b/packages/vscode-extension-bpmn-editor/README.md
@@ -11,6 +11,24 @@ Create and edit BPMN and BPMN2 files.
 - Native keyboard shortcuts (Press `shift+/` to display available combinations).
 - Export diagram to SVG (use the SVG icon on the top-right corner).
 
-#### Editing a new BPMN file
+### Editing a new BPMN file
 
 ![alt](./gifs/bpmn.gif?raw=true)
+
+### Settings
+
+| Setting                        | Description                                               | Default value                        |
+| ------------------------------ | --------------------------------------------------------- | ------------------------------------ |
+| `kogito.bpmn.runOnSave`        | Execute a command on each save operation of the BPMN file | _empty_                              |
+| `kogito.bpmn.filenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.bpmn.filePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
+
+The `kogito.bpmn.filenameTemplate` and `kogito.bpmn.filePath` settings accept the following variables as tokens:
+
+| Variable                       | Example                                   |
+| ------------------------------ | ----------------------------------------- |
+| **${workspaceFolder}**         | `/home/your-username/your-project`        |
+| **${fileDirname}**             | `/home/your-username/your-project/folder` |
+| **${fileExtname}**             | `.ext`                                    |
+| **${fileBasename}**            | `file.ext`                                |
+| **${fileBasenameNoExtension}** | `file`                                    |

--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -65,12 +65,12 @@
           "type": "string",
           "markdownDescription": "Execute a command on each save operation of the BPMN file."
         },
-        "kogito.bpmn.filenameTemplate": {
+        "kogito.bpmn.svgFilenameTemplate": {
           "type": "string",
           "default": "${fileBasenameNoExtension}-svg.svg",
           "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
-        "kogito.bpmn.filePath": {
+        "kogito.bpmn.svgFilePath": {
           "type": "string",
           "default": "${fileDirname}",
           "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`)."

--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -62,25 +62,18 @@
       "title": "BPMN Editor",
       "properties": {
         "kogito.bpmn.runOnSave": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Execute a command on each save operation of the BPMN file."
+          "type": "string",
+          "markdownDescription": "Execute a command on each save operation of the BPMN file."
         },
         "kogito.bpmn.filenameTemplate": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+          "type": "string",
+          "default": "${fileBasenameNoExtension}-svg.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
         "kogito.bpmn.filePath": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Where to save generated SVG files (defaults to current path)."
+          "type": "string",
+          "default": "${fileDirname}",
+          "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`)."
         }
       }
     },

--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -59,7 +59,7 @@
       }
     ],
     "configuration": {
-      "title": "BPMN",
+      "title": "BPMN Editor",
       "properties": {
         "kogito.bpmn.runOnSave": {
           "type": [
@@ -67,6 +67,20 @@
             "null"
           ],
           "description": "Execute a command on each save operation of the BPMN file."
+        },
+        "kogito.bpmn.filenameTemplate": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+        },
+        "kogito.bpmn.filePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Where to save generated SVG files (defaults to current path)."
         }
       }
     },

--- a/packages/vscode-extension-dmn-editor/README.md
+++ b/packages/vscode-extension-dmn-editor/README.md
@@ -24,13 +24,13 @@ DMN files must be inside a `src/` folder on your Workspace to be visible on the 
 
 ### Settings
 
-| Setting                       | Description                                              | Default value                        |
-| ----------------------------- | -------------------------------------------------------- | ------------------------------------ |
-| `kogito.dmn.runOnSave`        | Execute a command on each save operation of the DMN file | _empty_                              |
-| `kogito.dmn.filenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.dmn.filePath`         | Where to save generated SVG files                        | `${fileDirname}`                     |
+| Setting                          | Description                                              | Default value                        |
+| -------------------------------- | -------------------------------------------------------- | ------------------------------------ |
+| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                              |
+| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${fileDirname}`                     |
 
-The `kogito.dmn.filenameTemplate` and `kogito.dmn.filePath` settings accept the following variables as tokens:
+The `kogito.dmn.svgFilenameTemplate` and `kogito.dmn.svgFilePath` settings accept the following variables as tokens:
 
 | Variable                       | Example                                   |
 | ------------------------------ | ----------------------------------------- |

--- a/packages/vscode-extension-dmn-editor/README.md
+++ b/packages/vscode-extension-dmn-editor/README.md
@@ -12,12 +12,30 @@ Create and edit DMN and SceSim files.
 - Native keyboard shortcuts (Press `shift+/` to display available combinations).
 - Export diagram to SVG (use the SVG icon on the top-right corner).
 
-#### Editing a new DMN file
+### Editing a new DMN file
 
 ![alt](./gifs/dmn.gif?raw=true)
 
-#### Editing a SceSim file
+### Editing a SceSim file
 
 DMN files must be inside a `src/` folder on your Workspace to be visible on the Test Scenario Editor.
 
 ![alt](./gifs/scesim.gif?raw=true)
+
+### Settings
+
+| Setting                       | Description                                              | Default value                        |
+| ----------------------------- | -------------------------------------------------------- | ------------------------------------ |
+| `kogito.dmn.runOnSave`        | Execute a command on each save operation of the DMN file | _empty_                              |
+| `kogito.dmn.filenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.dmn.filePath`         | Where to save generated SVG files                        | `${fileDirname}`                     |
+
+The `kogito.dmn.filenameTemplate` and `kogito.dmn.filePath` settings accept the following variables as tokens:
+
+| Variable                       | Example                                   |
+| ------------------------------ | ----------------------------------------- |
+| **${workspaceFolder}**         | `/home/your-username/your-project`        |
+| **${fileDirname}**             | `/home/your-username/your-project/folder` |
+| **${fileExtname}**             | `.ext`                                    |
+| **${fileBasename}**            | `file.ext`                                |
+| **${fileBasenameNoExtension}** | `file`                                    |

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -63,25 +63,18 @@
       "title": "DMN Editor",
       "properties": {
         "kogito.dmn.runOnSave": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Execute a command on each save operation of the DMN file."
+          "type": "string",
+          "markdownDescription": "Execute a command on each save operation of the DMN file"
         },
         "kogito.dmn.filenameTemplate": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+          "type": "string",
+          "default": "${fileBasenameNoExtension}-svg.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
         "kogito.dmn.filePath": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Where to save generated SVG files (defaults to current path)."
+          "type": "string",
+          "default": "${fileDirname}",
+          "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`)."
         }
       }
     },

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -66,12 +66,12 @@
           "type": "string",
           "markdownDescription": "Execute a command on each save operation of the DMN file"
         },
-        "kogito.dmn.filenameTemplate": {
+        "kogito.dmn.svgFilenameTemplate": {
           "type": "string",
           "default": "${fileBasenameNoExtension}-svg.svg",
           "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
-        "kogito.dmn.filePath": {
+        "kogito.dmn.svgFilePath": {
           "type": "string",
           "default": "${fileDirname}",
           "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`)."

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -60,7 +60,7 @@
       }
     ],
     "configuration": {
-      "title": "DMN",
+      "title": "DMN Editor",
       "properties": {
         "kogito.dmn.runOnSave": {
           "type": [
@@ -68,6 +68,20 @@
             "null"
           ],
           "description": "Execute a command on each save operation of the DMN file."
+        },
+        "kogito.dmn.filenameTemplate": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+        },
+        "kogito.dmn.filePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Where to save generated SVG files (defaults to current path)."
         }
       }
     },

--- a/packages/vscode-extension-kogito-bundle/README.md
+++ b/packages/vscode-extension-kogito-bundle/README.md
@@ -13,10 +13,31 @@ Create and edit BPMN, DMN and SceSim files.
 - Native keyboard shortcuts (Press `shift+/` to display available combinations).
 - Export diagram to SVG (use the SVG icon on the top-right corner).
 
-#### Editing a new BPMN file
+### Editing a new BPMN file
 
 ![alt](./gifs/bpmn.gif?raw=true)
 
-#### Editing a new DMN file
+### Editing a new DMN file
 
 ![alt](./gifs/dmn.gif?raw=true)
+
+### Settings
+
+| Setting                        | Description                                               | Default value                        |
+| ------------------------------ | --------------------------------------------------------- | ------------------------------------ |
+| `kogito.bpmn.runOnSave`        | Execute a command on each save operation of the BPMN file | _empty_                              |
+| `kogito.dmn.runOnSave`         | Execute a command on each save operation of the DMN file  | _empty_                              |
+| `kogito.bpmn.filenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.dmn.filenameTemplate`  | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
+| `kogito.bpmn.filePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
+| `kogito.dmn.filePath`          | Where to save generated SVG files                         | `${fileDirname}`                     |
+
+The `kogito.{bpmn|dmn}.filenameTemplate` and `kogito.{bpmn|dmn}.filePath` settings accept the following variables as tokens:
+
+| Variable                       | Example                                   |
+| ------------------------------ | ----------------------------------------- |
+| **${workspaceFolder}**         | `/home/your-username/your-project`        |
+| **${fileDirname}**             | `/home/your-username/your-project/folder` |
+| **${fileExtname}**             | `.ext`                                    |
+| **${fileBasename}**            | `file.ext`                                |
+| **${fileBasenameNoExtension}** | `file`                                    |

--- a/packages/vscode-extension-kogito-bundle/README.md
+++ b/packages/vscode-extension-kogito-bundle/README.md
@@ -20,24 +20,3 @@ Create and edit BPMN, DMN and SceSim files.
 ### Editing a new DMN file
 
 ![alt](./gifs/dmn.gif?raw=true)
-
-### Settings
-
-| Setting                        | Description                                               | Default value                        |
-| ------------------------------ | --------------------------------------------------------- | ------------------------------------ |
-| `kogito.bpmn.runOnSave`        | Execute a command on each save operation of the BPMN file | _empty_                              |
-| `kogito.dmn.runOnSave`         | Execute a command on each save operation of the DMN file  | _empty_                              |
-| `kogito.bpmn.filenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.dmn.filenameTemplate`  | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.bpmn.filePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
-| `kogito.dmn.filePath`          | Where to save generated SVG files                         | `${fileDirname}`                     |
-
-The `kogito.{bpmn|dmn}.filenameTemplate` and `kogito.{bpmn|dmn}.filePath` settings accept the following variables as tokens:
-
-| Variable                       | Example                                   |
-| ------------------------------ | ----------------------------------------- |
-| **${workspaceFolder}**         | `/home/your-username/your-project`        |
-| **${fileDirname}**             | `/home/your-username/your-project/folder` |
-| **${fileExtname}**             | `.ext`                                    |
-| **${fileBasename}**            | `file.ext`                                |
-| **${fileBasenameNoExtension}** | `file`                                    |

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -29,7 +29,7 @@
   },
   "contributes": {
     "configuration": {
-      "title": "BPMN/DMN Test Configuration",
+      "title": "Kogito Tooling Dev Test Configuration",
       "properties": {
         "kogito.bpmn.runOnSave": {
           "type": [
@@ -46,6 +46,26 @@
           ],
           "default": "extension.kogito.silentlyGenerateSvg",
           "description": "Execute a command on each save operation of the DMN file"
+        },
+        "kogito.bpmn.filenameTemplate": {
+          "type": "string",
+          "default": "{filename}-svg.{ext}",
+          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+        },
+        "kogito.dmn.filenameTemplate": {
+          "type": "string",
+          "default": "{filename}-svg.{ext}",
+          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+        },
+        "kogito.bpmn.filePath": {
+          "type": "string",
+          "default": "./",
+          "description": "Where to save generated SVG files (defaults to same path as .bpmn file)."
+        },
+        "kogito.dmn.filePath": {
+          "type": "string",
+          "default": "./",
+          "description": "Where to save generated SVG files (defaults to same path as .dmn file)."
         }
       }
     },

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -168,8 +168,8 @@
     "lint": "yarn run run-script-if --bool \"$(build-env global.build.lint)\" --then \"yarn eslint ./src --ext .ts,.tsx\"",
     "test": "yarn run run-script-if --bool \"$(build-env global.build.test)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "test:it": "yarn run run-script-if --bool \"$(build-env global.build.testIT)\" --then \"yarn test:it:clean\" \"cpr it-tests/resources it-tests-tmp/resources\" \"tsc --project tsconfig.it-tests.json --skipLibCheck --sourceMap true\" \"extest setup-and-run --yarn -u -e ./test-resources -o it-tests/settings.json out/*.test.js\"",
-    "test:it:insider": "rimraf ./test-resource && rimraf ./out && tsc --project tsconfig.it-tests.json --skipLibCheck --sourceMap true && extest setup-and-run -t insider --yarn -u -e ./test-resources -o it-tests/settings.json out/*.test.js",
-    "test:it:clean": "rimraf ./dist-it-tests && rimraf ./test-resource && rimraf ./out && rimraf ./it-tests-tmp",
+    "test:it:insider": "rimraf ./test-resources && rimraf ./out && tsc --project tsconfig.it-tests.json --skipLibCheck --sourceMap true && extest setup-and-run -t insider --yarn -u -e ./test-resources -o it-tests/settings.json out/*.test.js",
+    "test:it:clean": "rimraf ./dist-it-tests && rimraf ./test-resources && rimraf ./out && rimraf ./it-tests-tmp && rimraf test-resou",
     "build:dev": "rimraf dist && webpack --env dev",
     "build:prod": "rimraf dist && yarn lint && webpack && yarn run test && yarn run package:prod && yarn test:it",
     "run:webmode": "yarn vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --version=stable"

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -32,40 +32,34 @@
       "title": "Kogito Tooling Dev Test Configuration",
       "properties": {
         "kogito.bpmn.runOnSave": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "default": "extension.kogito.silentlyGenerateSvg",
-          "description": "Execute a command on each save operation of the BPMN file."
+          "markdownDescription": "Execute a command on each save operation of the BPMN file."
         },
         "kogito.dmn.runOnSave": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "default": "extension.kogito.silentlyGenerateSvg",
-          "description": "Execute a command on each save operation of the DMN file"
+          "markdownDescription": "Execute a command on each save operation of the DMN file"
         },
         "kogito.bpmn.filenameTemplate": {
           "type": "string",
-          "default": "{filename}-svg.{ext}",
-          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+          "default": "${fileBasenameNoExtension}-svg.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
         "kogito.dmn.filenameTemplate": {
           "type": "string",
-          "default": "{filename}-svg.{ext}",
-          "description": "Filename template to be used when generating SVG files (defaults to '{filename}-svg.{ext})."
+          "default": "${fileBasenameNoExtension}-svg.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
         "kogito.bpmn.filePath": {
           "type": "string",
-          "default": "./",
-          "description": "Where to save generated SVG files (defaults to same path as .bpmn file)."
+          "default": "${fileDirname}",
+          "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`)."
         },
         "kogito.dmn.filePath": {
           "type": "string",
-          "default": "./",
-          "description": "Where to save generated SVG files (defaults to same path as .dmn file)."
+          "default": "${fileDirname}",
+          "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`)."
         }
       }
     },

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -41,22 +41,22 @@
           "default": "extension.kogito.silentlyGenerateSvg",
           "markdownDescription": "Execute a command on each save operation of the DMN file"
         },
-        "kogito.bpmn.filenameTemplate": {
+        "kogito.bpmn.svgFilenameTemplate": {
           "type": "string",
           "default": "${fileBasenameNoExtension}-svg.svg",
           "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
-        "kogito.dmn.filenameTemplate": {
+        "kogito.dmn.svgFilenameTemplate": {
           "type": "string",
           "default": "${fileBasenameNoExtension}-svg.svg",
           "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`)."
         },
-        "kogito.bpmn.filePath": {
+        "kogito.bpmn.svgFilePath": {
           "type": "string",
           "default": "${fileDirname}",
           "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`)."
         },
-        "kogito.dmn.filePath": {
+        "kogito.dmn.svgFilePath": {
           "type": "string",
           "default": "${fileDirname}",
           "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`)."

--- a/packages/vscode-extension/jest.config.js
+++ b/packages/vscode-extension/jest.config.js
@@ -26,4 +26,5 @@ module.exports = {
   moduleNameMapper: {
     "\\.(css|less|sass|scss)$": "<rootDir>/tests/__mocks__/styleMock.js",
   },
+  setupFiles: ["./setupTests.ts"],
 };

--- a/packages/vscode-extension/setupTests.ts
+++ b/packages/vscode-extension/setupTests.ts
@@ -1,0 +1,3 @@
+import { TextEncoder } from "util";
+
+global.TextEncoder = TextEncoder;

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -66,8 +66,8 @@ export async function generateSvg(args: {
       })
     : undefined;
 
-  const tokens: Record<SettingsValueInterpolationToken, string | undefined> = {
-    "${workspaceFolder}": workspace?.uri.fsPath,
+  const tokens: Record<SettingsValueInterpolationToken, string> = {
+    "${workspaceFolder}": workspace?.uri.fsPath ?? parsedPath.dir,
     "${fileDirname}": parsedPath.dir,
     "${fileExtname}": parsedPath.ext,
     "${fileBasename}": parsedPath.base,

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -30,10 +30,10 @@ type SettingsValueInterpolationToken =
   | "${fileBasename}"
   | "${fileBasenameNoExtension}";
 
-function interpolateSettingsValue(args: { tokens: Record<string, string | undefined>; value: string }) {
+function interpolateSettingsValue(args: { tokens: Record<string, string>; value: string }) {
   const { tokens, value } = args;
   return Object.entries(tokens).reduce(
-    (result, [tokenName, tokenValue]) => result.replaceAll(tokenName, tokenValue ?? ""),
+    (result, [tokenName, tokenValue]) => result.replaceAll(tokenName, tokenValue),
     value
   );
 }

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -58,8 +58,13 @@ export async function generateSvg(args: {
     return;
   }
 
-  const workspace = vscode.workspace.workspaceFolders?.length ? vscode.workspace.workspaceFolders[0] : null;
   const parsedPath = __path.parse(editor.document.uri.fsPath);
+  const workspace = vscode.workspace.workspaceFolders?.length
+    ? vscode.workspace.workspaceFolders.find((workspace) => {
+        const relative = __path.relative(workspace.uri.fsPath, editor.document.uri.fsPath);
+        return relative && !relative.startsWith("..") && !__path.isAbsolute(relative);
+      })
+    : undefined;
 
   const tokens: Record<SettingsValueInterpolationToken, string | undefined> = {
     "${workspaceFolder}": workspace?.uri.fsPath,
@@ -86,11 +91,11 @@ export async function generateSvg(args: {
 
   const svgFileName = interpolateSettingsValue({
     tokens,
-    value: svgFilenameTemplate.length ? svgFilenameTemplate : "${fileBasenameNoExtension}-svg.svg",
+    value: svgFilenameTemplate ? svgFilenameTemplate : "${fileBasenameNoExtension}-svg.svg",
   });
   const svgFilePath = interpolateSettingsValue({
     tokens,
-    value: svgFilePathTemplate.length ? svgFilePathTemplate : "${fileDirname}",
+    value: svgFilePathTemplate ? svgFilePathTemplate : "${fileDirname}",
   });
   const svgUri = editor.document.uri.with({ path: __path.resolve(svgFilePath, svgFileName) });
 

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -30,7 +30,7 @@ type SettingsValueInterpolationToken =
   | "${fileBasename}"
   | "${fileBasenameNoExtension}";
 
-function interpolateSettingsValue(args: { tokens: Record<string, string>; value: string }) {
+export function interpolateSettingsValue(args: { tokens: Record<string, string>; value: string }) {
   const { tokens, value } = args;
   return Object.entries(tokens).reduce(
     (result, [tokenName, tokenValue]) => result.replaceAll(tokenName, tokenValue),

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -44,8 +44,19 @@ export async function generateSvg(args: {
   }
 
   const parsedPath = __path.parse(editor.document.uri.fsPath);
-  const svgFileName = `${parsedPath.name}-svg.svg`;
-  const svgUri = editor.document.uri.with({ path: __path.join(parsedPath.dir, svgFileName) });
+  const fileExtension = parsedPath.ext.split('.').pop();
+
+  const svgFilenameTemplateId = `kogito.${fileExtension}.filenameTemplate`;
+  const svgFilePathId = `kogito.${fileExtension}.filePath`;
+
+  const svgFilenameTemplate = vscode.workspace.getConfiguration().get(svgFilenameTemplateId, "{filename}-svg.{ext}");
+  const svgFilePath = vscode.workspace.getConfiguration().get(svgFilePathId, "./");
+
+  const svgFileName = svgFilenameTemplate.replace("{filename}", parsedPath.name).replace("{ext}", "svg");
+  const svgUri = editor.document.uri.with({ path: __path.resolve(parsedPath.dir, svgFilePath, svgFileName) });
+
+  console.log({ svgFileName, svgUri, fileExtension, svgFilenameTemplateId, svgFilePathId, svgFilenameTemplate, svgFilePath });
+
   await vscode.workspace.fs.writeFile(svgUri, encoder.encode(previewSvg));
 
   if (args.displayNotification) {

--- a/packages/vscode-extension/tests/__mocks__/vscode.ts
+++ b/packages/vscode-extension/tests/__mocks__/vscode.ts
@@ -1,0 +1,1 @@
+export const vscode = {};

--- a/packages/vscode-extension/tests/generateSvg.test.ts
+++ b/packages/vscode-extension/tests/generateSvg.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { interpolateSettingsValue } from "@kie-tooling-core/vscode-extension/dist/generateSvg";
+
+describe("generateSvg", () => {
+  test("Should replace tokens with mapped values", () => {
+    const tokens = {
+      myToken1: "Token 1 Value",
+      "${myToken2}": "Token 2 Value",
+      myToken3: "10",
+    };
+
+    const originalText = "This text has myToken1, ${myToken2} and myToken3!";
+
+    const resultText = interpolateSettingsValue({ tokens, value: originalText });
+
+    expect(resultText).toBe("This text has Token 1 Value, Token 2 Value and 10!");
+  });
+});

--- a/packages/vscode-extension/tests/generateSvg.test.ts
+++ b/packages/vscode-extension/tests/generateSvg.test.ts
@@ -30,4 +30,15 @@ describe("generateSvg", () => {
 
     expect(resultText).toBe("This text has Token 1 Value, Token 2 Value and 10!");
   });
+  test("Should replace repeated tokens with mapped values", () => {
+    const tokens = {
+      myToken1: "Token 1 Value",
+    };
+
+    const originalText = "This text has myToken1myToken1myToken1 myToken1";
+
+    const resultText = interpolateSettingsValue({ tokens, value: originalText });
+
+    expect(resultText).toBe("This text has Token 1 ValueToken 1 ValueToken 1 Value Token 1 Value");
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "exclude": ["./**/node_modules", "./**/__tests__"],
   "compilerOptions": {
-    "lib": ["es6", "dom", "es2018.promise", "es2019"],
+    "lib": ["es6", "dom", "es2018.promise", "es2019", "esnext"],
     "target": "es5",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
# JIRA
https://issues.redhat.com/browse/KOGITO-6214

# On this PR
Introduces two new settings for each of the DMN and BPMN Editor VSCode extensions:
- `kogito.{dmn/bpmn}.svgFilenameTemplate`
Is the template to be used for the exported SVG filename and defaults to `${fileBasenameNoExtension}-svg.svg`.
- `kogito.{dmn/bpmn}.svgFilePath`
Is the path where the exported SVG should be saved and defaults to `${fileDirname}`.

<img width="1424" alt="Screen Shot 2021-11-26 at 17 19 00" src="https://user-images.githubusercontent.com/10515135/143626732-df3bf39e-3f1d-4490-923a-41b117b3b126.png">

They can use different tokens to refer to the workspace folder, the .bpmn/.dmn file name, path, and extension, according to this table:

| Variable                       | Example                                   |
| ------------------------------ | ----------------------------------------- |
| **${workspaceFolder}**         | `/home/your-username/your-project`        |
| **${fileDirname}**             | `/home/your-username/your-project/folder` |
| **${fileExtname}**             | `.ext`                                    |
| **${fileBasename}**            | `file.ext`                                |
| **${fileBasenameNoExtension}** | `file`                                    |

These variables were based on the ones already available in VSCode for the `launch.json` and `tasks.json` files. ([VSCode: Variables reference](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables-examples))

The idea is to, whenever it gets implemented in VSCode, be able to use the predefined variables instead of replicating them on our own, without breaking the user's settings. (Related issues: https://github.com/microsoft/vscode/issues/2809 and https://github.com/microsoft/vscode/issues/46471)

# Also on this PR

The new and existing settings (`runOnSave`) were changed to support the use of markdown descriptions and input fields (without the need to edit the `settings.json` file directly). ([VSCode: Configuration schema](https://code.visualstudio.com/api/references/contribution-points#Configuration-schema))
