### PR TITLE
Update MockitoJUnitRunner to non deprecated one

### DIFF
--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataprovider/CustomProviderTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataprovider/CustomProviderTest.java
@@ -25,7 +25,7 @@ import org.dashbuilder.dataset.def.DataSetDefRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefDeployerTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefDeployerTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/JDBCUtilsTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/JDBCUtilsTest.java
@@ -37,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JDBCUtilsTest {

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLDataSetMetadataTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLDataSetMetadataTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import static org.mockito.Mockito.*;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLInjectionAttacksTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLInjectionAttacksTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 import static org.dashbuilder.dataset.ExpenseReportsData.*;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SelectStatementTest.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SelectStatementTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;

--- a/packages/stunner-editors/appformer-client-api/src/test/java/org/appformer/client/stateControl/registry/impl/DefaultRegistryImplTest.java
+++ b/packages/stunner-editors/appformer-client-api/src/test/java/org/appformer/client/stateControl/registry/impl/DefaultRegistryImplTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserverTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserverTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/pmmleditor/marshaller/PMMLEditorMarshallerServiceProducerTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/pmmleditor/marshaller/PMMLEditorMarshallerServiceProducerTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/pmmleditor/marshaller/PMMLEditorMarshallerServiceTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/pmmleditor/marshaller/PMMLEditorMarshallerServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/stateControl/registry/impl/KogitoCommandRegistryTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/stateControl/registry/impl/KogitoCommandRegistryTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/stateControl/registry/producer/RegistryProducerTest.java
+++ b/packages/stunner-editors/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/stateControl/registry/producer/RegistryProducerTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RegistryProducerTest {

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaDataTest.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaDataTest.java
@@ -20,7 +20,7 @@ import org.drools.workbench.screens.scenariosimulation.client.factories.Scenario
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellEditAction;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/services/ScenarioSimulationKogitoRuntimeResourceContentServiceTest.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/services/ScenarioSimulationKogitoRuntimeResourceContentServiceTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.kogito.webapp.base.client.workarounds.KogitoResourceContentService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/DataTypeCacheTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/DataTypeCacheTest.java
@@ -25,7 +25,7 @@ import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunne
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyObject;

--- a/packages/stunner-editors/uberfire-api/src/test/java/org/uberfire/backend/vfs/PathFactoryTest.java
+++ b/packages/stunner-editors/uberfire-api/src/test/java/org/uberfire/backend/vfs/PathFactoryTest.java
@@ -19,7 +19,7 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportProducerTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportProducerTest.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.editor.commons.client.file.exports.jso.FileExportScriptInjector;
 
 import static org.junit.Assert.*;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/generator/LayoutGeneratorTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/generator/LayoutGeneratorTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.layout.editor.api.editor.LayoutColumn;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutInstance;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/dropdown/SingleLiveSearchSelectionHandlerTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/dropdown/SingleLiveSearchSelectionHandlerTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/dropdown/footer/LiveSearchFooterTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/dropdown/footer/LiveSearchFooterTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.widgets.common.client.dropdown.InlineCreationEditor;
 import org.uberfire.mvp.Command;
 

--- a/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/select/SelectComponentTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/select/SelectComponentTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
 

--- a/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/select/SelectOptionComponentTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/select/SelectOptionComponentTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
 

--- a/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/LoggingTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/LoggingTest.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
@@ -27,7 +27,7 @@ import com.google.gwt.user.client.Command;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.mockito.Mockito.doReturn;

--- a/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
@@ -27,7 +27,7 @@ import com.google.gwt.user.client.Command;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/InlineNotificationTest.java
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/InlineNotificationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/ModalTest.java
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/ModalTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/SelectTest.java
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/SelectTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Our codebase should move from a deprecated `org.mockito.runners.MockitoJUnitRunner` to non deprecated one `org.mockito.junit.MockitoJUnitRunner`.