### PR TITLE
KOGITO-6669: Search Service for Domain Objects

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -25,10 +24,11 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRefs;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
-import org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static java.util.Objects.isNull;
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 
 @Portable
@@ -117,16 +117,16 @@ public class Binding extends DMNModelInstrumentedBase implements HasExpression,
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        if (DomainObjectSearcherHelper.matches(getParameter(), uuid)) {
-            return getParameter();
+        if (matches(getParameter(), uuid)) {
+            return Optional.of(getParameter());
         }
 
-        if (!Objects.isNull(getExpression())) {
+        if (!isNull(getExpression())) {
             return getExpression().findDomainObject(uuid);
         }
 
-        return null;
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Binding.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -24,6 +25,8 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRefs;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
+import org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
@@ -31,7 +34,8 @@ import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRe
 @Portable
 public class Binding extends DMNModelInstrumentedBase implements HasExpression,
                                                                  HasTypeRefs,
-                                                                 HasVariable<InformationItem> {
+                                                                 HasVariable<InformationItem>,
+                                                                 HasDomainObject {
 
     private InformationItem parameter;
     private Expression expression;
@@ -110,5 +114,19 @@ public class Binding extends DMNModelInstrumentedBase implements HasExpression,
         hasTypeRefs.addAll(getNotNullHasTypeRefs(getParameter()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        if (DomainObjectSearcherHelper.matches(getParameter(), uuid)) {
+            return getParameter();
+        }
+
+        if (!Objects.isNull(getExpression())) {
+            return getExpression().findDomainObject(uuid);
+        }
+
+        return null;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
@@ -22,9 +22,11 @@ import java.util.stream.Collectors;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
@@ -60,6 +62,11 @@ public class Context extends Expression {
                 .map(contextEntryList -> contextEntryList.stream().map(ContextEntry::copy).collect(Collectors.toList()))
                 .orElse(null);
         return clonedContext;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+        return DomainObjectSearcherHelper.find(getContextEntry(), uuid);
     }
 
     public List<ContextEntry> getContextEntry() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Context.java
@@ -65,7 +65,7 @@ public class Context extends Expression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
         return DomainObjectSearcherHelper.find(getContextEntry(), uuid);
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
@@ -25,10 +25,10 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRefs;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
-import org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 
 @Portable
@@ -109,16 +109,16 @@ public class ContextEntry extends DMNModelInstrumentedBase implements HasExpress
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        if (DomainObjectSearcherHelper.matches(variable, uuid)) {
-            return variable;
+        if (matches(variable, uuid)) {
+            return Optional.of(variable);
         }
 
         if (!Objects.isNull(expression)) {
             return expression.findDomainObject(uuid);
         }
 
-        return null;
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntry.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -24,6 +25,8 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRefs;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
+import org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
@@ -31,7 +34,8 @@ import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRe
 @Portable
 public class ContextEntry extends DMNModelInstrumentedBase implements HasExpression,
                                                                       HasTypeRefs,
-                                                                      HasVariable<InformationItem> {
+                                                                      HasVariable<InformationItem>,
+                                                                      HasDomainObject {
 
     public static final String DEFAULT_EXPRESSION_VALUE = "null // auto-filled by the editor to avoid missing empty expression.";
 
@@ -102,5 +106,19 @@ public class ContextEntry extends DMNModelInstrumentedBase implements HasExpress
         hasTypeRefs.addAll(getNotNullHasTypeRefs(getVariable()));
 
         return hasTypeRefs;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        if (DomainObjectSearcherHelper.matches(variable, uuid)) {
+            return variable;
+        }
+
+        if (!Objects.isNull(expression)) {
+            return expression.findDomainObject(uuid);
+        }
+
+        return null;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -131,10 +130,10 @@ public class DecisionRule extends DMNElement implements HasTypeRefs,
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        final DomainObject domainObject = getDomainObject(getInputEntry(), uuid);
-        if (!Objects.isNull(domainObject)) {
+        final Optional<DomainObject> domainObject = getDomainObject(getInputEntry(), uuid);
+        if (domainObject.isPresent()) {
             return domainObject;
         }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRule.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -25,12 +26,15 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRefs;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.getDomainObject;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 
 @Portable
-public class DecisionRule extends DMNElement implements HasTypeRefs {
+public class DecisionRule extends DMNElement implements HasTypeRefs,
+                                                        HasDomainObject {
 
     private List<UnaryTests> inputEntry;
     private List<LiteralExpression> outputEntry;
@@ -124,5 +128,16 @@ public class DecisionRule extends DMNElement implements HasTypeRefs {
                                          inputEntry != null ? inputEntry.hashCode() : 0,
                                          outputEntry != null ? outputEntry.hashCode() : 0,
                                          annotationEntry != null ? annotationEntry.hashCode() : 0);
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        final DomainObject domainObject = getDomainObject(getInputEntry(), uuid);
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
+
+        return getDomainObject(getOutputEntry(), uuid);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
@@ -17,7 +17,6 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -102,15 +101,15 @@ public class DecisionTable extends Expression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        DomainObject domainObject = find(getInput(), uuid);
-        if (!Objects.isNull(domainObject)) {
+        Optional<DomainObject> domainObject = find(getInput(), uuid);
+        if (domainObject.isPresent()) {
             return domainObject;
         }
 
         domainObject = find(getOutput(), uuid);
-        if (!Objects.isNull(domainObject)) {
+        if (domainObject.isPresent()) {
             return domainObject;
         }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTable.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -25,8 +26,10 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.find;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 
 @Portable
@@ -96,6 +99,22 @@ public class DecisionTable extends Expression {
         clonedDecisionTable.preferredOrientation = preferredOrientation;
         clonedDecisionTable.outputLabel = outputLabel;
         return clonedDecisionTable;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        DomainObject domainObject = find(getInput(), uuid);
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
+
+        domainObject = find(getOutput(), uuid);
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
+
+        return find(getRule(), uuid);
     }
 
     public List<RuleAnnotationClause> getAnnotations() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.kie.workbench.common.dmn.api.definition.HasComponentWidths;
@@ -56,9 +57,9 @@ public abstract class Expression extends DMNElement implements HasTypeRef,
     /**
      * Find a {@link DomainObject} in the expression with the given the UUID.
      * @param uuid The UUID of the {@link DomainObject}.
-     * @return The found domain object or null if the object was not found.
+     * @return The found domain object or empty if the object was not found.
      */
-    public abstract DomainObject findDomainObject(final String uuid);
+    public abstract Optional<DomainObject> findDomainObject(final String uuid);
 
     // -----------------------
     // DMN properties

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Expression.java
@@ -24,11 +24,13 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
 import static java.util.Collections.singletonList;
 
 public abstract class Expression extends DMNElement implements HasTypeRef,
-                                                               HasComponentWidths {
+                                                               HasComponentWidths,
+                                                               HasDomainObject {
 
     protected QName typeRef;
 
@@ -50,6 +52,13 @@ public abstract class Expression extends DMNElement implements HasTypeRef,
      * Its purpose is to exploit polymorphism when we deeply copy the Expression boxed inside the {@link Decision}
      */
     public abstract Expression copy();
+
+    /**
+     * Find a {@link DomainObject} in the expression with the given the UUID.
+     * @param uuid The UUID of the {@link DomainObject}.
+     * @return The found domain object or null if the object was not found.
+     */
+    public abstract DomainObject findDomainObject(final String uuid);
 
     // -----------------------
     // DMN properties

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
@@ -77,10 +77,10 @@ public class FunctionDefinition extends Expression implements HasExpression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        final DomainObject domainObject = getDomainObject(getFormalParameter(), uuid);
-        if (!Objects.isNull(domainObject)) {
+        final Optional<DomainObject> domainObject = getDomainObject(getFormalParameter(), uuid);
+        if (domainObject.isPresent()) {
             return domainObject;
         }
 
@@ -88,7 +88,7 @@ public class FunctionDefinition extends Expression implements HasExpression {
             return getExpression().findDomainObject(uuid);
         }
 
-        return null;
+        return Optional.empty();
     }
 
     private List<InformationItem> cloneFormalParameterList() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinition.java
@@ -28,8 +28,10 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.getDomainObject;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 
@@ -72,6 +74,21 @@ public class FunctionDefinition extends Expression implements HasExpression {
         clonedFunctionDefinition.kind = kind;
         clonedFunctionDefinition.getAdditionalAttributes().putAll(cloneAdditionalAttributes());
         return clonedFunctionDefinition;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        final DomainObject domainObject = getDomainObject(getFormalParameter(), uuid);
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
+
+        if (!Objects.isNull(getExpression())) {
+            return getExpression().findDomainObject(uuid);
+        }
+
+        return null;
     }
 
     private List<InformationItem> cloneFormalParameterList() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/HasDomainObject.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/HasDomainObject.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model;
+
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+
+/**
+ * Defines a class that contains {@link DomainObject} that is searchable.
+ */
+public interface HasDomainObject {
+
+    /**
+     * Find a {@link DomainObject} with the given UUID.
+     * @param uuid The UUID.
+     * @return The {@link DomainObject} or null if none is found.
+     */
+    DomainObject findDomainObject(final String uuid);
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/HasDomainObject.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/HasDomainObject.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.Optional;
+
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
 /**
@@ -26,7 +28,7 @@ public interface HasDomainObject {
     /**
      * Find a {@link DomainObject} with the given UUID.
      * @param uuid The UUID.
-     * @return The {@link DomainObject} or null if none is found.
+     * @return The {@link DomainObject} or empty if none is found.
      */
-    DomainObject findDomainObject(final String uuid);
+    Optional<DomainObject> findDomainObject(final String uuid);
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.definition.La
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
@@ -52,7 +53,8 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
         i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.InputClause"),
         startElement = "id")
 public class InputClause extends DMNElement implements HasTypeRefs,
-                                                       DomainObject {
+                                                       DomainObject,
+                                                       HasDomainObject {
 
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
@@ -174,5 +176,15 @@ public class InputClause extends DMNElement implements HasTypeRefs,
                                          description != null ? description.hashCode() : 0,
                                          inputExpression != null ? inputExpression.hashCode() : 0,
                                          inputValues != null ? inputValues.hashCode() : 0);
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        if (matches(this, uuid)) {
+            return this;
+        }
+
+        return inputExpression.findDomainObject(uuid);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClause.java
@@ -179,10 +179,10 @@ public class InputClause extends DMNElement implements HasTypeRefs,
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
         if (matches(this, uuid)) {
-            return this;
+            return Optional.of(this);
         }
 
         return inputExpression.findDomainObject(uuid);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
@@ -48,6 +48,7 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static java.util.Collections.singletonList;
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
 
@@ -67,7 +68,8 @@ public class InputClauseLiteralExpression extends DMNModelInstrumentedBase imple
                                                                                       HasText,
                                                                                       HasTypeRef,
                                                                                       DMNPropertySet,
-                                                                                      DomainObject {
+                                                                                      DomainObject,
+                                                                                      HasDomainObject {
 
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
@@ -115,10 +117,10 @@ public class InputClauseLiteralExpression extends DMNModelInstrumentedBase imple
 
     public InputClauseLiteralExpression copy() {
         final InputClauseLiteralExpression clonedInputClauseLiteralExpression = new InputClauseLiteralExpression();
-        clonedInputClauseLiteralExpression.description =  Optional.ofNullable(description).map(Description::copy).orElse(null);
-        clonedInputClauseLiteralExpression.typeRef =  Optional.ofNullable(typeRef).map(QName::copy).orElse(null);
-        clonedInputClauseLiteralExpression.typeRefHolder =  Optional.ofNullable(typeRefHolder).map(QNameHolder::copy).orElse(null);
-        clonedInputClauseLiteralExpression.text =  Optional.ofNullable(text).map(Text::copy).orElse(null);
+        clonedInputClauseLiteralExpression.description = Optional.ofNullable(description).map(Description::copy).orElse(null);
+        clonedInputClauseLiteralExpression.typeRef = Optional.ofNullable(typeRef).map(QName::copy).orElse(null);
+        clonedInputClauseLiteralExpression.typeRefHolder = Optional.ofNullable(typeRefHolder).map(QNameHolder::copy).orElse(null);
+        clonedInputClauseLiteralExpression.text = Optional.ofNullable(text).map(Text::copy).orElse(null);
         clonedInputClauseLiteralExpression.importedValues = Optional.ofNullable(importedValues).map(ImportedValues::copy).orElse(null);
         return clonedInputClauseLiteralExpression;
     }
@@ -250,5 +252,19 @@ public class InputClauseLiteralExpression extends DMNModelInstrumentedBase imple
                                          typeRef != null ? typeRef.hashCode() : 0,
                                          text != null ? text.hashCode() : 0,
                                          importedValues != null ? importedValues.hashCode() : 0);
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        if (matches(this, uuid)) {
+            return this;
+        }
+
+        if (matches(getImportedValues(), uuid)) {
+            return getImportedValues();
+        }
+
+        return null;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpression.java
@@ -255,16 +255,16 @@ public class InputClauseLiteralExpression extends DMNModelInstrumentedBase imple
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
         if (matches(this, uuid)) {
-            return this;
+            return Optional.of(this);
         }
 
         if (matches(getImportedValues(), uuid)) {
-            return getImportedValues();
+            return Optional.of(getImportedValues());
         }
 
-        return null;
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
@@ -74,13 +74,14 @@ public class Invocation extends Expression implements HasExpression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
-        DomainObject domainObject = null;
+        Optional<DomainObject> domainObject = Optional.empty();
         if (!Objects.isNull(getExpression())) {
             domainObject = getExpression().findDomainObject(uuid);
         }
-        if (!Objects.isNull(domainObject)) {
+
+        if (domainObject.isPresent()) {
             return domainObject;
         }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Invocation.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -26,8 +27,10 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.find;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 
@@ -68,6 +71,20 @@ public class Invocation extends Expression implements HasExpression {
         clonedInvocation.expression = Optional.ofNullable(expression).map(Expression::copy).orElse(null);
         clonedInvocation.binding = binding.stream().map(Binding::copy).collect(Collectors.toList());
         return clonedInvocation;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        DomainObject domainObject = null;
+        if (!Objects.isNull(getExpression())) {
+            domainObject = getExpression().findDomainObject(uuid);
+        }
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
+
+        return find(getBinding(), uuid);
     }
 
     @Override

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
@@ -67,13 +67,13 @@ public class List extends Expression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
         return getExpression().stream()
                 .filter(hasExpression -> !isNull(hasExpression.getExpression()))
                 .map(hasExpression -> hasExpression.getExpression().findDomainObject(uuid))
-                .filter(domainObject -> !isNull(domainObject))
-                .findFirst()
-                .orElse(null);
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
     }
 
     private Function<HasExpression, HasExpression> expressionWrapperMappingFn(final List clonedList) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/List.java
@@ -26,8 +26,10 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static java.util.Objects.isNull;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefsFromExpressions;
 
 @Portable
@@ -62,6 +64,16 @@ public class List extends Expression {
         clonedList.componentWidths = new ArrayList<>(componentWidths);
         clonedList.expression = expression.stream().map(expressionWrapperMappingFn(clonedList)).collect(Collectors.toList());
         return clonedList;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+        return getExpression().stream()
+                .filter(hasExpression -> !isNull(hasExpression.getExpression()))
+                .map(hasExpression -> hasExpression.getExpression().findDomainObject(uuid))
+                .filter(domainObject -> !isNull(domainObject))
+                .findFirst()
+                .orElse(null);
     }
 
     private Function<HasExpression, HasExpression> expressionWrapperMappingFn(final List clonedList) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
@@ -40,6 +40,7 @@ import org.kie.workbench.common.stunner.core.definition.annotation.definition.La
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
 
@@ -102,6 +103,14 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
         clonedLiteralExpression.importedValues = Optional.ofNullable(importedValues).map(ImportedValues::copy).orElse(null);
         clonedLiteralExpression.expressionLanguage = Optional.ofNullable(expressionLanguage).map(ExpressionLanguage::copy).orElse(null);
         return clonedLiteralExpression;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+        if (matches(this, uuid)) {
+            return this;
+        }
+        return null;
     }
 
     // -----------------------

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpression.java
@@ -106,11 +106,11 @@ public class LiteralExpression extends Expression implements IsLiteralExpression
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
         if (matches(this, uuid)) {
-            return this;
+            return Optional.of(this);
         }
-        return null;
+        return Optional.empty();
     }
 
     // -----------------------

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
@@ -227,16 +227,16 @@ public class OutputClause extends DMNElement implements HasTypeRef,
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
 
         if (matches(this, uuid)) {
-            return this;
+            return Optional.of(this);
         }
 
         if (matches(getDefaultOutputEntry(), uuid)) {
-            return getDefaultOutputEntry();
+            return Optional.of(getDefaultOutputEntry());
         }
 
-        return null;
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/OutputClause.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static java.util.Collections.singletonList;
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getNotNullHasTypeRefs;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.COLLAPSIBLE_CONTAINER;
 import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.processing.fields.fieldInitializers.nestedForms.AbstractEmbeddedFormsInitializer.FIELD_CONTAINER_PARAM;
@@ -53,7 +54,8 @@ import static org.kie.workbench.common.forms.adf.engine.shared.formGeneration.pr
         i18n = @I18nSettings(keyPreffix = "org.kie.workbench.common.dmn.api.definition.model.OutputClause"),
         startElement = "id")
 public class OutputClause extends DMNElement implements HasTypeRef,
-                                                        DomainObject {
+                                                        DomainObject,
+                                                        HasDomainObject {
 
     @Category
     private static final String stunnerCategory = Categories.DOMAIN_OBJECTS;
@@ -222,5 +224,19 @@ public class OutputClause extends DMNElement implements HasTypeRef,
                                          defaultOutputEntry != null ? defaultOutputEntry.hashCode() : 0,
                                          name != null ? name.hashCode() : 0,
                                          typeRef != null ? typeRef.hashCode() : 0);
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+
+        if (matches(this, uuid)) {
+            return this;
+        }
+
+        if (matches(getDefaultOutputEntry(), uuid)) {
+            return getDefaultOutputEntry();
+        }
+
+        return null;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
@@ -24,8 +24,10 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.find;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 
 @Portable
@@ -65,6 +67,11 @@ public class Relation extends Expression {
         clonedRelation.column = column.stream().map(InformationItem::copy).collect(Collectors.toList());
         clonedRelation.row = row.stream().map(List::copy).collect(Collectors.toList());
         return clonedRelation;
+    }
+
+    @Override
+    public DomainObject findDomainObject(final String uuid) {
+        return find(getRow(), uuid);
     }
 
     public java.util.List<InformationItem> getColumn() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -28,6 +29,7 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
 import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.find;
+import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.getDomainObject;
 import static org.kie.workbench.common.dmn.api.definition.model.common.HasTypeRefHelper.getFlatHasTypeRefs;
 
 @Portable
@@ -71,6 +73,10 @@ public class Relation extends Expression {
 
     @Override
     public DomainObject findDomainObject(final String uuid) {
+        final DomainObject domainObject = getDomainObject(getColumn(), uuid);
+        if (!Objects.isNull(domainObject)) {
+            return domainObject;
+        }
         return find(getRow(), uuid);
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/Relation.java
@@ -16,7 +16,6 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -72,9 +71,9 @@ public class Relation extends Expression {
     }
 
     @Override
-    public DomainObject findDomainObject(final String uuid) {
-        final DomainObject domainObject = getDomainObject(getColumn(), uuid);
-        if (!Objects.isNull(domainObject)) {
+    public Optional<DomainObject> findDomainObject(final String uuid) {
+        final Optional<DomainObject> domainObject = getDomainObject(getColumn(), uuid);
+        if (domainObject.isPresent()) {
             return domainObject;
         }
         return find(getRow(), uuid);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelper.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model.common;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.kie.workbench.common.dmn.api.definition.model.HasDomainObject;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Utility class to find {@link DomainObject}.
+ */
+public class DomainObjectSearcherHelper {
+
+    private DomainObjectSearcherHelper() {
+        // Private constructor as recommended by SonarCloud
+    }
+
+    /**
+     * Search in a list of {@link HasDomainObject} for the {@link DomainObject} with the given ID.
+     *
+     * @param list The list.
+     * @param uuid The given UUID.
+     * @param <D>  A class that implements {@link HasDomainObject}
+     * @return The found {@link DomainObject} or null if none was found.
+     */
+    public static <D extends HasDomainObject> DomainObject find(final List<D> list,
+                                                                final String uuid) {
+        for (final D hasDomainObject : list) {
+            final DomainObject result = hasDomainObject.findDomainObject(uuid);
+            if (!isNull(result)) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get a {@link DomainObject} with the given UUID from a {@link List} of {@link DomainObject}.
+     *
+     * @param list The list.
+     * @param uuid The given UUID.
+     * @param <D>  A class that implements {@link DomainObject}
+     * @return The found {@link DomainObject} or null if none was found.
+     */
+    public static <D extends DomainObject> DomainObject getDomainObject(final List<D> list,
+                                                                        final String uuid) {
+        for (final D domainObject : list) {
+            if (Objects.equals(domainObject.getDomainObjectUUID(), uuid)) {
+                return domainObject;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Verifies if the given {@link DomainObject} has the given UUID, doing null check.
+     *
+     * @param object           The {@link DomainObject}.
+     * @param domainObjectUUID The UUID.
+     * @return True if it matches false otherwise.
+     */
+    public static boolean matches(final DomainObject object,
+                                  final String domainObjectUUID) {
+        if (!Objects.isNull(object)) {
+            return Objects.equals(object.getDomainObjectUUID(), domainObjectUUID);
+        }
+        return false;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelper.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/main/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelper.java
@@ -18,11 +18,10 @@ package org.kie.workbench.common.dmn.api.definition.model.common;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.kie.workbench.common.dmn.api.definition.model.HasDomainObject;
 import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
-
-import static java.util.Objects.isNull;
 
 /**
  * Utility class to find {@link DomainObject}.
@@ -41,16 +40,16 @@ public class DomainObjectSearcherHelper {
      * @param <D>  A class that implements {@link HasDomainObject}
      * @return The found {@link DomainObject} or null if none was found.
      */
-    public static <D extends HasDomainObject> DomainObject find(final List<D> list,
-                                                                final String uuid) {
+    public static <D extends HasDomainObject> Optional<DomainObject> find(final List<D> list,
+                                                                          final String uuid) {
         for (final D hasDomainObject : list) {
-            final DomainObject result = hasDomainObject.findDomainObject(uuid);
-            if (!isNull(result)) {
+            final Optional<DomainObject> result = hasDomainObject.findDomainObject(uuid);
+            if (result.isPresent()) {
                 return result;
             }
         }
 
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -59,17 +58,17 @@ public class DomainObjectSearcherHelper {
      * @param list The list.
      * @param uuid The given UUID.
      * @param <D>  A class that implements {@link DomainObject}
-     * @return The found {@link DomainObject} or null if none was found.
+     * @return The found {@link DomainObject} or empty if none was found.
      */
-    public static <D extends DomainObject> DomainObject getDomainObject(final List<D> list,
+    public static <D extends DomainObject> Optional<DomainObject> getDomainObject(final List<D> list,
                                                                         final String uuid) {
         for (final D domainObject : list) {
             if (Objects.equals(domainObject.getDomainObjectUUID(), uuid)) {
-                return domainObject;
+                return Optional.of(domainObject);
             }
         }
 
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -43,7 +45,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-
 public class BindingTest {
 
     private static final String ITEM_ID = "ITEM-ID";
@@ -139,9 +140,10 @@ public class BindingTest {
 
         binding.setParameter(parameter);
 
-        final DomainObject result = binding.findDomainObject(uuid);
+        final Optional<DomainObject> result = binding.findDomainObject(uuid);
 
-        assertEquals(parameter, result);
+        assertTrue(result.isPresent());
+        assertEquals(parameter, result.get());
     }
 
     @Test
@@ -150,7 +152,7 @@ public class BindingTest {
         final Binding binding = new Binding();
 
         final Expression expression = mock(Expression.class);
-        final DomainObject expressionDomainObject = mock(DomainObject.class);
+        final Optional<DomainObject> expressionDomainObject =  Optional.of(mock(DomainObject.class));
 
         final InformationItem parameter = new InformationItem(new Id(ANOTHER_UUID),
                                                               null,
@@ -162,7 +164,7 @@ public class BindingTest {
 
         when(expression.findDomainObject(UUID)).thenReturn(expressionDomainObject);
 
-        final DomainObject result = binding.findDomainObject(UUID);
+        final Optional<DomainObject> result = binding.findDomainObject(UUID);
 
         assertEquals(expressionDomainObject, result);
         verify(expression).findDomainObject(UUID);
@@ -180,8 +182,8 @@ public class BindingTest {
 
         binding.setParameter(parameter);
 
-        final DomainObject result = binding.findDomainObject(UUID);
+        final Optional<DomainObject> result = binding.findDomainObject(UUID);
 
-        assertNull(result);
+        assertFalse(result.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/BindingTest.java
@@ -27,6 +27,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -38,6 +39,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -47,6 +49,9 @@ public class BindingTest {
     private static final String ITEM_ID = "ITEM-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String INFORMATION_ITEM_NAME = "INFORMATION-ITEM-NAME";
+    private static final String UUID = "uuid";
+    private static final String ANOTHER_UUID = "another uuid";
+
     private Binding binding;
 
     @Before
@@ -119,5 +124,64 @@ public class BindingTest {
         assertEquals(DESCRIPTION, target.getParameter().getDescription().getValue());
         assertEquals(INFORMATION_ITEM_NAME, target.getParameter().getName().getValue());
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getParameter().getTypeRef());
+    }
+
+    @Test
+    public void testFindDomainObject_WhenParameterMatches() {
+
+        final Binding binding = new Binding();
+        final String uuid = "uuid";
+
+        final InformationItem parameter = new InformationItem(new Id(uuid),
+                                                              null,
+                                                              null,
+                                                              null);
+
+        binding.setParameter(parameter);
+
+        final DomainObject result = binding.findDomainObject(uuid);
+
+        assertEquals(parameter, result);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenParameterDoesNotMatches() {
+
+        final Binding binding = new Binding();
+
+        final Expression expression = mock(Expression.class);
+        final DomainObject expressionDomainObject = mock(DomainObject.class);
+
+        final InformationItem parameter = new InformationItem(new Id(ANOTHER_UUID),
+                                                              null,
+                                                              null,
+                                                              null);
+
+        binding.setExpression(expression);
+        binding.setParameter(parameter);
+
+        when(expression.findDomainObject(UUID)).thenReturn(expressionDomainObject);
+
+        final DomainObject result = binding.findDomainObject(UUID);
+
+        assertEquals(expressionDomainObject, result);
+        verify(expression).findDomainObject(UUID);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenParameterDoesNotMatchesAndExpressionIsNull() {
+
+        final Binding binding = new Binding();
+
+        final InformationItem parameter = new InformationItem(new Id(ANOTHER_UUID),
+                                                              null,
+                                                              null,
+                                                              null);
+
+        binding.setParameter(parameter);
+
+        final DomainObject result = binding.findDomainObject(UUID);
+
+        assertNull(result);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +32,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -105,9 +108,10 @@ public class ContextEntryTest {
 
         contextEntry.setVariable(variable);
 
-        final DomainObject result = contextEntry.findDomainObject(UUID);
+        final Optional<DomainObject> result = contextEntry.findDomainObject(UUID);
 
-        assertEquals(variable, result);
+        assertTrue(result.isPresent());
+        assertEquals(variable, result.get());
     }
 
     @Test
@@ -125,11 +129,12 @@ public class ContextEntryTest {
         contextEntry.setVariable(variable);
         contextEntry.setExpression(expression);
 
-        when(expression.findDomainObject(UUID)).thenReturn(expressionDomainObject);
+        when(expression.findDomainObject(UUID)).thenReturn(Optional.of(expressionDomainObject));
 
-        final DomainObject result = contextEntry.findDomainObject(UUID);
+        final Optional<DomainObject> result = contextEntry.findDomainObject(UUID);
 
-        assertEquals(result, expressionDomainObject);
+        assertTrue(result.isPresent());
+        assertEquals(result.get(), expressionDomainObject);
         verify(expression).findDomainObject(UUID);
     }
 
@@ -145,8 +150,8 @@ public class ContextEntryTest {
 
         contextEntry.setVariable(variable);
 
-        final DomainObject result = contextEntry.findDomainObject(UUID);
+        final Optional<DomainObject> result = contextEntry.findDomainObject(UUID);
 
-        assertNull(result);
+        assertFalse(result.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextEntryTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -36,6 +37,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +46,8 @@ public class ContextEntryTest {
     private static final String ITEM_ID = "item-id";
     private static final String DESCRIPTION = "description";
     private static final String INFORMATION_ITEM_NAME = "item-name";
+    private static final String UUID = "uuid";
+    private static final String ANOTHER_UUID = "another uuid";
     private ContextEntry contextEntry;
 
     @Before
@@ -87,5 +91,62 @@ public class ContextEntryTest {
         assertEquals(DESCRIPTION, target.getVariable().getDescription().getValue());
         assertEquals(INFORMATION_ITEM_NAME, target.getVariable().getName().getValue());
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getVariable().getTypeRef());
+    }
+
+    @Test
+    public void testFindDomainObject_WhenVariableMatches() {
+
+        final ContextEntry contextEntry = new ContextEntry();
+
+        final InformationItem variable = new InformationItem(new Id(UUID),
+                                                             null,
+                                                             null,
+                                                             null);
+
+        contextEntry.setVariable(variable);
+
+        final DomainObject result = contextEntry.findDomainObject(UUID);
+
+        assertEquals(variable, result);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenVariableDoesNotMatches() {
+
+        final ContextEntry contextEntry = new ContextEntry();
+        final Expression expression = mock(Expression.class);
+        final DomainObject expressionDomainObject = mock(DomainObject.class);
+
+        final InformationItem variable = new InformationItem(new Id(ANOTHER_UUID),
+                                                             null,
+                                                             null,
+                                                             null);
+
+        contextEntry.setVariable(variable);
+        contextEntry.setExpression(expression);
+
+        when(expression.findDomainObject(UUID)).thenReturn(expressionDomainObject);
+
+        final DomainObject result = contextEntry.findDomainObject(UUID);
+
+        assertEquals(result, expressionDomainObject);
+        verify(expression).findDomainObject(UUID);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenVariableDoesNotMatchesAndExpressionIsNull() {
+
+        final ContextEntry contextEntry = new ContextEntry();
+
+        final InformationItem variable = new InformationItem(new Id(ANOTHER_UUID),
+                                                             null,
+                                                             null,
+                                                             null);
+
+        contextEntry.setVariable(variable);
+
+        final DomainObject result = contextEntry.findDomainObject(UUID);
+
+        assertNull(result);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -42,6 +44,8 @@ public class ContextTest {
 
     private static final String CONTEXT_ID = "CONTEXT-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String UUID = "uuid";
+
     private Context context;
 
     @Before
@@ -86,5 +90,29 @@ public class ContextTest {
         assertNotEquals(CONTEXT_ID, target.getId().getValue());
         assertEquals(DESCRIPTION, target.getDescription().getValue());
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+    }
+
+    @Test
+    public void testFindDomainObject() {
+
+        final ContextEntry entry1 = mock(ContextEntry.class);
+        final ContextEntry entry2 = mock(ContextEntry.class);
+        final ContextEntry entry3 = mock(ContextEntry.class);
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+
+        when(entry1.findDomainObject(UUID)).thenReturn(null);
+        when(entry2.findDomainObject(UUID)).thenReturn(null);
+        when(entry3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        context.getContextEntry().add(entry1);
+        context.getContextEntry().add(entry2);
+        context.getContextEntry().add(entry3);
+
+        final DomainObject actual = context.findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
+        verify(entry1).findDomainObject(UUID);
+        verify(entry2).findDomainObject(UUID);
+        verify(entry3).findDomainObject(UUID);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ContextTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,6 +34,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -100,17 +102,18 @@ public class ContextTest {
         final ContextEntry entry3 = mock(ContextEntry.class);
         final DomainObject expectedDomainObject = mock(DomainObject.class);
 
-        when(entry1.findDomainObject(UUID)).thenReturn(null);
-        when(entry2.findDomainObject(UUID)).thenReturn(null);
-        when(entry3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(entry1.findDomainObject(UUID)).thenReturn(Optional.empty());
+        when(entry2.findDomainObject(UUID)).thenReturn(Optional.empty());
+        when(entry3.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
         context.getContextEntry().add(entry1);
         context.getContextEntry().add(entry2);
         context.getContextEntry().add(entry3);
 
-        final DomainObject actual = context.findDomainObject(UUID);
+        final Optional<DomainObject> actual = context.findDomainObject(UUID);
 
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
         verify(entry1).findDomainObject(UUID);
         verify(entry2).findDomainObject(UUID);
         verify(entry3).findDomainObject(UUID);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
@@ -25,12 +25,14 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -42,6 +44,8 @@ public class DecisionRuleTest {
 
     private static final String DECISION_RULE_ID = "DECISION_RULE_ID";
     private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String UUID = "uuid";
+
     private DecisionRule decisionRule;
 
     @Before
@@ -78,4 +82,117 @@ public class DecisionRuleTest {
         assertTrue(target.getInputEntry().isEmpty());
         assertTrue(target.getOutputEntry().isEmpty());
     }
+
+    @Test
+    public void testFindDomainObject_FromInputEntry() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+        final UnaryTests inputEntry1 = mock(UnaryTests.class);
+        final UnaryTests inputEntry2 = mock(UnaryTests.class);
+        final UnaryTests inputEntry3 = mock(UnaryTests.class);
+
+        when(inputEntry2.getDomainObjectUUID()).thenReturn(UUID);
+
+        decisionRule.getInputEntry().add(inputEntry1);
+        decisionRule.getInputEntry().add(inputEntry2);
+        decisionRule.getInputEntry().add(inputEntry3);
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertEquals(inputEntry2, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromOutputEntry() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+        final UnaryTests inputEntry1 = mock(UnaryTests.class);
+        final UnaryTests inputEntry2 = mock(UnaryTests.class);
+        final UnaryTests inputEntry3 = mock(UnaryTests.class);
+        final LiteralExpression outputEntry1 = mock(LiteralExpression.class);
+        final LiteralExpression outputEntry2 = mock(LiteralExpression.class);
+        final LiteralExpression outputEntry3 = mock(LiteralExpression.class);
+
+        decisionRule.getInputEntry().add(inputEntry1);
+        decisionRule.getInputEntry().add(inputEntry2);
+        decisionRule.getInputEntry().add(inputEntry3);
+
+        when(outputEntry2.getDomainObjectUUID()).thenReturn(UUID);
+
+        decisionRule.getOutputEntry().add(outputEntry1);
+        decisionRule.getOutputEntry().add(outputEntry2);
+        decisionRule.getOutputEntry().add(outputEntry3);
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertEquals(outputEntry2, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNoneMatches() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+        final UnaryTests inputEntry1 = mock(UnaryTests.class);
+        final UnaryTests inputEntry2 = mock(UnaryTests.class);
+        final LiteralExpression outputEntry1 = mock(LiteralExpression.class);
+        final LiteralExpression outputEntry2 = mock(LiteralExpression.class);
+
+        decisionRule.getInputEntry().add(inputEntry1);
+        decisionRule.getInputEntry().add(inputEntry2);
+        decisionRule.getOutputEntry().add(outputEntry1);
+        decisionRule.getOutputEntry().add(outputEntry2);
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromInput() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+        final UnaryTests input1 = mock(UnaryTests.class);
+        final UnaryTests input2 = mock(UnaryTests.class);
+        final UnaryTests input3 = mock(UnaryTests.class);
+
+        when(input3.getDomainObjectUUID()).thenReturn(UUID);
+
+        decisionRule.getInputEntry().addAll(asList(input1, input2, input3));
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertEquals(input3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromOutput() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+        final UnaryTests input1 = mock(UnaryTests.class);
+        final UnaryTests input2 = mock(UnaryTests.class);
+        final UnaryTests input3 = mock(UnaryTests.class);
+        final LiteralExpression output1 = mock(LiteralExpression.class);
+        final LiteralExpression output2 = mock(LiteralExpression.class);
+        final LiteralExpression output3 = mock(LiteralExpression.class);
+
+        decisionRule.getInputEntry().addAll(asList(input1, input2, input3));
+        decisionRule.getOutputEntry().addAll(asList(output1, output2, output3));
+
+        when(output3.getDomainObjectUUID()).thenReturn(UUID);
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertEquals(output3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final DecisionRule decisionRule = new DecisionRule();
+
+        final DomainObject actual = decisionRule.findDomainObject(UUID);
+
+        assertNull(actual);
+    }
 }
+

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionRuleTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,9 +31,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -97,9 +98,10 @@ public class DecisionRuleTest {
         decisionRule.getInputEntry().add(inputEntry2);
         decisionRule.getInputEntry().add(inputEntry3);
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertEquals(inputEntry2, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(inputEntry2, actual.get());
     }
 
     @Test
@@ -123,9 +125,10 @@ public class DecisionRuleTest {
         decisionRule.getOutputEntry().add(outputEntry2);
         decisionRule.getOutputEntry().add(outputEntry3);
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertEquals(outputEntry2, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(outputEntry2, actual.get());
     }
 
     @Test
@@ -142,9 +145,9 @@ public class DecisionRuleTest {
         decisionRule.getOutputEntry().add(outputEntry1);
         decisionRule.getOutputEntry().add(outputEntry2);
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
     }
 
     @Test
@@ -159,9 +162,10 @@ public class DecisionRuleTest {
 
         decisionRule.getInputEntry().addAll(asList(input1, input2, input3));
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertEquals(input3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(input3, actual.get());
     }
 
     @Test
@@ -180,9 +184,10 @@ public class DecisionRuleTest {
 
         when(output3.getDomainObjectUUID()).thenReturn(UUID);
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertEquals(output3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(output3, actual.get());
     }
 
     @Test
@@ -190,9 +195,9 @@ public class DecisionRuleTest {
 
         final DecisionRule decisionRule = new DecisionRule();
 
-        final DomainObject actual = decisionRule.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionRule.findDomainObject(UUID);
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
     }
 }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,9 +33,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.api.definition.model.BuiltinAggregator.SUM;
 import static org.mockito.Mockito.doReturn;
@@ -142,17 +143,18 @@ public class DecisionTableTest {
         final InputClause input2 = mock(InputClause.class);
         final InputClause input3 = mock(InputClause.class);
 
-        when(input3.findDomainObject(UUID)).thenReturn(input3);
+        when(input3.findDomainObject(UUID)).thenReturn(Optional.of(input3));
 
         decisionTable.getInput().addAll(asList(input1, input2, input3));
 
-        final DomainObject actual = decisionTable.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionTable.findDomainObject(UUID);
 
         verify(input1).findDomainObject(UUID);
         verify(input2).findDomainObject(UUID);
         verify(input3).findDomainObject(UUID);
 
-        assertEquals(input3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(input3, actual.get());
     }
 
     @Test
@@ -166,12 +168,12 @@ public class DecisionTableTest {
         final OutputClause output2 = mock(OutputClause.class);
         final OutputClause output3 = mock(OutputClause.class);
 
-        when(output3.findDomainObject(UUID)).thenReturn(output3);
+        when(output3.findDomainObject(UUID)).thenReturn(Optional.of(output3));
 
         decisionTable.getInput().addAll(asList(input1, input2, input3));
         decisionTable.getOutput().addAll(asList(output1, output2, output3));
 
-        final DomainObject actual = decisionTable.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionTable.findDomainObject(UUID);
 
         verify(input1).findDomainObject(UUID);
         verify(input2).findDomainObject(UUID);
@@ -181,7 +183,8 @@ public class DecisionTableTest {
         verify(output2).findDomainObject(UUID);
         verify(output3).findDomainObject(UUID);
 
-        assertEquals(output3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(output3, actual.get());
     }
 
     @Test
@@ -199,13 +202,13 @@ public class DecisionTableTest {
         final DecisionRule decisionRule3 = mock(DecisionRule.class);
         final DomainObject expectedDomainObject = mock(DomainObject.class);
 
-        when(decisionRule3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(decisionRule3.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
         decisionTable.getInput().addAll(asList(input1, input2, input3));
         decisionTable.getOutput().addAll(asList(output1, output2, output3));
         decisionTable.getRule().addAll(asList(decisionRule1, decisionRule2, decisionRule3));
 
-        final DomainObject actual = decisionTable.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionTable.findDomainObject(UUID);
 
         verify(input1).findDomainObject(UUID);
         verify(input2).findDomainObject(UUID);
@@ -219,7 +222,8 @@ public class DecisionTableTest {
         verify(decisionRule2).findDomainObject(UUID);
         verify(decisionRule3).findDomainObject(UUID);
 
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
     }
 
     @Test
@@ -227,8 +231,8 @@ public class DecisionTableTest {
 
         final DecisionTable decisionTable = new DecisionTable();
 
-        final DomainObject actual = decisionTable.findDomainObject(UUID);
+        final Optional<DomainObject> actual = decisionTable.findDomainObject(UUID);
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/DecisionTableTest.java
@@ -27,17 +27,20 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.dmn.api.definition.model.BuiltinAggregator.SUM;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -47,6 +50,7 @@ public class DecisionTableTest {
     private static final String TABLE_ID = "TABLE-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String OUTPUT_LABEL = "OUTPUT-LABEL";
+    private static final String UUID = "uuid";
     private DecisionTable decisionTable;
 
     @Before
@@ -128,5 +132,103 @@ public class DecisionTableTest {
         assertEquals(SUM, target.getAggregation());
         assertEquals(DecisionTableOrientation.RULE_AS_ROW, target.getPreferredOrientation());
         assertEquals(OUTPUT_LABEL, target.getOutputLabel());
+    }
+
+    @Test
+    public void testFindDomainObject_FromInput() {
+
+        final DecisionTable decisionTable = new DecisionTable();
+        final InputClause input1 = mock(InputClause.class);
+        final InputClause input2 = mock(InputClause.class);
+        final InputClause input3 = mock(InputClause.class);
+
+        when(input3.findDomainObject(UUID)).thenReturn(input3);
+
+        decisionTable.getInput().addAll(asList(input1, input2, input3));
+
+        final DomainObject actual = decisionTable.findDomainObject(UUID);
+
+        verify(input1).findDomainObject(UUID);
+        verify(input2).findDomainObject(UUID);
+        verify(input3).findDomainObject(UUID);
+
+        assertEquals(input3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromOutput() {
+
+        final DecisionTable decisionTable = new DecisionTable();
+        final InputClause input1 = mock(InputClause.class);
+        final InputClause input2 = mock(InputClause.class);
+        final InputClause input3 = mock(InputClause.class);
+        final OutputClause output1 = mock(OutputClause.class);
+        final OutputClause output2 = mock(OutputClause.class);
+        final OutputClause output3 = mock(OutputClause.class);
+
+        when(output3.findDomainObject(UUID)).thenReturn(output3);
+
+        decisionTable.getInput().addAll(asList(input1, input2, input3));
+        decisionTable.getOutput().addAll(asList(output1, output2, output3));
+
+        final DomainObject actual = decisionTable.findDomainObject(UUID);
+
+        verify(input1).findDomainObject(UUID);
+        verify(input2).findDomainObject(UUID);
+        verify(input3).findDomainObject(UUID);
+
+        verify(output1).findDomainObject(UUID);
+        verify(output2).findDomainObject(UUID);
+        verify(output3).findDomainObject(UUID);
+
+        assertEquals(output3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromRule() {
+
+        final DecisionTable decisionTable = new DecisionTable();
+        final InputClause input1 = mock(InputClause.class);
+        final InputClause input2 = mock(InputClause.class);
+        final InputClause input3 = mock(InputClause.class);
+        final OutputClause output1 = mock(OutputClause.class);
+        final OutputClause output2 = mock(OutputClause.class);
+        final OutputClause output3 = mock(OutputClause.class);
+        final DecisionRule decisionRule1 = mock(DecisionRule.class);
+        final DecisionRule decisionRule2 = mock(DecisionRule.class);
+        final DecisionRule decisionRule3 = mock(DecisionRule.class);
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+
+        when(decisionRule3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        decisionTable.getInput().addAll(asList(input1, input2, input3));
+        decisionTable.getOutput().addAll(asList(output1, output2, output3));
+        decisionTable.getRule().addAll(asList(decisionRule1, decisionRule2, decisionRule3));
+
+        final DomainObject actual = decisionTable.findDomainObject(UUID);
+
+        verify(input1).findDomainObject(UUID);
+        verify(input2).findDomainObject(UUID);
+        verify(input3).findDomainObject(UUID);
+
+        verify(output1).findDomainObject(UUID);
+        verify(output2).findDomainObject(UUID);
+        verify(output3).findDomainObject(UUID);
+
+        verify(decisionRule1).findDomainObject(UUID);
+        verify(decisionRule2).findDomainObject(UUID);
+        verify(decisionRule3).findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final DecisionTable decisionTable = new DecisionTable();
+
+        final DomainObject actual = decisionTable.findDomainObject(UUID);
+
+        assertNull(actual);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,8 +41,8 @@ public class ExpressionTest {
             }
 
             @Override
-            public DomainObject findDomainObject(final String uuid) {
-                return null;
+            public Optional<DomainObject> findDomainObject(final String uuid) {
+                return Optional.empty();
             }
 
             @Override

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ExpressionTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -36,6 +37,11 @@ public class ExpressionTest {
             @Override
             public Expression copy() {
                 return expression;
+            }
+
+            @Override
+            public DomainObject findDomainObject(final String uuid) {
+                return null;
             }
 
             @Override

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
@@ -27,15 +27,18 @@ import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition.Kind
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +47,7 @@ public class FunctionDefinitionTest {
 
     private static final String FUNCTION_ID = "FUNCTION-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String UUID = "uuid";
     private FunctionDefinition functionDefinition;
 
     @Before
@@ -117,5 +121,53 @@ public class FunctionDefinitionTest {
     @Test
     public void testKindFromValueWithDefault() {
         assertEquals(Kind.FEEL, Kind.fromValue("Something"));
+    }
+
+    @Test
+    public void testFindDomainObject_FromFormalParameter() {
+
+        final FunctionDefinition functionDefinition = new FunctionDefinition();
+        final InformationItem formalParameter1 = mock(InformationItem.class);
+        final InformationItem formalParameter2 = mock(InformationItem.class);
+        final InformationItem formalParameter3 = mock(InformationItem.class);
+
+        when(formalParameter3.getDomainObjectUUID()).thenReturn(UUID);
+
+        functionDefinition.getFormalParameter().addAll(asList(formalParameter1, formalParameter2, formalParameter3));
+
+        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+
+        assertEquals(formalParameter3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromExpression() {
+
+        final FunctionDefinition functionDefinition = new FunctionDefinition();
+        final InformationItem formalParameter1 = mock(InformationItem.class);
+        final InformationItem formalParameter2 = mock(InformationItem.class);
+        final InformationItem formalParameter3 = mock(InformationItem.class);
+        final Expression expression = mock(Expression.class);
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+
+        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        functionDefinition.setExpression(expression);
+        functionDefinition.getFormalParameter().addAll(asList(formalParameter1, formalParameter2, formalParameter3));
+
+        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
+        verify(expression).findDomainObject(UUID);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final FunctionDefinition functionDefinition = new FunctionDefinition();
+
+        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+
+        assertNull(actual);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/FunctionDefinitionTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,9 +33,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -135,9 +137,10 @@ public class FunctionDefinitionTest {
 
         functionDefinition.getFormalParameter().addAll(asList(formalParameter1, formalParameter2, formalParameter3));
 
-        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+        final Optional<DomainObject> actual = functionDefinition.findDomainObject(UUID);
 
-        assertEquals(formalParameter3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(formalParameter3, actual.get());
     }
 
     @Test
@@ -150,14 +153,15 @@ public class FunctionDefinitionTest {
         final Expression expression = mock(Expression.class);
         final DomainObject expectedDomainObject = mock(DomainObject.class);
 
-        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(expression.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
         functionDefinition.setExpression(expression);
         functionDefinition.getFormalParameter().addAll(asList(formalParameter1, formalParameter2, formalParameter3));
 
-        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+        final Optional<DomainObject> actual = functionDefinition.findDomainObject(UUID);
 
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
         verify(expression).findDomainObject(UUID);
     }
 
@@ -166,8 +170,8 @@ public class FunctionDefinitionTest {
 
         final FunctionDefinition functionDefinition = new FunctionDefinition();
 
-        final DomainObject actual = functionDefinition.findDomainObject(UUID);
+        final Optional<DomainObject> actual = functionDefinition.findDomainObject(UUID);
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,9 +30,10 @@ import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class InputClauseLiteralExpressionTest {
 
@@ -82,9 +84,10 @@ public class InputClauseLiteralExpressionTest {
                                                                                           null,
                                                                                           null);
 
-        final DomainObject actual = inputClause.findDomainObject(uuid);
+        final Optional<DomainObject> actual = inputClause.findDomainObject(uuid);
 
-        assertEquals(inputClause, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(inputClause, actual.get());
     }
 
     @Test
@@ -99,9 +102,10 @@ public class InputClauseLiteralExpressionTest {
                                                                                           null,
                                                                                           importedValues);
 
-        final DomainObject actual = inputClause.findDomainObject(uuid);
+        final Optional<DomainObject> actual = inputClause.findDomainObject(uuid);
 
-        assertEquals(inputClause, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(inputClause, actual.get());
     }
 
     @Test
@@ -109,8 +113,8 @@ public class InputClauseLiteralExpressionTest {
 
         final InputClauseLiteralExpression inputClause = new InputClauseLiteralExpression();
 
-        final DomainObject actual = inputClause.findDomainObject("some id");
+        final Optional<DomainObject> actual = inputClause.findDomainObject("some id");
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseLiteralExpressionTest.java
@@ -25,11 +25,13 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class InputClauseLiteralExpressionTest {
 
@@ -68,5 +70,47 @@ public class InputClauseLiteralExpressionTest {
         assertEquals(TEXT, target.getText().getValue());
         assertEquals(DESCRIPTION, target.getDescription().getValue());
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
+    }
+
+    @Test
+    public void testFindDomainObject_WhenInputClauseLiteralExpressionMatches() {
+
+        final String uuid = "uuid";
+        final InputClauseLiteralExpression inputClause = new InputClauseLiteralExpression(new Id(uuid),
+                                                                                          null,
+                                                                                          null,
+                                                                                          null,
+                                                                                          null);
+
+        final DomainObject actual = inputClause.findDomainObject(uuid);
+
+        assertEquals(inputClause, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenImportedValueMatches() {
+
+        final ImportedValues importedValues = new ImportedValues();
+        // The UUID for ImporterValues is read-only, so we can't set it for test
+        final String uuid = importedValues.getDomainObjectUUID();
+        final InputClauseLiteralExpression inputClause = new InputClauseLiteralExpression(new Id(uuid),
+                                                                                          null,
+                                                                                          null,
+                                                                                          null,
+                                                                                          importedValues);
+
+        final DomainObject actual = inputClause.findDomainObject(uuid);
+
+        assertEquals(inputClause, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingMatches() {
+
+        final InputClauseLiteralExpression inputClause = new InputClauseLiteralExpression();
+
+        final DomainObject actual = inputClause.findDomainObject("some id");
+
+        assertNull(actual);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -45,6 +47,8 @@ public class InputClauseTest {
     private static final String TEXT = "TEXT";
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String CLAUSE_ID = "CLAUSE-ID";
+    private static final String UUID = "uuid";
+    private static final String ANOTHER_UUID = "another uuid";
     private InputClause inputClause;
 
     @Before
@@ -91,6 +95,38 @@ public class InputClauseTest {
         assertNotEquals(UNARY_ID, target.getInputValues().getId().getValue());
         assertEquals(TEXT, target.getInputValues().getText().getValue());
         assertEquals(ConstraintType.ENUMERATION, target.getInputValues().getConstraintType());
+    }
+
+    @Test
+    public void testFindDomainObject_WhenInputClauseMatches() {
+
+        final InputClause inputClause = new InputClause(new Id(UUID),
+                                                        null,
+                                                        null,
+                                                        null);
+
+        final DomainObject actual = inputClause.findDomainObject(UUID);
+
+        assertEquals(inputClause, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenInputClauseDoesNotMatches() {
+
+        final InputClauseLiteralExpression expression = mock(InputClauseLiteralExpression.class);
+        final InputClause inputClause = new InputClause(new Id(ANOTHER_UUID),
+                                                        null,
+                                                        expression,
+                                                        null);
+
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+
+        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        final DomainObject actual = inputClause.findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
+        verify(expression).findDomainObject(UUID);
     }
 
     private InputClauseUnaryTests buildInputClauseUnaryTests() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InputClauseTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -105,9 +107,10 @@ public class InputClauseTest {
                                                         null,
                                                         null);
 
-        final DomainObject actual = inputClause.findDomainObject(UUID);
+        final Optional<DomainObject> actual = inputClause.findDomainObject(UUID);
 
-        assertEquals(inputClause, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(inputClause, actual.get());
     }
 
     @Test
@@ -121,11 +124,12 @@ public class InputClauseTest {
 
         final DomainObject expectedDomainObject = mock(DomainObject.class);
 
-        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(expression.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
-        final DomainObject actual = inputClause.findDomainObject(UUID);
+        final Optional<DomainObject> actual = inputClause.findDomainObject(UUID);
 
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
         verify(expression).findDomainObject(UUID);
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,7 +45,6 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-
 public class InvocationTest {
 
     private static final String INVOCATION_ID = "INVOCATION-ID";
@@ -116,13 +116,13 @@ public class InvocationTest {
         final Invocation invocation = new Invocation();
         invocation.setExpression(expression);
 
+        when(expression.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
-        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
-
-        final DomainObject actual = invocation.findDomainObject(UUID);
+        final Optional<DomainObject> actual = invocation.findDomainObject(UUID);
 
         verify(expression).findDomainObject(UUID);
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
     }
 
     @Test
@@ -138,15 +138,16 @@ public class InvocationTest {
         invocation.getBinding().addAll(Arrays.asList(binding1, binding2, binding3));
         invocation.setExpression(expression);
 
-        when(binding3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(binding3.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
-        final DomainObject actual = invocation.findDomainObject(UUID);
+        final Optional<DomainObject> actual = invocation.findDomainObject(UUID);
 
         verify(expression).findDomainObject(UUID);
         verify(binding1).findDomainObject(UUID);
         verify(binding2).findDomainObject(UUID);
         verify(binding3).findDomainObject(UUID);
 
-        assertEquals(expectedDomainObject, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/InvocationTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -27,6 +28,7 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -38,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,6 +49,7 @@ public class InvocationTest {
 
     private static final String INVOCATION_ID = "INVOCATION-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String UUID = "uuid";
     private Invocation invocation;
 
     @Before
@@ -102,5 +106,47 @@ public class InvocationTest {
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
         assertNull(target.getExpression());
         assertTrue(target.getBinding().isEmpty());
+    }
+
+    @Test
+    public void testFindDomainObject_FromExpression() {
+
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+        final Expression expression = mock(Expression.class);
+        final Invocation invocation = new Invocation();
+        invocation.setExpression(expression);
+
+
+        when(expression.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        final DomainObject actual = invocation.findDomainObject(UUID);
+
+        verify(expression).findDomainObject(UUID);
+        assertEquals(expectedDomainObject, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_FromBinding() {
+
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+        final Expression expression = mock(Expression.class);
+        final Invocation invocation = new Invocation();
+        final Binding binding1 = mock(Binding.class);
+        final Binding binding2 = mock(Binding.class);
+        final Binding binding3 = mock(Binding.class);
+
+        invocation.getBinding().addAll(Arrays.asList(binding1, binding2, binding3));
+        invocation.setExpression(expression);
+
+        when(binding3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        final DomainObject actual = invocation.findDomainObject(UUID);
+
+        verify(expression).findDomainObject(UUID);
+        verify(binding1).findDomainObject(UUID);
+        verify(binding2).findDomainObject(UUID);
+        verify(binding3).findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,9 +34,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -109,13 +110,13 @@ public class ListTest {
         final HasExpression hasExpression3 = mock(HasExpression.class);
         final HasExpression hasExpression4 = mock(HasExpression.class);
 
-        final Expression expressionThatReturnsNull = mock(Expression.class);
+        final Expression expressionThatReturnsEmpty = mock(Expression.class);
         final Expression expression = mock(Expression.class);
         final DomainObject domainObject = mock(DomainObject.class);
 
-        when(expression.findDomainObject(UUID)).thenReturn(domainObject);
-        when(expressionThatReturnsNull.findDomainObject(UUID)).thenReturn(null);
-        when(hasExpression3.getExpression()).thenReturn(expressionThatReturnsNull);
+        when(expression.findDomainObject(UUID)).thenReturn(Optional.of(domainObject));
+        when(expressionThatReturnsEmpty.findDomainObject(UUID)).thenReturn(Optional.empty());
+        when(hasExpression3.getExpression()).thenReturn(expressionThatReturnsEmpty);
         when(hasExpression4.getExpression()).thenReturn(expression);
 
         list.getExpression().addAll(Arrays.asList(hasExpression1,
@@ -123,9 +124,10 @@ public class ListTest {
                                                   hasExpression3,
                                                   hasExpression4));
 
-        final DomainObject foundDomainObject = list.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = list.findDomainObject(UUID);
 
-        assertEquals(domainObject, foundDomainObject);
+        assertTrue(foundDomainObject.isPresent());
+        assertEquals(domainObject, foundDomainObject.get());
     }
 
     @Test
@@ -142,8 +144,8 @@ public class ListTest {
                                                   hasExpression3,
                                                   hasExpression4));
 
-        final DomainObject foundDomainObject = list.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = list.findDomainObject(UUID);
 
-        assertNull(foundDomainObject);
+        assertFalse(foundDomainObject.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/ListTest.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,12 +28,14 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -45,18 +47,20 @@ public class ListTest {
 
     private static final String LIST_ID = "LIST_ID";
     private static final String DESCRIPTION = "DESCRIPTION";
-    private org.kie.workbench.common.dmn.api.definition.model.List list;
+    private static final String UUID = "uuid";
+
+    private List list;
 
     @Before
     public void setup() {
-        this.list = spy(new org.kie.workbench.common.dmn.api.definition.model.List());
+        this.list = spy(new List());
     }
 
     @Test
     public void testGetHasTypeRefs() {
         final Expression expression1 = mock(Expression.class); //added
         final Expression expression2 = mock(Expression.class); //added
-        final List<HasExpression> hasExpressions = asList(HasExpression.wrap(list, expression1), HasExpression.wrap(list, expression2));
+        final java.util.List<HasExpression> hasExpressions = asList(HasExpression.wrap(list, expression1), HasExpression.wrap(list, expression2));
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef2 = mock(HasTypeRef.class);
 
@@ -65,8 +69,8 @@ public class ListTest {
         when(expression1.getHasTypeRefs()).thenReturn(asList(hasTypeRef1));
         when(expression2.getHasTypeRefs()).thenReturn(asList(hasTypeRef2));
 
-        final List<HasTypeRef> actualHasTypeRefs = list.getHasTypeRefs();
-        final List<HasTypeRef> expectedHasTypeRefs = asList(list, hasTypeRef1, hasTypeRef2);
+        final java.util.List<HasTypeRef> actualHasTypeRefs = list.getHasTypeRefs();
+        final java.util.List<HasTypeRef> expectedHasTypeRefs = asList(list, hasTypeRef1, hasTypeRef2);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
     }
@@ -80,19 +84,66 @@ public class ListTest {
 
     @Test
     public void testCopy() {
-        final org.kie.workbench.common.dmn.api.definition.model.List source = new org.kie.workbench.common.dmn.api.definition.model.List(
+        final List source = new List(
                 new Id(LIST_ID),
                 new Description(DESCRIPTION),
                 BuiltInType.BOOLEAN.asQName(),
                 new ArrayList<>()
         );
 
-        final org.kie.workbench.common.dmn.api.definition.model.List target = source.copy();
+        final List target = source.copy();
 
         assertNotNull(target);
         assertNotEquals(LIST_ID, target.getId().getValue());
         assertEquals(DESCRIPTION, target.getDescription().getValue());
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
         assertTrue(target.getExpression().isEmpty());
+    }
+
+    @Test
+    public void testFindDomainObject() {
+
+        final List list = new List();
+        final HasExpression hasExpression1 = mock(HasExpression.class);
+        final HasExpression hasExpression2 = mock(HasExpression.class);
+        final HasExpression hasExpression3 = mock(HasExpression.class);
+        final HasExpression hasExpression4 = mock(HasExpression.class);
+
+        final Expression expressionThatReturnsNull = mock(Expression.class);
+        final Expression expression = mock(Expression.class);
+        final DomainObject domainObject = mock(DomainObject.class);
+
+        when(expression.findDomainObject(UUID)).thenReturn(domainObject);
+        when(expressionThatReturnsNull.findDomainObject(UUID)).thenReturn(null);
+        when(hasExpression3.getExpression()).thenReturn(expressionThatReturnsNull);
+        when(hasExpression4.getExpression()).thenReturn(expression);
+
+        list.getExpression().addAll(Arrays.asList(hasExpression1,
+                                                  hasExpression2,
+                                                  hasExpression3,
+                                                  hasExpression4));
+
+        final DomainObject foundDomainObject = list.findDomainObject(UUID);
+
+        assertEquals(domainObject, foundDomainObject);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final List list = new List();
+        final HasExpression hasExpression1 = mock(HasExpression.class);
+        final HasExpression hasExpression2 = mock(HasExpression.class);
+        final HasExpression hasExpression3 = mock(HasExpression.class);
+        final HasExpression hasExpression4 = mock(HasExpression.class);
+
+        list.getExpression().addAll(Arrays.asList(hasExpression1,
+                                                  hasExpression2,
+                                                  hasExpression3,
+                                                  hasExpression4));
+
+        final DomainObject foundDomainObject = list.findDomainObject(UUID);
+
+        assertNull(foundDomainObject);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.dmn.api.property.dmn.ExpressionLanguage;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Collections.singletonList;
@@ -41,6 +42,7 @@ public class LiteralExpressionTest {
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String TEXT = "TEXT";
     private static final String EXPRESSION_LANGUAGE = "EXPRESSION-LANGUAGE";
+    private static final String UUID = "uuid";
     private LiteralExpression literalExpression;
 
     @Before
@@ -83,5 +85,30 @@ public class LiteralExpressionTest {
         assertEquals(TEXT, target.getText().getValue());
         assertNull(target.getImportedValues());
         assertEquals(EXPRESSION_LANGUAGE, target.getExpressionLanguage().getValue());
+    }
+
+    @Test
+    public void testFindDomainObject() {
+
+        final LiteralExpression literalExpression = new LiteralExpression(new Id(UUID),
+                                                                          null,
+                                                                          null,
+                                                                          null,
+                                                                          null,
+                                                                          null);
+
+        final DomainObject foundDomainObject = literalExpression.findDomainObject(UUID);
+
+        assertEquals(literalExpression, foundDomainObject);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final LiteralExpression literalExpression = new LiteralExpression();
+
+        final DomainObject foundDomainObject = literalExpression.findDomainObject(UUID);
+
+        assertNull(foundDomainObject);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/LiteralExpressionTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.api.definition.model;
 
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +33,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LiteralExpressionTest {
@@ -97,9 +101,10 @@ public class LiteralExpressionTest {
                                                                           null,
                                                                           null);
 
-        final DomainObject foundDomainObject = literalExpression.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = literalExpression.findDomainObject(UUID);
 
-        assertEquals(literalExpression, foundDomainObject);
+        assertTrue(foundDomainObject.isPresent());
+        assertEquals(literalExpression, foundDomainObject.get());
     }
 
     @Test
@@ -107,8 +112,8 @@ public class LiteralExpressionTest {
 
         final LiteralExpression literalExpression = new LiteralExpression();
 
-        final DomainObject foundDomainObject = literalExpression.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = literalExpression.findDomainObject(UUID);
 
-        assertNull(foundDomainObject);
+        assertFalse(foundDomainObject.isPresent());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +32,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -107,9 +109,10 @@ public class OutputClauseTest {
                                                            null,
                                                            null);
 
-        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = outputClause.findDomainObject(UUID);
 
-        assertEquals(outputClause, foundDomainObject);
+        assertTrue(foundDomainObject.isPresent());
+        assertEquals(outputClause, foundDomainObject.get());
     }
 
     @Test
@@ -125,9 +128,10 @@ public class OutputClauseTest {
 
         outputClause.setDefaultOutputEntry(literalExpression);
 
-        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = outputClause.findDomainObject(UUID);
 
-        assertEquals(literalExpression, foundDomainObject);
+        assertTrue(foundDomainObject.isPresent());
+        assertEquals(literalExpression, foundDomainObject.get());
     }
 
     @Test
@@ -135,9 +139,9 @@ public class OutputClauseTest {
 
         final OutputClause outputClause = new OutputClause();
 
-        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+        final Optional<DomainObject> foundDomainObject = outputClause.findDomainObject(UUID);
 
-        assertNull(foundDomainObject);
+        assertFalse(foundDomainObject.isPresent());
     }
 
     private OutputClauseUnaryTests buildOutputClauseUnaryTests() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/OutputClauseTest.java
@@ -26,12 +26,14 @@ import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Text;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -46,6 +48,7 @@ public class OutputClauseTest {
     private static final String TEXT = "TEXT";
     private static final String CLAUSE_ID = "CLAUSE_ID";
     private static final String UNARY_ID = "UNARY_ID";
+    private static final String UUID = "uuid";
     private OutputClause outputClause;
 
     @Before
@@ -92,6 +95,49 @@ public class OutputClauseTest {
         assertNotEquals(UNARY_ID, target.getOutputValues().getId().getValue());
         assertEquals(TEXT, target.getOutputValues().getText().getValue());
         assertEquals(ConstraintType.ENUMERATION, target.getOutputValues().getConstraintType());
+    }
+
+    @Test
+    public void testFindDomainObject_WhenOutputClauseMatches() {
+
+        final OutputClause outputClause = new OutputClause(new Id(UUID),
+                                                           null,
+                                                           null,
+                                                           null,
+                                                           null,
+                                                           null);
+
+        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+
+        assertEquals(outputClause, foundDomainObject);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenDefaultOutputEntryMatches() {
+
+        final OutputClause outputClause = new OutputClause();
+
+        final OutputClauseLiteralExpression literalExpression = new OutputClauseLiteralExpression(new Id(UUID),
+                                                                                                  null,
+                                                                                                  null,
+                                                                                                  null,
+                                                                                                  null);
+
+        outputClause.setDefaultOutputEntry(literalExpression);
+
+        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+
+        assertEquals(literalExpression, foundDomainObject);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingMatches() {
+
+        final OutputClause outputClause = new OutputClause();
+
+        final DomainObject foundDomainObject = outputClause.findDomainObject(UUID);
+
+        assertNull(foundDomainObject);
     }
 
     private OutputClauseUnaryTests buildOutputClauseUnaryTests() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
@@ -110,7 +110,24 @@ public class RelationTest {
     }
 
     @Test
-    public void testFindDomainObject() {
+    public void testFindDomainObject_WhenColumnMatches() {
+
+        final Relation relation = new Relation();
+        final InformationItem informationItem1 = mock(InformationItem.class);
+        final InformationItem informationItem2 = mock(InformationItem.class);
+        final InformationItem informationItem3 = mock(InformationItem.class);
+
+        when(informationItem3.getDomainObjectUUID()).thenReturn(UUID);
+
+        relation.getColumn().addAll(Arrays.asList(informationItem1, informationItem2, informationItem3));
+
+        final DomainObject actual = relation.findDomainObject(UUID);
+
+        assertEquals(informationItem3, actual);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenRowMatches() {
 
         final Relation relation = new Relation();
         final List list1 = mock(List.class);
@@ -137,7 +154,11 @@ public class RelationTest {
         final List list1 = mock(List.class);
         final List list2 = mock(List.class);
         final List list3 = mock(List.class);
+        final InformationItem informationItem1 = mock(InformationItem.class);
+        final InformationItem informationItem2 = mock(InformationItem.class);
+        final InformationItem informationItem3 = mock(InformationItem.class);
 
+        relation.getColumn().addAll(Arrays.asList(informationItem1, informationItem2, informationItem3));
         relation.getRow().addAll(Arrays.asList(list1, list2, list3));
 
         final DomainObject actual = relation.findDomainObject(UUID);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,9 +33,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -121,9 +122,10 @@ public class RelationTest {
 
         relation.getColumn().addAll(Arrays.asList(informationItem1, informationItem2, informationItem3));
 
-        final DomainObject actual = relation.findDomainObject(UUID);
+        final Optional<DomainObject> actual = relation.findDomainObject(UUID);
 
-        assertEquals(informationItem3, actual);
+        assertTrue(actual.isPresent());
+        assertEquals(informationItem3, actual.get());
     }
 
     @Test
@@ -135,13 +137,13 @@ public class RelationTest {
         final List list3 = mock(List.class);
         final DomainObject expectedDomainObject = mock(DomainObject.class);
 
-        when(list3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+        when(list3.findDomainObject(UUID)).thenReturn(Optional.of(expectedDomainObject));
 
         relation.getRow().addAll(Arrays.asList(list1, list2, list3));
 
-        final DomainObject actual = relation.findDomainObject(UUID);
-
-        assertEquals(expectedDomainObject, actual);
+        final Optional<DomainObject> actual = relation.findDomainObject(UUID);
+        assertTrue(actual.isPresent());
+        assertEquals(expectedDomainObject, actual.get());
         verify(list1).findDomainObject(UUID);
         verify(list2).findDomainObject(UUID);
         verify(list3).findDomainObject(UUID);
@@ -161,9 +163,9 @@ public class RelationTest {
         relation.getColumn().addAll(Arrays.asList(informationItem1, informationItem2, informationItem3));
         relation.getRow().addAll(Arrays.asList(list1, list2, list3));
 
-        final DomainObject actual = relation.findDomainObject(UUID);
+        final Optional<DomainObject> actual = relation.findDomainObject(UUID);
 
-        assertNull(actual);
+        assertFalse(actual.isPresent());
 
         verify(list1).findDomainObject(UUID);
         verify(list2).findDomainObject(UUID);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/RelationTest.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.dmn.api.definition.model;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,16 +27,19 @@ import org.kie.workbench.common.dmn.api.definition.HasTypeRef;
 import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +47,7 @@ public class RelationTest {
 
     private static final String RELATION_ID = "RELATION-ID";
     private static final String DESCRIPTION = "DESCRIPTION";
+    private static final String UUID = "uuid";
     private Relation relation;
 
     @Before
@@ -55,10 +59,10 @@ public class RelationTest {
     public void testGetHasTypeRefs() {
         final InformationItem column1 = mock(InformationItem.class);
         final InformationItem column2 = mock(InformationItem.class);
-        final List<InformationItem> column = asList(column1, column2);
-        final org.kie.workbench.common.dmn.api.definition.model.List row1 = mock(org.kie.workbench.common.dmn.api.definition.model.List.class);
-        final org.kie.workbench.common.dmn.api.definition.model.List row2 = mock(org.kie.workbench.common.dmn.api.definition.model.List.class);
-        final List<org.kie.workbench.common.dmn.api.definition.model.List> row = asList(row1, row2);
+        final java.util.List<InformationItem> column = asList(column1, column2);
+        final List row1 = mock(List.class);
+        final List row2 = mock(List.class);
+        final java.util.List<List> row = asList(row1, row2);
         final HasTypeRef hasTypeRef1 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef2 = mock(HasTypeRef.class);
         final HasTypeRef hasTypeRef3 = mock(HasTypeRef.class);
@@ -72,8 +76,8 @@ public class RelationTest {
         when(row1.getHasTypeRefs()).thenReturn(asList(hasTypeRef3));
         when(row2.getHasTypeRefs()).thenReturn(asList(hasTypeRef4));
 
-        final List<HasTypeRef> actualHasTypeRefs = relation.getHasTypeRefs();
-        final List<HasTypeRef> expectedHasTypeRefs = asList(relation, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
+        final java.util.List<HasTypeRef> actualHasTypeRefs = relation.getHasTypeRefs();
+        final java.util.List<HasTypeRef> expectedHasTypeRefs = asList(relation, hasTypeRef1, hasTypeRef2, hasTypeRef3, hasTypeRef4);
 
         assertEquals(expectedHasTypeRefs, actualHasTypeRefs);
     }
@@ -103,5 +107,45 @@ public class RelationTest {
         assertEquals(BuiltInType.BOOLEAN.asQName(), target.getTypeRef());
         assertTrue(target.getColumn().isEmpty());
         assertTrue(target.getRow().isEmpty());
+    }
+
+    @Test
+    public void testFindDomainObject() {
+
+        final Relation relation = new Relation();
+        final List list1 = mock(List.class);
+        final List list2 = mock(List.class);
+        final List list3 = mock(List.class);
+        final DomainObject expectedDomainObject = mock(DomainObject.class);
+
+        when(list3.findDomainObject(UUID)).thenReturn(expectedDomainObject);
+
+        relation.getRow().addAll(Arrays.asList(list1, list2, list3));
+
+        final DomainObject actual = relation.findDomainObject(UUID);
+
+        assertEquals(expectedDomainObject, actual);
+        verify(list1).findDomainObject(UUID);
+        verify(list2).findDomainObject(UUID);
+        verify(list3).findDomainObject(UUID);
+    }
+
+    @Test
+    public void testFindDomainObject_WhenNothingHasBeenFound() {
+
+        final Relation relation = new Relation();
+        final List list1 = mock(List.class);
+        final List list2 = mock(List.class);
+        final List list3 = mock(List.class);
+
+        relation.getRow().addAll(Arrays.asList(list1, list2, list3));
+
+        final DomainObject actual = relation.findDomainObject(UUID);
+
+        assertNull(actual);
+
+        verify(list1).findDomainObject(UUID);
+        verify(list2).findDomainObject(UUID);
+        verify(list3).findDomainObject(UUID);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelperTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelperTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.dmn.api.definition.model.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.HasDomainObject;
+import org.kie.workbench.common.stunner.core.domainobject.DomainObject;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DomainObjectSearcherHelperTest {
+
+    private static final String UUID = "the uuid";
+
+    @Test
+    public void testFind() {
+
+
+        final DomainObject domainObject = mock(DomainObject.class);
+        final HasDomainObject hasDo1 = mock(HasDomainObject.class);
+        final HasDomainObject hasDo2 = mock(HasDomainObject.class);
+        final HasDomainObject hasDo3 = mock(HasDomainObject.class);
+        final HasDomainObject hasDo4 = mock(HasDomainObject.class);
+        when(hasDo4.findDomainObject(UUID)).thenReturn(domainObject);
+
+        final List<HasDomainObject> list = Arrays.asList(hasDo1,
+                                                         hasDo2,
+                                                         hasDo3,
+                                                         hasDo4);
+        final DomainObject result = DomainObjectSearcherHelper.find(list, UUID);
+
+        assertEquals(domainObject, result);
+
+        verify(hasDo1).findDomainObject(UUID);
+        verify(hasDo2).findDomainObject(UUID);
+        verify(hasDo3).findDomainObject(UUID);
+        verify(hasDo4).findDomainObject(UUID);
+    }
+
+    @Test
+    public void testGetDomainObject() {
+
+        final String uuid1 = "uuid1";
+        final String uuid2 = "uuid2";
+        final String uuid3 = "uuid3";
+        final DomainObject domainObject1 = createDomainObject(uuid1);
+        final DomainObject domainObject2 = createDomainObject(uuid2);
+        final DomainObject domainObject3 = createDomainObject(uuid3);
+
+        final List<DomainObject> list = Arrays.asList(domainObject1,
+                                                      domainObject2,
+                                                      domainObject3);
+
+        assertEquals(domainObject3, DomainObjectSearcherHelper.getDomainObject(list, uuid3));
+        assertEquals(domainObject2, DomainObjectSearcherHelper.getDomainObject(list, uuid2));
+        assertEquals(domainObject1, DomainObjectSearcherHelper.getDomainObject(list, uuid1));
+    }
+
+    @Test
+    public void testMatches() {
+
+        final DomainObject domainObject1 = createDomainObject(UUID);
+
+        assertTrue(DomainObjectSearcherHelper.matches(domainObject1, UUID));
+        assertFalse(DomainObjectSearcherHelper.matches(domainObject1, "another"));
+    }
+
+    @Test
+    public void testMatches_WhenItIsNull() {
+
+        assertFalse(DomainObjectSearcherHelper.matches(null, UUID));
+    }
+
+    private DomainObject createDomainObject(final String uuid) {
+
+        final DomainObject domainObject = mock(DomainObject.class);
+        when(domainObject.getDomainObjectUUID()).thenReturn(uuid);
+        return domainObject;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelperTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-api/src/test/java/org/kie/workbench/common/dmn/api/definition/model/common/DomainObjectSearcherHelperTest.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.dmn.api.definition.model.common;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,21 +41,21 @@ public class DomainObjectSearcherHelperTest {
     @Test
     public void testFind() {
 
-
         final DomainObject domainObject = mock(DomainObject.class);
         final HasDomainObject hasDo1 = mock(HasDomainObject.class);
         final HasDomainObject hasDo2 = mock(HasDomainObject.class);
         final HasDomainObject hasDo3 = mock(HasDomainObject.class);
         final HasDomainObject hasDo4 = mock(HasDomainObject.class);
-        when(hasDo4.findDomainObject(UUID)).thenReturn(domainObject);
+        when(hasDo4.findDomainObject(UUID)).thenReturn(Optional.of(domainObject));
 
         final List<HasDomainObject> list = Arrays.asList(hasDo1,
                                                          hasDo2,
                                                          hasDo3,
                                                          hasDo4);
-        final DomainObject result = DomainObjectSearcherHelper.find(list, UUID);
+        final Optional<DomainObject> result = DomainObjectSearcherHelper.find(list, UUID);
 
-        assertEquals(domainObject, result);
+        assertTrue(result.isPresent());
+        assertEquals(domainObject, result.get());
 
         verify(hasDo1).findDomainObject(UUID);
         verify(hasDo2).findDomainObject(UUID);
@@ -76,9 +77,9 @@ public class DomainObjectSearcherHelperTest {
                                                       domainObject2,
                                                       domainObject3);
 
-        assertEquals(domainObject3, DomainObjectSearcherHelper.getDomainObject(list, uuid3));
-        assertEquals(domainObject2, DomainObjectSearcherHelper.getDomainObject(list, uuid2));
-        assertEquals(domainObject1, DomainObjectSearcherHelper.getDomainObject(list, uuid1));
+        assertEquals(domainObject3, DomainObjectSearcherHelper.getDomainObject(list, uuid3).get());
+        assertEquals(domainObject2, DomainObjectSearcherHelper.getDomainObject(list, uuid2).get());
+        assertEquals(domainObject1, DomainObjectSearcherHelper.getDomainObject(list, uuid1).get());
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorView.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorView.java
@@ -75,4 +75,6 @@ public interface ExpressionEditorView extends org.jboss.errai.ui.client.local.ap
     void reloadEditor();
 
     void clear();
+
+    void selectDomainObject(final String uuid);
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -113,7 +113,6 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.KeyboardOperati
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
-import static java.util.Objects.isNull;
 import static java.util.stream.Stream.concat;
 import static org.kie.workbench.common.dmn.api.definition.model.ItemDefinition.ITEM_DEFINITION_COMPARATOR;
 import static org.kie.workbench.common.dmn.api.definition.model.common.DomainObjectSearcherHelper.matches;
@@ -421,9 +420,9 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         } else if (businessKnowledgeModelMatches(uuid)) {
             return getBusinessKnowledgeModel();
         } else {
-            final DomainObject domainObject = hasExpression.getExpression().findDomainObject(uuid);
-            if (!isNull(domainObject)) {
-                return domainObject;
+            final Optional<DomainObject> domainObject = hasExpression.getExpression().findDomainObject(uuid);
+            if (domainObject.isPresent()) {
+                return domainObject.get();
             }
             return new NOPDomainObject();
         }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/BoxedExpressionService.java
@@ -92,4 +92,9 @@ public class BoxedExpressionService {
     public static void onLogicTypeSelect(final String selectedLogicType) {
         expressionEditor.onLogicTypeSelect(selectedLogicType);
     }
+
+    @JsMethod
+    public static void selectObject(final String uuid) {
+        expressionEditor.selectDomainObject(uuid);
+    }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -220,6 +220,13 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
         });
     }
 
+    public Promise<Void> searchDomainObject(String uuid) {
+        return promises.create((resolve, reject) -> {
+            //commands.getUndoSessionCommand().execute();
+        });
+    }
+
+
     private DMNDiagramEditor.View getView() {
         return (DMNDiagramEditor.View) getBaseEditorView();
     }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -220,12 +220,11 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
         });
     }
 
-    public Promise<Void> searchDomainObject(String uuid) {
+    public Promise<Void> searchDomainObject(final String uuid) {
         return promises.create((resolve, reject) -> {
-            //commands.getUndoSessionCommand().execute();
+            throw new UnsupportedOperationException("This diagram does not support search for domain objects");
         });
     }
-
 
     private DMNDiagramEditor.View getView() {
         return (DMNDiagramEditor.View) getBaseEditorView();

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorActivity.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorActivity.java
@@ -102,4 +102,9 @@ public class DMNDiagramEditorActivity extends AbstractActivity implements Editor
     public Promise<Void> redo() {
         return realPresenter.redo();
     }
+
+    @Override
+    public Promise<Void> searchDomainObject(String uuid) {
+        return realPresenter.searchDomainObject(uuid);
+    }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -36,11 +36,13 @@ import org.kie.workbench.common.dmn.client.common.KogitoChannelHelper;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
+import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
 import org.kie.workbench.common.dmn.client.editors.search.DMNEditorSearchIndex;
 import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
+import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
 import org.kie.workbench.common.dmn.showcase.client.feel.FEELDemoEditor;
 import org.kie.workbench.common.dmn.webapp.common.client.docks.preview.PreviewDiagramDock;
@@ -192,6 +194,14 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
     public void openFEELEditor() {
         dialogBox.center();
         dialogBox.show();
+    }
+
+    public Promise<Void> searchDomainObject(final String uuid) {
+        return promises.create((resolve, reject) -> {
+            final DMNSession session = sessionManager.getCurrentSession();
+            final ExpressionEditorView.Presenter expressionEditor = session.getExpressionEditor();
+            expressionEditor.getView().selectDomainObject(uuid);
+        });
     }
 
     public Promise<Void> undo() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorActivity.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditorActivity.java
@@ -114,6 +114,11 @@ public class DMNDiagramEditorActivity extends AbstractActivity implements Editor
         return realPresenter.redo();
     }
 
+    @Override
+    public Promise<Void> searchDomainObject(String uuid) {
+        return realPresenter.searchDomainObject(uuid);
+    }
+
     @FunctionalInterface
     @JsFunction
     public interface DoAction {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/index.html
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/index.html
@@ -38,6 +38,8 @@
       <input type="button" value="FEEL Editor" onclick="openFEELEditor()" />
       <input type="button" value="Undo" onclick="undo()" />
       <input type="button" value="Redo" onclick="redo()" />
+      <input type="text" id="input-search" />
+      <input type="button" value="Search Domain Object" onclick="search()" />
     </div>
     <iframe id="editorFrame" src="editor.html" width="100%" height="880px" scrolling="no"></iframe>
   </body>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/static/test.js
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/static/test.js
@@ -70,6 +70,13 @@ function redo() {
   window.frames.editorFrame.contentWindow.gwtEditorBeans.get("DMNDiagramEditor").get().redo();
 }
 
+function search() {
+  window.frames.editorFrame.contentWindow.gwtEditorBeans
+    .get("DMNDiagramEditor")
+    .get()
+    .searchDomainObject(document.getElementById("input-search").value);
+}
+
 const openFile = (event) => {
   const input = event.target;
   const reader = new FileReader();

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/EditorActivity.java
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/EditorActivity.java
@@ -44,4 +44,8 @@ public interface EditorActivity extends Activity {
     default Promise<Void> redo() {
         throw new UnsupportedOperationException("The editor does not support redo.");
     }
+
+    default Promise<Void> searchDomainObject(final String uuid) {
+        throw new UnsupportedOperationException("The editor does not support search domain object.");
+    }
 }

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/JSFunctions.java
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/JSFunctions.java
@@ -61,6 +61,9 @@ public class JSFunctions {
         $wnd.GWTEditor.prototype.redo = function () {
             return this.instance.@org.uberfire.client.mvp.EditorActivity::redo()();
         };
+        $wnd.GWTEditor.prototype.searchDomainObject = function (uuid) {
+            return this.instance.@org.uberfire.client.mvp.EditorActivity::searchDomainObject(Ljava/lang/String;)(uuid);
+        };
 
     }-*/;
 


### PR DESCRIPTION
**The problem:**
When you select a cell in the the new boxed expression edition, you must to select the Domain Object related to the cell in the GWT/Java world in order to populate the properties panel in the right side of the editor.

**The solution:**
When a cell is selected in the boxed expression editor, its communicates the GWT/Java world about that passing the UUID of the selected cell.

This PR searches for the respective Domain Object in the GWT/Java world and select it.

In order to make the test easily while the integration with new boxed expression editor is not done, I added a search box in the DMN testing webapp:
![image](https://user-images.githubusercontent.com/7305741/153052521-5eaf2a85-6c65-4eb5-88bc-7df3eb2f11b6.png)
*This search box can be removed once the new boxed expression editor have its integration with the search service implemented.*

This search box works when you are in boxed expression editor. It just select the item with the UUID that you searched, so you can check if the search is working by accessing the properties panel at the right and see if the item that you searched is selected. Also noticed that the rectangle around the selected item in the boxed expression is not triggered by this mechanism.

If a item not found or a blank one is searched, the selection is cleared.

For the integration with boxed expression editor, a method called  "selectObject" was created in the file `BoxedExpressionService`. @vpellegrino can change the name of this method to another one if he wants when the integration was implemented.

Demo video of the featuring working: https://issues.redhat.com/secure/attachment/12686691/12686691_search+domain+object.mp4