### PR TITLE
Improvements for update deployment + deploy daily version

### DIFF
--- a/.github/actions/deploy-openshift/action.yml
+++ b/.github/actions/deploy-openshift/action.yml
@@ -1,6 +1,9 @@
 name: "Deploy to OpenShift"
 
 inputs:
+  image_tag:
+    description: "Container Image Tag"
+    required: true
   image_url:
     description: "Container Image URL"
     required: true
@@ -58,17 +61,28 @@ runs:
 
         if ! oc get deploy ${{ inputs.app_name }} > /dev/null 2>&1; then
           echo "Create the app '${{ inputs.app_name }}'"
-          oc new-app ${{ inputs.image_url }} --name=${{ inputs.app_name }} --env-file=${{ inputs.deployment_envvars_file_path }}
+
+          oc create imagestream ${{ inputs.app_name }}
+          oc import-image ${{ inputs.app_name }}:${{ inputs.image_tag }} --from=${{ inputs.image_url }} --confirm
+          oc tag ${{ inputs.app_name }}:${{ inputs.image_tag }} ${{ inputs.app_name }}:latest
+
+          oc label imagestreams/${{ inputs.app_name }} app=${{ inputs.app_name }}
+          oc label imagestreams/${{ inputs.app_name }} app.kubernetes.io/component=${{ inputs.app_name }}
+          oc label imagestreams/${{ inputs.app_name }} app.kubernetes.io/instance=${{ inputs.app_name }}
+          oc label imagestreams/${{ inputs.app_name }} app.kubernetes.io/part-of=${{ inputs.part_of }}
+
+          oc new-app ${{ inputs.app_name }}:latest --name=${{ inputs.app_name }} --env-file=${{ inputs.deployment_envvars_file_path }}
           oc create route edge --service=${{ inputs.app_name }}
 
-          oc label imagestreams/${{ inputs.app_name }} app.kubernetes.io/part-of=${{ inputs.part_of }}
           oc label services/${{ inputs.app_name }} app.kubernetes.io/part-of=${{ inputs.part_of }}
           oc label routes/${{ inputs.app_name }} app.kubernetes.io/part-of=${{ inputs.part_of }}
           oc label deployments/${{ inputs.app_name }} app.kubernetes.io/part-of=${{ inputs.part_of }}
           oc label deployments/${{ inputs.app_name }} app.openshift.io/runtime=${{ inputs.deployment_icon }}
         else
           echo "App '${{ inputs.app_name }}' already exists. Update the ImageStream instead."
-          oc import-image ${{ inputs.app_name }}:latest
+          oc tag -d ${{ inputs.app_name }}:latest
+          oc import-image ${{ inputs.app_name }}:${{ inputs.image_tag }} --from=${{ inputs.image_url }} --confirm
+          oc tag ${{ inputs.app_name }}:${{ inputs.image_tag }} ${{ inputs.app_name }}:latest
           cat ${{ inputs.deployment_envvars_file_path }} | oc set env deploy/${{ inputs.app_name }} -
         fi
 

--- a/.github/workflows/publish_daily_dev_version.yml
+++ b/.github/workflows/publish_daily_dev_version.yml
@@ -23,8 +23,27 @@ jobs:
       DMN_DEV_SANDBOX__baseImageBuildTags: "daily-dev"
       DMN_DEV_SANDBOX__onlineEditorUrl: "https://kiegroup.github.io/kogito-online/dev"
 
+      KIE_SANDBOX__imageRegistry: "quay.io"
+      KIE_SANDBOX__imageAccount: "kie-tools"
+      KIE_SANDBOX__imageName: "kie-sandbox-image"
+      KIE_SANDBOX__imageBuildTags: "daily-dev"
+
+      KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry: "quay.io"
+      KIE_SANDBOX_EXTENDED_SERVICES__imageAccount: "kie-tools"
+      KIE_SANDBOX_EXTENDED_SERVICES__imageName: "kie-sandbox-extended-services-image"
+      KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags: "daily-dev"
+
+      CORS_PROXY__imageRegistry: "quay.io"
+      CORS_PROXY__imageAccount: "kie-tools"
+      CORS_PROXY__imageName: "cors-proxy-image"
+      CORS_PROXY__imageBuildTags: "daily-dev"
+
+      OPENSHIFT_NAMESPACE: "kie-sandbox"
+      OPENSHIFT_PART_OF: "daily-dev-kie-sandbox-app"
+      DEPLOY_TAG: "daily-dev"
+
     steps:
