### PR TITLE
KOGITO-3660: Generate input/output columns, based on the type of the input nodes/the type decision node

### DIFF
--- a/packages/boxed-expression-component/showcase/index.tsx
+++ b/packages/boxed-expression-component/showcase/index.tsx
@@ -63,6 +63,7 @@ export const App: React.FunctionComponent = () => {
     broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => setExpressionDefinition(definition),
     notifyUserAction(): void {},
     openManageDataType(): void {},
+    onLogicTypeSelect(): void {},
   };
 
   const onTypedExpressionChange = useCallback((e) => {

--- a/packages/boxed-expression-component/src/api/BoxedExpressionEditor.ts
+++ b/packages/boxed-expression-component/src/api/BoxedExpressionEditor.ts
@@ -42,6 +42,7 @@ declare global {
     broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => void;
     notifyUserAction: () => void;
     openManageDataType: () => void;
+    onLogicTypeSelect: (selectedLogicType: string) => void;
   }
 
   //API that BoxedExpressionEditor (bee) and its wrapper are expecting to be defined in the Window namespace

--- a/packages/boxed-expression-component/src/api/BoxedExpressionEditorGWTService.ts
+++ b/packages/boxed-expression-component/src/api/BoxedExpressionEditorGWTService.ts
@@ -39,4 +39,5 @@ export interface BoxedExpressionEditorGWTService {
   broadcastDecisionTableExpressionDefinition: (definition: DecisionTableProps) => void;
   notifyUserAction: () => void;
   openManageDataType: () => void;
+  onLogicTypeSelect: (selectedLogicType: string) => void;
 }

--- a/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -153,6 +153,9 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
       boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
       const selectedLogicType = itemId as LogicType;
       onLogicTypeUpdating(selectedLogicType);
+      if (!isHeadless) {
+        boxedExpression.boxedExpressionEditorGWTService?.onLogicTypeSelect(selectedLogicType);
+      }
     },
     [boxedExpression.boxedExpressionEditorGWTService, onLogicTypeUpdating]
   );

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -79,6 +79,9 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorWrapp
     openManageDataType(): void {
       window.beeApiWrapper?.openManageDataType();
     },
+    onLogicTypeSelect(selectedLogicType: string): void {
+      window.beeApiWrapper?.onLogicTypeSelect(selectedLogicType);
+    },
     resetExpressionDefinition: (definition: ExpressionProps) => {
       setExpressionDefinition(definition);
       window.beeApiWrapper?.resetExpressionDefinition?.(definition);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -72,7 +72,9 @@ import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.P
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props.RelationProps;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.BoxedExpressionService;
 import org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.util.ExpressionPropsFiller;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinition;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionEditorDefinitions;
+import org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType;
 import org.kie.workbench.common.dmn.client.editors.expressions.types.function.supplementary.pmml.PMMLDocumentMetadataProvider;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypePageTabActiveEvent;
 import org.kie.workbench.common.dmn.client.editors.types.common.HiddenHelper;
@@ -487,6 +489,11 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         dataTypePageActiveEvent.fire(new DataTypePageTabActiveEvent());
     }
 
+    public void onLogicTypeSelect(final String selectedLogicType) {
+        final ExpressionType expressionType = ExpressionType.getTypeByText(selectedLogicType);
+        expressionEditorDefinitionsSupplier.get().getExpressionEditorDefinition(expressionType).ifPresent(this::enrichModelExpression);
+    }
+
     void executeExpressionCommand(final FillExpressionCommand expressionCommand) {
         expressionCommand.execute();
         updateCanvasNodeNameCommand.execute(getNodeUUID(), getHasName().orElse(null));
@@ -571,6 +578,17 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                     .toArray(EntryInfo[]::new);
             return new ModelsFromDocument(modelName, parametersFromModel);
         };
+    }
+
+    private void enrichModelExpression(final ExpressionEditorDefinition<Expression> expressionExpressionEditorDefinition) {
+        final Optional<Expression> modelExpression = expressionExpressionEditorDefinition.getModelClass();
+        expressionExpressionEditorDefinition.enrich(Optional.of(getNodeUUID()), hasExpression, modelExpression);
+        modelExpression.ifPresent(this::reloadNewBoxedExpressionEditorWithUpdatedModel);
+    }
+
+    private void reloadNewBoxedExpressionEditorWithUpdatedModel(final Expression expression) {
+        getHasExpression().setExpression(expression);
+        loadNewBoxedExpressionEditor();
     }
 
     @EventHandler("returnToLink")

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -490,8 +490,10 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     }
 
     public void onLogicTypeSelect(final String selectedLogicType) {
-        final ExpressionType expressionType = ExpressionType.getTypeByText(selectedLogicType);
-        expressionEditorDefinitionsSupplier.get().getExpressionEditorDefinition(expressionType).ifPresent(this::enrichModelExpression);
+        expressionEditorDefinitionsSupplier
+                .get()
+                .getExpressionEditorDefinition(ExpressionType.getTypeByText(selectedLogicType))
+                .ifPresent(this::enrichModelExpression);
     }
 
     void executeExpressionCommand(final FillExpressionCommand expressionCommand) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
