### PR TITLE
Fix lienzo-webapp SDM server not running

### DIFF
--- a/packages/stunner-editors/lienzo-webapp/pom.xml
+++ b/packages/stunner-editors/lienzo-webapp/pom.xml
@@ -87,32 +87,34 @@
 	</pluginRepositories>
 
 	<dependencies>
-		<!-- Lienzo -->
-		<dependency>
-			<groupId>org.kie.kogito.stunner.editors</groupId>
-			<artifactId>lienzo-core</artifactId>
-		</dependency>
-		<!-- GWT -->
 		<dependency>
 			<groupId>com.google.gwt</groupId>
 			<artifactId>gwt-user</artifactId>
 		</dependency>
-		<!-- JsInterop & Elemental2 -->
+		<dependency>
+			<groupId>org.kie.kogito.stunner.editors</groupId>
+			<artifactId>lienzo-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.google.jsinterop</groupId>
 			<artifactId>base</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-core</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-dom</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-promise</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Test -->
 		<dependency>


### PR DESCRIPTION
Hey @tiagobento 

Just a quick fix for properly running the Jetty server in the `lienzo-webapp` (lienzo showcase), actually SDM doesn't work. It does not affects at all the downtream modules, so completely a safe change, I think no need for anybody else review.

Thanks!  