### PR TITLE
KOGITO-6210: BPMN editor loses data assignment

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.java
@@ -103,6 +103,8 @@ public interface StunnerFormsClientFieldsConstants extends Messages {
 
     String RenameDiagramVariableError();
 
+    String DuplicatedVariableIDError(String processIDName);
+
     String DuplicatedVariableNameError(String variableName);
 
     String DuplicatedAttributeNameError(String attributeName);

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImpl.java
@@ -265,7 +265,12 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
 
         name.addChangeHandler(event -> {
             String value = name.getText();
-            if (isDuplicateName(value)) {
+            if (isDuplicateID(value)) {
+                notification.fire(new NotificationEvent(StunnerFormsClientFieldsConstants.CONSTANTS.DuplicatedVariableIDError(value),
+                                                        NotificationEvent.NotificationType.ERROR));
+                name.setValue(currentName);
+                ValueChangeEvent.fire(name, currentName);
+            } else if (isDuplicateName(value)) {
                 notification.fire(new NotificationEvent(StunnerFormsClientFieldsConstants.CONSTANTS.DuplicatedVariableNameError(value),
                                                         NotificationEvent.NotificationType.ERROR));
                 name.setValue(currentName);
@@ -474,6 +479,10 @@ public class VariableListItemWidgetViewImpl implements VariableListItemWidgetVie
         deleteButton.setEnabled(!readOnly);
         dataTypeComboBox.setReadOnly(readOnly);
         name.setEnabled(!readOnly);
+    }
+
+    protected boolean isDuplicateID(final String id) {
+        return parentWidget.isDuplicateID(id);
     }
 
     private boolean isDuplicateName(final String name) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRenderer.java
@@ -223,6 +223,16 @@ public class VariablesEditorFieldRenderer extends FieldRenderer<VariablesEditorF
     }
 
     /**
+     * Tests whether a Row ID is duplicate across the whole process
+     * @param id
+     * @return
+     */
+    @Override
+    public boolean isDuplicateID(final String id) {
+        return VariableUtils.matchesProcessID(graph, id);
+    }
+
+    /**
      * Tests whether a Row name occurs more than once in the list of rows
      * @param name
      * @return

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetView.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorWidgetView.java
@@ -41,6 +41,8 @@ public interface VariablesEditorWidgetView extends IsWidget {
 
         void addVariable();
 
+        boolean isDuplicateID(final String id);
+
         boolean isDuplicateName(final String name);
 
         boolean isBoundToNodes(final String name);

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/util/VariableUtils.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/util/VariableUtils.java
@@ -33,6 +33,7 @@ import java.util.stream.StreamSupport;
 
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDefinition;
 import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagram;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseAdHocSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseReusableSubprocess;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseUserTask;
@@ -96,6 +97,18 @@ public class VariableUtils {
 
     public static Collection<VariableUsage> findVariableUsages(Node node, String variableName) {
         return findVariableUsages(Collections.singletonList(node), variableName);
+    }
+
+    public static boolean matchesProcessID(Graph graph, String variableName) {
+        if (StringUtils.isEmpty(variableName)) {
+            return false;
+        }
+        Iterable<Node> nodes = graph.nodes();
+        return StreamSupport.stream(nodes.spliterator(), false)
+                .filter(VariableUtils::isBPMNDiagramImpl)
+                .map(node -> ((View) node.getContent()))
+                .map(view -> (BPMNDiagramImpl) view.getDefinition())
+                .anyMatch(bpmnDiagram -> Objects.equals(bpmnDiagram.getDiagramSet().getId().getValue(), variableName));
     }
 
     @SuppressWarnings("unchecked")
@@ -172,6 +185,11 @@ public class VariableUtils {
     private static boolean isBPMNDefinition(Node node) {
         return node.getContent() instanceof View &&
                 ((View) node.getContent()).getDefinition() instanceof BPMNDefinition;
+    }
+
+    protected static boolean isBPMNDiagramImpl(Node node) {
+        return node.getContent() instanceof View &&
+                ((View) node.getContent()).getDefinition() instanceof BPMNDiagramImpl;
     }
 
     private static String getDisplayName(BPMNDefinition definition) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/resources/org/kie/workbench/common/stunner/bpmn/client/forms/fields/i18n/StunnerFormsClientFieldsConstants.properties
@@ -54,6 +54,7 @@ ProcessModel=Process Model
 ConfirmCloseBusinessProcessEditor=Business Process may contain unsaved changes. Are you sure you would like to close the editor?
 DeleteDiagramVariableError=This Process Variable cannot be deleted because is used in one or more tasks or other process nodes. To Delete the variable, please delete tasks assignment variables first or any other usages in the process nodes.
 RenameDiagramVariableError=This Process Variable cannot be renamed because is used in one or more tasks or other process nodes. To Rename the variable, please delete tasks assignment variables first or any other usages in the process nodes.
+DuplicatedVariableIDError=The Variable cannot have the same name as the Process ID ({0}).
 DuplicatedVariableNameError=A Variable with this name: {0} already exists
 DuplicatedAttributeNameError=An Attribute with this name: {0} already exists
 AssignmentNameAlreadyInUseAsMultipleInstanceInputOutputVariable=Assignment name: {0} is already in use as the multiple instance data input or data output in current node.

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariableListItemWidgetViewImplTest.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
@@ -169,6 +170,7 @@ public class VariableListItemWidgetViewImplTest {
         doCallRealMethod().when(view).getModel();
         doCallRealMethod().when(view).setModel(any(VariableRow.class));
         doCallRealMethod().when(view).getModelValue(any());
+        doCallRealMethod().when(view).isDuplicateID(anyString());
         doCallRealMethod().when(view).setTextBoxModelValue(any(TextBox.class),
                                                            any());
         doCallRealMethod().when(view).setListBoxModelValue(any(),
@@ -370,7 +372,17 @@ public class VariableListItemWidgetViewImplTest {
     }
 
     @Test
-    public void testNameChangeHandlerWhenDuplicate() {
+    public void testNameChangeHandlerWhenDuplicateID() {
+        when(parent.isDuplicateID(VARIABLE_NEW_NAME)).thenReturn(true);
+        prepareNameChange(VARIABLE_NEW_NAME, MODEL_NEW_TO_STRING);
+        verify(parent).isDuplicateID(VARIABLE_NEW_NAME);
+        verify(notification).fire(new NotificationEvent(StunnerFormsClientFieldsConstants.CONSTANTS.DuplicatedVariableIDError(VARIABLE_NEW_NAME),
+                                                        NotificationEvent.NotificationType.ERROR));
+        verify(name).setValue(VARIABLE_NAME);
+    }
+
+    @Test
+    public void testNameChangeHandlerWhenDuplicateName() {
         when(parent.isDuplicateName(VARIABLE_NEW_NAME)).thenReturn(true);
         prepareNameChange(VARIABLE_NEW_NAME, MODEL_NEW_TO_STRING);
         verify(parent).isDuplicateName(VARIABLE_NEW_NAME);
@@ -382,9 +394,11 @@ public class VariableListItemWidgetViewImplTest {
     @Test
     public void testNameChangeHandlerWhenNotDuplicateAndNotBoundToNodes() {
         when(parent.isDuplicateName(VARIABLE_NEW_NAME)).thenReturn(false);
+        when(parent.isDuplicateID(VARIABLE_NEW_NAME)).thenReturn(false);
         when(parent.isBoundToNodes(VARIABLE_NAME)).thenReturn(false);
         prepareNameChange(VARIABLE_NEW_NAME, MODEL_NEW_TO_STRING);
         verify(parent).isDuplicateName(VARIABLE_NEW_NAME);
+        verify(parent).isDuplicateID(VARIABLE_NEW_NAME);
         verify(parent).isBoundToNodes(VARIABLE_NAME);
         verify(parent).notifyModelChanged();
     }
@@ -514,5 +528,12 @@ public class VariableListItemWidgetViewImplTest {
                times(1)).setReadOnly(false);
         verify(name,
                times(1)).setEnabled(true);
+    }
+
+    @Test
+    public void testIsDuplicateID() {
+        String id = "expected_id";
+        view.isDuplicateID(id);
+        verify(parent).isDuplicateID(id);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/variablesEditor/VariablesEditorFieldRendererTest.java
@@ -31,8 +31,10 @@ import org.kie.workbench.common.forms.dynamic.client.rendering.formGroups.impl.d
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.Variable;
 import org.kie.workbench.common.stunner.bpmn.client.forms.fields.model.VariableRow;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Id;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.Name;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.TaskGeneralSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.task.IsMultipleInstance;
@@ -64,6 +66,8 @@ import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class VariablesEditorFieldRendererTest {
+
+    private static final String PROCESS_ID = "process_ID";
 
     @Mock
     private VariablesEditorWidgetView variablesEditorWidgetView;
@@ -384,6 +388,34 @@ public class VariablesEditorFieldRendererTest {
         when(variablesEditorWidgetView.getVariableRows()).thenReturn(variableRows);
         assertTrue(variablesEditor.isDuplicateName("var2"));
         assertFalse(variablesEditor.isDuplicateName("var1"));
+    }
+
+    @Test
+    public void testIdDuplicateID() {
+        Id id = new Id(PROCESS_ID);
+        BPMNDiagramImpl bpmnDiagram = new BPMNDiagramImpl();
+        bpmnDiagram.getDiagramSet().setId(id);
+
+        Node node = mock(Node.class);
+        View view = mock(View.class);
+
+        List<Node> nodes = new ArrayList<>();
+        nodes.add(node);
+
+        when(node.getContent()).thenReturn(view);
+        when(view.getDefinition()).thenReturn(bpmnDiagram);
+        when(abstractClientSessionManager.getCurrentSession()).thenReturn(clientFullSession);
+        when(clientFullSession.getCanvasHandler()).thenReturn(canvasHandler);
+        when(canvasHandler.getDiagram()).thenReturn(diagram);
+        when(diagram.getGraph()).thenReturn(graph);
+        when(graph.nodes()).thenReturn(nodes);
+        when(diagram.getMetadata()).thenReturn(metadata);
+        when(metadata.getPath()).thenReturn(path);
+
+        variablesEditor.getFormGroup(RenderMode.READ_ONLY_MODE);
+
+        assertTrue(variablesEditor.isDuplicateID(PROCESS_ID));
+        assertFalse(variablesEditor.isDuplicateID("NOT_PROCESS_ID"));
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/VariableUtilsTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/util/VariableUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.bpmn.definition.BPMNDiagramImpl;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseCatchingIntermediateEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseEndEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.BaseReusableSubprocess;
@@ -50,6 +51,7 @@ import org.kie.workbench.common.stunner.bpmn.definition.StartSignalEvent;
 import org.kie.workbench.common.stunner.bpmn.definition.UserTask;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.AssignmentsInfo;
 import org.kie.workbench.common.stunner.bpmn.definition.property.dataio.DataIOSet;
+import org.kie.workbench.common.stunner.bpmn.definition.property.diagram.Id;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.BPMNGeneralSet;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.Name;
 import org.kie.workbench.common.stunner.bpmn.definition.property.general.TaskGeneralSet;
@@ -69,6 +71,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.bpmn.client.util.VariableUtils.FindVariableUsagesFlag;
 import static org.kie.workbench.common.stunner.bpmn.client.util.VariableUtils.findVariableUsages;
 import static org.mockito.Mockito.mock;
@@ -89,6 +93,7 @@ public class VariableUtilsTest {
     private static final String EVENT_OUTPUT_ASSIGNMENTS_INFO_VALUE_CFV = "||output1:var1||[dout]output1->" + CASE_FILE_VARIABLE_PREFIX + "var1";
     private static final String COLLECTION = "COLLECTION";
     private static final String COLLECTION_CFV = CASE_FILE_VARIABLE_PREFIX + COLLECTION;
+    private static final String PROCESS_ID = "process_ID";
 
     @Mock
     private Graph graph;
@@ -409,6 +414,32 @@ public class VariableUtilsTest {
         List<VariableUsage> expectedUsages = Arrays.asList(new VariableUsage(CASE_FILE_VARIABLE_PREFIX + "var1", VariableUsage.USAGE_TYPE.MULTIPLE_INSTANCE_INPUT_COLLECTION, nodes.get(0), NODE_NAME),
                                                            new VariableUsage(CASE_FILE_VARIABLE_PREFIX + "var1", VariableUsage.USAGE_TYPE.MULTIPLE_INSTANCE_OUTPUT_COLLECTION, nodes.get(0), NODE_NAME));
         testFindVariableUsages_caseFileVariable("var1", nodes, expectedUsages);
+    }
+
+    @Test
+    public void testMatchesProcessID() {
+        BPMNDiagramImpl bpmnDiagram = mockBpmnDiagram();
+        List<Node> nodes = mockNodeList(bpmnDiagram);
+        when(graph.nodes()).thenReturn(nodes);
+        boolean result1 = VariableUtils.matchesProcessID(graph, PROCESS_ID);
+        boolean result2 = VariableUtils.matchesProcessID(graph, "NOT_PROCESS_ID");
+        assertTrue(result1);
+        assertFalse(result2);
+    }
+
+    @Test
+    public void testIsBPMNDiagramImpl() {
+        BPMNDiagramImpl bpmnDiagram = mockBpmnDiagram();
+        BaseUserTask userTask = mockUserTask(NODE_NAME, ASSIGNMENTS_INFO_VALUE);
+
+        List<Node> nodes1 = mockNodeList(bpmnDiagram);
+        List<Node> nodes2 = mockNodeList(userTask);
+
+        boolean result1 = VariableUtils.isBPMNDiagramImpl(nodes1.get(0));
+        boolean result2 = VariableUtils.isBPMNDiagramImpl(nodes2.get(0));
+
+        assertTrue(result1);
+        assertFalse(result2);
     }
 
     private void testFindVariableUsages(String variableName, List<Node> nodes, List<VariableUsage> expectedUsages) {
@@ -754,5 +785,12 @@ public class VariableUtilsTest {
         Name result = mock(Name.class);
         when(result.getValue()).thenReturn(value);
         return result;
+    }
+
+    private BPMNDiagramImpl mockBpmnDiagram() {
+        Id id = new Id(PROCESS_ID);
+        BPMNDiagramImpl bpmnDiagram = new BPMNDiagramImpl();
+        bpmnDiagram.getDiagramSet().setId(id);
+        return bpmnDiagram;
     }
 }


### PR DESCRIPTION
This problem happened anytime a process id had the same value as a process variable name. This would result in duplicated IDs in the BPMN file. The fix was to assign a unique ID do property instead of using its name.

JIRA: [KOGITO-6210](https://issues.redhat.com/browse/KOGITO-6210)

VS Code: [VSCode Extension](https://drive.google.com/file/d/1Fv46-NbWIx0ZKuxZAmrjhwnmro5DlCeo/view?usp=sharing)