### PR TITLE
KOGITO-6168/KOGITO-6194 : Additional JS Methods

### DIFF
--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditor.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditor.ts
@@ -63,4 +63,12 @@ export class BpmnEditorImpl extends GwtEditorWrapper implements BpmnEditor {
   public getDimensions(uuid: string) {
     return window.canvas.getDimensions(uuid);
   }
+
+  public applyState(uuid: string, state: string) {
+    window.canvas.applyState(uuid, state);
+  }
+
+  public centerNode(uuid: string) {
+    window.canvas.centerNode(uuid);
+  }
 }

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
@@ -109,4 +109,20 @@ export class BpmnEditorEnvelopeApiImpl
     }
     return editor.getDimensions(uuid);
   }
+
+  public async canvas_applyState(uuid: string, state: string) {
+    const editor = this.bpmnArgs.view().getEditor();
+    if (!editor) {
+      throw new Error("Editor not found.");
+    }
+    return editor.applyState(uuid, state);
+  }
+
+  public async canvas_centerNode(uuid: string) {
+    const editor = this.bpmnArgs.view().getEditor();
+    if (!editor) {
+      throw new Error("Editor not found.");
+    }
+    return editor.centerNode(uuid);
+  }
 }

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
@@ -111,7 +111,7 @@ export class BpmnEditorEnvelopeApiImpl
   }
 
   public async canvas_applyState(uuid: string, state: string) {
-    const editor = this.bpmnArgs.view().getEditor();
+    const editor = this.view().getEditor();
     if (!editor) {
       throw new Error("Editor not found.");
     }
@@ -119,7 +119,7 @@ export class BpmnEditorEnvelopeApiImpl
   }
 
   public async canvas_centerNode(uuid: string) {
-    const editor = this.bpmnArgs.view().getEditor();
+    const editor = this.view().getEditor();
     if (!editor) {
       throw new Error("Editor not found.");
     }

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEditor.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEditor.ts
@@ -63,4 +63,12 @@ export class DmnEditorImpl extends GwtEditorWrapper implements DmnEditor {
   public getDimensions(uuid: string) {
     return window.canvas.getDimensions(uuid);
   }
+
+  public applyState(uuid: string, state: string) {
+    window.canvas.applyState(uuid, state);
+  }
+
+  public centerNode(uuid: string) {
+    window.canvas.centerNode(uuid);
+  }
 }

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
@@ -109,4 +109,20 @@ export class DmnEditorEnvelopeApiImpl
     }
     return editor.getDimensions(uuid);
   }
