### PR TITLE
DROOLS-1963: Replace errai.dom wrappers with elemental2

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImpl.java
@@ -28,9 +28,9 @@ import javax.inject.Named;
 import com.google.gwt.event.dom.client.ClickEvent;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;
-import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -85,8 +85,8 @@ public class NameAndUrlPopoverViewImpl extends AbstractPopoverViewImpl implement
     }
 
     @Inject
-    public NameAndUrlPopoverViewImpl(final Div popoverElement,
-                                     final Div popoverContentElement,
+    public NameAndUrlPopoverViewImpl(final HTMLDivElement popoverElement,
+                                     final HTMLDivElement popoverContentElement,
                                      final JQueryProducer.JQuery<Popover> jQueryPopover,
                                      final TranslationService translationService,
                                      final HTMLButtonElement cancelButton,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImpl.java
@@ -22,7 +22,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.Scheduler;
-import org.jboss.errai.common.client.dom.Div;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.Span;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
@@ -64,8 +64,8 @@ public class HitPolicyPopoverViewImpl extends AbstractPopoverViewImpl implements
     public HitPolicyPopoverViewImpl(final Select lstHitPolicies,
                                     final Select lstBuiltinAggregator,
                                     final BuiltinAggregatorUtils builtinAggregatorUtils,
-                                    final Div popoverElement,
-                                    final Div popoverContentElement,
+                                    final HTMLDivElement popoverElement,
+                                    final HTMLDivElement popoverContentElement,
                                     final Span hitPolicyLabel,
                                     final Span builtinAggregatorLabel,
                                     final JQueryProducer.JQuery<Popover> jQueryPopover,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImpl.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.api.IsElement;
-import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.UnorderedList;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
@@ -51,8 +51,8 @@ public class KindPopoverViewImpl extends AbstractPopoverViewImpl implements Kind
     @Inject
     public KindPopoverViewImpl(final UnorderedList definitionsContainer,
                                final ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews,
-                               final Div popoverElement,
-                               final Div popoverContentElement,
+                               final HTMLDivElement popoverElement,
+                               final HTMLDivElement popoverContentElement,
                                final JQueryProducer.JQuery<Popover> jQueryPopover) {
         super(popoverElement,
               popoverContentElement,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImpl.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.Event;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -59,8 +60,8 @@ public class ParametersPopoverViewImpl extends AbstractPopoverViewImpl implement
     public ParametersPopoverViewImpl(final Div parametersContainer,
                                      final Div addParameter,
                                      final ManagedInstance<ParameterView> parameterViews,
-                                     final Div popoverElement,
-                                     final Div popoverContentElement,
+                                     final HTMLDivElement popoverElement,
+                                     final HTMLDivElement popoverContentElement,
                                      final JQueryProducer.JQuery<Popover> jQueryPopover) {
         super(popoverElement,
               popoverContentElement,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImpl.java
@@ -21,8 +21,8 @@ import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.api.IsElement;
-import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.UnorderedList;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
@@ -51,8 +51,8 @@ public class UndefinedExpressionSelectorPopoverViewImpl extends AbstractPopoverV
     @Inject
     public UndefinedExpressionSelectorPopoverViewImpl(final UnorderedList definitionsContainer,
                                                       final ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews,
-                                                      final Div popoverElement,
-                                                      final Div popoverContentElement,
+                                                      final HTMLDivElement popoverElement,
+                                                      final HTMLDivElement popoverContentElement,
                                                       final JQueryProducer.JQuery<Popover> jQueryPopover) {
         super(popoverElement,
               popoverContentElement,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverViewImpl.java
@@ -27,15 +27,16 @@ import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.EventListener;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.KeyboardEvent;
 import org.gwtbootstrap3.client.ui.DropDown;
 import org.gwtbootstrap3.extras.select.client.ui.Select;
-import org.jboss.errai.common.client.dom.Button;
-import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.Element;
-import org.jboss.errai.common.client.dom.EventListener;
 import org.jboss.errai.common.client.dom.Input;
 import org.jboss.errai.common.client.dom.Span;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -166,8 +167,8 @@ public class ValueAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl imp
     @Inject
     public ValueAndDataTypePopoverViewImpl(final Input valueEditor,
                                            final DataTypePickerWidget typeRefEditor,
-                                           final Div popoverElement,
-                                           final Div popoverContentElement,
+                                           final HTMLDivElement popoverElement,
+                                           final HTMLDivElement popoverContentElement,
                                            final Span valueLabel,
                                            final Span dataTypeLabel,
                                            final JQueryProducer.JQuery<Popover> jQueryPopover,
@@ -212,15 +213,13 @@ public class ValueAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl imp
     protected void setKeyDownListeners() {
         super.setKeyDownListeners();
 
-        final Element manageButton = getManageButton();
+        final HTMLElement manageButton = getManageButton();
         manageButton.addEventListener(BrowserEvents.KEYDOWN,
-                                      getManageButtonKeyDownEventListener(),
-                                      false);
+                                      getManageButtonKeyDownEventListener());
 
-        final Element typeSelectorButton = getTypeSelectorButton();
+        final HTMLElement typeSelectorButton = getTypeSelectorButton();
         typeSelectorButton.addEventListener(BrowserEvents.KEYDOWN,
-                                            getTypeSelectorKeyDownEventListener(),
-                                            false);
+                                            getTypeSelectorKeyDownEventListener());
     }
 
     @Override
@@ -237,12 +236,12 @@ public class ValueAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl imp
         return (e) -> manageButtonKeyDownEventListener(e);
     }
 
-    Button getTypeSelectorButton() {
-        return (Button) getElement().querySelector(TYPE_SELECTOR_BUTTON_SELECTOR);
+    HTMLButtonElement getTypeSelectorButton() {
+        return (HTMLButtonElement) new Elemental2DomUtil().asHTMLElement((HTMLElement) getElement().querySelector(TYPE_SELECTOR_BUTTON_SELECTOR));
     }
 
-    Button getManageButton() {
-        return (Button) getElement().querySelector(MANAGE_BUTTON_SELECTOR);
+    HTMLButtonElement getManageButton() {
+        return (HTMLButtonElement) new Elemental2DomUtil().asHTMLElement((HTMLElement) getElement().querySelector(MANAGE_BUTTON_SELECTOR));
     }
 
     void typeSelectorKeyDownEventListener(final Object event) {
@@ -258,7 +257,7 @@ public class ValueAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl imp
                 onClosedByKeyboard();
             } else if (isTabKeyPressed(keyEvent)) {
                 if (keyEvent.shiftKey) {
-                    final Button manageButton = getManageButton();
+                    final HTMLButtonElement manageButton = getManageButton();
                     manageButton.focus();
                 } else {
                     valueEditor.focus();
@@ -372,7 +371,7 @@ public class ValueAndDataTypePopoverViewImpl extends AbstractPopoverViewImpl imp
             hide(false);
             onClosedByKeyboard();
         } else if (event.isShiftKeyDown() && isTab(event)) {
-            final Button typeSelectorButton = getTypeSelectorButton();
+            final HTMLButtonElement typeSelectorButton = getTypeSelectorButton();
             typeSelectorButton.focus();
             event.preventDefault();
         }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/popover/AbstractPopoverViewImpl.java
@@ -21,9 +21,9 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.google.gwt.dom.client.BrowserEvents;
+import elemental2.dom.EventListener;
+import elemental2.dom.HTMLDivElement;
 import elemental2.dom.KeyboardEvent;
-import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.EventListener;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.kie.workbench.common.dmn.client.editors.types.CanBeClosedByKeyboard;
 import org.uberfire.client.views.pfly.widgets.JQueryProducer;
@@ -41,10 +41,10 @@ public abstract class AbstractPopoverViewImpl implements PopoverView {
     static final String PLACEMENT = "auto top";
 
     @DataField("popover")
-    protected Div popoverElement;
+    protected HTMLDivElement popoverElement;
 
     @DataField("popover-content")
-    protected Div popoverContentElement;
+    protected HTMLDivElement popoverContentElement;
 
     protected JQueryProducer.JQuery<Popover> jQueryPopover;
 
@@ -60,8 +60,8 @@ public abstract class AbstractPopoverViewImpl implements PopoverView {
         //CDI proxy
     }
 
-    public AbstractPopoverViewImpl(final Div popoverElement,
-                                   final Div popoverContentElement,
+    public AbstractPopoverViewImpl(final HTMLDivElement popoverElement,
+                                   final HTMLDivElement popoverContentElement,
                                    final JQueryProducer.JQuery<Popover> jQueryPopover) {
         this.popoverElement = popoverElement;
         this.popoverContentElement = popoverContentElement;
@@ -109,7 +109,7 @@ public abstract class AbstractPopoverViewImpl implements PopoverView {
     }
 
     protected void onShownFocus() {
-        popoverContentElement.getStyle().setProperty("outline", "none");
+        popoverContentElement.style.setProperty("outline", "none");
         popoverContentElement.focus();
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/documentation/links/NameAndUrlPopoverViewImplTest.java
@@ -21,9 +21,9 @@ import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLInputElement;
-import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,10 +50,10 @@ import static org.mockito.Mockito.when;
 public class NameAndUrlPopoverViewImplTest {
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private JQueryProducer.JQuery<Popover> jQueryPopover;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/hitpolicy/HitPolicyPopoverViewImplTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.jboss.errai.common.client.dom.Div;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Span;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -63,10 +63,10 @@ public class HitPolicyPopoverViewImplTest {
     private HTMLElement element;
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private Span hitPolicyLabel;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/kindselector/KindPopoverViewImplTest.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.dmn.client.editors.expressions.types.function.kindselector;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.jboss.errai.common.client.dom.Div;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.UnorderedList;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -49,10 +49,10 @@ public class KindPopoverViewImplTest {
     private ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews;
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private JQueryProducer.JQuery<Popover> jQueryPopover;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/function/parameters/ParametersPopoverViewImplTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import com.google.gwt.user.client.Event;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -83,10 +84,10 @@ public class ParametersPopoverViewImplTest {
     private HTMLElement element;
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private JQueryProducer.JQuery<Popover> jQueryProducer;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/undefined/selector/UndefinedExpressionSelectorPopoverViewImplTest.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.dmn.client.editors.expressions.types.undefined.
 import java.util.Arrays;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.jboss.errai.common.client.dom.Div;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.UnorderedList;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -52,10 +52,10 @@ public class UndefinedExpressionSelectorPopoverViewImplTest {
     private ManagedInstance<ListSelectorTextItemView> listSelectorTextItemViews;
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private JQueryProducer.JQuery<Popover> jQueryPopover;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/ValueAndDataTypePopoverViewImplTest.java
@@ -26,13 +26,14 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.Event;
+import elemental2.dom.EventListener;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
 import elemental2.dom.KeyboardEvent;
-import org.jboss.errai.common.client.dom.Button;
-import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.EventListener;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.dom.Input;
 import org.jboss.errai.common.client.dom.Span;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,10 +82,10 @@ public class ValueAndDataTypePopoverViewImplTest {
     private DataTypePickerWidget dataTypeEditor;
 
     @Mock
-    private Div popoverElement;
+    private HTMLDivElement popoverElement;
 
     @Mock
-    private Div popoverContentElement;
+    private HTMLDivElement popoverContentElement;
 
     @Mock
     private Span valueLabel;
@@ -120,10 +121,10 @@ public class ValueAndDataTypePopoverViewImplTest {
     private TranslationService translationService;
 
     @Mock
-    private Button manageButton;
+    private HTMLButtonElement manageButton;
 
     @Mock
-    private Button typeSelectorButton;
+    private HTMLButtonElement typeSelectorButton;
 
     @Mock
     private EventListener keyDownCallback;
@@ -170,8 +171,8 @@ public class ValueAndDataTypePopoverViewImplTest {
             }
         });
 
-        when(element.querySelector(MANAGE_BUTTON_SELECTOR)).thenReturn(manageButton);
-        when(element.querySelector(TYPE_SELECTOR_BUTTON_SELECTOR)).thenReturn(typeSelectorButton);
+        when(element.querySelector(MANAGE_BUTTON_SELECTOR)).thenReturn(new Elemental2DomUtil().asHTMLElement(manageButton));
+        when(element.querySelector(TYPE_SELECTOR_BUTTON_SELECTOR)).thenReturn(new Elemental2DomUtil().asHTMLElement(typeSelectorButton));
         when(presenter.getValueLabel()).thenReturn(VALUE_LABEL);
 
         view.init(presenter);


### PR DESCRIPTION
This change is related to small number of classes in:
- `packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/`

the DROOLS-1963 initiative will be re-evaluated once old expression editor is removed.

For more details see:
- https://issues.redhat.com/browse/DROOLS-1963