### PR TITLE
KOGITO-6338: [KIE Sandbox] Issues after first release

### DIFF
--- a/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
@@ -96,15 +96,17 @@ export function SingleEditorApp(props: {
     setFullscreen(true);
   }, []);
 
+  const { getFileContents, getFileName } = props;
+
   const openExternalEditor = useMemo(
     () =>
       globals.externalEditorManager?.open &&
       (() => {
-        props.getFileContents().then((fileContent) => {
-          globals.externalEditorManager?.open?.(props.getFileName(), fileContent!, props.readonly);
+        getFileContents().then((fileContent) => {
+          globals.externalEditorManager?.open?.(getFileName(), fileContent!, props.readonly);
         });
       }),
-    [globals.externalEditorManager, props.getFileName, props.readonly]
+    [globals.externalEditorManager, getFileContents, getFileName, props.readonly]
   );
 
   const linkToExternalEditor = useMemo(() => {

--- a/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorApp.tsx
@@ -96,17 +96,22 @@ export function SingleEditorApp(props: {
     setFullscreen(true);
   }, []);
 
-  const openExternalEditor = useCallback(() => {
-    props.getFileContents().then((fileContent) => {
-      globals.externalEditorManager?.open?.(props.getFileName(), fileContent!, props.readonly);
-    });
-  }, [globals.externalEditorManager]);
+  const openExternalEditor = useMemo(
+    () =>
+      globals.externalEditorManager?.open &&
+      (() => {
+        props.getFileContents().then((fileContent) => {
+          globals.externalEditorManager?.open?.(props.getFileName(), fileContent!, props.readonly);
+        });
+      }),
+    [globals.externalEditorManager, props.getFileName, props.readonly]
+  );
 
   const linkToExternalEditor = useMemo(() => {
     return globals.externalEditorManager?.getLink?.(
       `${props.fileInfo.org}/${props.fileInfo.repo}/${props.fileInfo.gitRef}/${props.fileInfo.path}`
     );
-  }, [globals.externalEditorManager]);
+  }, [globals.externalEditorManager, props.fileInfo]);
 
   const onEditorReady = useCallback(() => {
     setTextModeAvailable(true);

--- a/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
@@ -29,7 +29,7 @@ export function SingleEditorToolbar(props: {
   onFullScreen: () => void;
   onSeeAsSource: () => void;
   onSeeAsDiagram: () => void;
-  onOpenInExternalEditor: () => void;
+  onOpenInExternalEditor: (() => void) | undefined;
   linkToExternalEditor: string | undefined;
 }) {
   const globals = useGlobals();
@@ -55,7 +55,7 @@ export function SingleEditorToolbar(props: {
 
   const openInExternalEditor = useCallback((e: any) => {
     e.preventDefault();
-    props.onOpenInExternalEditor();
+    props.onOpenInExternalEditor?.();
   }, []);
 
   const copyLinkToExternalEditor = useCallback((e: any) => {
@@ -118,7 +118,7 @@ export function SingleEditorToolbar(props: {
             {i18n.seeAsDiagram}
           </button>
         )}
-        {globals.externalEditorManager && (
+        {globals.externalEditorManager && props.onOpenInExternalEditor && (
           <button
             data-testid={"open-ext-editor-button"}
             className={"btn d-none d-md-inline-block kogito-button"}

--- a/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
+++ b/packages/chrome-extension/src/app/components/single/SingleEditorToolbar.tsx
@@ -29,8 +29,8 @@ export function SingleEditorToolbar(props: {
   onFullScreen: () => void;
   onSeeAsSource: () => void;
   onSeeAsDiagram: () => void;
-  onOpenInExternalEditor: (() => void) | undefined;
-  linkToExternalEditor: string | undefined;
+  onOpenInExternalEditor?: () => void;
+  linkToExternalEditor?: string;
 }) {
   const globals = useGlobals();
   const [copyLinkSuccessAlertVisible, setCopyLinkSuccessAlertVisible] = useState(false);

--- a/packages/chrome-extension/tests/app/components/single/__snapshots__/SingleEditorToolbar.test.tsx.snap
+++ b/packages/chrome-extension/tests/app/components/single/__snapshots__/SingleEditorToolbar.test.tsx.snap
@@ -79,12 +79,6 @@ exports[`SingleEditorToolbar copied to clipboard message 1`] = `
     >
       See as source
     </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
-    </button>
     <div
       class="position-relative"
     >
@@ -122,12 +116,6 @@ exports[`SingleEditorToolbar readonly false | textMode false | textModeAvailable
     >
       See as source
     </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
-    </button>
     <div
       class="position-relative"
     >
@@ -163,12 +151,6 @@ exports[`SingleEditorToolbar readonly false | textMode false | textModeAvailable
       data-testid="see-as-source-button"
     >
       See as source
-    </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
     </button>
     <div
       class="position-relative"
@@ -208,12 +190,6 @@ exports[`SingleEditorToolbar readonly false | textMode true | textModeAvailable 
     >
       See as diagram
     </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
-    </button>
     <div
       class="position-relative"
     >
@@ -243,12 +219,6 @@ exports[`SingleEditorToolbar readonly false | textMode true | textModeAvailable 
       data-testid="see-as-diagram-button"
     >
       See as diagram
-    </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
     </button>
     <div
       class="position-relative"
@@ -286,12 +256,6 @@ exports[`SingleEditorToolbar readonly true | textMode false | textModeAvailable 
       disabled=""
     >
       See as source
-    </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
     </button>
     <div
       class="position-relative"
@@ -331,12 +295,6 @@ exports[`SingleEditorToolbar readonly true | textMode true | textModeAvailable f
     >
       See as diagram
     </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
-    </button>
     <div
       class="position-relative"
     >
@@ -366,12 +324,6 @@ exports[`SingleEditorToolbar see as diagram 1`] = `
       data-testid="see-as-diagram-button"
     >
       See as diagram
-    </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
     </button>
     <div
       class="position-relative"
@@ -408,12 +360,6 @@ exports[`SingleEditorToolbar see as source 1`] = `
       data-testid="see-as-source-button"
     >
       See as source
-    </button>
-    <button
-      class="btn d-none d-md-inline-block kogito-button"
-      data-testid="open-ext-editor-button"
-    >
-      Open in Test Online Editor
     </button>
     <div
       class="position-relative"

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
@@ -43,7 +43,6 @@ export function DmnDevSandboxContextProvider(props: Props) {
   const [isDeploymentsDropdownOpen, setDeploymentsDropdownOpen] = useState(false);
   const [isConfirmDeployModalOpen, setConfirmDeployModalOpen] = useState(false);
   const [deployments, setDeployments] = useState([] as OpenShiftDeployedModel[]);
-  const loadDeploymentsTask = useRef<number>();
 
   const onDisconnect = useCallback(
     (closeModals: boolean) => {
@@ -126,21 +125,18 @@ export function DmnDevSandboxContextProvider(props: Props) {
     }
 
     if (settings.openshift.status === OpenShiftInstanceStatus.CONNECTED && isDeploymentsDropdownOpen) {
-      loadDeploymentsTask.current = window.setInterval(() => {
+      const loadDeploymentsTask = window.setInterval(() => {
         settingsDispatch.openshift.service
           .loadDeployments(settings.openshift.config)
           .then((deployments) => setDeployments(deployments))
           .catch((error) => {
             setDeployments([]);
-            window.clearInterval(loadDeploymentsTask.current);
+            window.clearInterval(loadDeploymentsTask);
             console.error(error);
           });
       }, LOAD_DEPLOYMENTS_POLLING_TIME);
-    } else {
-      window.clearInterval(loadDeploymentsTask.current);
+      return () => window.clearInterval(loadDeploymentsTask);
     }
-
-    return () => window.clearInterval(loadDeploymentsTask.current);
   }, [
     onDisconnect,
     settings.openshift,

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
@@ -79,6 +79,7 @@ export function DmnDevSandboxContextProvider(props: Props) {
       try {
         await settingsDispatch.openshift.service.deploy({
           targetFilePath: workspaceFile.relativePath,
+          workspaceId: workspaceFile.workspaceId,
           workspaceZipBlob: zipBlob,
           config: settings.openshift.config,
           onlineEditorUrl: (baseUrl) =>

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
@@ -140,7 +140,7 @@ export function DmnDevSandboxContextProvider(props: Props) {
       window.clearInterval(loadDeploymentsTask.current);
     }
 
-    return () => clearInterval(loadDeploymentsTask.current);
+    return () => window.clearInterval(loadDeploymentsTask.current);
   }, [
     onDisconnect,
     settings.openshift,

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxContextProvider.tsx
@@ -25,6 +25,7 @@ import { OpenShiftInstanceStatus } from "../../openshift/OpenShiftInstanceStatus
 import { useSettings, useSettingsDispatch } from "../../settings/SettingsContext";
 import { isConfigValid } from "../../openshift/OpenShiftSettingsConfig";
 import { useWorkspaces, WorkspaceFile } from "../../workspace/WorkspacesContext";
+import { NEW_WORKSPACE_DEFAULT_NAME } from "../../workspace/services/WorkspaceDescriptorService";
 
 interface Props {
   children: React.ReactNode;
@@ -75,10 +76,15 @@ export function DmnDevSandboxContextProvider(props: Props) {
         onlyExtensions: ["dmn"],
       });
 
+      const descriptorService = await workspaces.descriptorService.get(workspaceFile.workspaceId);
+
+      const workspaceName =
+        descriptorService.name !== NEW_WORKSPACE_DEFAULT_NAME ? descriptorService.name : workspaceFile.name;
+
       try {
         await settingsDispatch.openshift.service.deploy({
           targetFilePath: workspaceFile.relativePath,
-          workspaceId: workspaceFile.workspaceId,
+          workspaceName,
           workspaceZipBlob: zipBlob,
           config: settings.openshift.config,
           onlineEditorUrl: (baseUrl) =>

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
@@ -25,7 +25,6 @@ import { basename } from "path";
 import { useCallback, useMemo } from "react";
 import { useOnlineI18n } from "../../i18n";
 import { OpenShiftDeployedModel, OpenShiftDeployedModelState } from "../../openshift/OpenShiftDeployedModel";
-import { useWorkspacePromise } from "../../workspace/hooks/WorkspaceHooks";
 
 interface Props {
   id: number;
@@ -34,25 +33,25 @@ interface Props {
 
 export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
   const { i18n } = useOnlineI18n();
-  const workspacePromise = useWorkspacePromise(props.deployment.workspaceId);
 
   const deploymentName = useMemo(() => {
-    const maxSize = 25;
-    const isSingleFileWorkspace = workspacePromise.data?.files && workspacePromise.data?.files?.length === 1;
-    if (!workspacePromise.data || isSingleFileWorkspace) {
+    const maxSize = 30;
+
+    let name = props.deployment.workspaceName;
+    let extension = "";
+
+    if (!name) {
       const originalFilename = basename(props.deployment.uri);
-      const extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
-      const name = originalFilename.replace(`.${extension}`, "");
-
-      if (name.length < maxSize) {
-        return originalFilename;
-      }
-
-      return `${name.substring(0, maxSize)}... .${extension}`;
+      extension = ` ${originalFilename.substring(originalFilename.lastIndexOf("."))}`;
+      name = originalFilename.replace(extension, "");
     }
 
-    return workspacePromise.data.descriptor.name.substring(0, maxSize);
-  }, [workspacePromise.data, props.deployment.uri]);
+    if (name.length < maxSize) {
+      return name;
+    }
+
+    return `${name.substring(0, maxSize)}...${extension}`;
+  }, [props.deployment.uri, props.deployment.workspaceName]);
 
   const stateIcon = useMemo(() => {
     if (props.deployment.state === OpenShiftDeployedModelState.UP) {

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDeploymentDropdownItem.tsx
@@ -38,8 +38,8 @@ export function DmnDevSandboxDeploymentDropdownItem(props: Props) {
 
   const deploymentName = useMemo(() => {
     const maxSize = 25;
-    const isMultifileWorkspace = workspacePromise.data?.files && workspacePromise.data?.files?.length > 1;
-    if (!workspacePromise.data || !isMultifileWorkspace) {
+    const isSingleFileWorkspace = workspacePromise.data?.files && workspacePromise.data?.files?.length === 1;
+    if (!workspacePromise.data || isSingleFileWorkspace) {
       const originalFilename = basename(props.deployment.uri);
       const extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
       const name = originalFilename.replace(`.${extension}`, "");

--- a/packages/online-editor/src/editor/DmnDevSandbox/OpenshiftDeploymentsDropdown.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/OpenshiftDeploymentsDropdown.tsx
@@ -56,7 +56,6 @@ export function OpenshiftDeploymentsDropdown() {
       ? [
           <DropdownSeparator key={"dropdown-dmn-dev-sandbox-separator-deployments-1"} />,
           <DropdownItem
-            style={{ minWidth: "400px" }}
             key={"dropdown-dmn-dev-sandbox-setup-as"}
             component={"button"}
             onClick={openOpenShiftSettings}
@@ -113,7 +112,7 @@ export function OpenshiftDeploymentsDropdown() {
         className="kogito--editor__light-tooltip"
         content={<div>{`You're not connected to any OpenShift instance.`}</div>}
         trigger={!isDmnDevSandboxConnected ? "mouseenter" : ""}
-        position="left"
+        position="auto"
       >
         <Dropdown
           position={"right"}
@@ -128,6 +127,7 @@ export function OpenshiftDeploymentsDropdown() {
           }
           isOpen={dmnDevSandbox.isDeploymentsDropdownOpen}
           isPlain={true}
+          className="kogito--editor__responsive-dropdown"
           dropdownItems={[
             <DropdownGroup key={"openshift-deployments-group"} label={"OpenShift deployments"}>
               {items}

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -20,7 +20,6 @@ import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
-// import { Panel, PanelMain, PanelMainBody, PanelHeader, PanelFooter } from '@patternfly/react-core/dist/js/components/Panel';
 import { SupportedFileExtensions, useEditorEnvelopeLocator } from "../envelopeLocator/EditorEnvelopeLocatorContext";
 import { useHistory } from "react-router";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
@@ -35,7 +34,7 @@ import {
 } from "@patternfly/react-core/dist/js/components/Card";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Stack, StackItem } from "@patternfly/react-core/dist/js/layouts/Stack";
-import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
+import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
 import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { useWorkspaces, WorkspaceFile } from "../workspace/WorkspacesContext";
@@ -134,9 +133,9 @@ export function HomePage() {
 
   return (
     <OnlineEditorPage>
-      <PageSection>
-        <Split isWrappable={true} hasGutter={true}>
-          <SplitItem isFilled={true}>
+      <PageSection isFilled={true}>
+        <Grid hasGutter>
+          <GridItem sm={12} xl={6}>
             <PageSection variant={"light"} isFilled={true} style={{ height: "100%" }}>
               <TextContent>
                 <Text component={TextVariants.h1}>Create</Text>
@@ -166,8 +165,8 @@ export function HomePage() {
                 />
               </Gallery>
             </PageSection>
-          </SplitItem>
-          <SplitItem isFilled={true}>
+          </GridItem>
+          <GridItem sm={12} xl={6}>
             <PageSection variant={"light"} isFilled={true} style={{ height: "100%" }}>
               <TextContent>
                 <Text component={TextVariants.h1}>Import</Text>
@@ -184,10 +183,10 @@ export function HomePage() {
                 <UploadCard expandWorkspace={expandWorkspace} />
               </Gallery>
             </PageSection>
-          </SplitItem>
-        </Split>
+          </GridItem>
+        </Grid>
       </PageSection>
-      <PageSection isFilled={true} variant={"light"} hasOverflowScroll={true} style={{ paddingBottom: 0 }}>
+      <PageSection isFilled={true} variant={"light"} hasOverflowScroll={false}>
         <PromiseStateWrapper
           promise={workspaceDescriptorsPromise}
           rejected={(e) => <>Error fetching workspaces: {e + ""}</>}
@@ -354,12 +353,12 @@ export function WorkspaceCard(props: { workspaceId: string; isSelected: boolean;
                     extension: editableFiles[0].extension,
                   })}
                 >
-                  <CardHeaderMain>
+                  <CardHeaderMain style={{ width: "100%" }}>
                     <Flex>
                       <FlexItem>
                         <CardTitle>
                           <TextContent>
-                            <Text component={TextVariants.h3}>
+                            <Text component={TextVariants.h3} style={{ textOverflow: "ellipsis", overflow: "hidden" }}>
                               <TaskIcon />
                               &nbsp;&nbsp;
                               {editableFiles[0].nameWithoutExtension}
@@ -418,12 +417,12 @@ export function WorkspaceCard(props: { workspaceId: string; isSelected: boolean;
               onClick={props.onSelect}
             >
               <CardHeader>
-                <CardHeaderMain>
+                <CardHeaderMain style={{ width: "100%" }}>
                   <Flex>
                     <FlexItem>
                       <CardTitle>
                         <TextContent>
-                          <Text component={TextVariants.h3}>
+                          <Text component={TextVariants.h3} style={{ textOverflow: "ellipsis", overflow: "hidden" }}>
                             <FolderIcon />
                             &nbsp;&nbsp;
                             {workspaceName}
@@ -486,9 +485,9 @@ export function NewModelCard(props: { title: string; extension: SupportedFileExt
         </TextContent>
       </CardBody>
       <CardFooter>
-        <Flex>
+        <Grid>
           <Link to={{ pathname: routes.newModel.path({ extension: props.extension }) }}>
-            <Button isLarge={true} variant={ButtonVariant.secondary} ouiaId={`new-${props.extension}-button`}>
+            <Button variant={ButtonVariant.secondary} ouiaId={`new-${props.extension}-button`}>
               New {props.title}
             </Button>
           </Link>
@@ -510,7 +509,7 @@ export function NewModelCard(props: { title: string; extension: SupportedFileExt
               Try sample
             </Button>
           </Link>
-        </Flex>
+        </Grid>
       </CardFooter>
     </Card>
   );

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -20,6 +20,7 @@ import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
+// import { Panel, PanelMain, PanelMainBody, PanelHeader, PanelFooter } from '@patternfly/react-core/dist/js/components/Panel';
 import { SupportedFileExtensions, useEditorEnvelopeLocator } from "../envelopeLocator/EditorEnvelopeLocatorContext";
 import { useHistory } from "react-router";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -133,7 +133,7 @@ export function HomePage() {
 
   return (
     <OnlineEditorPage>
-      <PageSection isFilled={true}>
+      <PageSection isFilled={false}>
         <Grid hasGutter>
           <GridItem sm={12} xl={6}>
             <PageSection variant={"light"} isFilled={true} style={{ height: "100%" }}>

--- a/packages/online-editor/src/openshift/OpenShiftDeployedModel.tsx
+++ b/packages/online-editor/src/openshift/OpenShiftDeployedModel.tsx
@@ -28,5 +28,5 @@ export interface OpenShiftDeployedModel {
   baseUrl: string;
   creationTimestamp: Date;
   state: OpenShiftDeployedModelState;
-  workspaceId: string;
+  workspaceName: string;
 }

--- a/packages/online-editor/src/openshift/OpenShiftDeployedModel.tsx
+++ b/packages/online-editor/src/openshift/OpenShiftDeployedModel.tsx
@@ -28,4 +28,5 @@ export interface OpenShiftDeployedModel {
   baseUrl: string;
   creationTimestamp: Date;
   state: OpenShiftDeployedModelState;
+  workspaceId: string;
 }

--- a/packages/online-editor/src/openshift/OpenShiftService.tsx
+++ b/packages/online-editor/src/openshift/OpenShiftService.tsx
@@ -24,7 +24,7 @@ import {
   ListDeployments,
 } from "./resources/Deployment";
 import { GetProject } from "./resources/Project";
-import { KOGITO_CREATED_BY, KOGITO_URI, KOGITO_WORKSPACE_ID, Resource, ResourceFetch } from "./resources/Resource";
+import { KOGITO_CREATED_BY, KOGITO_URI, KOGITO_WORKSPACE_NAME, Resource, ResourceFetch } from "./resources/Resource";
 import { CreateRoute, DeleteRoute, ListRoutes, Route, Routes } from "./resources/Route";
 import { CreateService, DeleteService } from "./resources/Service";
 import { isConfigValid, OpenShiftSettingsConfig } from "./OpenShiftSettingsConfig";
@@ -98,14 +98,14 @@ export class OpenShiftService {
           baseUrl: baseUrl,
           creationTimestamp: new Date(deployment.metadata.creationTimestamp),
           state: this.extractDeploymentStateWithUploadStatus(deployment, uploadStatus),
-          workspaceId: deployment.metadata.labels[KOGITO_WORKSPACE_ID],
+          workspaceName: deployment.metadata.annotations[KOGITO_WORKSPACE_NAME],
         };
       });
   }
 
   public async deploy(args: {
     targetFilePath: string;
-    workspaceId: string;
+    workspaceName: string;
     workspaceZipBlob: Blob;
     config: OpenShiftSettingsConfig;
     onlineEditorUrl: (baseUrl: string) => string;
@@ -129,7 +129,7 @@ export class OpenShiftService {
         uri: args.targetFilePath,
         createdBy: DEFAULT_CREATED_BY,
         baseUrl: baseUrl,
-        workspaceId: args.workspaceId,
+        workspaceName: args.workspaceName,
       }),
       rollbacks
     );

--- a/packages/online-editor/src/openshift/OpenShiftService.tsx
+++ b/packages/online-editor/src/openshift/OpenShiftService.tsx
@@ -24,7 +24,7 @@ import {
   ListDeployments,
 } from "./resources/Deployment";
 import { GetProject } from "./resources/Project";
-import { KOGITO_CREATED_BY, KOGITO_URI, Resource, ResourceFetch } from "./resources/Resource";
+import { KOGITO_CREATED_BY, KOGITO_URI, KOGITO_WORKSPACE_ID, Resource, ResourceFetch } from "./resources/Resource";
 import { CreateRoute, DeleteRoute, ListRoutes, Route, Routes } from "./resources/Route";
 import { CreateService, DeleteService } from "./resources/Service";
 import { isConfigValid, OpenShiftSettingsConfig } from "./OpenShiftSettingsConfig";
@@ -98,12 +98,14 @@ export class OpenShiftService {
           baseUrl: baseUrl,
           creationTimestamp: new Date(deployment.metadata.creationTimestamp),
           state: this.extractDeploymentStateWithUploadStatus(deployment, uploadStatus),
+          workspaceId: deployment.metadata.labels[KOGITO_WORKSPACE_ID],
         };
       });
   }
 
   public async deploy(args: {
     targetFilePath: string;
+    workspaceId: string;
     workspaceZipBlob: Blob;
     config: OpenShiftSettingsConfig;
     onlineEditorUrl: (baseUrl: string) => string;
@@ -127,6 +129,7 @@ export class OpenShiftService {
         uri: args.targetFilePath,
         createdBy: DEFAULT_CREATED_BY,
         baseUrl: baseUrl,
+        workspaceId: args.workspaceId,
       }),
       rollbacks
     );

--- a/packages/online-editor/src/openshift/resources/Deployment.tsx
+++ b/packages/online-editor/src/openshift/resources/Deployment.tsx
@@ -19,7 +19,7 @@ import {
   JAVA_RUNTIME_VERSION,
   KOGITO_CREATED_BY,
   KOGITO_URI,
-  KOGITO_WORKSPACE_ID,
+  KOGITO_WORKSPACE_NAME,
   Resource,
   ResourceArgs,
   ResourceFetch,
@@ -48,7 +48,7 @@ export interface CreateDeploymentArgs {
   uri: string;
   createdBy: string;
   baseUrl: string;
-  workspaceId: string;
+  workspaceName: string;
 }
 
 export class CreateDeployment extends ResourceFetch {
@@ -67,6 +67,7 @@ export class CreateDeployment extends ResourceFetch {
       metadata:
         annotations:
           ${KOGITO_URI}: ${this.args.uri}
+          ${KOGITO_WORKSPACE_NAME}: ${this.args.workspaceName}
         name: ${this.args.resourceName}
         namespace: ${this.args.namespace}
         labels:
@@ -78,7 +79,6 @@ export class CreateDeployment extends ResourceFetch {
           app.openshift.io/runtime: quarkus
           app.openshift.io/runtime-version: ${JAVA_RUNTIME_VERSION}
           ${KOGITO_CREATED_BY}: ${this.args.createdBy}
-          ${KOGITO_WORKSPACE_ID}: ${this.args.workspaceId}
       spec:
         replicas: 1
         selector:

--- a/packages/online-editor/src/openshift/resources/Deployment.tsx
+++ b/packages/online-editor/src/openshift/resources/Deployment.tsx
@@ -19,6 +19,7 @@ import {
   JAVA_RUNTIME_VERSION,
   KOGITO_CREATED_BY,
   KOGITO_URI,
+  KOGITO_WORKSPACE_ID,
   Resource,
   ResourceArgs,
   ResourceFetch,
@@ -47,6 +48,7 @@ export interface CreateDeploymentArgs {
   uri: string;
   createdBy: string;
   baseUrl: string;
+  workspaceId: string;
 }
 
 export class CreateDeployment extends ResourceFetch {
@@ -76,6 +78,7 @@ export class CreateDeployment extends ResourceFetch {
           app.openshift.io/runtime: quarkus
           app.openshift.io/runtime-version: ${JAVA_RUNTIME_VERSION}
           ${KOGITO_CREATED_BY}: ${this.args.createdBy}
+          ${KOGITO_WORKSPACE_ID}: ${this.args.workspaceId}
       spec:
         replicas: 1
         selector:

--- a/packages/online-editor/src/openshift/resources/Resource.tsx
+++ b/packages/online-editor/src/openshift/resources/Resource.tsx
@@ -28,12 +28,14 @@ export interface Resource {
     labels: Record<string, string>;
     annotations: Record<string, string>;
     creationTimestamp: string;
+    workspaceId: string;
   };
 }
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 export const KOGITO_CREATED_BY = "kogito.kie.org/created-by";
+export const KOGITO_WORKSPACE_ID = "kogito.kie.org/workspace-id";
 export const KOGITO_URI = "kogito.kie.org/uri";
 export const JAVA_RUNTIME_VERSION = "openjdk-11-el7";
 

--- a/packages/online-editor/src/openshift/resources/Resource.tsx
+++ b/packages/online-editor/src/openshift/resources/Resource.tsx
@@ -35,7 +35,7 @@ export interface Resource {
 export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 export const KOGITO_CREATED_BY = "kogito.kie.org/created-by";
-export const KOGITO_WORKSPACE_ID = "kogito.kie.org/workspace-id";
+export const KOGITO_WORKSPACE_NAME = "kogito.kie.org/workspace-name";
 export const KOGITO_URI = "kogito.kie.org/uri";
 export const JAVA_RUNTIME_VERSION = "openjdk-11-el7";
 

--- a/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
+++ b/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
@@ -17,6 +17,7 @@
 import { Page, PageHeaderToolsItem } from "@patternfly/react-core/dist/js/components/Page";
 import { Brand } from "@patternfly/react-core/dist/js/components/Brand";
 import * as React from "react";
+import { useState } from "react";
 import { useRoutes } from "../navigation/Hooks";
 import { useHistory } from "react-router";
 import { Masthead, MastheadBrand, MastheadMain } from "@patternfly/react-core/dist/js/components/Masthead";
@@ -33,8 +34,8 @@ export function OnlineEditorPage(props: { children?: React.ReactNode }) {
   return (
     <Page
       header={
-        <Masthead aria-label={"Page header"}>
-          <MastheadMain>
+        <Masthead aria-label={"Page header"} display={{ default: "stack" }}>
+          <MastheadMain style={{ justifyContent: "space-between" }}>
             <PageHeaderToolsItem className={"pf-l-flex"}>
               <MastheadBrand
                 onClick={() => history.push({ pathname: routes.home.path({}) })}
@@ -56,24 +57,24 @@ export function OnlineEditorPage(props: { children?: React.ReactNode }) {
                 </Flex>
               </MastheadBrand>
             </PageHeaderToolsItem>
+            <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
+              <FlexItem>
+                <PageHeaderToolsItem>
+                  <OpenshiftDeploymentsDropdown />
+                </PageHeaderToolsItem>
+              </FlexItem>
+              <FlexItem>
+                <PageHeaderToolsItem>
+                  <SettingsButton />
+                </PageHeaderToolsItem>
+              </FlexItem>
+              <FlexItem>
+                <PageHeaderToolsItem>
+                  <KieToolingExtendedServicesIcon />
+                </PageHeaderToolsItem>
+              </FlexItem>
+            </Flex>
           </MastheadMain>
-          <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
-            <FlexItem>
-              <PageHeaderToolsItem>
-                <OpenshiftDeploymentsDropdown />
-              </PageHeaderToolsItem>
-            </FlexItem>
-            <FlexItem>
-              <PageHeaderToolsItem>
-                <SettingsButton />
-              </PageHeaderToolsItem>
-            </FlexItem>
-            <FlexItem>
-              <PageHeaderToolsItem>
-                <KieToolingExtendedServicesIcon />
-              </PageHeaderToolsItem>
-            </FlexItem>
-          </Flex>
         </Masthead>
       }
     >

--- a/packages/online-editor/src/settings/OpenShiftSettingsTabWizardConfig.tsx
+++ b/packages/online-editor/src/settings/OpenShiftSettingsTabWizardConfig.tsx
@@ -177,7 +177,7 @@ export function OpenShiftSettingsTabWizardConfig(props: {
                 </TextContent>
               </ListItem>
             </List>
-            <Form isHorizontal={true} className="pf-u-mt-md">
+            <Form isHorizontal={true} className="pf-u-mt-md" onSubmit={(e) => e.preventDefault()}>
               <FormGroup
                 fieldId={"dmn-dev-sandbox-config-namespace"}
                 label={i18n.terms.namespace}

--- a/packages/online-editor/src/workspace/hooks/WorkspaceHooks.tsx
+++ b/packages/online-editor/src/workspace/hooks/WorkspaceHooks.tsx
@@ -96,25 +96,30 @@ export function useWorkspacePromise(workspaceId: string | undefined) {
         return;
       }
 
-      const descriptor = await workspaces.descriptorService.get(workspaceId);
-      if (canceled.get()) {
-        return;
-      }
+      try {
+        const descriptor = await workspaces.descriptorService.get(workspaceId);
+        if (canceled.get()) {
+          return;
+        }
 
-      if (!descriptor) {
+        if (!descriptor) {
+          setWorkspacePromise({ error: `Can't find Workspace with id '${workspaceId}'` });
+          return;
+        }
+
+        const files = await workspaces.getFiles({
+          fs: await workspaces.fsService.getWorkspaceFs(workspaceId),
+          workspaceId,
+        });
+        if (canceled.get()) {
+          return;
+        }
+
+        setWorkspacePromise({ data: { descriptor, files } });
+      } catch (error) {
         setWorkspacePromise({ error: `Can't find Workspace with id '${workspaceId}'` });
         return;
       }
-
-      const files = await workspaces.getFiles({
-        fs: await workspaces.fsService.getWorkspaceFs(workspaceId),
-        workspaceId,
-      });
-      if (canceled.get()) {
-        return;
-      }
-
-      setWorkspacePromise({ data: { descriptor, files } });
     },
     [setWorkspacePromise, workspaceId, workspaces]
   );

--- a/packages/online-editor/src/workspace/services/WorkspaceDescriptorService.tsx
+++ b/packages/online-editor/src/workspace/services/WorkspaceDescriptorService.tsx
@@ -26,7 +26,7 @@ import { GIST_DEFAULT_BRANCH, GIT_DEFAULT_BRANCH } from "./GitService";
 import { jsonParseWithUrl } from "../../json/JsonParse";
 
 const WORKSPACE_DESCRIPTORS_FS_NAME = "workspaces";
-const NEW_WORKSPACE_DEFAULT_NAME = `Untitled Folder`;
+export const NEW_WORKSPACE_DEFAULT_NAME = `Untitled Folder`;
 
 export class WorkspaceDescriptorService {
   constructor(

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -631,3 +631,9 @@ section.kogito-tooling--settings-tab {
 .kogito-tooling--problems-tab-content {
   overflow: auto;
 }
+
+@media screen and (min-width: 576px) {
+  .kogito--editor__responsive-dropdown .pf-c-dropdown__menu {
+    min-width: 400px;
+  }
+}


### PR DESCRIPTION
# JIRA Issues
- https://issues.redhat.com/browse/KOGITO-6366
- https://issues.redhat.com/browse/KOGITO-6367
- https://issues.redhat.com/browse/KOGITO-6368
- https://issues.redhat.com/browse/KOGITO-6369
- https://issues.redhat.com/browse/KOGITO-6370
- https://issues.redhat.com/browse/KOGITO-6371

# On this PR
- [KIE Sandbox] Pressing enter when configuring OpenShift no longer refreshes the page
- [KIE Sandbox] Stop OpenShift deployments polling when the dropdown is closed
- [KIE Sandbox] Use workspace name for OpenShift deployments whenever the workspace has multiple files
- [Chrome Extension] Remove the "Open in KIE Sandbox" button when no `open` function is available
- [KIE Sandbox] Improve OpenShift deployments dropdown for mobile
- [KIE Sandbox] Fix scrolling the Workspaces list on the home page

## Home responsiveness

https://user-images.githubusercontent.com/10515135/145893710-729db121-4e70-4cee-9b55-4397e04bfd43.mp4

## Workspace deployment + deployments dropdown responsiveness
|Desktop|Mobile|
|-----------|---------|
|![Screenshot from 2021-12-13 13-51-59](https://user-images.githubusercontent.com/10515135/145893865-829c80dd-640e-4661-bd6f-e5e83a70829c.png)|![Screenshot from 2021-12-13 13-52-22](https://user-images.githubusercontent.com/10515135/145893867-9ad20279-5459-4a76-aca9-93fb704c4c45.png)|

