### PR TITLE
KOGITO-6928: Expression in Assignments that contains comma is saved with incorrect value when reopening a process

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentData.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentData.java
@@ -245,7 +245,7 @@ public class AssignmentData {
     public void setAssignments(final String sAssignments) {
         assignments.clear();
         if (sAssignments != null && !sAssignments.isEmpty()) {
-            String[] as = sAssignments.split(",");
+            String[] as = sAssignments.split(",(?=\\[din])|,(?=\\[dout])");
             for (String a : as) {
                 if (!a.isEmpty()) {
                     Assignment ass = Assignment.deserialize(this,

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentDataTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/model/AssignmentDataTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.bpmn.client.forms.fields.model;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,9 +34,32 @@ public class AssignmentDataTest extends AssignmentBaseTest {
         super.setUp();
     }
 
+
+
     @After
     public void tearDown() {
         super.tearDown();
+    }
+
+    @Test
+    public void testSetAssignments() {
+        AssignmentData assignmentData = new AssignmentData();
+        String assignment1 = "function.getValue(par1,par1)";
+        String assignment2 = "function.getValue(par2,par2)";
+        String assignment3 = "function.getValue(par3.Cpar3)";
+        String assignment4 = "function.getValue(par4,Cpar4)";
+        String sAssignments = "[din]DIA1=" + assignment1 + "," +
+                              "[din]DIA2=" + assignment2+ "," +
+                              "[dout]" + assignment3 + "=DOA1," +
+                              "[dout]" + assignment4 + "=DOA2";
+        assignmentData.setAssignments(sAssignments);
+        List<Assignment> result = assignmentData.getAssignments();
+        assertEquals(4, result.stream().count());
+        assertEquals(assignment1, result.get(0).getExpression());
+        assertEquals(assignment2, result.get(1).getExpression());
+        assertEquals(assignment3, result.get(2).getExpression());
+        assertEquals(assignment4, result.get(3).getExpression());
+
     }
 
     @Test


### PR DESCRIPTION
Fixed problem with deserialization. The comma was used inside the expression and as a separator for the full assignments string. That caused the problem.

JIRA: [KOGITO-6928](https://issues.redhat.com/browse/KOGITO-6928)

VS Code: [VSCode Extension](https://drive.google.com/file/d/1Y2KhRHxfJeHdMQXg9d1HBM_g0bjL4y8u/view?usp=sharing)