### PR TITLE
Skip setup kogito-tooling-bot step for dry-runs

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -257,6 +257,7 @@ jobs:
           ref: gh-pages
 
       - name: "Setup kogito-tooling-bot"
+        if: ${{ !inputs.dry_run }}
         uses: ./kogito-tooling/.github/actions/setup-kogito-tooling-bot
         with:
           path: kogito-online
@@ -339,6 +340,7 @@ jobs:
           ref: gh-pages
 
       - name: "Setup kogito-tooling-bot"
+        if: ${{ !inputs.dry_run }}
         uses: ./kogito-tooling/.github/actions/setup-kogito-tooling-bot
         with:
           path: kogito-online
@@ -648,6 +650,7 @@ jobs:
           ref: gh-pages
 
       - name: "Setup kogito-tooling-bot"
+        if: ${{ !inputs.dry_run }}
         uses: ./kogito-tooling/.github/actions/setup-kogito-tooling-bot
         with:
           path: kogito-online

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -71,7 +71,7 @@ jobs:
           repository: kiegroup/kogito-online-staging
 
       - name: "Setup kogito-tooling-bot"
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: ./kogito-tooling/.github/actions/setup-kogito-tooling-bot
         with:
           path: kogito-online-staging


### PR DESCRIPTION
**Note**: Some dry-run workflows will fail because the workflow code comes from `main`, not this PR.