### PR TITLE
KOGITO-6932: DMN editor: text annotation is not saved correctly when creating it by copy and paste

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcess.java
@@ -29,6 +29,7 @@ import com.google.gwt.regexp.shared.RegExp;
 import org.kie.workbench.common.dmn.api.definition.HasText;
 import org.kie.workbench.common.dmn.api.definition.HasVariable;
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.definition.model.DMNElement;
 import org.kie.workbench.common.dmn.api.definition.model.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.model.Decision;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
@@ -99,6 +100,10 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
             cloneDRGElementBasicInfo((DRGElement) source, (DRGElement) target);
         }
 
+        if (source instanceof DMNElement) {
+            cloneDMNElement((DMNElement) source, (DMNElement) target);
+        }
+
         if (source instanceof HasText) {
             cloneTextElementBasicInfo((HasText) source, (HasText) target);
         }
@@ -120,11 +125,14 @@ public class DMNDeepCloneProcess extends DeepCloneProcess implements IDeepCloneP
         return target;
     }
 
+    private void cloneDMNElement(final DMNElement source, final DMNElement target) {
+        target.setId(new Id());
+        target.setDescription(source.getDescription().copy());
+    }
+
     private void cloneDRGElementBasicInfo(final DRGElement source, final DRGElement target) {
         final String uniqueNodeName = composeUniqueNodeName(source.getName().getValue());
-        target.setId(new Id());
         target.setNameHolder(new NameHolder(new Name(uniqueNodeName)));
-        target.setDescription(source.getDescription().copy());
         target.setParent(source.getParent());
         target.getLinksHolder().getValue().getLinks().addAll(cloneExternalLinkList(source));
     }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/commands/clone/DMNDeepCloneProcessTest.java
@@ -165,8 +165,10 @@ public class DMNDeepCloneProcessTest extends AbstractCloneProcessTest {
     @Test
     public void testCloneWhenSourceIsTextAnnotation() {
         final TextAnnotation source = buildTextAnnotation();
+        final TextAnnotation target = new TextAnnotation();
+        target.getId().setValue(SOURCE_ID);
 
-        final TextAnnotation cloned = dmnDeepCloneProcess.clone(source, new TextAnnotation());
+        final TextAnnotation cloned = dmnDeepCloneProcess.clone(source, target);
 
         assertThat(cloned).isNotNull();
         assertThat(cloned.getId().getValue()).isNotEqualTo(SOURCE_ID);


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/KOGITO-6932

**Cause of the issue and fix:**
The issue was caused because the ID of the cloned `TextAnnotation` was not being updated.
The `DMNDeepCloneProcess` receive two parameters: the `source` and the `target`. 
It calls the super method that clones everything in the first level (even references to the same object, so a inner object in `source` and `target` would be the same). 

The `DMNDeepCloneProcess` then resolves those cloned references to a news instances, clone values that super method can't clone, and **sets a new ID for the `target`**.

A new ID for the cloned item should be set in `cloneDRGElementBasicInfo`.

But `TextAnnotation` it is an exception and it is not a DRGElement, so that's why the new ID was not being set.