### PR TITLE
KOGITO-6404: Remove unused log4j dependencies

### DIFF
--- a/packages/dashbuilder/kie-soup-dataset/pom.xml
+++ b/packages/dashbuilder/kie-soup-dataset/pom.xml
@@ -55,18 +55,6 @@
         <version>${version.com.googlecode.jsonsimple}</version>
         <type>jar</type>
       </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${version.org.apache.logging.log4j}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${version.org.apache.logging.log4j}</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
For more details see:
- https://issues.redhat.com/browse/KOGITO-6404
- https://github.com/kiegroup/kie-soup/pull/239/files