-      - name: "Support longpaths"
+      - name: "Support longpaths (Windows only)"
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true
 
@@ -79,6 +98,85 @@ jobs:
           registry: "${{ env.DMN_DEV_SANDBOX__baseImageRegistry }}/${{ env.DMN_DEV_SANDBOX__baseImageAccount }}"
           username: "${{ env.DMN_DEV_SANDBOX__baseImageAccount }}"
           password: "${{ secrets.QUAY_REGISTRY_PASSWORD }}"
+
+      - name: "Push kie-sandbox-extended-services-image to quay.io (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }}"
+          tags: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags }}"
+          registry: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}"
+          username: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}"
+          password: "${{ secrets.QUAY_REGISTRY_PASSWORD }}"
+
+      - name: "Push cors-proxy-image to quay.io (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: "${{ env.CORS_PROXY__imageName }}"
+          tags: "${{ env.CORS_PROXY__imageBuildTags }}"
+          registry: "${{ env.CORS_PROXY__imageRegistry }}/${{ env.CORS_PROXY__imageAccount }}"
+          username: "${{ env.CORS_PROXY__imageAccount }}"
+          password: "${{ secrets.QUAY_REGISTRY_PASSWORD }}"
+
+      - name: "Push kie-sandbox-image to quay.io (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: "${{ env.KIE_SANDBOX__imageName }}"
+          tags: "${{ env.KIE_SANDBOX__imageBuildTags }}"
+          registry: "${{ env.KIE_SANDBOX__imageRegistry }}/${{ env.KIE_SANDBOX__imageAccount }}"
+          username: "${{ env.KIE_SANDBOX__imageAccount }}"
+          password: "${{ secrets.QUAY_REGISTRY_PASSWORD }}"
+
+      - name: "Deploy kie-sandbox-extended-services-image to OpenShift (Ubuntu only)"
+        id: deploy_kie_sandbox_extended_services_image
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./kie-tools/.github/actions/deploy-openshift
+        with:
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }}:${{ env.DEPLOY_TAG }}"
+          app_name: "daily-dev-kie-sandbox-extended-services"
+          part_of: ${{ env.OPENSHIFT_PART_OF }}
+          openshift_server: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          openshift_namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          deployment_icon: "golang"
+
+      - name: "Deploy cors-proxy-image to OpenShift (Ubuntu only)"
+        id: deploy_cors_proxy_image
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./kie-tools/.github/actions/deploy-openshift
+        with:
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.CORS_PROXY__imageRegistry }}/${{ env.CORS_PROXY__imageAccount }}/${{ env.CORS_PROXY__imageName }}:${{ env.DEPLOY_TAG }}"
+          app_name: "daily-dev-cors-proxy"
+          part_of: ${{ env.OPENSHIFT_PART_OF }}
+          openshift_server: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          openshift_namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          deployment_icon: "nodejs"
+
+      - name: "Prepare environment variables for OpenShift deployment (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          echo "KIE_SANDBOX_EXTENDED_SERVICES_URL=${{ steps.deploy_kie_sandbox_extended_services_image.outputs.route_url }}" >> deployment.env
+          echo "CORS_PROXY_URL=${{ steps.deploy_cors_proxy_image.outputs.route_url }}" >> deployment.env
+
+      - name: "Deploy kie-sandbox-image to OpenShift (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
+        uses: ./kie-tools/.github/actions/deploy-openshift
+        with:
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.KIE_SANDBOX__imageRegistry }}/${{ env.KIE_SANDBOX__imageAccount }}/${{ env.KIE_SANDBOX__imageName }}:${{ env.DEPLOY_TAG }}"
+          app_name: "daily-dev-kie-sandbox"
+          part_of: ${{ env.OPENSHIFT_PART_OF }}
+          openshift_server: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          openshift_namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+          deployment_envvars_file_path: ./deployment.env
+          deployment_icon: "js"
 
       - name: "Upload VS Code Extension (dev) (Ubuntu only)"
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -215,7 +215,6 @@ jobs:
           lerna run build:prod --scope=@kie-tools/kie-sandbox-image --include-dependencies --stream
 
       - name: "Push kie-sandbox-image to quay.io"
