### PR TITLE
Fix for "Sonar :: stunner-editors" workflow

### DIFF
--- a/packages/build-env/graph.dot
+++ b/packages/build-env/graph.dot
@@ -169,6 +169,7 @@ digraph G {
   "@kie-tools/stunner-editors" -> "@kie-tools/stunner-editors-dmn-loader" [ style = "solid", color = "black" ];
   "@kie-tools/stunner-editors-dmn-loader" -> "@kie-tools/boxed-expression-component" [ style = "solid", color = "blue" ];
   "@kie-tools/stunner-editors-dmn-loader" -> "@kie-tools/import-java-classes-component" [ style = "solid", color = "blue" ];
+  "@kie-tools/stunner-editors-dmn-loader" -> "@kie-tools-core/keyboard-shortcuts" [ style = "solid", color = "blue" ];
   "@kie-tools/uniforms-bootstrap4-codegen" -> "@kie-tools-core/webpack-base" [ style = "dashed", color = "blue" ];
   "@kie-tools/uniforms-patternfly-codegen" -> "@kie-tools-core/webpack-base" [ style = "dashed", color = "blue" ];
   "@kie-tools/unitables" -> "@kie-tools/boxed-expression-component" [ style = "solid", color = "blue" ];

--- a/packages/stunner-editors-dmn-loader/package.json
+++ b/packages/stunner-editors-dmn-loader/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@kie-tools/boxed-expression-component": "0.0.0",
     "@kie-tools/import-java-classes-component": "0.0.0",
+    "@kie-tools-core/keyboard-shortcuts": "0.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
This workflow [1] has been failing for quite a while, throwing the following error:

```
TS2307: Cannot find module '@kie-tools-core/keyboard-shortcuts/dist/channel' or its corresponding type declarations.
```

So, I'm adding the missing dependency.

[1] https://github.com/kiegroup/kie-tools/actions/workflows/sonar_analysis_stunner_editors.yml