### PR TITLE
KOGITO-6673 - Wrong label in Advanced Data Properties Tab

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/resources/org/kie/workbench/common/stunner/bpmn/resources/i18n/StunnerBPMNConstants.properties
@@ -490,6 +490,7 @@ VariablesEditorWidget.TagsX=Variable Tags
 # AdvancedData
 #######################
 org.kie.workbench.common.stunner.bpmn.definition.property.variables.RootProcessAdvancedData.label=Advanced
+org.kie.workbench.common.stunner.bpmn.definition.property.variables.AdvancedData.label=Advanced
 
 #######################
 # Common Properties


### PR DESCRIPTION
This fixes the label. Also adds the possibility to translate it.

**JIRA**: [KOGITO-6673](https://issues.redhat.com/browse/KOGITO-6673)