### PR TITLE
Align checkoutRepo with kogito-runtimes Jenkinsfile

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
 
 void checkoutRepo(String repo, String dirName=repo) {
     dir(dirName) {
-        githubscm.checkoutIfExists(repo, changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
+        checkout(githubscm.resolveRepository('kogito-tooling', changeAuthor, changeBranch, false))
     }
 }
 


### PR DESCRIPTION
Use the same command for repository checkout as we use in:
- https://github.com/kiegroup/kogito-runtimes/blob/main/.ci/jenkins/Jenkinsfile.sonarcloud