### PR TITLE
Create new env var to customize KIE Sandbox's URL in IT tests

### DIFF
--- a/packages/build-env/index.js
+++ b/packages/build-env/index.js
@@ -97,6 +97,11 @@ const ENV_VARS = {
     default: undefined,
     description: "",
   },
+  ONLINE_EDITOR__url: {
+    name: "ONLINE_EDITOR__url",
+    default: undefined,
+    description: "",
+  },
   DMN_DEV_SANDBOX__baseImageRegistry: {
     name: "DMN_DEV_SANDBOX__baseImageRegistry",
     default: "quay.io",
@@ -317,6 +322,7 @@ module.exports = {
 
   onlineEditor: {
     dev: {
+      urlProperty: ENV_VARS.ONLINE_EDITOR__url.name,
       port: 9001,
     },
     gtmId: getOrDefault(ENV_VARS.ONLINE_EDITOR__gtmId),

--- a/packages/build-env/index.js
+++ b/packages/build-env/index.js
@@ -97,9 +97,9 @@ const ENV_VARS = {
     default: undefined,
     description: "",
   },
-  ONLINE_EDITOR__url: {
-    name: "ONLINE_EDITOR__url",
-    default: undefined,
+  ONLINE_EDITOR__cypressUrl: {
+    name: "ONLINE_EDITOR__cypressUrl",
+    default: "https://localhost:9001/",
     description: "",
   },
   DMN_DEV_SANDBOX__baseImageRegistry: {
@@ -322,7 +322,7 @@ module.exports = {
 
   onlineEditor: {
     dev: {
-      urlProperty: ENV_VARS.ONLINE_EDITOR__url.name,
+      cypressUrl: getOrDefault(ENV_VARS.ONLINE_EDITOR__cypressUrl),
       port: 9001,
     },
     gtmId: getOrDefault(ENV_VARS.ONLINE_EDITOR__gtmId),

--- a/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
+++ b/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
@@ -18,7 +18,9 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Expression Editor Test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("Test New Expresssion editor - context", () => {

--- a/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
+++ b/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
@@ -18,9 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Expression Editor Test", () => {
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("Test New Expresssion editor - context", () => {

--- a/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
+++ b/packages/online-editor/it-tests/integration/DMNExpressionEditor.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Expression Editor Test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("Test New Expresssion editor - context", () => {

--- a/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Guided Tour Test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("follow first guided tour instruction", () => {

--- a/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
@@ -18,7 +18,9 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Guided Tour Test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("follow first guided tour instruction", () => {

--- a/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNGuidedTourTest.ts
@@ -18,9 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Guided Tour Test", () => {
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("follow first guided tour instruction", () => {

--- a/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
@@ -18,9 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Runner Test", () => {
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("Test DMN Runner on DMN sample", () => {

--- a/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Runner Test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("Test DMN Runner on DMN sample", () => {

--- a/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
+++ b/packages/online-editor/it-tests/integration/DMNRunnerTest.ts
@@ -18,7 +18,9 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("DMN Runner Test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("Test DMN Runner on DMN sample", () => {

--- a/packages/online-editor/it-tests/integration/NewFileTest.ts
+++ b/packages/online-editor/it-tests/integration/NewFileTest.ts
@@ -18,9 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("New file test", () => {
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("should create new empty BPMN", () => {

--- a/packages/online-editor/it-tests/integration/NewFileTest.ts
+++ b/packages/online-editor/it-tests/integration/NewFileTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("New file test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("should create new empty BPMN", () => {

--- a/packages/online-editor/it-tests/integration/NewFileTest.ts
+++ b/packages/online-editor/it-tests/integration/NewFileTest.ts
@@ -18,7 +18,9 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("New file test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("should create new empty BPMN", () => {

--- a/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
+++ b/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
@@ -21,7 +21,9 @@ describe("Open from source test", () => {
     "https://raw.githubusercontent.com/kiegroup/kie-tools/main/packages/online-editor/it-tests/fixtures/";
 
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("should open BPMN file from GitHub url", () => {

--- a/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
+++ b/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
@@ -21,9 +21,7 @@ describe("Open from source test", () => {
     "https://raw.githubusercontent.com/kiegroup/kie-tools/main/packages/online-editor/it-tests/fixtures/";
 
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("should open BPMN file from GitHub url", () => {

--- a/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
+++ b/packages/online-editor/it-tests/integration/OpenFromSourceTest.ts
@@ -21,7 +21,7 @@ describe("Open from source test", () => {
     "https://raw.githubusercontent.com/kiegroup/kie-tools/main/packages/online-editor/it-tests/fixtures/";
 
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("should open BPMN file from GitHub url", () => {

--- a/packages/online-editor/it-tests/integration/TrySampleTest.ts
+++ b/packages/online-editor/it-tests/integration/TrySampleTest.ts
@@ -18,9 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("Try sample test", () => {
   beforeEach(() => {
-    cy.visit(
-      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
-    );
+    cy.visit("/");
   });
 
   it("should create BPMN sample", () => {

--- a/packages/online-editor/it-tests/integration/TrySampleTest.ts
+++ b/packages/online-editor/it-tests/integration/TrySampleTest.ts
@@ -18,7 +18,9 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("Try sample test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(
+      Cypress.env(buildEnv.onlineEditor.dev.urlProperty) ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`
+    );
   });
 
   it("should create BPMN sample", () => {

--- a/packages/online-editor/it-tests/integration/TrySampleTest.ts
+++ b/packages/online-editor/it-tests/integration/TrySampleTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("Try sample test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("should create BPMN sample", () => {

--- a/packages/online-editor/it-tests/integration/UploadFileTest.ts
+++ b/packages/online-editor/it-tests/integration/UploadFileTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("Upload file test", () => {
   beforeEach(() => {
-    cy.visit(`https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
   });
 
   it("should upload BPMN file", () => {

--- a/packages/online-editor/it-tests/integration/UploadFileTest.ts
+++ b/packages/online-editor/it-tests/integration/UploadFileTest.ts
@@ -18,7 +18,7 @@ import * as buildEnv from "@kie-tools/build-env";
 
 describe("Upload file test", () => {
   beforeEach(() => {
-    cy.visit(Cypress.env("ONLINE_EDITOR_URL") ?? `https://localhost:${buildEnv.onlineEditor.dev.port}/`);
+    cy.visit("/");
   });
 
   it("should upload BPMN file", () => {

--- a/packages/online-editor/it-tests/plugins/index.ts
+++ b/packages/online-editor/it-tests/plugins/index.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-module.exports = (on: any, config: any) => {};
+module.exports = (on: any, config: any) => {
+  // use regular env. properties instead of the ones with the "CYPRESS_" prefix
+  config.env = process.env;
+  return config;
+};

--- a/packages/online-editor/it-tests/plugins/index.ts
+++ b/packages/online-editor/it-tests/plugins/index.ts
@@ -14,8 +14,4 @@
  * limitations under the License.
  */
 
-module.exports = (on: any, config: any) => {
-  // use regular env. properties instead of the ones with the "CYPRESS_" prefix
-  config.env = process.env;
-  return config;
-};
+module.exports = (on: any, config: any) => {};

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -46,8 +46,8 @@
     "build:dev": "rimraf dist && webpack --env dev",
     "build:prod": "yarn lint && yarn test && rimraf dist && webpack && yarn test:it",
     "start": "webpack serve --host 0.0.0.0 --env dev",
-    "cy:open": "yarn run cypress open --project it-tests",
-    "cy:run": "yarn run cypress run --headed -b chrome --project it-tests",
+    "cy:open": "yarn run cypress open --project it-tests --config baseUrl=$(build-env onlineEditor.dev.cypressUrl)",
+    "cy:run": "yarn run cypress run --headed -b chrome --project it-tests --config baseUrl=$(build-env onlineEditor.dev.cypressUrl)",
     "test:it:start:extended-services": "npm --prefix ../extended-services run start",
     "test:it": "yarn run run-script-if --bool \"$(build-env global.build.testIT)\" --then  \"yarn rimraf ./dist-it-tests\" \"yarn run start-server-and-test test:it:start:extended-services http-get://0.0.0.0:21345/ping start https-get://0.0.0.0:$(build-env onlineEditor.dev.port) cy:run\""
   },


### PR DESCRIPTION
If `CYPRESS_ONLINE_EDITOR_URL` env. variable is set, it will be used as entry point for the Cypress integration tests.