### PR TITLE
KOGITO-3664: Create link to "Custom Data Types" page

### DIFF
--- a/packages/boxed-expression-component/showcase/index.tsx
+++ b/packages/boxed-expression-component/showcase/index.tsx
@@ -62,6 +62,7 @@ export const App: React.FunctionComponent = () => {
     broadcastFunctionExpressionDefinition: (definition: FunctionProps) => setExpressionDefinition(definition),
     broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => setExpressionDefinition(definition),
     notifyUserAction(): void {},
+    openManageDataType(): void {},
   };
 
   const copyToClipboard = useCallback(

--- a/packages/boxed-expression-component/showcase/index.tsx
+++ b/packages/boxed-expression-component/showcase/index.tsx
@@ -52,7 +52,7 @@ export const App: React.FunctionComponent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   //Defining global function that will be available in the Window namespace and used by the BoxedExpressionEditor component
-  window.beeApi = {
+  const boxedExpressionEditorGWTService = {
     resetExpressionDefinition: (definition: ExpressionProps) => setExpressionDefinition(definition),
     broadcastLiteralExpressionDefinition: (definition: LiteralExpressionProps) => setExpressionDefinition(definition),
     broadcastRelationExpressionDefinition: (definition: RelationProps) => setExpressionDefinition(definition),
@@ -101,6 +101,7 @@ export const App: React.FunctionComponent = () => {
     <div className="showcase">
       <div className="boxed-expression">
         <BoxedExpressionEditor
+          boxedExpressionEditorGWTService={boxedExpressionEditorGWTService}
           decisionNodeId="_00000000-0000-0000-0000-000000000000"
           expressionDefinition={expressionDefinition}
           dataTypes={dataTypes}

--- a/packages/boxed-expression-component/showcase/index.tsx
+++ b/packages/boxed-expression-component/showcase/index.tsx
@@ -33,7 +33,7 @@ import {
   RelationProps,
 } from "../src";
 import { Button, Modal } from "@patternfly/react-core";
-import { CopyIcon, PenIcon } from "@patternfly/react-icons";
+import { PenIcon } from "@patternfly/react-icons";
 import { dataTypes, pmmlParams } from "../tests/components/test-utils";
 import "../src/components/BoxedExpressionEditor/base-no-reset-wrapped.css";
 import ReactJson from "react-json-view";
@@ -64,11 +64,6 @@ export const App: React.FunctionComponent = () => {
     notifyUserAction(): void {},
     openManageDataType(): void {},
   };
-
-  const copyToClipboard = useCallback(
-    () => navigator.clipboard.writeText(JSON.stringify(expressionDefinition)),
-    [expressionDefinition]
-  );
 
   const onTypedExpressionChange = useCallback((e) => {
     setTypedExpressionDefinition(e.target.value);
@@ -113,13 +108,6 @@ export const App: React.FunctionComponent = () => {
         <div className="buttons">
           <Button
             variant="secondary"
-            icon={<CopyIcon />}
-            iconPosition="left"
-            onClick={copyToClipboard}
-            ouiaId="copy-expression-json"
-          />
-          <Button
-            variant="secondary"
             icon={<PenIcon />}
             iconPosition="left"
             onClick={handleModalToggle}
@@ -128,7 +116,7 @@ export const App: React.FunctionComponent = () => {
         </div>
 
         <pre>
-          <ReactJson src={expressionDefinition} name={false} />
+          <ReactJson src={expressionDefinition} name={false} enableClipboard />
         </pre>
       </div>
 

--- a/packages/boxed-expression-component/src/api/BoxedExpressionEditor.ts
+++ b/packages/boxed-expression-component/src/api/BoxedExpressionEditor.ts
@@ -41,6 +41,7 @@ declare global {
     broadcastFunctionExpressionDefinition: (definition: FunctionProps) => void;
     broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => void;
     notifyUserAction: () => void;
+    openManageDataType: () => void;
   }
 
   //API that BoxedExpressionEditor (bee) and its wrapper are expecting to be defined in the Window namespace

--- a/packages/boxed-expression-component/src/api/BoxedExpressionEditorGWTService.ts
+++ b/packages/boxed-expression-component/src/api/BoxedExpressionEditorGWTService.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ContextProps,
+  DecisionTableProps,
+  ExpressionProps,
+  FunctionProps,
+  InvocationProps,
+  ListProps,
+  LiteralExpressionProps,
+  RelationProps,
+} from "./ExpressionProps";
+
+/**
+ * This interface defines all the API methods which BoxedExpressionEditor component can use to dialog with GWT Layer
+ */
+export interface BoxedExpressionEditorGWTService {
+  resetExpressionDefinition: (definition: ExpressionProps) => void;
+  broadcastLiteralExpressionDefinition: (definition: LiteralExpressionProps) => void;
+  broadcastRelationExpressionDefinition: (definition: RelationProps) => void;
+  broadcastContextExpressionDefinition: (definition: ContextProps) => void;
+  broadcastListExpressionDefinition: (definition: ListProps) => void;
+  broadcastInvocationExpressionDefinition: (definition: InvocationProps) => void;
+  broadcastFunctionExpressionDefinition: (definition: FunctionProps) => void;
+  broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => void;
+  notifyUserAction: () => void;
+  openManageDataType: () => void;
+}

--- a/packages/boxed-expression-component/src/api/index.ts
+++ b/packages/boxed-expression-component/src/api/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./BoxedExpressionEditor";
+export * from "./BoxedExpressionEditorGWTService";
 export * from "./BuiltinAggregation";
 export * from "./ContextEntry";
 export * from "./DataType";

--- a/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -17,7 +17,7 @@
 import { I18nDictionariesProvider } from "@kie-tooling-core/i18n/dist/react-components";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { DataTypeProps, ExpressionProps, PMMLParams } from "../../api";
+import { BoxedExpressionEditorGWTService, DataTypeProps, ExpressionProps, PMMLParams } from "../../api";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -29,6 +29,8 @@ import "@patternfly/react-styles/css/components/Drawer/drawer.css";
 import "./base-no-reset-wrapped.css";
 
 export interface BoxedExpressionEditorProps {
+  /** The API methods which BoxedExpressionEditor component can use to dialog with GWT Layer */
+  boxedExpressionEditorGWTService?: BoxedExpressionEditorGWTService;
   /** Identifier of the decision node, where the expression will be hold */
   decisionNodeId: string;
   /** All expression properties used to define it */
@@ -78,6 +80,7 @@ export function BoxedExpressionEditor(props: BoxedExpressionEditorProps) {
       ctx={BoxedExpressionEditorI18nContext}
     >
       <BoxedExpressionProvider
+        boxedExpressionEditorGWTService={props.boxedExpressionEditorGWTService}
         decisionNodeId={props.decisionNodeId}
         expressionDefinition={expressionDefinition}
         dataTypes={props.dataTypes}

--- a/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
+++ b/packages/boxed-expression-component/src/components/BoxedExpressionEditor/BoxedExpressionProvider.tsx
@@ -42,6 +42,7 @@ export function BoxedExpressionProvider(props: BoxedExpressionProviderProps) {
   return (
     <BoxedExpressionGlobalContext.Provider
       value={{
+        boxedExpressionEditorGWTService: props.boxedExpressionEditorGWTService,
         decisionNodeId: props.decisionNodeId,
         dataTypes: props.dataTypes,
         pmmlParams: props.pmmlParams,

--- a/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
@@ -104,7 +104,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
         ["name", "dataType", "contextEntries", "result", "entryInfoWidth", "entryExpressionWidth"]
       );
     },
-    [contextExpression, setSupervisorHash, rows]
+    [boxedExpressionEditorGWTService, contextExpression, setSupervisorHash, rows]
   );
 
   const setInfoWidth = useCallback(

--- a/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
@@ -44,14 +44,14 @@ import * as _ from "lodash";
 import { ContextEntryExpression } from "./ContextEntryExpression";
 import { getContextEntryInfoCell } from "./ContextEntryInfoCell";
 import { hashfy, Resizer } from "../Resizer";
-import { BoxedExpressionGlobalContext } from "../../context";
+import { useBoxedExpression } from "../../context";
 
 const DEFAULT_CONTEXT_ENTRY_NAME = "ContextEntry-1";
 const DEFAULT_CONTEXT_ENTRY_DATA_TYPE = DataType.Undefined;
 
 export const ContextExpression: React.FunctionComponent<ContextProps> = (contextExpression: ContextProps) => {
   const { i18n } = useBoxedExpressionEditorI18n();
-  const { setSupervisorHash } = React.useContext(BoxedExpressionGlobalContext);
+  const { setSupervisorHash, boxedExpressionEditorGWTService } = useBoxedExpression();
 
   const rows = useMemo(
     () =>
@@ -98,7 +98,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
             contextExpression.onUpdatingRecursiveExpression?.(expression);
           } else {
             setSupervisorHash(hashfy(expression));
-            window.beeApi?.broadcastContextExpressionDefinition?.(updatedDefinition as ContextProps);
+            boxedExpressionEditorGWTService?.broadcastContextExpressionDefinition?.(updatedDefinition as ContextProps);
           }
         },
         ["name", "dataType", "contextEntries", "result", "entryInfoWidth", "entryExpressionWidth"]

--- a/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
@@ -16,7 +16,7 @@
 
 import * as _ from "lodash";
 import * as React from "react";
-import { PropsWithChildren, useCallback, useContext, useMemo, useRef } from "react";
+import { PropsWithChildren, useCallback, useMemo, useRef } from "react";
 import { ColumnInstance, DataRecord } from "react-table";
 import {
   Annotation,
@@ -34,7 +34,7 @@ import {
   TableHeaderVisibility,
   TableOperation,
 } from "../../api";
-import { BoxedExpressionGlobalContext } from "../../context";
+import { useBoxedExpression } from "../../context";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { hashfy } from "../Resizer";
 import { getColumnsAtLastLevel, Table } from "../Table";
@@ -58,7 +58,7 @@ interface SpreadFunction {
 }
 
 export function DecisionTableExpression(decisionTable: PropsWithChildren<DecisionTableProps>) {
-  const globalContext = useContext(BoxedExpressionGlobalContext);
+  const { setSupervisorHash, decisionNodeId, boxedExpressionEditorGWTService } = useBoxedExpression();
 
   const { i18n } = useBoxedExpressionEditorI18n();
 
@@ -97,8 +97,6 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
     ],
     [i18n]
   );
-
-  const { setSupervisorHash } = useContext(BoxedExpressionGlobalContext);
 
   const getHandlerConfiguration = useMemo(() => {
     const configuration: { [columnGroupType: string]: GroupOperations[] } = {};
@@ -168,7 +166,7 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
     };
     const outputSection = {
       groupType: DecisionTableColumnType.OutputClause,
-      accessor: globalContext.decisionNodeId,
+      accessor: decisionNodeId,
       label: decisionTable.name ?? DECISION_NODE_DEFAULT_NAME,
       dataType: decisionTable.dataType ?? DataType.Undefined,
       cssClasses: "decision-table--output",
@@ -186,7 +184,7 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
 
     return [inputSection, outputSection, annotationSection] as ColumnInstance[];
   }, [
-    globalContext.decisionNodeId,
+    decisionNodeId,
     decisionTable.annotations,
     decisionTable.dataType,
     decisionTable.input,
@@ -292,7 +290,9 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
           updatedDefinition,
           () => {
             setSupervisorHash(hashfy(updatedDefinition));
-            window.beeApi?.broadcastDecisionTableExpressionDefinition?.(updatedDefinition as DecisionTableProps);
+            boxedExpressionEditorGWTService?.broadcastDecisionTableExpressionDefinition?.(
+              updatedDefinition as DecisionTableProps
+            );
           },
           ["name", "dataType", "hitPolicy", "aggregation", "input", "output", "annotations", "rules"]
         );

--- a/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/components/DecisionTableExpression/DecisionTableExpression.tsx
@@ -298,7 +298,7 @@ export function DecisionTableExpression(decisionTable: PropsWithChildren<Decisio
         );
       }
     },
-    [columns, decisionTable, rows, setSupervisorHash]
+    [boxedExpressionEditorGWTService, columns, decisionTable, rows, setSupervisorHash]
   );
 
   const singleOutputChildDataType = useRef(DataType.Undefined);

--- a/packages/boxed-expression-component/src/components/DecisionTableExpression/HitPolicySelector.tsx
+++ b/packages/boxed-expression-component/src/components/DecisionTableExpression/HitPolicySelector.tsx
@@ -58,7 +58,7 @@ export const HitPolicySelector: React.FunctionComponent<HitPolicySelectorProps> 
     (event: React.MouseEvent<Element, MouseEvent>, itemId: string) => {
       const updatedHitPolicy = itemId as HitPolicy;
       const hitPolicySupportsAggregation = _.includes(BUILT_IN_AGGREGATION_AVAILABILITY, updatedHitPolicy);
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       onHitPolicySelect(updatedHitPolicy);
       if (hitPolicySupportsAggregation) {
         setBuiltInAggregatorSelectDisabled(false);
@@ -83,7 +83,7 @@ export const HitPolicySelector: React.FunctionComponent<HitPolicySelectorProps> 
 
   const builtInAggregatorSelectionCallback = useCallback(
     (event: React.MouseEvent<Element, MouseEvent>, itemId: string) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       onBuiltInAggregatorSelect(itemId as BuiltinAggregation);
       setBuiltInAggregatorSelectOpen(false);
     },

--- a/packages/boxed-expression-component/src/components/DecisionTableExpression/HitPolicySelector.tsx
+++ b/packages/boxed-expression-component/src/components/DecisionTableExpression/HitPolicySelector.tsx
@@ -68,7 +68,7 @@ export const HitPolicySelector: React.FunctionComponent<HitPolicySelectorProps> 
       }
       setHitPolicySelectOpen(false);
     },
-    [onBuiltInAggregatorSelect, onHitPolicySelect]
+    [boxedExpression.boxedExpressionEditorGWTService, onBuiltInAggregatorSelect, onHitPolicySelect]
   );
 
   const renderHitPolicyItems = useCallback(
@@ -87,7 +87,7 @@ export const HitPolicySelector: React.FunctionComponent<HitPolicySelectorProps> 
       onBuiltInAggregatorSelect(itemId as BuiltinAggregation);
       setBuiltInAggregatorSelectOpen(false);
     },
-    [onBuiltInAggregatorSelect]
+    [boxedExpression.boxedExpressionEditorGWTService, onBuiltInAggregatorSelect]
   );
 
   const renderBuiltInAggregationItems = useCallback(

--- a/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.css
+++ b/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.css
@@ -26,6 +26,11 @@
   padding-top: 10px;
 }
 
+.edit-expression-menu > .expression-data-type .manage-datatype {
+  float: right;
+  padding: 0;
+}
+
 .edit-expression-menu * {
   font-size: var(--small-font-size);
 }

--- a/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -81,7 +81,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
     (event) => {
       setExpressionName(event.target.value);
       if (event.type === "blur") {
-        window.beeApi?.notifyUserAction();
+        boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
         onExpressionUpdate({
           name: event.target.value,
           dataType,
@@ -93,7 +93,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
 
   const onDataTypeChange = useCallback(
     (dataType: DataType) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       setDataType(dataType);
       onExpressionUpdate({
         name: expressionName,
@@ -103,7 +103,10 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
     [expressionName, onExpressionUpdate]
   );
 
-  const openManageDataType = useCallback(() => window.beeApi?.openManageDataType(), []);
+  const openManageDataType = useCallback(
+    () => boxedExpression.boxedExpressionEditorGWTService?.openManageDataType(),
+    []
+  );
 
   return (
     <PopoverMenu

--- a/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -88,7 +88,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
         });
       }
     },
-    [dataType, onExpressionUpdate]
+    [boxedExpression.boxedExpressionEditorGWTService, dataType, onExpressionUpdate]
   );
 
   const onDataTypeChange = useCallback(
@@ -100,12 +100,12 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
         dataType: dataType,
       });
     },
-    [expressionName, onExpressionUpdate]
+    [boxedExpression.boxedExpressionEditorGWTService, expressionName, onExpressionUpdate]
   );
 
   const openManageDataType = useCallback(
     () => boxedExpression.boxedExpressionEditorGWTService?.openManageDataType(),
-    []
+    [boxedExpression.boxedExpressionEditorGWTService]
   );
 
   return (

--- a/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -22,6 +22,8 @@ import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { DataType, ExpressionProps } from "../../api";
 import { useBoxedExpression } from "../../context";
 import { DataTypeSelector } from "./DataTypeSelector";
+import { CogIcon } from "@patternfly/react-icons";
+import { Button } from "@patternfly/react-core";
 
 export interface EditExpressionMenuProps {
   /** Optional children element to be considered for triggering the edit expression menu */
@@ -101,6 +103,8 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
     [expressionName, onExpressionUpdate]
   );
 
+  const openManageDataType = useCallback(() => window.beeApi?.openManageDataType(), []);
+
   return (
     <PopoverMenu
       title={title}
@@ -123,6 +127,15 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
           </div>
           <div className="expression-data-type">
             <label>{dataTypeField}</label>
+            <Button
+              variant="link"
+              className="manage-datatype"
+              icon={<CogIcon />}
+              iconPosition="left"
+              onClick={openManageDataType}
+            >
+              {i18n.manage}
+            </Button>
             <DataTypeSelector selectedDataType={dataType} onDataTypeChange={onDataTypeChange} />
           </div>
         </div>

--- a/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
+++ b/packages/boxed-expression-component/src/components/EditExpressionMenu/EditExpressionMenu.tsx
@@ -131,6 +131,7 @@ export const EditExpressionMenu: React.FunctionComponent<EditExpressionMenuProps
           <div className="expression-data-type">
             <label>{dataTypeField}</label>
             <Button
+              ouiaId="manage-data-type-link"
               variant="link"
               className="manage-datatype"
               icon={<CogIcon />}

--- a/packages/boxed-expression-component/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -19,6 +19,7 @@ import { useCallback, useRef } from "react";
 import "./ExpressionContainer.css";
 import { ExpressionProps, LogicType } from "../../api";
 import { LogicTypeSelector } from "../LogicTypeSelector";
+import { useBoxedExpression } from "../../context";
 
 export interface ExpressionContainerProps {
   /** Expression properties */
@@ -31,6 +32,8 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
   selectedExpression,
   onExpressionChange,
 }: ExpressionContainerProps) => {
+  const { boxedExpressionEditorGWTService } = useBoxedExpression();
+
   const expressionContainerRef = useRef<HTMLDivElement>(null);
 
   const updateExpressionNameAndDataType = useCallback(
@@ -64,7 +67,7 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
       dataType: selectedExpression.dataType,
       logicType: LogicType.Undefined,
     };
-    window.beeApi?.resetExpressionDefinition?.(updatedExpression);
+    boxedExpressionEditorGWTService?.resetExpressionDefinition?.(updatedExpression);
     onExpressionChange?.(updatedExpression);
   }, [onExpressionChange, selectedExpression.dataType, selectedExpression.name, selectedExpression.id]);
 

--- a/packages/boxed-expression-component/src/components/ExpressionContainer/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/components/ExpressionContainer/ExpressionContainer.tsx
@@ -69,7 +69,13 @@ export const ExpressionContainer: (props: ExpressionContainerProps) => JSX.Eleme
     };
     boxedExpressionEditorGWTService?.resetExpressionDefinition?.(updatedExpression);
     onExpressionChange?.(updatedExpression);
-  }, [onExpressionChange, selectedExpression.dataType, selectedExpression.name, selectedExpression.id]);
+  }, [
+    boxedExpressionEditorGWTService,
+    onExpressionChange,
+    selectedExpression.dataType,
+    selectedExpression.name,
+    selectedExpression.id,
+  ]);
 
   return (
     <div className="expression-container">

--- a/packages/boxed-expression-component/src/components/FunctionExpression/EditParameters.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/EditParameters.tsx
@@ -46,7 +46,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
         dataType: DataType.Undefined,
       },
     ]);
