### PR TITLE
KOGITO-6417: [DMN Designer] Undo/redo in Boxed Expression Editor for editable cells is not working properly

### DIFF
--- a/packages/boxed-expression-component/showcase/index.tsx
+++ b/packages/boxed-expression-component/showcase/index.tsx
@@ -34,9 +34,60 @@ import {
 } from "../src";
 import { Button, Modal } from "@patternfly/react-core";
 import { PenIcon } from "@patternfly/react-icons";
-import { dataTypes, pmmlParams } from "../tests/components/test-utils";
 import "../src/components/BoxedExpressionEditor/base-no-reset-wrapped.css";
 import ReactJson from "react-json-view";
+
+/**
+ * Constants copied from tests to fix debugger
+ */
+export const dataTypes = [
+  { typeRef: "Undefined", name: "<Undefined>", isCustom: false },
+  { typeRef: "Any", name: "Any", isCustom: false },
+  { typeRef: "Boolean", name: "boolean", isCustom: false },
+  { typeRef: "Context", name: "context", isCustom: false },
+  { typeRef: "Date", name: "date", isCustom: false },
+  { typeRef: "DateTime", name: "date and time", isCustom: false },
+  { typeRef: "DateTimeDuration", name: "days and time duration", isCustom: false },
+  { typeRef: "Number", name: "number", isCustom: false },
+  { typeRef: "String", name: "string", isCustom: false },
+  { typeRef: "Time", name: "time", isCustom: false },
+  { typeRef: "YearsMonthsDuration", name: "years and months duration", isCustom: false },
+  { typeRef: "tPerson", name: "tPerson", isCustom: true },
+];
+
+export const pmmlParams = [
+  {
+    document: "document",
+    modelsFromDocument: [
+      { model: "model", parametersFromModel: [{ id: "p1", name: "p-1", dataType: DataType.Number }] },
+    ],
+  },
+  {
+    document: "mining pmml",
+    modelsFromDocument: [
+      {
+        model: "MiningModelSum",
+        parametersFromModel: [
+          { id: "i1", name: "input1", dataType: DataType.Any },
+          { id: "i2", name: "input2", dataType: DataType.Any },
+          { id: "i3", name: "input3", dataType: DataType.Any },
+        ],
+      },
+    ],
+  },
+  {
+    document: "regression pmml",
+    modelsFromDocument: [
+      {
+        model: "RegressionLinear",
+        parametersFromModel: [
+          { id: "i1", name: "i1", dataType: DataType.Number },
+          { id: "i2", name: "i2", dataType: DataType.Number },
+        ],
+      },
+    ],
+  },
+];
 
 export const App: React.FunctionComponent = () => {
   //This definition comes directly from the decision node

--- a/packages/boxed-expression-component/src/@types/react-table.d.ts
+++ b/packages/boxed-expression-component/src/@types/react-table.d.ts
@@ -66,6 +66,4 @@ declare module "react-table" {
     /** Disabling table handler on the header of this column */
     disableHandlerOnHeader?: boolean;
   }
-
-  export type DataRecord = Record<string, unknonw>;
 }

--- a/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
+++ b/packages/boxed-expression-component/src/components/Table/EditableCell.tsx
@@ -77,7 +77,6 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
       }
 
       if (value !== newValue) {
-        boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
         onCellUpdate(rowIndex, columnId, newValue ?? value);
       }
 
@@ -87,6 +86,7 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
   );
 
   const triggerEditMode = useCallback(() => {
+    boxedExpression.boxedExpressionEditorGWTService?.notifyUserAction();
     setPreviousValue(value);
     blurActiveElement();
     setMode(EDIT_MODE);
@@ -127,8 +127,8 @@ export function EditableCell({ value, rowIndex, columnId, onCellUpdate, readOnly
         return;
       }
 
-      onCellUpdate(rowIndex, columnId, newValue ?? value);
       triggerEditMode();
+      onCellUpdate(rowIndex, columnId, newValue ?? value);
     },
     [triggerEditMode, value, triggerReadMode, onCellUpdate, rowIndex, columnId, boxedExpression.editorRef]
   );

--- a/packages/boxed-expression-component/src/index.tsx
+++ b/packages/boxed-expression-component/src/index.tsx
@@ -67,4 +67,6 @@ declare module "react-table" {
     /** Disabling table handler on the header of this column */
     disableHandlerOnHeader?: boolean;
   }
+
+  export type DataRecord = Record<string, unknown>;
 }

--- a/packages/feel-input-component/src/FeelInput/FeelInput.tsx
+++ b/packages/feel-input-component/src/FeelInput/FeelInput.tsx
@@ -32,6 +32,7 @@ export interface FeelInputProps {
 
 export interface FeelInputRef {
   setMonacoValue: (newValue: string) => void;
+  getMonacoValue: () => string | undefined;
 }
 
 export const FeelInput = React.forwardRef<FeelInputRef, FeelInputProps>(
@@ -74,6 +75,7 @@ export const FeelInput = React.forwardRef<FeelInputRef, FeelInputProps>(
 
     useImperativeHandle(forwardRef, () => ({
       setMonacoValue: (newValue: string) => FeelEditorService.getStandaloneEditor()?.setValue(newValue),
+      getMonacoValue: () => FeelEditorService.getStandaloneEditor()?.getValue(),
     }));
 
     return (


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-6417

TL;DR: go to "the solution" at the end of the text.

A quick explanation about how the undo/redo works and talks between TS/JavaScript (where the editor is implemented) and GWT/Java world (where the undo/redo is implemented):
- The undo/redo works by saving the status of the current Expression every time an user action is performed. 
- This notification from TS/JavaScript world to GWT/Java world is made by the method `notifyUserAction()`.
- The method `onCellUpdate` passes the data from TS/JavaScript world to GWT/Java world.

So when user presses CTRL+Z (or click on "Undo"), the saved status is restored and all changes performed after the `notifyUserAction()` is discarded.

**The issue:**
SCENARIO 1: If user double clicks on the cell and types, everything works. No issue in this scenario.
SCENARIO 2: If user starts to type without double-clicking the cell, the first letter is not considered an user action, only the subsequent typed letters. This is the issue reported in the ticket.

**The cause:**
We was calling `notifyUserAction` in the `triggerReadMode`. The `triggerReadMode` reports to GWT world the changes made by calling the `onCellUpdate`, so we was calling the `notifyUserAction` before `onCellUpdate` here. It makes sense.

But after implementation of the feel autocomplete to the new Boxed Expression Editor, a new scenario of communication between TS/Js-GTW/Java world was introduced. The method `onTextAreaChange` used by the feel autocomplete also needs to call `onCellUpdate`. 
The solution could be call `notifyUserAction` in the `onTextAreaChange`, but then we will have a double call to `notifyUserAction`.

But remember: if user starts to edit double-clicking the cell it does not call `onTextAreaChange`. 

**The solution :**
Change the moment that `notifyUserAction` is called.
This PR change it from `triggerReadMode` before update to GWT world to `triggerEditMode` before starts everything!
Also it changes the order of the call in the `onTextAreaChange` to call the `triggerEditMode` before the update of the cell content (`onCellUpdate`).

@yesamer