### PR TITLE
Backport boxed-expression-component cypress test command config

### DIFF
--- a/packages/boxed-expression-component/package.json
+++ b/packages/boxed-expression-component/package.json
@@ -15,7 +15,7 @@
     "build:showcase": "rimraf ./dist-dev && webpack -c ./showcase/webpack.config.js --env prod",
     "deploy": "gh-pages -d dist-dev",
     "cy:open": "yarn run cypress open --project it-tests",
-    "cy:run": "yarn run cypress run -b chrome --project it-tests",
+    "cy:run": "yarn run cypress run -b chrome --project it-tests --config watchForFileChanges=false",
     "test:it": "yarn run run-script-if --bool \"$(build-env global.build.testIT)\" --then \"yarn rimraf ./dist-it-tests\" \"yarn run start-server-and-test start http-get://0.0.0.0:$(build-env boxedExpressionComponent.dev.port) cy:run\""
   },
   "dependencies": {


### PR DESCRIPTION
This changes were introduced as part of [1], due to CI issues mentioned in [2]. As now the monorepo migration is done, we could probably backport this change into kogito-tooling.

[1]
https://github.com/kiegroup/kogito-editors-java/pull/174

[2]
https://github.com/kiegroup/kogito-editors-java/pull/174/commits/184330ee420064591b4dda9e3fb52f8c254129f2