### PR TITLE
KOGITO-6693: JavaCodeCompletion configuration

### DIFF
--- a/packages/vscode-extension-bpmn-editor/package.json
+++ b/packages/vscode-extension-bpmn-editor/package.json
@@ -49,7 +49,7 @@
   },
   "contributes": {
     "javaExtensions": [
-      "./server/vscode-java-code-completion-extension-plugin-core.jar"
+      "./dist/server/vscode-java-code-completion-extension-plugin-core.jar"
     ],
     "customEditors": [
       {

--- a/packages/vscode-extension-dmn-editor/package.json
+++ b/packages/vscode-extension-dmn-editor/package.json
@@ -49,7 +49,7 @@
   },
   "contributes": {
     "javaExtensions": [
-      "./server/vscode-java-code-completion-extension-plugin-core.jar"
+      "./dist/server/vscode-java-code-completion-extension-plugin-core.jar"
     ],
     "customEditors": [
       {

--- a/packages/vscode-extension-pack-kogito-kie-editors/package.json
+++ b/packages/vscode-extension-pack-kogito-kie-editors/package.json
@@ -29,7 +29,7 @@
   },
   "contributes": {
     "javaExtensions": [
-      "./server/vscode-java-code-completion-extension-plugin-core.jar"
+      "./dist/server/vscode-java-code-completion-extension-plugin-core.jar"
     ],
     "configuration": {
       "title": "KIE Tools Dev Test Configuration",

--- a/packages/vscode-extension/src/KogitoEditorChannelApiImpl.ts
+++ b/packages/vscode-extension/src/KogitoEditorChannelApiImpl.ts
@@ -34,9 +34,10 @@ import {
   JavaCodeCompletionApi,
   JavaCodeCompletionAccessor,
   JavaCodeCompletionClass,
+  JavaCodeCompletionChannelApi,
 } from "@kie-tools-core/vscode-java-code-completion/dist/api";
 
-export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
+export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi, JavaCodeCompletionChannelApi {
   private readonly decoder = new TextDecoder("utf-8");
 
   constructor(
@@ -137,13 +138,13 @@ export class KogitoEditorChannelApiImpl implements KogitoEditorChannelApi {
     this.notificationsApi.kogitoNotifications_removeNotifications(path);
   }
 
-  public kogitoJavaCodeCompletion_getAccessors(fqcn: string, query: string): Promise<JavaCodeCompletionAccessor[]> {
+  public kogitoJavaCodeCompletion__getAccessors(fqcn: string, query: string): Promise<JavaCodeCompletionAccessor[]> {
     return this.javaCodeCompletionApi.getAccessors(fqcn, query);
   }
-  public kogitoJavaCodeCompletion_getClasses(query: string): Promise<JavaCodeCompletionClass[]> {
+  public kogitoJavaCodeCompletion__getClasses(query: string): Promise<JavaCodeCompletionClass[]> {
     return this.javaCodeCompletionApi.getClasses(query);
   }
-  public kogitoJavaCodeCompletion_isLanguageServerAvailable(): Promise<boolean> {
+  public kogitoJavaCodeCompletion__isLanguageServerAvailable(): Promise<boolean> {
     return this.javaCodeCompletionApi.isLanguageServerAvailable();
   }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/README.md
+++ b/packages/vscode-java-code-completion-extension-plugin/README.md
@@ -14,12 +14,12 @@ The first run will take quite a while since maven will download all the required
 
 ## Usage
 
-Once compiled you need to copy the generated JAR in a folder inside the extension, and you need to configure that location path in _contributes_ section in pacakge.json
+Once compiled you need to copy the generated JAR in a folder inside the extension, and you need to configure that location path in _contributes_ section in package.json
 
 ```json
 "contributes": {
     "javaExtensions": [
-      "./server/vscode-java-code-completion-extension-plugin.jar"
+      "./dist/server/vscode-java-code-completion-extension-plugin-core.jar"
     ],
     ...
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: lib/freemarker-2.3.31.jar,
  .
 Import-Package: com.google.gson,
- com.google.gson.stream,
- org.apache.log4j
+ com.google.gson.stream
 
 

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
@@ -55,13 +55,13 @@ public class ActivationChecker {
 
     public String getActivatorUri() {
         if (this.existActivator() && StringUtils.isNotEmpty(this.activatorUri)) {
-            return "file://" + this.activatorUri;
+            return this.activatorUri;
         } else {
             throw new ActivationCheckerException("Activator URI is not present");
         }
     }
 
     private String getRootUri() {
-        return "file://" + this.workspaceUtil.getWorkspace();
+        return this.workspaceUtil.getWorkspace();
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.kogito.core.internal.util.WorkspaceUtil;
 
@@ -54,8 +53,8 @@ public class ActivationChecker {
     }
 
     public String getActivatorUri() {
-        if (this.existActivator() && StringUtils.isNotEmpty(this.activatorUri)) {
-            return this.activatorUri;
+        if (this.existActivator() && this.activatorUri != null && !this.activatorUri.isEmpty()) {
+            return "file://" + this.activatorUri;
         } else {
             throw new ActivationCheckerException("Activator URI is not present");
         }


### PR DESCRIPTION
This PR fixes all configuration issues found on the JavaCodeCompletion module until now.

Issues:
- `vscode-java-code-completion-extension-plugin-core.jar` path was wrong;
- `KogitoEditorChannelApiImpl` didn't implement `JavaCodeCompletionChannelApi`
- ` org.apache.log4j` import in `MANIFEST.MF` file results to an error - removed
- ` "file://"` prefix on workspace root results to an error;
- `StringUtils` library seems not correctly imported - removed as used in one point only to check if a string is empty

Unfortunately, still an issue persists, which requires further investigations.

[Trace - 6:03:24 PM] Received response 'workspace/executeCommand - (3)' in 1165ms. Request failed: Internal error. (-32603).
Error data: "java.util.concurrent.CompletionException: java.lang.reflect.InaccessibleObjectException: Unable to make field volatile java.lang.Object java.util.concurrent.CompletableFuture.result accessible: module java.base does not \"opens java.util.concurrent\" to unnamed module @27e77123\n\tat java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture.postFire(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)\n\tat java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)\n\tat java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)\n\tat java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)\n\tat java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)\n\tat java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)\nCaused by: java.lang.reflect.InaccessibleObjectException: Unable to make field volatile java.lang.Object java.util.concurrent.CompletableFuture.result accessible: module java.base does not \"opens java.util.concurrent\" to unnamed module @27e77123\n\tat java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(Unknown Source)\n\tat java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(Unknown Source)\n\tat java.base/java.lang.reflect.Field.checkCanSetAccessible(Unknown Source)\n\tat java.base/java.lang.reflect.Field.setAccessible(Unknown Source)\n\tat com.google.gson.internal.reflect.UnsafeReflectionAccessor.makeAccessible(UnsafeReflectionAccessor.java:44)\n\tat com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:159)\n\tat com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:102)\n\tat com.google.gson.Gson.getAdapter(Gson.java:458)\n\tat com.google.gson.Gson.toJson(Gson.java:696)\n\tat org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.write(MessageTypeAdapter.java:423)\n\tat org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.write(MessageTypeAdapter.java:55)\n\tat com.google.gson.Gson.toJson(Gson.java:704)\n\tat com.google.gson.Gson.toJson(Gson.java:683)\n\tat org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.serialize(MessageJsonHandler.java:145)\n\tat org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.serialize(MessageJsonHandler.java:140)\n\tat org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer.consume(StreamMessageConsumer.java:59)\n\tat org.eclipse.jdt.ls.core.internal.ParentProcessWatcher.lambda$0(ParentProcessWatcher.java:123)\n\tat org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.lambda$handleRequest$1(RemoteEndpoint.java:281)\n\t... 10 more\n"