### PR TITLE
Use local references for reusable workflows

### DIFF
--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   dry_run:
-    uses: kiegroup/kie-tools/.github/workflows/release_build.yml@main
+    uses: ./.github/workflows/release_build.yml
     with:
       dry_run: true
       base_ref: ${{ github.event.pull_request && github.base_ref || github.ref }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -47,7 +47,7 @@ jobs:
 
   build_and_publish:
     needs: [prepare]
-    uses: kiegroup/kie-tools/.github/workflows/release_build.yml@main
+    uses: ./.github/workflows/release_build.yml
     with:
       dry_run: false
       base_ref: ${{ needs.prepare.outputs.release_ref }}

--- a/.github/workflows/staging_dry_run.yml
+++ b/.github/workflows/staging_dry_run.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   dry_run:
-    uses: kiegroup/kie-tools/.github/workflows/staging_build.yml@main
+    uses: ./.github/workflows/staging_build.yml
     with:
       dry_run: true
       base_ref: ${{ github.event.pull_request && github.base_ref || github.ref }}

--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -52,7 +52,7 @@ jobs:
 
   build_and_publish:
     needs: [create_release]
-    uses: kiegroup/kie-tools/.github/workflows/staging_build.yml@main
+    uses: ./.github/workflows/staging_build.yml
     with:
       dry_run: false
       base_ref: ${{ github.ref }}


### PR DESCRIPTION
Update workflows since now we can use local references for them.

Ref: https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/