### PR TITLE
Use `github.base_ref` instead of `github.event.pull_request.base.sha` on CI

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           KOGITO_TOOLING_BUILD_examples: "true"
         run: |
-          export REF=${{ github.event.pull_request.base.sha }} &&
+          export REF=${{ github.base_ref }} &&
           export SCOPE=$(diff <(echo "$(lerna ls --since $REF --include-dependencies --all | cut -d' ' -f1)") <(echo "$(lerna ls --since $REF  --all | cut -d' ' -f1)") --changed-group-format='%<%>' --unchanged-group-format='' | xargs -I{} echo -n ' --scope="{}"') &&
           echo $REF $SCOPE &&
           yarn run-script-if --silent --env SCOPE --eq "" \
@@ -75,7 +75,7 @@ jobs:
           DISPLAY: ":99.0"
           START_SERVER_AND_TEST_INSECURE: "true"
         run: |
-          lerna run build:prod --stream --concurrency 1 --since ${{ github.event.pull_request.base.sha }}
+          lerna run build:prod --stream --concurrency 1 --since ${{ github.base_ref }}
 
       - name: "Check generated resources (you should commit those!)"
         shell: bash


### PR DESCRIPTION
This way, the diff will consider the branch name instead of a fixed SHA.