### PR TITLE
Mutually exclusive decision to run `CI` or `CI :: Full`

### DIFF
--- a/.github/actions/deploy-openshift/action.yml
+++ b/.github/actions/deploy-openshift/action.yml
@@ -1,4 +1,5 @@
 name: "Deploy to OpenShift"
+description: ""
 
 inputs:
   image_tag:

--- a/.github/actions/merge-pr-changes/action.yml
+++ b/.github/actions/merge-pr-changes/action.yml
@@ -7,20 +7,40 @@ inputs:
     required: false
     default: "."
 
+outputs:
+  base_sha:
+    description: "Base SHA"
+    value: ${{ steps.merge_changes.outputs.base_sha }}
+  head_sha:
+    description: "Head SHA"
+    value: ${{ steps.merge_changes.outputs.head_sha }}
+
 runs:
   using: "composite"
   steps:
     - name: "Merge changes"
+      id: merge_changes
       shell: bash
       run: |
         echo "STEP: Merge changes"
         cd ${{ inputs.path }}
         if [ ${{ github.event.pull_request }} ]; then
           user=$(node -e "console.log('${{ github.event.pull_request.head.label }}'.match(/(.+)\:(.+)$/)[1])")
+
           echo "Merge changes from $user/${{ github.head_ref }}"
           git remote add $user https://github.com/$user/kie-tools.git
           git fetch $user
+
+          echo "Before merging..."
+          git log -n 1
+          echo "::set-output name=base_sha::$(git rev-parse HEAD)"
+
           git merge --squash $user/${{ github.head_ref }}
+          git commit --no-edit
+
+          echo "After merging..."
+          git log -n 1
+          echo "::set-output name=head_sha::$(git rev-parse HEAD)"
         else
           echo "Skip merge, not a pull request"
         fi

--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -3,8 +3,6 @@ name: "CI :: Monorepo"
 on:
   pull_request:
     branches: "**"
-    paths:
-      - "packages/**"
 
 concurrency:
   group: monorepo-pr-ci-${{ github.event.pull_request.number }}
@@ -33,14 +31,37 @@ jobs:
         uses: ./.github/actions/setup-kie-tools-bot
 
       - name: "Merge PR changes"
+        id: merge_changes
         uses: ./.github/actions/merge-pr-changes
 
+      - name: "Check if should run or not"
+        id: check_diff_paths
+        shell: bash
+        run: |
+          # If there are no changed files in dirs that are not `packages` or `examples`,
+          # it means that all changed files are in either `packages` or `examples`, so we should run the normal CI.
+
+          read -r -a DIFF_PATHS <<< $(git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- ':!packages' ':!examples')
+          echo $DIFF_PATHS
+
+          if [ ${#DIFF_PATHS[@]} -eq 0 ]; then
+            echo '`CI` will run.'
+            echo "::set-output name=should_run::true"
+          else
+            echo '`CI :: Full` is already running, no need to run this one.'
+            echo "::set-output name=should_run::false"
+          fi
+
+          echo "Done"
+
       - name: "Setup environment"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
 
       - name: "Build dependencies"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         shell: bash
         env:
           KIE_TOOLS_BUILD_examples: "true"
@@ -53,6 +74,7 @@ jobs:
             --else "lerna run --stream build:dev $SCOPE"
 
       - name: "Build changed and dependents"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         env:
           WEBPACK__minimize: "false"
           KIE_TOOLS_BUILD_lint: "true"
@@ -66,6 +88,7 @@ jobs:
           lerna run build:prod --stream --since ${{ github.base_ref }}
 
       - name: "Check generated resources (you should commit those!)"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         shell: bash
         run: |
           git diff
@@ -73,7 +96,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2
-        if: always() && !cancelled()
+        if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         with:
           name: artifacts-${{ matrix.os }}
           if-no-files-found: warn
@@ -84,7 +107,7 @@ jobs:
 
       - name: "Upload IT Tests artifacts"
         uses: actions/upload-artifact@v2
-        if: always() && !cancelled()
+        if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         with:
           name: it-tests-artifacts-${{ matrix.os }}
           if-no-files-found: warn

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: "**"
-    paths-ignore:
-      - "packages/**"
 
 concurrency:
   group: ${{ github.event.pull_request && format('monorepo-pr-ci-full-{0}', github.event.pull_request.number) || 'monorepo-pr-ci-full-push-main' }}
@@ -35,14 +33,40 @@ jobs:
         uses: ./.github/actions/setup-kie-tools-bot
 
       - name: "Merge PR changes"
+        id: merge_changes
         uses: ./.github/actions/merge-pr-changes
 
+      - name: "Check if should run or not"
+        id: check_diff_paths
+        shell: bash
+        run: |
+          # If there are no changed files outside `packages` or `examples`,
+          # we don't need to run the full CI.
+
+          read -r -a DIFF_PATHS <<< $(git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- ':!packages' ':!examples')
+          echo $DIFF_PATHS
+
+          if [ ${{ ! github.event.pull_request }} ]; then
+            echo 'Push to the main branch happened, should run'
+            echo "::set-output name=should_run::true"
+          elif [ ${#DIFF_PATHS[@]} -eq 0 ]; then
+            echo '`CI` is already running, no need to run this one.'
+            echo "::set-output name=should_run::false"
+          else
+            echo '`CI :: Full` will run.'
+            echo "::set-output name=should_run::true"
+          fi
+
+          echo "Done"
+
       - name: "Setup environment"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
 
       - name: "Build"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         env:
           WEBPACK__minimize: "false"
           WEBPACK__tsLoaderTranspileOnly: "false"
@@ -57,6 +81,7 @@ jobs:
           lerna run build:prod --stream --concurrency 1
 
       - name: "Check generated resources (you should commit those!)"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         shell: bash
         run: |
           git diff
@@ -64,7 +89,7 @@ jobs:
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2
-        if: always() && !cancelled()
+        if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         with:
           name: artifacts-${{ matrix.os }}
           if-no-files-found: warn
@@ -75,7 +100,7 @@ jobs:
 
       - name: "Upload IT Tests artifacts"
         uses: actions/upload-artifact@v2
-        if: always() && !cancelled()
+        if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         with:
           name: it-tests-artifacts-${{ matrix.os }}
           if-no-files-found: warn


### PR DESCRIPTION
With GitHub Action's `paths` and `paths-ignore`, we can't properly do that.

This PR changes this decision to a manual shell check, which give us more flexibility and saves resources.