-        id: push_kie_sandbox_image
         if: ${{ !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -285,7 +284,6 @@ jobs:
           lerna run build:prod --scope=@kie-tools/kie-sandbox-extended-services-image --include-dependencies --stream
 
       - name: "Push kie-sandbox-extended-services-image to quay.io"
-        id: push_kie_sandbox_extended_services_image
         if: ${{ !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -347,7 +345,6 @@ jobs:
           lerna run build:prod --scope=@kie-tools/cors-proxy-image --include-dependencies --stream
 
       - name: "Push cors-proxy-image to quay.io"
-        id: push_cors_proxy_image
         if: ${{ !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -237,7 +237,8 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: ./.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_kie_sandbox_image.outputs.registry-path }}
+          image_tag: ${{ inputs.tag }}
+          image_url: "${{ env.KIE_SANDBOX__imageRegistry }}/${{ env.KIE_SANDBOX__imageAccount }}/${{ env.KIE_SANDBOX__imageName }}:${{ inputs.tag }}"
           app_name: ${{ env.OPENSHIFT_APP_NAME }}
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}
@@ -299,7 +300,8 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: ./.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_kie_sandbox_extended_services_image.outputs.registry-path }}
+          image_tag: ${{ inputs.tag }}
+          image_url: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }}:${{ inputs.tag }}"
           app_name: ${{ env.OPENSHIFT_APP_NAME }}
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}
@@ -360,7 +362,8 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: ./.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_cors_proxy_image.outputs.registry-path }}
+          image_tag: ${{ inputs.tag }}
+          image_url: "${{ env.CORS_PROXY__imageRegistry }}/${{ env.CORS_PROXY__imageAccount }}/${{ env.CORS_PROXY__imageName }}:${{ inputs.tag }}"
           app_name: ${{ env.OPENSHIFT_APP_NAME }}
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -154,7 +154,6 @@ jobs:
           password: "${{ secrets.quay_registry_password }}"
 
       - name: "STAGING: Push kie-sandbox-extended-services-image to quay.io (Ubuntu only)"
-        id: push_kie_sandbox_extended_services_image
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -179,7 +178,6 @@ jobs:
           deployment_icon: "golang"
 
       - name: "STAGING: Push cors-proxy-image to quay.io (Ubuntu only)"
-        id: push_cors_proxy_image
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -204,7 +202,6 @@ jobs:
           deployment_icon: "nodejs"
 
       - name: "STAGING: Push kie-sandbox-image to quay.io (Ubuntu only)"
-        id: push_kie_sandbox_image
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -222,7 +219,6 @@ jobs:
           echo "CORS_PROXY_URL=${{ steps.deploy_cors_proxy_image.outputs.route_url }}" >> deployment.env
 
       - name: "STAGING: Deploy kie-sandbox-image to OpenShift (Ubuntu only)"
-        id: deploy_kie_sandbox_image
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: ./kie-tools/.github/actions/deploy-openshift
         with:

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -72,6 +72,8 @@ jobs:
       CORS_PROXY__imageName: "cors-proxy-image"
       CORS_PROXY__imageBuildTags: "${{ inputs.tag }}-prerelease"
 
+      DEPLOY_TAG: "${{ inputs.tag }}-prerelease"
+
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -167,7 +169,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: ./kie-tools/.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_kie_sandbox_extended_services_image.outputs.registry-path }}
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }}:${{ env.DEPLOY_TAG }}"
           app_name: "staging-kie-sandbox-extended-services"
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}
@@ -191,7 +194,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: ./kie-tools/.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_cors_proxy_image.outputs.registry-path }}
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.CORS_PROXY__imageRegistry }}/${{ env.CORS_PROXY__imageAccount }}/${{ env.CORS_PROXY__imageName }}:${{ env.DEPLOY_TAG }}"
           app_name: "staging-cors-proxy"
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}
@@ -222,7 +226,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: ./kie-tools/.github/actions/deploy-openshift
         with:
-          image_url: ${{ steps.push_kie_sandbox_image.outputs.registry-path }}
+          image_tag: ${{ env.DEPLOY_TAG }}
+          image_url: "${{ env.KIE_SANDBOX__imageRegistry }}/${{ env.KIE_SANDBOX__imageAccount }}/${{ env.KIE_SANDBOX__imageName }}:${{ env.DEPLOY_TAG }}"
           app_name: "staging-kie-sandbox"
           part_of: ${{ env.OPENSHIFT_PART_OF }}
           openshift_server: ${{ secrets.openshift_server }}


### PR DESCRIPTION
In this PR:
- Improvements for the `deploy-openshift` action so that an update automatically triggers a re-deploy.
- Publish a `daily-dev` version of KIE Sandbox images to quay.io.
- Deploy a `daily-dev` version of KIE Sandbox to OpenShift.