@@ -87,4 +87,9 @@ public class BoxedExpressionService {
     public static void openManageDataType() {
         expressionEditor.openManageDataType();
     }
+
+    @JsMethod
+    public static void onLogicTypeSelect(final String selectedLogicType) {
+        expressionEditor.onLogicTypeSelect(selectedLogicType);
+    }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionType.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionType.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.dmn.client.editors.expressions.types;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 public enum ExpressionType {
 
     UNDEFINED("<Undefined>"),
@@ -33,6 +36,15 @@ public enum ExpressionType {
 
     ExpressionType(final String text) {
         this.text = text;
+    }
+
+    public static ExpressionType getTypeByText(final String text) {
+        final String trimmedText = Optional.ofNullable(text).orElse("").trim();
+        return Arrays
+                .stream(values())
+                .filter(expressionType -> expressionType.getText().equalsIgnoreCase(trimmedText))
+                .findAny()
+                .orElse(UNDEFINED);
     }
 
     public String getText() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -108,6 +108,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorViewImpl.ENABLED_BETA_CSS_CLASS;
 import static org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType.LITERAL_EXPRESSION;
+import static org.kie.workbench.common.dmn.client.editors.expressions.types.ExpressionType.UNDEFINED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -329,6 +330,7 @@ public class ExpressionEditorViewImplTest {
         when(expressionEditorDefinitionsSupplier.get()).thenReturn(expressionEditorDefinitions);
         when(undefinedExpressionEditorDefinition.getModelClass()).thenReturn(Optional.empty());
         when(undefinedExpressionEditorDefinition.getName()).thenReturn(UNDEFINED_EXPRESSION_DEFINITION_NAME);
+        when(undefinedExpressionEditorDefinition.getType()).thenReturn(UNDEFINED);
         when(undefinedExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
                                                            any(Optional.class),
@@ -339,6 +341,7 @@ public class ExpressionEditorViewImplTest {
 
         when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(new LiteralExpression()));
         when(literalExpressionEditorDefinition.getName()).thenReturn(LITERAL_EXPRESSION.getText());
+        when(literalExpressionEditorDefinition.getType()).thenReturn(LITERAL_EXPRESSION);
         when(literalExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
                                                          any(Optional.class),
@@ -815,5 +818,15 @@ public class ExpressionEditorViewImplTest {
                 .isNotEmpty()
                 .hasSize(1)
                 .anyMatch(typeProps -> typeProps.isCustom && typeProps.name.equals(customDataType) && typeProps.typeRef.equals(customDataType));
+    }
+
+    @Test
+    public void testOnLogicTypeSelect() {
+        doNothing().when(view).loadNewBoxedExpressionEditor();
+
+        view.onLogicTypeSelect(LITERAL_EXPRESSION.getText());
+
+        verify(literalExpressionEditorDefinition).enrich(any(), any(), any());
+        verify(view).loadNewBoxedExpressionEditor();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionTypeTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/ExpressionTypeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.client.editors.expressions.types;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpressionTypeTest {
+
+    @Test
+    public void testGetTypeByText_whenTextIsOk_thenTypeIsReturned() {
+        assertThat(ExpressionType.getTypeByText("Relation")).isEqualTo(ExpressionType.RELATION);
+    }
+
+    @Test
+    public void testGetTypeByText_whenTextIsOkButWithLeadingOrTrailingSpaces_thenTypeIsReturned() {
+        assertThat(ExpressionType.getTypeByText(" Relation  ")).isEqualTo(ExpressionType.RELATION);
+    }
+
+    @Test
+    public void testGetTypeByText_whenTextIsOkButWithWrongCase_thenTypeIsReturned() {
+        assertThat(ExpressionType.getTypeByText("RELATIoN")).isEqualTo(ExpressionType.RELATION);
+    }
+
+    @Test
+    public void testGetTypeByText_whenTextIsWrong_thenTypeIsUndefined() {
+        assertThat(ExpressionType.getTypeByText("Rellllation")).isEqualTo(ExpressionType.UNDEFINED);
+    }
+
+    @Test
+    public void testGetTypeByText_whenTextIsEmpty_thenTypeIsUndefined() {
+        assertThat(ExpressionType.getTypeByText("")).isEqualTo(ExpressionType.UNDEFINED);
+    }
+
+    @Test
+    public void testGetTypeByText_whenTextIsNull_thenTypeIsUndefined() {
+        assertThat(ExpressionType.getTypeByText(null)).isEqualTo(ExpressionType.UNDEFINED);
+    }
+}


### PR DESCRIPTION
![KOGITO-3660](https://user-images.githubusercontent.com/22591802/152507892-73a8016c-ec30-4dff-a0ea-dd79537c2597.gif)
Using Enricher strategy for enrich expression models like we were doing in the legacy editor.