-  }, [parameters, setParameters]);
+  }, [boxedExpressionEditorGWTService, parameters, setParameters]);
 
   const onNameChange = useCallback(
     (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
@@ -57,7 +57,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
       parametersCopy[index].name = event.target.value;
       setParameters([...parametersCopy]);
     },
-    [parameters, setParameters]
+    [boxedExpressionEditorGWTService, parameters, setParameters]
   );
 
   const onDataTypeChange = useCallback(
@@ -67,7 +67,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
       parametersCopy[index].dataType = dataType;
       setParameters([...parametersCopy]);
     },
-    [parameters, setParameters]
+    [boxedExpressionEditorGWTService, parameters, setParameters]
   );
 
   const onParameterRemove = useCallback(
@@ -75,7 +75,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
       boxedExpressionEditorGWTService?.notifyUserAction();
       setParameters([...parameters.slice(0, index), ...parameters.slice(index + 1)]);
     },
-    [parameters, setParameters]
+    [boxedExpressionEditorGWTService, parameters, setParameters]
   );
 
   return (

--- a/packages/boxed-expression-component/src/components/FunctionExpression/EditParameters.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/EditParameters.tsx
@@ -23,6 +23,7 @@ import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
 import { DataType, EntryInfo, generateNextAvailableEntryName, generateUuid } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
+import { useBoxedExpression } from "../../context";
 
 export interface EditParametersProps {
   /** List of parameters */
@@ -32,10 +33,11 @@ export interface EditParametersProps {
 }
 
 export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ parameters, setParameters }) => {
+  const { boxedExpressionEditorGWTService } = useBoxedExpression();
   const { i18n } = useBoxedExpressionEditorI18n();
 
   const addParameter = useCallback(() => {
-    window.beeApi?.notifyUserAction();
+    boxedExpressionEditorGWTService?.notifyUserAction();
     setParameters([
       ...parameters,
       {
@@ -50,7 +52,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
     (index: number) => (event: ChangeEvent<HTMLInputElement>) => {
       const parametersCopy = [...parameters].map((parameter) => Object.assign({}, parameter));
       if (parametersCopy[index].name != event.target.value) {
-        window.beeApi?.notifyUserAction();
+        boxedExpressionEditorGWTService?.notifyUserAction();
       }
       parametersCopy[index].name = event.target.value;
       setParameters([...parametersCopy]);
@@ -60,7 +62,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
 
   const onDataTypeChange = useCallback(
     (index: number) => (dataType: DataType) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpressionEditorGWTService?.notifyUserAction();
       const parametersCopy = [...parameters].map((parameter) => Object.assign({}, parameter));
       parametersCopy[index].dataType = dataType;
       setParameters([...parametersCopy]);
@@ -70,7 +72,7 @@ export const EditParameters: React.FunctionComponent<EditParametersProps> = ({ p
 
   const onParameterRemove = useCallback(
     (index: number) => () => {
-      window.beeApi?.notifyUserAction();
+      boxedExpressionEditorGWTService?.notifyUserAction();
       setParameters([...parameters.slice(0, index), ...parameters.slice(index + 1)]);
     },
     [parameters, setParameters]

--- a/packages/boxed-expression-component/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/FunctionExpression.tsx
@@ -343,7 +343,7 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (
         );
       }
     },
-    [extendDefinitionBasedOnFunctionKind, setSupervisorHash, functionExpression]
+    [boxedExpressionEditorGWTService, extendDefinitionBasedOnFunctionKind, setSupervisorHash, functionExpression]
   );
 
   const editParametersPopoverAppendTo = useCallback(() => {

--- a/packages/boxed-expression-component/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/FunctionExpression.tsx
@@ -58,7 +58,7 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (
   const FIRST_ENTRY_ID = "0";
   const SECOND_ENTRY_ID = "1";
   const { i18n } = useBoxedExpressionEditorI18n();
-  const { editorRef, setSupervisorHash, pmmlParams } = useBoxedExpression();
+  const { editorRef, setSupervisorHash, pmmlParams, boxedExpressionEditorGWTService } = useBoxedExpression();
   const pmmlDocument = useMemo(
     () => (functionExpression as PmmlFunctionProps).document,
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -324,7 +324,9 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (
           updatedDefinition,
           () => {
             setSupervisorHash(hashfy(updatedDefinition));
-            window.beeApi?.broadcastFunctionExpressionDefinition?.(updatedDefinition as FunctionProps);
+            boxedExpressionEditorGWTService?.broadcastFunctionExpressionDefinition?.(
+              updatedDefinition as FunctionProps
+            );
           },
           [
             "name",

--- a/packages/boxed-expression-component/src/components/FunctionExpression/FunctionKindSelector.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/FunctionKindSelector.tsx
@@ -43,7 +43,7 @@ export const FunctionKindSelector: React.FunctionComponent<FunctionKindSelectorP
       onFunctionKindSelect(itemId as FunctionKind);
       hide();
     },
-    [onFunctionKindSelect]
+    [boxedExpression.boxedExpressionEditorGWTService, onFunctionKindSelect]
   );
 
   const renderFunctionKindItems = useCallback(

--- a/packages/boxed-expression-component/src/components/FunctionExpression/FunctionKindSelector.tsx
+++ b/packages/boxed-expression-component/src/components/FunctionExpression/FunctionKindSelector.tsx
@@ -39,7 +39,7 @@ export const FunctionKindSelector: React.FunctionComponent<FunctionKindSelectorP
 
   const functionKindSelectionCallback = useCallback(
     (hide: () => void) => (event?: React.MouseEvent, itemId?: string | number) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       onFunctionKindSelect(itemId as FunctionKind);
       hide();
     },

--- a/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./InvocationExpression.css";
 import * as React from "react";
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   ColumnsUpdateArgs,
   ContextEntries,
@@ -41,7 +41,7 @@ import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { ColumnInstance, DataRecord } from "react-table";
 import { ContextEntryExpressionCell, getContextEntryInfoCell } from "../ContextExpression";
 import * as _ from "lodash";
-import { BoxedExpressionGlobalContext } from "../../context";
+import { useBoxedExpression } from "../../context";
 import { hashfy } from "../Resizer";
 
 const DEFAULT_PARAMETER_NAME = "p-1";
@@ -69,7 +69,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
     );
   }, [invocationProps.bindingEntries]);
 
-  const { setSupervisorHash } = useContext(BoxedExpressionGlobalContext);
+  const { boxedExpressionEditorGWTService, setSupervisorHash } = useBoxedExpression();
 
   const spreadInvocationExpressionDefinition = useCallback(
     (invocationExpressionUpdated?: Partial<InvocationProps>) => {
@@ -101,7 +101,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
           updatedDefinition,
           () => {
             setSupervisorHash(hashfy(updatedDefinition));
-            window.beeApi?.broadcastInvocationExpressionDefinition?.(updatedDefinition);
+            boxedExpressionEditorGWTService?.broadcastInvocationExpressionDefinition?.(updatedDefinition);
           },
           ["name", "dataType", "bindingEntries", "invokedFunction", "entryInfoWidth", "entryExpressionWidth"]
         );
@@ -113,7 +113,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
   const onBlurCallback = useCallback(
     (event) => {
       if (invocationProps.invokedFunction != event.target.value) {
-        window.beeApi?.notifyUserAction();
+        boxedExpressionEditorGWTService?.notifyUserAction();
       }
       spreadInvocationExpressionDefinition({ invokedFunction: event.target.value });
     },

--- a/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/components/InvocationExpression/InvocationExpression.tsx
@@ -107,7 +107,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
         );
       }
     },
-    [invocationProps, rows, setSupervisorHash]
+    [boxedExpressionEditorGWTService, invocationProps, rows, setSupervisorHash]
   );
 
   const onBlurCallback = useCallback(
@@ -117,7 +117,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = (i
       }
       spreadInvocationExpressionDefinition({ invokedFunction: event.target.value });
     },
-    [spreadInvocationExpressionDefinition, invocationProps.invokedFunction]
+    [boxedExpressionEditorGWTService, spreadInvocationExpressionDefinition, invocationProps.invokedFunction]
   );
 
   const headerCellElement = useMemo(

--- a/packages/boxed-expression-component/src/components/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/components/ListExpression/ListExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./ListExpression.css";
 import * as React from "react";
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   ContextEntryRecord,
   DataType,
@@ -114,7 +114,7 @@ export const ListExpression: React.FunctionComponent<ListProps> = (listExpressio
         ["width", "items"]
       );
     },
-    [listExpression, items, setSupervisorHash]
+    [boxedExpressionEditorGWTService, listExpression, items, setSupervisorHash]
   );
 
   const setListWidth = useCallback(

--- a/packages/boxed-expression-component/src/components/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/components/ListExpression/ListExpression.tsx
@@ -36,13 +36,13 @@ import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { DataRecord, Row } from "react-table";
 import { hashfy } from "../Resizer";
-import { BoxedExpressionGlobalContext } from "../../context";
+import { useBoxedExpression } from "../../context";
 
 const LIST_EXPRESSION_MIN_WIDTH = 430;
 
 export const ListExpression: React.FunctionComponent<ListProps> = (listExpression: ListProps) => {
   const { i18n } = useBoxedExpressionEditorI18n();
-  const { setSupervisorHash } = useContext(BoxedExpressionGlobalContext);
+  const { boxedExpressionEditorGWTService, setSupervisorHash } = useBoxedExpression();
 
   const generateLiteralExpression = useMemo(
     () =>
@@ -108,7 +108,7 @@ export const ListExpression: React.FunctionComponent<ListProps> = (listExpressio
             listExpression.onUpdatingRecursiveExpression?.(updatedDefinition);
           } else {
             setSupervisorHash(hashfy(updatedDefinition));
-            window.beeApi?.broadcastListExpressionDefinition?.(updatedDefinition as ListProps);
+            boxedExpressionEditorGWTService?.broadcastListExpressionDefinition?.(updatedDefinition as ListProps);
           }
         },
         ["width", "items"]

--- a/packages/boxed-expression-component/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/packages/boxed-expression-component/src/components/LiteralExpression/LiteralExpression.tsx
@@ -63,7 +63,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
         ["name", "dataType", "content", "width"]
       );
     },
-    [literalExpression]
+    [boxedExpressionEditorGWTService, literalExpression]
   );
 
   const onExpressionUpdate = useCallback(

--- a/packages/boxed-expression-component/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/packages/boxed-expression-component/src/components/LiteralExpression/LiteralExpression.tsx
@@ -27,12 +27,15 @@ import {
 import { EditExpressionMenu, EXPRESSION_NAME } from "../EditExpressionMenu";
 import { Resizer } from "../Resizer";
 import { EditableCell } from "../Table";
+import { useBoxedExpression } from "../../context";
 
 const HEADER_WIDTH = 250;
 
 export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = (
   literalExpression: LiteralExpressionProps
 ) => {
+  const { boxedExpressionEditorGWTService } = useBoxedExpression();
+
   const spreadLiteralExpressionDefinition = useCallback(
     (literalExpressionUpdate?: Partial<LiteralExpressionProps>) => {
       const expressionDefinition: LiteralExpressionProps = {
@@ -54,7 +57,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
           if (literalExpression.isHeadless) {
             literalExpression.onUpdatingRecursiveExpression?.(expressionDefinition);
           } else {
-            window.beeApi?.broadcastLiteralExpressionDefinition?.(expressionDefinition);
+            boxedExpressionEditorGWTService?.broadcastLiteralExpressionDefinition?.(expressionDefinition);
           }
         },
         ["name", "dataType", "content", "width"]

--- a/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -154,7 +154,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
       const selectedLogicType = itemId as LogicType;
       onLogicTypeUpdating(selectedLogicType);
     },
-    [onLogicTypeUpdating]
+    [boxedExpression.boxedExpressionEditorGWTService, onLogicTypeUpdating]
   );
 
   const buildLogicSelectorMenu = useMemo(

--- a/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -150,7 +150,7 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
 
   const onLogicTypeSelect = useCallback(
     (event?: React.MouseEvent, itemId?: string | number) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       const selectedLogicType = itemId as LogicType;
       onLogicTypeUpdating(selectedLogicType);
     },

--- a/packages/boxed-expression-component/src/components/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/components/RelationExpression/RelationExpression.tsx
@@ -33,10 +33,12 @@ import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { Column as ReactTableColumn, Column, ColumnInstance, DataRecord } from "react-table";
 import { DEFAULT_MIN_WIDTH } from "../Resizer";
+import { useBoxedExpression } from "../../context";
 
 export const RelationExpression: React.FunctionComponent<RelationProps> = (relationProps: RelationProps) => {
   const FIRST_COLUMN_NAME = "column-1";
   const { i18n } = useBoxedExpressionEditorI18n();
+  const { boxedExpressionEditorGWTService } = useBoxedExpression();
 
   const handlerConfiguration = [
     {
@@ -84,7 +86,7 @@ export const RelationExpression: React.FunctionComponent<RelationProps> = (relat
           if (relationProps.isHeadless) {
             relationProps.onUpdatingRecursiveExpression?.(expressionDefinition);
           } else {
-            window.beeApi?.broadcastRelationExpressionDefinition?.(expressionDefinition);
+            boxedExpressionEditorGWTService?.broadcastRelationExpressionDefinition?.(expressionDefinition);
           }
         },
         ["columns", "rows"]

--- a/packages/boxed-expression-component/src/components/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/components/RelationExpression/RelationExpression.tsx
@@ -31,7 +31,7 @@ import {
 } from "../../api";
 import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
-import { Column as ReactTableColumn, Column, ColumnInstance, DataRecord } from "react-table";
+import { Column, ColumnInstance, DataRecord } from "react-table";
 import { DEFAULT_MIN_WIDTH } from "../Resizer";
 import { useBoxedExpression } from "../../context";
 
@@ -92,7 +92,7 @@ export const RelationExpression: React.FunctionComponent<RelationProps> = (relat
         ["columns", "rows"]
       );
     },
-    [relationProps, columns, rows]
+    [boxedExpressionEditorGWTService, relationProps, columns, rows]
   );
 
   const convertColumnsForTheTable = useMemo(

--- a/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
+++ b/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
@@ -188,7 +188,7 @@ export const Resizer: React.FunctionComponent<ResizerProps> = ({
 
       setSupervisorHash("-");
     },
-    [cells, initialResizerWidth, setSupervisorHash, widthValue]
+    [boxedExpression.boxedExpressionEditorGWTService, cells, initialResizerWidth, setSupervisorHash, widthValue]
   );
 
   return (

--- a/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
+++ b/packages/boxed-expression-component/src/components/Resizer/Resizer.tsx
@@ -179,7 +179,7 @@ export const Resizer: React.FunctionComponent<ResizerProps> = ({
   const onResizeStop = useCallback(
     (_, data) => {
       const newResizerWidth = widthValue(data.size.width);
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       cells.forEach((cell) => {
         const delta = newResizerWidth - initialResizerWidth;
         const cellInitialWidth = widthValue(cell.element.dataset.initialWidth);

--- a/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
+++ b/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
@@ -70,7 +70,7 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
       }
 
       if (value !== newValue) {
-        window.beeApi?.notifyUserAction();
+        boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
         onCellUpdate(rowIndex, columnId, newValue ?? value);
       }
 
@@ -181,7 +181,7 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
     if (!value) {
       return "";
     }
-    if (value !== null && typeof value === "object") {
+    if (typeof value === "object") {
       return value[columnId];
     }
     return `${value}`;

--- a/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
+++ b/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
@@ -76,7 +76,7 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
 
       focusTextArea(textarea.current);
     },
-    [mode, columnId, onCellUpdate, rowIndex, value]
+    [boxedExpression.boxedExpressionEditorGWTService, mode, columnId, onCellUpdate, rowIndex, value]
   );
 
   const triggerEditMode = useCallback(() => {

--- a/packages/boxed-expression-component/src/components/Table/TableHandler.tsx
+++ b/packages/boxed-expression-component/src/components/Table/TableHandler.tsx
@@ -226,7 +226,7 @@ export const TableHandler: React.FunctionComponent<TableHandlerProps> = ({
 
   const handlingOperation = useCallback(
     (tableOperation: TableOperation) => {
-      window.beeApi?.notifyUserAction();
+      boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       switch (tableOperation) {
         case TableOperation.ColumnInsertLeft:
           updateTargetColumns(insertBefore, TableOperation.ColumnInsertLeft);

--- a/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
+++ b/packages/boxed-expression-component/src/context/BoxedExpressionGlobalContext.tsx
@@ -16,9 +16,10 @@
 
 import * as React from "react";
 import { useContext } from "react";
-import { DataTypeProps, PMMLParams } from "../api";
+import { BoxedExpressionEditorGWTService, DataTypeProps, PMMLParams } from "../api";
 
 export interface BoxedExpressionGlobalContextProps {
+  boxedExpressionEditorGWTService?: BoxedExpressionEditorGWTService;
   decisionNodeId: string;
   pmmlParams?: PMMLParams;
   dataTypes: DataTypeProps[];

--- a/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
@@ -58,6 +58,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
   invocation: string;
   list: string;
   literalExpression: string;
+  manage: string;
   methodSignature: string;
   model: string;
   name: string;

--- a/packages/boxed-expression-component/src/i18n/locales/en.ts
+++ b/packages/boxed-expression-component/src/i18n/locales/en.ts
@@ -59,6 +59,7 @@ export const en: BoxedExpressionEditorI18n = {
   invocation: "Invocation",
   list: "List",
   literalExpression: "Literal expression",
+  manage: "Manage",
   methodSignature: "method signature",
   model: "model",
   name: "Name",

--- a/packages/boxed-expression-component/tests/components/DecisionTableExpression/DecisionTableExpression.test.tsx
+++ b/packages/boxed-expression-component/tests/components/DecisionTableExpression/DecisionTableExpression.test.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { DataType, DecisionTableProps, HitPolicy, LogicType } from "@kogito-tooling/boxed-expression-component";
+import {
+  BoxedExpressionEditorGWTService,
+  DataType,
+  DecisionTableProps,
+  HitPolicy,
+  LogicType,
+} from "@kogito-tooling/boxed-expression-component";
 import { fireEvent, render } from "@testing-library/react";
 import {
   flushPromises,
@@ -156,10 +162,18 @@ describe("DecisionTableExpression tests", () => {
 
   test("should append a row, with empty values, except for input column, whose value is dash symbol, when user inserts a row below", async () => {
     const mockedBroadcastDefinition = jest.fn();
-    mockBroadcastDefinition(mockedBroadcastDefinition);
+    const boxedExpressionEditorGWTService = {
+      broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) =>
+        mockedBroadcastDefinition(definition),
+      notifyUserAction: () => {},
+    } as BoxedExpressionEditorGWTService;
+
     const { container, baseElement } = render(
       usingTestingBoxedExpressionI18nContext(
-        wrapComponentInContext(<DecisionTableExpression id="decision-node-id" logicType={LogicType.DecisionTable} />)
+        wrapComponentInContext(
+          <DecisionTableExpression id="decision-node-id" logicType={LogicType.DecisionTable} />,
+          boxedExpressionEditorGWTService
+        )
       ).wrapper
     );
 
@@ -189,12 +203,4 @@ describe("DecisionTableExpression tests", () => {
       })
     );
   });
-
-  function mockBroadcastDefinition(mockedBroadcastDefinition: jest.Mock) {
-    window.beeApi = _.extend(window.beeApi || {}, {
-      broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) =>
-        mockedBroadcastDefinition(definition),
-      notifyUserAction: () => {},
-    });
-  }
 });

--- a/packages/boxed-expression-component/tests/components/EditExpressionMenu/EditExpressionMenu.test.tsx
+++ b/packages/boxed-expression-component/tests/components/EditExpressionMenu/EditExpressionMenu.test.tsx
@@ -101,6 +101,28 @@ describe("EditExpressionMenu tests", () => {
     expect(container.querySelector(".expression-data-type label")!.innerHTML).toBe(dataTypeFieldLabel);
   });
 
+  test("should render manage data type button", async () => {
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <div>
+          <div id="container">Popover</div>
+          <EditExpressionMenu
+            selectedExpressionName="Expression Name"
+            arrowPlacement={() => document.getElementById("container")!}
+            appendTo={() => document.getElementById("container")!}
+            onExpressionUpdate={(expression) => {
+              console.log(expression);
+            }}
+          />
+        </div>
+      ).wrapper
+    );
+
+    await activatePopover(container as HTMLElement);
+
+    expect(container.querySelector("button.manage-datatype")).toBeTruthy();
+  });
+
   test("should render undefined as data type, when it is not pre-selected", async () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(

--- a/packages/boxed-expression-component/tests/components/test-utils.tsx
+++ b/packages/boxed-expression-component/tests/components/test-utils.tsx
@@ -26,6 +26,7 @@ import { act } from "react-dom/test-utils";
 import { fireEvent } from "@testing-library/react";
 import { BoxedExpressionGlobalContext } from "@kogito-tooling/boxed-expression-component/dist/context";
 import {
+  BoxedExpressionEditorGWTService,
   BoxedExpressionProvider,
   BoxedExpressionProviderProps,
   DataType,
@@ -134,6 +135,7 @@ export function usingTestingBoxedExpressionProviderContext(
     ctx: usedCtx,
     wrapper: (
       <BoxedExpressionProvider
+        boxedExpressionEditorGWTService={usedCtx.boxedExpressionEditorGWTService}
         decisionNodeId={usedCtx.decisionNodeId}
         expressionDefinition={usedCtx.expressionDefinition}
         dataTypes={usedCtx.dataTypes}
@@ -146,10 +148,14 @@ export function usingTestingBoxedExpressionProviderContext(
   };
 }
 
-export function wrapComponentInContext(component: JSX.Element): JSX.Element {
+export function wrapComponentInContext(
+  component: JSX.Element,
+  boxedExpressionEditorGWTService?: BoxedExpressionEditorGWTService
+): JSX.Element {
   return (
     <BoxedExpressionGlobalContext.Provider
       value={{
+        boxedExpressionEditorGWTService,
         decisionNodeId: "_00000000-0000-0000-0000-000000000000",
         dataTypes,
         pmmlParams,

--- a/packages/online-editor/README.md
+++ b/packages/online-editor/README.md
@@ -1,0 +1,23 @@
+# Integration tests
+
+There is a set of cypress tests in `it-tests` folder. To run them, please refer to one option bellow.
+
+## Run tests manually
+
+More suitable for running particular tests from `it-tests`.
+
+- `packages/extended-services$ yarn start`
+- `packages/online-editor$ yarn start`
+- `packages/online-editor$ yarn cy:open`
+
+## Run tests automatically
+
+More suitable for running `it-tests` completely.
+
+- `packages/online-editor$ START_SERVER_AND_TEST_INSECURE=true KOGITO_TOOLING_BUILD_testIT=true yarn test:it`
+
+> **NOTE:**
+> Before test development, you may need to build `online-editor` as:
+>
+> - `kogito-tooling$ yarn bootstrap`
+> - `kogito-tooling$ yarn build:dev:until @kogito-tooling/online-editor`

--- a/packages/online-editor/it-tests/fixtures/testModelWithCustomDataType.dmn
+++ b/packages/online-editor/it-tests/fixtures/testModelWithCustomDataType.dmn
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_A5B848F9-30F8-4466-9B06-1BC448D60D83" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_68EA36F8-1D7B-4816-B953-1B30C615352C" name="testModelWithCustomDataType" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_A5B848F9-30F8-4466-9B06-1BC448D60D83">
   <dmn:extensionElements/>
-  <dmn:itemDefinition id="_CD90E737-4A24-4064-ACEF-54DE70DEECAB" name="tSalary" isCollection="false">
-    <dmn:itemComponent id="_1011C88D-300B-42C5-8F7F-D8A90DB03209" name="Amount" isCollection="false">
-      <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_F07291A6-5801-4A87-BFE4-5B9A4149AD7F" name="Currency" isCollection="false">
-      <dmn:typeRef>string</dmn:typeRef>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
   <dmn:inputData id="_E9CE3F2E-3746-4A3A-AE8F-BF7D01814AD1" name="Offered Currency">
     <dmn:extensionElements/>
     <dmn:variable id="_548E5DB2-AD0E-4C1E-B338-D0FD902D90B8" name="Offered Currency" typeRef="string"/>
@@ -63,8 +55,9 @@
       <di:extension>
         <kie:ComponentsWidthsExtension>
           <kie:ComponentWidths dmnElementRef="_EE4B37ED-BCFF-4A83-BF9B-8B095C8530A2">
-            <kie:width>162</kie:width>
-            <kie:width>152</kie:width>
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
             <kie:width>100</kie:width>
             <kie:width>100</kie:width>
           </kie:ComponentWidths>

--- a/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
+++ b/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
@@ -23,24 +23,24 @@ describe("DMN Expression Editor Test", () => {
 
   it("Test New Expresssion editor - context", () => {
     // click Create new decision model button (new DMN)
-    cy.ouiaId("try-dmn-sample-button").click();
+    cy.ouia({ ouiaId: "try-dmn-sample-button" }).click();
 
     // wait until loading dialog disappears
     cy.loadEditor();
 
     // close DMN guided tour dialog
-    cy.ouiaId("dmn-guided-tour").children("button[aria-label='Close']").click();
+    cy.ouia({ ouiaId: "dmn-guided-tour" }).children("button[aria-label='Close']").click();
 
     cy.getEditor().within(() => {
       // open decision navigator and check new expression editor for expressions
-      cy.ouiaId("docks-item-org.kie.dmn.decision.navigator").children("button").click();
+      cy.ouia({ ouiaId: "docks-item-org.kie.dmn.decision.navigator" }).children("button").click();
 
       cy.get("li[data-i18n-prefix='DecisionNavigatorTreeView.']").within(($navigator) => {
         cy.get("[title='Back End Ratio'] div span").contains("Context").click();
       });
       // check using beta version
       cy.get("[data-field='beta-boxed-expression-toggle'] [data-field='try-it']").click();
-      cy.ouiaId("expression-container").contains("Back End Ratio").should("be.visible");
+      cy.ouia({ ouiaId: "expression-container" }).contains("Back End Ratio").should("be.visible");
       cy.get(".expression-title").contains("Back End Ratio").should("be.visible");
       cy.get(".expression-type").contains("Context").should("be.visible");
     });
@@ -48,24 +48,24 @@ describe("DMN Expression Editor Test", () => {
 
   it("Test New Expresssion editor - function", () => {
     // click Create new decision model button (new DMN)
-    cy.ouiaId("try-dmn-sample-button").click();
+    cy.ouia({ ouiaId: "try-dmn-sample-button" }).click();
 
     // wait until loading dialog disappears
     cy.loadEditor();
 
     // close DMN guided tour dialog
-    cy.ouiaId("dmn-guided-tour").children("button[aria-label='Close']").click();
+    cy.ouia({ ouiaId: "dmn-guided-tour" }).children("button[aria-label='Close']").click();
 
     cy.getEditor().within(() => {
       // open decision navigator and check new expression editor for expressions
-      cy.ouiaId("docks-item-org.kie.dmn.decision.navigator").children("button").click();
+      cy.ouia({ ouiaId: "docks-item-org.kie.dmn.decision.navigator" }).children("button").click();
 
       cy.get("li[data-i18n-prefix='DecisionNavigatorTreeView.']").within(($navigator) => {
         cy.get("[title='PITI'] div span").contains("Function").click();
       });
       // check using beta version
       cy.get("[data-field='beta-boxed-expression-toggle'] [data-field='try-it']").click();
-      cy.ouiaId("expression-container").contains("PITI").should("be.visible");
+      cy.ouia({ ouiaId: "expression-container" }).contains("PITI").should("be.visible");
       cy.get(".expression-title").contains("PITI").should("be.visible");
       cy.get(".expression-type").contains("Function").should("be.visible");
     });
@@ -74,24 +74,24 @@ describe("DMN Expression Editor Test", () => {
   // TODO - unskip once kogito-editors-java bump is available
   it.skip("Test New Expresssion editor - decision table", () => {
     // click Create new decision model button (new DMN)
-    cy.ouiaId("try-dmn-sample-button").click();
+    cy.ouia({ ouiaId: "try-dmn-sample-button" }).click();
 
     // wait until loading dialog disappears
     cy.loadEditor();
 
     // close DMN guided tour dialog
-    cy.ouiaId("dmn-guided-tour").children("button[aria-label='Close']").click();
+    cy.ouia({ ouiaId: "dmn-guided-tour" }).children("button[aria-label='Close']").click();
 
     cy.getEditor().within(() => {
       // open decision navigator and check new expression editor for expressions
-      cy.ouiaId("docks-item-org.kie.dmn.decision.navigator").children("button").click();
+      cy.ouia({ ouiaId: "docks-item-org.kie.dmn.decision.navigator" }).children("button").click();
 
       cy.get("li[data-i18n-prefix='DecisionNavigatorTreeView.']").within(($navigator) => {
         cy.get("[title='Credit Score Rating'] div span").contains("Decision Table").click();
       });
       // check using beta version
       cy.get("[data-field='beta-boxed-expression-toggle'] [data-field='try-it']").click();
-      cy.ouiaId("expression-container").contains("Credit Score Rating").should("be.visible");
+      cy.ouia({ ouiaId: "expression-container" }).contains("Credit Score Rating").should("be.visible");
       cy.get(".expression-title").contains("Credit Score Rating").should("be.visible");
       cy.get(".expression-type").contains("Decision Table").should("be.visible");
     });
@@ -104,11 +104,11 @@ describe("DMN Expression Editor Test", () => {
     cy.loadEditor();
 
     // close DMN guided tour dialog
-    cy.ouiaId("dmn-guided-tour").children("button[aria-label='Close']").click();
+    cy.ouia({ ouiaId: "dmn-guided-tour" }).children("button[aria-label='Close']").click();
 
     cy.getEditor().within(() => {
       // open decision navigator
-      cy.ouiaId("docks-item-org.kie.dmn.decision.navigator").children("button").click();
+      cy.ouia({ ouiaId: "docks-item-org.kie.dmn.decision.navigator" }).children("button").click();
 
       // open decision table expression
       cy.get("li[data-i18n-prefix='DecisionNavigatorTreeView.']").within(($navigator) => {
@@ -117,12 +117,70 @@ describe("DMN Expression Editor Test", () => {
       // activate editor beta version
       cy.get("[data-field='beta-boxed-expression-toggle'] [data-field='try-it']").click();
 
-      cy.get("[data-ouia-component-type='expression-column-header-cell-info']:contains('tSalary')").should("not.exist");
+      cy.get(".header-cell-info").contains("Final Salary").click();
+      // cy.ouia("edit-expression-data-type").click();
+
+      // define custom tSalary data type
+      cy.ouia({ ouiaId: "manage-data-type-link" }).click();
+      cy.ouia({ ouiaType: "add-data-type-button", ouiaId: "first" }).click();
+
+      // root
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("input[data-type-field='name-input']").type("tSalary");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").should("be.visible");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").within(($navigator) => {
+          cy.get("button[data-toggle='dropdown']").click();
+        });
+      });
+      cy.get(".bs-searchbox input").last().type("Structure");
+      cy.get("ul").find("li.active").find("a").contains("Structure").click();
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("[data-type-field='save-button']").click();
+      });
+
+      // Amount
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("input[data-type-field='name-input']").type("Amount");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").should("be.visible");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").within(($navigator) => {
+          cy.get("button[data-toggle='dropdown']").click();
+        });
+      });
+      cy.get(".bs-searchbox input").last().type("number");
+      cy.get("ul").find("li.active").find("a").contains("number").click();
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("[data-type-field='save-button']").click();
+      });
+
+      cy.ouia({ ouiaId: "Amount" }).within(($row) => {
+        cy.get("[data-type-field='add-data-type-row-button']").click();
+      });
+
+      // Currency
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("input[data-type-field='name-input']").type("Currency");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").should("be.visible");
+        cy.get("[data-i18n-prefix='DataTypeSelectView.']").within(($navigator) => {
+          cy.get("button[data-toggle='dropdown']").click();
+        });
+      });
+      cy.get(".bs-searchbox input").last().type("string");
+      cy.get("ul").find("li.active").find("a").contains("string").click();
+      cy.ouia({ ouiaId: "Insert a name" }).within(($row) => {
+        cy.get("[data-type-field='save-button']").click();
+      });
+
+      // go back to expression editor
+      cy.get("[data-ouia-component-id='Editor'] a").click();
+
+      // activate editor beta version
+      cy.get("[data-field='beta-boxed-expression-toggle'] [data-field='try-it']").click();
 
       cy.get(".header-cell-info").contains("Final Salary").click();
-      cy.ouiaId("edit-expression-data-type").click();
-      cy.ouiaId("expression-popover-menu").within(($menu) => {
-        cy.ouiaId("tSalary").click({ force: true });
+      cy.ouia({ ouiaId: "edit-expression-data-type" }).click();
+
+      cy.ouia({ ouiaId: "expression-popover-menu" }).within(($menu) => {
+        cy.ouia({ ouiaId: "tSalary" }).click({ force: true });
       });
 
       cy.get("[data-ouia-component-type='expression-column-header-cell-info']:contains('tSalary')").should(

--- a/packages/online-editor/it-tests/support/commands.ts
+++ b/packages/online-editor/it-tests/support/commands.ts
@@ -28,10 +28,10 @@ declare namespace Cypress {
 
     /**
      * Search elements by data-ouia component attributes.
-     * @param id string
+     * @param locator component type and component id according to OUIA specification
      * @param opts optional - config object
      */
-    ouiaId(id: string, opts?: Record<string, any>): Chainable<Element>;
+    ouia(locator: { ouiaType?: string; ouiaId: string }, opts?: Record<string, any>): Chainable<Element>;
   }
 }
 
@@ -47,12 +47,15 @@ Cypress.Commands.add("loadEditor", () => {
   });
 });
 
-Cypress.Commands.add("ouiaId", { prevSubject: "optional" }, (subject, id: string, options = {}) => {
-  const idSelector = `[data-ouia-component-id='${id}']`;
+Cypress.Commands.add("ouia", { prevSubject: "optional" }, (subject, locator, options = {}) => {
+  let selector = `[data-ouia-component-id='${locator.ouiaId}']`;
+  if (locator.ouiaType !== undefined && locator.ouiaType !== "") {
+    selector = `[data-ouia-component-type='${locator.ouiaType}']` + selector;
+  }
 
   if (subject) {
-    cy.wrap(subject, options).find(idSelector, options);
+    cy.wrap(subject, options).find(selector, options);
   } else {
-    cy.get(idSelector, options);
+    cy.get(selector, options);
   }
 });

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -16,6 +16,7 @@
 
 import {
   BoxedExpressionEditor,
+  BoxedExpressionEditorGWTService,
   BoxedExpressionEditorProps,
   ContextProps,
   DataTypeProps,
@@ -34,7 +35,26 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import * as ReactDOM from "react-dom";
 
-const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps> = ({
+export interface BoxedExpressionEditorWrapperProps {
+  /** Identifier of the decision node, where the expression will be hold */
+  decisionNodeId: string;
+  /** All expression properties used to define it */
+  expressionDefinition: ExpressionProps;
+  /** The data type elements that can be used in the editor */
+  dataTypes: DataTypeProps[];
+  /**
+   * A boolean used for making (or not) the clear button available on the root expression
+   * Note that this parameter will be used only for the root expression.
+   *
+   * Each expression (internally) has a `noClearAction` property (ExpressionProps interface).
+   * You can set directly it for enabling or not the clear button for such expression.
+   * */
+  clearSupportedOnRootExpression?: boolean;
+  /** PMML parameters */
+  pmmlParams?: PMMLParams;
+}
+
+const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorWrapperProps> = ({
   decisionNodeId,
   expressionDefinition,
   dataTypes,
@@ -52,7 +72,7 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps
 
   //The wrapper defines these function in order to keep expression definition state updated,
   //And to propagate such definition to DMN Editor (GWT world), by calling beeApiWrapper APIs
-  window.beeApi = {
+  const boxedExpressionEditorGWTService: BoxedExpressionEditorGWTService = {
     notifyUserAction(): void {
       window.beeApiWrapper?.notifyUserAction();
     },
@@ -95,6 +115,7 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps
 
   return (
     <BoxedExpressionEditor
+      boxedExpressionEditorGWTService={boxedExpressionEditorGWTService}
       decisionNodeId={decisionNodeId}
       expressionDefinition={updatedDefinition}
       dataTypes={dataTypes}

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -56,6 +56,9 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorProps
     notifyUserAction(): void {
       window.beeApiWrapper?.notifyUserAction();
     },
+    openManageDataType(): void {
+      window.beeApiWrapper?.openManageDataType();
+    },
     resetExpressionDefinition: (definition: ExpressionProps) => {
       setExpressionDefinition(definition);
       window.beeApiWrapper?.resetExpressionDefinition?.(definition);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -73,6 +73,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.Bo
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionPropsFiller;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.pmml.PMMLDocumentMetadataProvider;
+import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.js.DMNLoader;
@@ -162,6 +163,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     private Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent;
     private Event<DomainObjectSelectionEvent> domainObjectSelectionEvent;
     private Event<ExpressionEditorChanged> editorSelectedEvent;
+    private Event<DataTypePageTabActiveEvent> dataTypePageActiveEvent;
     private PMMLDocumentMetadataProvider pmmlDocumentMetadataProvider;
     private DefinitionUtils definitionUtils;
     private ItemDefinitionUtils itemDefinitionUtils;
@@ -194,6 +196,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                     final Event<RefreshFormPropertiesEvent> refreshFormPropertiesEvent,
                                     final Event<DomainObjectSelectionEvent> domainObjectSelectionEvent,
                                     final Event<ExpressionEditorChanged> editorSelectedEvent,
+                                    final Event<DataTypePageTabActiveEvent> dataTypePageActiveEvent,
                                     final PMMLDocumentMetadataProvider pmmlDocumentMetadataProvider,
                                     final DefinitionUtils definitionUtils,
                                     final ItemDefinitionUtils itemDefinitionUtils,
@@ -218,6 +221,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         this.refreshFormPropertiesEvent = refreshFormPropertiesEvent;
         this.domainObjectSelectionEvent = domainObjectSelectionEvent;
         this.editorSelectedEvent = editorSelectedEvent;
+        this.dataTypePageActiveEvent = dataTypePageActiveEvent;
         this.pmmlDocumentMetadataProvider = pmmlDocumentMetadataProvider;
         this.definitionUtils = definitionUtils;
         this.itemDefinitionUtils = itemDefinitionUtils;
@@ -470,6 +474,22 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                                                                         itemDefinitionUtils));
     }
 
+    public void notifyUserAction() {
+        final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = createCommandBuilder();
+        final SaveCurrentStateCommand expressionCommand = new SaveCurrentStateCommand(getHasExpression(),
+                                                                                      getEditorSelectedEvent(),
+                                                                                      this,
+                                                                                      getNodeUUID());
+        addExpressionCommand(expressionCommand, commandBuilder);
+        addUpdatePropertyNameCommand(commandBuilder);
+
+        execute(commandBuilder);
+    }
+
+    public void openManageDataType() {
+        dataTypePageActiveEvent.fire(new DataTypePageTabActiveEvent());
+    }
+
     void executeExpressionCommand(final FillExpressionCommand expressionCommand) {
         expressionCommand.execute();
     }
@@ -607,18 +627,6 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     String getNodeUUID() {
         return nodeUUID;
-    }
-
-    public void notifyUserAction() {
-        final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder = createCommandBuilder();
-        final SaveCurrentStateCommand expressionCommand = new SaveCurrentStateCommand(getHasExpression(),
-                                                                                      getEditorSelectedEvent(),
-                                                                                      this,
-                                                                                      getNodeUUID());
-        addExpressionCommand(expressionCommand, commandBuilder);
-        addUpdatePropertyNameCommand(commandBuilder);
-
-        execute(commandBuilder);
     }
 
     void execute(final CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
@@ -82,4 +82,9 @@ public class BoxedExpressionService {
     public static void notifyUserAction() {
         expressionEditor.notifyUserAction();
     }
+
+    @JsMethod
+    public static void openManageDataType() {
+        expressionEditor.openManageDataType();
+    }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -63,6 +63,7 @@ import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.L
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.pmml.PMMLDocumentMetadataProvider;
+import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.ItemDefinitionUtils;
 import org.kie.workbench.common.dmn.client.session.DMNEditorSession;
 import org.kie.workbench.common.dmn.client.widgets.grid.BaseExpressionGrid;
@@ -187,6 +188,9 @@ public class ExpressionEditorViewImplTest {
     private EventSourceMock<ExpressionEditorChanged> editorSelectedEvent;
 
     @Mock
+    private EventSourceMock<DataTypePageTabActiveEvent> dataTypePageActiveEvent;
+
+    @Mock
     private PMMLDocumentMetadataProvider pmmlDocumentMetadataProvider;
 
     @Mock
@@ -304,6 +308,7 @@ public class ExpressionEditorViewImplTest {
                                                      refreshFormPropertiesEvent,
                                                      domainObjectSelectionEvent,
                                                      editorSelectedEvent,
+                                                     dataTypePageActiveEvent,
                                                      pmmlDocumentMetadataProvider,
                                                      definitionUtils,
                                                      itemDefinitionUtils,
@@ -713,6 +718,13 @@ public class ExpressionEditorViewImplTest {
         assertEquals(editorSelectedEvent, command.getEditorSelectedEvent());
         assertEquals(view, command.getView());
         assertEquals(NODE_UUID, command.getNodeUUID());
+    }
+
+    @Test
+    public void testOpenManageDataType() {
+        view.openManageDataType();
+
+        verify(dataTypePageActiveEvent).fire(any(DataTypePageTabActiveEvent.class));
     }
 
     @Test


### PR DESCRIPTION
- Adding the "Manage" link to name/data type popover:
![image](https://user-images.githubusercontent.com/22591802/150535405-54e57963-1382-43da-b815-b3d3bb9e4b98.png)
- Usage an injected object for retrieving functions to call from GWT world, instead of using `window` namespace.