### PR TITLE
Upgrade chromedriver to version 98

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@vscode/test-web": "^0.0.22",
     "babel-loader": "^8.2.2",
     "chai": "^4.3.4",
-    "chromedriver": "^96.0.0",
+    "chromedriver": "^98.0.0",
     "circular-dependency-plugin": "^5.2.2",
     "compressing": "^1.5.1",
     "copy-webpack-plugin": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,10 +3539,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@testim/chrome-version@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
-  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+"@testim/chrome-version@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.2.tgz#092005c5b77bd3bb6576a4677110a11485e11864"
+  integrity sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==
 
 "@testing-library/dom@^7.28.1":
   version "7.31.0"
@@ -5299,12 +5299,19 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1, axios@^0.21.2:
+axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
 
 azure-devops-node-api@^11.0.1:
   version "11.0.1"
@@ -6895,13 +6902,13 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^96.0.0:
-  version "96.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
-  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
+chromedriver@^98.0.0:
+  version "98.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-98.0.0.tgz#b2c3c1941fad4cdfadad5d4c46923e02f089fd30"
+  integrity sha512-Oi6Th5teK+VI4nti+423/dFkENYHEMOdUvqwJHzOaNwXqLwZ8FuSaKBybgALCctGapwJbd+tmPv3qSd6tUUIHQ==
   dependencies:
-    "@testim/chrome-version" "^1.0.7"
-    axios "^0.21.2"
+    "@testim/chrome-version" "^1.1.2"
+    axios "^0.24.0"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -9821,6 +9828,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+follow-redirects@^1.14.4:
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Upgrade needed due to:
```
chrome-extension-pack-kogito-kie-editors: FAIL it-tests/tests/BpmnFullScreenTest.ts
chrome-extension-pack-kogito-kie-editors:   ● BpmnFullScreenTest
chrome-extension-pack-kogito-kie-editors:     SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 96
chrome-extension-pack-kogito-kie-editors:     Current browser version is 98.0.4758.80 with binary path /usr/bin/google-chrome
chrome-extension-pack-kogito-kie-editors:       at Object.throwDecodedError (../../node_modules/selenium-webdriver/lib/error.js:539:15)
chrome-extension-pack-kogito-kie-editors:       at parseHttpResponse (../../node_modules/selenium-webdriver/lib/http.js:647:13)
chrome-extension-pack-kogito-kie-editors:       at Executor.execute (../../node_modules/selenium-webdriver/lib/http.js:573:28)
```
- https://github.com/kiegroup/kie-tools/runs/5126548048?check_suite_focus=true#:~:text=27460-,chrome%2Dextension%2Dpack%2Dkogito%2Dkie%2Deditors%3A%20FAIL%20it%2Dtests/tests,pack%2Dkogito%2Dkie%2Deditors%3A%20Test%20Suites%3A%207%20failed%2C%207%20total,-27497
- https://github.com/kiegroup/kie-tools/pull/787