### PR TITLE
Bump `maven-jaxb2-plugin` version to `0.15.1`

### DIFF
--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -243,7 +243,6 @@
     <version.jarjar.plugin>1.5</version.jarjar.plugin>
     <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
     <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
-    <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.kie.gwthelper.maven>1.3</version.org.kie.gwthelper.maven>
     <version.replacer.plugin>1.5.2</version.replacer.plugin>
     <version.resources.plugin>3.1.0</version.resources.plugin>
@@ -1327,12 +1326,6 @@
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${version.jacoco.plugin}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.jvnet.jaxb2.maven2</groupId>
-          <artifactId>maven-jaxb2-plugin</artifactId>
-          <version>${version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin}</version>
         </plugin>
 
         <plugin>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -247,7 +247,7 @@
     <version.jar.plugin>3.1.0</version.jar.plugin>
     <version.jarjar.plugin>1.5</version.jarjar.plugin>
     <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
-    <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
+    <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.15.1</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.kie.gwthelper.maven>1.3</version.org.kie.gwthelper.maven>
     <version.replacer.plugin>1.5.2</version.replacer.plugin>
     <version.resources.plugin>3.1.0</version.resources.plugin>


### PR DESCRIPTION
Bump `maven-jaxb2-plugin` to lastest version, `0.15.1`.
This enables compatibility with JDK17 too.
The same dependency has been removed from SWF, as XML marshalling not used.