### PR TITLE
KOGITO-5157: Temporarily hiding the import-java-classes button 

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPage.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPage.java
@@ -114,7 +114,8 @@ public class DataTypesPage extends DMNPage {
         }
         refreshPageView();
 
-        dataTypeList.activate();
+        /* Temporary hide the import-java-classes button, to be restored in KOGITO-6276 */
+        //dataTypeList.activate();
     }
 
     @Override

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPageTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/DataTypesPageTest.java
@@ -146,7 +146,7 @@ public class DataTypesPageTest {
 
         verify(page, never()).reload();
         verify(page).refreshPageView();
-        verify(dataTypeList, times(1)).activate();
+        //verify(dataTypeList, times(1)).activate();
     }
 
     @Test
@@ -158,7 +158,7 @@ public class DataTypesPageTest {
 
         verify(page).reload();
         verify(page).refreshPageView();
-        verify(dataTypeList, times(1)).activate();
+        //verify(dataTypeList, times(1)).activate();
     }
 
     @Test


### PR DESCRIPTION
Extension of https://github.com/kiegroup/kogito-tooling/pull/751

As the current status of the functionality is still in progress and the results from LSP extensions are mocked, I disabled the rendering of the import-java-classes button, to be restored in KOGITO-6276