+
+  public async canvas_applyState(uuid: string, state: string) {
+    const editor = this.dmnArgs.view().getEditor();
+    if (!editor) {
+      throw new Error("Editor not found.");
+    }
+    return editor.applyState(uuid, state);
+  }
+
+  public async canvas_centerNode(uuid: string) {
+    const editor = this.dmnArgs.view().getEditor();
+    if (!editor) {
+      throw new Error("Editor not found.");
+    }
+    return editor.centerNode(uuid);
+  }
 }

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
@@ -111,7 +111,7 @@ export class DmnEditorEnvelopeApiImpl
   }
 
   public async canvas_applyState(uuid: string, state: string) {
-    const editor = this.dmnArgs.view().getEditor();
+    const editor = this.view().getEditor();
     if (!editor) {
       throw new Error("Editor not found.");
     }
@@ -119,7 +119,7 @@ export class DmnEditorEnvelopeApiImpl
   }
 
   public async canvas_centerNode(uuid: string) {
-    const editor = this.dmnArgs.view().getEditor();
+    const editor = this.view().getEditor();
     if (!editor) {
       throw new Error("Editor not found.");
     }

--- a/packages/kie-bc-editors/src/jslienzo/CanvasApi.ts
+++ b/packages/kie-bc-editors/src/jslienzo/CanvasApi.ts
@@ -80,6 +80,21 @@ export interface CanvasApi {
    * @param uuid ID attribute of a target node
    */
   getDimensions(uuid: string): number[];
+
+  /**
+   * Applies state to a node with provided UUID.
+   *
+   * @param uuid ID attribute of a target node
+   * @param state attribute of a target node
+   */
+  applyState(uuid: string, state: string): void;
+
+  /**
+   * Centers node in viewable canvas area with provided UUID.
+   *
+   * @param uuid ID attribute of a target node
+   */
+  centerNode(uuid: string): void;
 }
 
 /**
@@ -102,4 +117,8 @@ export interface CanvasEnvelopeApi {
   canvas_getAbsoluteLocation(uuid: string): Promise<number[]>;
 
   canvas_getDimensions(uuid: string): Promise<number[]>;
+
+  canvas_applyState(uuid: string, state: string): Promise<void>;
+
+  canvas_centerNode(uuid: string): Promise<void>;
 }

--- a/packages/kie-bc-editors/src/jslienzo/CanvasApi.ts
+++ b/packages/kie-bc-editors/src/jslienzo/CanvasApi.ts
@@ -85,7 +85,7 @@ export interface CanvasApi {
    * Applies state to a node with provided UUID.
    *
    * @param uuid ID attribute of a target node
-   * @param state attribute of a target node
+   * @param state attribute of a target node valid states ('none', 'selected', 'highlight', 'invalid')
    */
   applyState(uuid: string, state: string): void;
 

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -74,3 +74,6 @@ The returned object will contain the methods needed to manipulate the Editor:
   - `getLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the canvas location of a node with provided UUID.
   - `getAbsoluteLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the window location for a node with provided UUID.
   - `getDimensions(uuid: string): Promise<number[]>`: Returns a Promise containing the dimensions of a node with provided UUID.
+  - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
+  - `centerNode(uuid: string): Promise<void>`: Centers node on viewable Canvas.
+  

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -74,5 +74,5 @@ The returned object will contain the methods needed to manipulate the Editor:
   - `getLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the canvas location of a node with provided UUID.
   - `getAbsoluteLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the window location for a node with provided UUID.
   - `getDimensions(uuid: string): Promise<number[]>`: Returns a Promise containing the dimensions of a node with provided UUID.
-  - `applyState(uuid: string, state: string)`: Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
+  - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
   - `centerNode(uuid: string): Promise<void>`: Centers node on viewable Canvas.

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -74,5 +74,5 @@ The returned object will contain the methods needed to manipulate the Editor:
   - `getLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the canvas location of a node with provided UUID.
   - `getAbsoluteLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the window location for a node with provided UUID.
   - `getDimensions(uuid: string): Promise<number[]>`: Returns a Promise containing the dimensions of a node with provided UUID.
-  - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
+  - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID [None, Selected, Highlight, Invalid].
   - `centerNode(uuid: string): Promise<void>`: Centers node on viewable Canvas.

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -76,4 +76,3 @@ The returned object will contain the methods needed to manipulate the Editor:
   - `getDimensions(uuid: string): Promise<number[]>`: Returns a Promise containing the dimensions of a node with provided UUID.
   - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
   - `centerNode(uuid: string): Promise<void>`: Centers node on viewable Canvas.
-  

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -74,5 +74,5 @@ The returned object will contain the methods needed to manipulate the Editor:
   - `getLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the canvas location of a node with provided UUID.
   - `getAbsoluteLocation(uuid: string): Promise<number[]>`: Returns a Promise containing the window location for a node with provided UUID.
   - `getDimensions(uuid: string): Promise<number[]>`: Returns a Promise containing the dimensions of a node with provided UUID.
-  - `applyState(uuid: string, state: string): Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
+  - `applyState(uuid: string, state: string)`: Promise<void>`: Applies state to a node given the UUID ("None", "Selected", "Highlight", "Error").
   - `centerNode(uuid: string): Promise<void>`: Centers node on viewable Canvas.

--- a/packages/kie-editors-standalone/src/bpmn/index.ts
+++ b/packages/kie-editors-standalone/src/bpmn/index.ts
@@ -132,6 +132,12 @@ export function open(args: {
       getDimensions: (uuid: string) => {
         return envelopeServer.envelopeApi.requests.canvas_getDimensions(uuid);
       },
+      applyState: (uuid: string, state: string) => {
+        return envelopeServer.envelopeApi.requests.canvas_applyState(uuid, state);
+      },
+      centerNode: (uuid: string) => {
+        return envelopeServer.envelopeApi.requests.canvas_centerNode(uuid);
+      },
     },
   };
 }

--- a/packages/kie-editors-standalone/src/dmn/index.ts
+++ b/packages/kie-editors-standalone/src/dmn/index.ts
@@ -132,6 +132,12 @@ export function open(args: {
       getDimensions: (uuid: string) => {
         return envelopeServer.envelopeApi.requests.canvas_getDimensions(uuid);
       },
+      applyState: (uuid: string, state: string) => {
+        return envelopeServer.envelopeApi.requests.canvas_applyState(uuid, state);
+      },
+      centerNode: (uuid: string) => {
+        return envelopeServer.envelopeApi.requests.canvas_centerNode(uuid);
+      },
     },
   };
 }

--- a/packages/kie-editors-standalone/src/jsdiagram/CanvasEditorApi.ts
+++ b/packages/kie-editors-standalone/src/jsdiagram/CanvasEditorApi.ts
@@ -80,4 +80,19 @@ export interface CanvasEditorApi {
    * @param uuid ID attribute of a target node
    */
   getDimensions(uuid: string): Promise<number[]>;
+
+  /**
+   * Applies the state to a node given the UUID.
+   *
+   * @param uuid ID attribute of a target node
+   * @state state attribute of a target node
+   */
+  applyState(uuid: string, state: string): Promise<void>;
+
+  /**
+   * Centers a node in the viewable canvas with provided UUID.
+   *
+   * @param uuid ID attribute of a target node
+   */
+  centerNode(uuid: string): Promise<void>;
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.GuidedTourB
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoPanel;
+import org.kie.workbench.common.stunner.client.lienzo.util.StunnerStateApplier;
 import org.kie.workbench.common.stunner.client.widgets.editor.EditorSessionCommands;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
@@ -55,6 +56,7 @@ import org.kie.workbench.common.stunner.core.client.command.SessionCommandManage
 import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.documentation.DocumentationView;
 import org.kie.workbench.common.stunner.forms.client.event.RefreshFormPropertiesEvent;
@@ -153,7 +155,12 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer());
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
+                @Override
+                public Shape getShape(String uuid) {
+                    return stunnerEditor.getCanvasHandler().getCanvas().getShape(uuid);
+                }
+            });
             setupJsCanvasTypeNative(jsCanvas);
         }
     }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.lienzo.util;
+
+import com.ait.lienzo.client.core.types.JSShapeStateApplier;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
+import org.kie.workbench.common.stunner.core.client.shape.ShapeState;
+
+public abstract class StunnerStateApplier implements JSShapeStateApplier {
+
+    public abstract Shape getShape(String uuid);
+
+    @Override
+    public void applyState(String UUID, String state) {
+
+        Shape shape = getShape(UUID);
+        if (shape != null) {
+            ShapeState shapeState = null;
+            switch (state.toLowerCase()) {
+                case "none":
+                    shapeState = ShapeState.NONE;
+                    break;
+                case "selected":
+                    shapeState = ShapeState.SELECTED;
+                    break;
+                case "highlight":
+                    shapeState = ShapeState.HIGHLIGHT;
+                    break;
+                case "invalid":
+                    shapeState = ShapeState.INVALID;
+                    break;
+            }
+
+            if (shapeState != null) {
+                shape.applyState(shapeState);
+            }
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/util/StunnerStateApplier.java
@@ -43,6 +43,8 @@ public abstract class StunnerStateApplier implements JSShapeStateApplier {
                 case "invalid":
                     shapeState = ShapeState.INVALID;
                     break;
+                default:
+                    //Nothing to do if not valid value
             }
 
             if (shapeState != null) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/README.md
@@ -92,3 +92,5 @@ It provides buttons for creating new processes, opening an existing process and 
         jsl.getLocation('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red')         // gets location
         jsl.getAbsoluteLocation('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red') // gets absolute location
         jsl.getDimensions('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'red')       // gets dimensions
+        jsl.applyState('_A9481DBC-3E87-40EE-9925-733B24404BC0', 'invalid')      // applies state (none, highlight, selected, invalid)
+        jsl.centerNode('_A9481DBC-3E87-40EE-9925-733B24404BC0')                 // centers node in viewable canvas

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/main/java/org/kie/workbench/common/stunner/kogito/client/editor/BPMNDiagramEditor.java
@@ -30,6 +30,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.promise.Promise;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoPanel;
+import org.kie.workbench.common.stunner.client.lienzo.util.StunnerStateApplier;
 import org.kie.workbench.common.stunner.client.widgets.editor.EditorSessionCommands;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.client.widgets.presenters.session.SessionPresenter;
@@ -41,6 +42,7 @@ import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
 import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
+import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.client.validation.canvas.CanvasDiagramValidator;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
@@ -233,7 +235,12 @@ public class BPMNDiagramEditor {
         if (canvas != null) {
             LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
             LienzoBoundsPanel lienzoPanel = panel.getView();
-            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer());
+            JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
+                @Override
+                public Shape getShape(String uuid) {
+                    return stunnerEditor.getCanvasHandler().getCanvas().getShape(uuid);
+                }
+            });
             setupJsCanvasTypeNative(jsCanvas);
         }
     }

--- a/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
+++ b/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
@@ -18,5 +18,10 @@ package com.ait.lienzo.client.core.types;
 
 public interface JSShapeStateApplier {
 
+    /**
+     * Applies state to given node
+     * @param UUID UUID of the node to change the state
+     * @param state State to be changed, valid values ('none', 'selected', 'highlight', 'invalid')
+     */
     void applyState(String UUID, String state);
 }

--- a/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
+++ b/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JSShapeStateApplier.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ait.lienzo.client.core.types;
+
+public interface JSShapeStateApplier {
+
+    void applyState(String UUID, String state);
+}

--- a/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -263,11 +263,15 @@ public class JsCanvas implements JsCanvasNodeLister {
     }
 
     public void applyState(String UUID, String state) {
-        stateApplier.applyState(UUID, state);
+        if (UUID != null && state != null) {
+            stateApplier.applyState(UUID, state);
+        }
     }
 
     public void center(String UUID) {
-        centerNode(UUID);
+        if (UUID != null) {
+            centerNode(UUID);
+        }
     }
 
     public void centerNode(String UUID) {

--- a/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/packages/stunner-editors/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -28,8 +28,8 @@ import com.ait.lienzo.client.core.shape.wires.WiresManager;
 import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.shape.wires.types.JsWiresShape;
 import com.ait.lienzo.client.widget.panel.LienzoPanel;
+import com.ait.lienzo.client.widget.panel.impl.ScrollablePanel;
 import com.ait.lienzo.tools.client.collection.NFastArrayList;
-import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLCanvasElement;
 import jsinterop.annotations.JsType;
 
@@ -38,13 +38,15 @@ public class JsCanvas implements JsCanvasNodeLister {
 
     LienzoPanel panel;
     Layer layer;
+    protected JSShapeStateApplier stateApplier;
     public static JsCanvasEvents events;
     public static JsCanvasAnimations animations;
     public static JsCanvasLogger logger;
 
-    public JsCanvas(LienzoPanel panel, Layer layer) {
+    public JsCanvas(LienzoPanel panel, Layer layer, JSShapeStateApplier stateApplier) {
         this.panel = panel;
         this.layer = layer;
+        this.stateApplier = stateApplier;
         this.events = null;
     }
 
@@ -258,6 +260,42 @@ public class JsCanvas implements JsCanvasNodeLister {
             ids.add(shape.getID());
         }
         return ids;
+    }
+
+    public void applyState(String UUID, String state) {
+        stateApplier.applyState(UUID, state);
+    }
+
+    public void center(String UUID) {
+        centerNode(UUID);
+    }
+
+    public void centerNode(String UUID) {
+        NFastArrayList<Double> absoluteLocation = getAbsoluteLocation(UUID);
+
+        if (absoluteLocation != null) {
+
+            double width = layer.getViewport().getWidth();
+            double height = layer.getViewport().getHeight();
+
+            NFastArrayList<Double> dimensions = getDimensions(UUID);
+            double nodeWidth = 0;
+            double nodeHeight = 0;
+
+            if (dimensions != null) {
+                nodeWidth = dimensions.get(0);
+                nodeHeight = dimensions.get(1);
+            }
+
+            double translatedX = -absoluteLocation.get(0) + (width / 2) - (nodeWidth / 2);
+            double translatedY = -absoluteLocation.get(1) + (height / 2) - (nodeHeight / 2);
+
+            if (translatedX <= 0 && translatedY <= 0) { // prevent moving (0,0) Dotten Line right/below
+                layer.getViewport().getTransform().translate(-layer.getViewport().getTransform().getTranslateX(), -layer.getViewport().getTransform().getTranslateY());
+                layer.getViewport().getTransform().translate(translatedX, translatedY);
+                ((ScrollablePanel) panel).refresh();
+            }
+        }
     }
 
     @Override

--- a/packages/stunner-editors/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
+++ b/packages/stunner-editors/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
@@ -26,10 +26,11 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class JsCanvasTest {
@@ -39,6 +40,9 @@ public class JsCanvasTest {
 
     @Mock
     private JsWiresShape jsWiresShape;
+
+    @Mock
+    JSShapeStateApplier shapeStateApplier;
 
     @Test
     public void testGetBackgroundColor() {
@@ -213,5 +217,21 @@ public class JsCanvasTest {
         assertEquals(null, dimensions);
         dimensions = jsCanvas.getDimensions("");
         assertEquals(null, dimensions);
+    }
+
+    @Test
+    public void testApplyState() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "None");
+        verify(shapeStateApplier, times(1)).applyState("someId", "None");
+    }
+
+    @Test
+    public void testCenter() {
+        doCallRealMethod().when(jsCanvas).center(anyString());
+        jsCanvas.center("someId");
+        verify(jsCanvas, times(1)).centerNode("someId");
     }
 }

--- a/packages/stunner-editors/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
+++ b/packages/stunner-editors/lienzo-tests/src/test/java/com/ait/lienzo/client/core/types/JsCanvasTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
 @RunWith(LienzoMockitoTestRunner.class)
 public class JsCanvasTest {
 
@@ -220,12 +219,54 @@ public class JsCanvasTest {
     }
 
     @Test
-    public void testApplyState() {
+    public void testApplyStateNulls() {
         jsCanvas.stateApplier = shapeStateApplier;
         doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
 
-        jsCanvas.applyState("someId", "None");
-        verify(shapeStateApplier, times(1)).applyState("someId", "None");
+        jsCanvas.applyState(null, null);
+        verify(shapeStateApplier, never()).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", null);
+        verify(shapeStateApplier, never()).applyState(anyString(), anyString());
+
+        jsCanvas.applyState(null, "none");
+        verify(shapeStateApplier, never()).applyState(anyString(), anyString());
+    }
+
+    @Test
+    public void testApplyStateNone() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "none");
+        verify(shapeStateApplier, times(1)).applyState("someId", "none");
+    }
+
+    @Test
+    public void testApplyStateSelected() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "selected");
+        verify(shapeStateApplier, times(1)).applyState("someId", "selected");
+    }
+
+    @Test
+    public void testApplyStateHighlight() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "highlight");
+        verify(shapeStateApplier, times(1)).applyState("someId", "highlight");
+    }
+
+    @Test
+    public void testApplyStateInvalid() {
+        jsCanvas.stateApplier = shapeStateApplier;
+        doCallRealMethod().when(jsCanvas).applyState(anyString(), anyString());
+
+        jsCanvas.applyState("someId", "invalid");
+        verify(shapeStateApplier, times(1)).applyState("someId", "invalid");
     }
 
     @Test
@@ -233,5 +274,12 @@ public class JsCanvasTest {
         doCallRealMethod().when(jsCanvas).center(anyString());
         jsCanvas.center("someId");
         verify(jsCanvas, times(1)).centerNode("someId");
+    }
+
+    @Test
+    public void testCenterNull() {
+        doCallRealMethod().when(jsCanvas).center(anyString());
+        jsCanvas.center(null);
+        verify(jsCanvas, never()).centerNode(anyString());
     }
 }

--- a/packages/stunner-editors/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
+++ b/packages/stunner-editors/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
@@ -71,7 +71,8 @@ public abstract class BaseExample implements Example {
         MousePanMediator pan = new MousePanMediator(EventFilter.META);
         this.panel.getViewport().pushMediator(pan);
 
-        jsCanvas = new JsCanvas(this.panel, this.layer);
+        jsCanvas = new JsCanvas(this.panel, this.layer, (UUID, state) -> {
+        });
         setupJsCanvasTypes(jsCanvas);
     }
 

--- a/packages/stunner-editors/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
+++ b/packages/stunner-editors/lienzo-webapp/src/main/java/org/kie/lienzo/client/BaseExample.java
@@ -71,8 +71,7 @@ public abstract class BaseExample implements Example {
         MousePanMediator pan = new MousePanMediator(EventFilter.META);
         this.panel.getViewport().pushMediator(pan);
 
-        jsCanvas = new JsCanvas(this.panel, this.layer, (UUID, state) -> {
-        });
+        jsCanvas = new JsCanvas(this.panel, this.layer, null);
         setupJsCanvasTypes(jsCanvas);
     }
 


### PR DESCRIPTION
Hi @romartin @handreyrc this is the part of the envelope exposing two methods, can you review it? This PR depends on PR. https://github.com/kiegroup/kogito-editors-java/pull/185

To test the envelope 
1) Unzip file from https://drive.google.com/drive/folders/1TL7JEJ3EyIoQDY18oQlGRTnKJZju9dY3?usp=sharing
2) In browser open file in path to path similar to 
bpmn
file:///home/jenrique/development/kogito-tooling/packages/kie-editors-standalone/dist/resources/bpmn/index.html
dmn
file:///home/jenrique/development/kogito-tooling/packages/kie-editors-standalone/dist/resources/dmn/index.html
3) Place a node on canvas
4) in Developer console type
a) await editor.canvas.getNodeIds()
b) To test apply state type 
await editor.canvas.applyState("[Node id from step a]", "state"), valid state values are "None", "Selected", "Highlight", "Invalid"
c) To test centerNode type
await editor.canvas.centerNode("[Node id from step a]")

Thanks, let me know

 