### PR TITLE
KOGITO-7067: [DMN Designer] DMN Editor: Slowness while opening large DMN file

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java
@@ -63,6 +63,8 @@ public class DecisionNavigatorPresenter extends AbstractActivity {
 
     private DMNDiagramsSession dmnDiagramsSession;
 
+    private boolean isRefreshComponentsViewSuspended;
+
     double latestDeferred = 0;
 
     @Inject
@@ -110,7 +112,9 @@ public class DecisionNavigatorPresenter extends AbstractActivity {
     }
 
     public void onRefreshDecisionComponents(final @Observes RefreshDecisionComponents events) {
-        refreshComponentsView();
+        if (!isRefreshComponentsViewSuspended) {
+            refreshComponentsView();
+        }
     }
 
     public DecisionNavigatorTreePresenter getTreePresenter() {
@@ -145,7 +149,7 @@ public class DecisionNavigatorPresenter extends AbstractActivity {
         treePresenter.setupItems(getItems());
     }
 
-    void refreshComponentsView() {
+    public void refreshComponentsView() {
         decisionComponents.refresh();
     }
 
@@ -178,6 +182,10 @@ public class DecisionNavigatorPresenter extends AbstractActivity {
 
     void clearTimeout(final double latestDeferred) {
         DomGlobal.clearTimeout(latestDeferred);
+    }
+
+    public void setIsRefreshComponentsViewSuspended(final boolean isRefreshComponentsViewSuspended) {
+        this.isRefreshComponentsViewSuspended = isRefreshComponentsViewSuspended;
     }
 
     public interface View extends UberElemental<DecisionNavigatorPresenter>,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenterTest.java
@@ -218,6 +218,32 @@ public class DecisionNavigatorPresenterTest {
     }
 
     @Test
+    public void testOnRefreshDecisionComponents_WhenRefreshComponentsIsSuspended() {
+
+        presenter.setIsRefreshComponentsViewSuspended(true);
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+
+        verify(decisionComponents, never()).refresh();
+    }
+
+    @Test
+    public void testOnRefreshDecisionComponents_WhenSuspendAndResume() {
+
+        presenter.setIsRefreshComponentsViewSuspended(true);
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+
+        verify(decisionComponents, never()).refresh();
+
+        presenter.setIsRefreshComponentsViewSuspended(false);
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+        presenter.onRefreshDecisionComponents(mock(RefreshDecisionComponents.class));
+
+        verify(decisionComponents, times(2)).refresh();
+    }
+
+    @Test
     public void testDefer() {
 
         final Command cmd = mock(Command.class);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -30,6 +30,7 @@ import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.common.KogitoChannelHelper;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
+import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -113,6 +114,7 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
     protected final DRDNameChanger drdNameChanger;
 
     private final ConfirmationDialog confirmationDialog;
+    private final DecisionNavigatorPresenter decisionNavigatorPresenter;
 
     protected AbstractDMNDiagramEditor(final View view,
                                        final MultiPageEditorContainerView containerView,
@@ -138,7 +140,8 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
                                        final KogitoChannelHelper kogitoChannelHelper,
                                        final GuidedTourBridgeInitializer guidedTourBridgeInitializer,
                                        final DRDNameChanger drdNameChanger,
-                                       final ConfirmationDialog confirmationDialog) {
+                                       final ConfirmationDialog confirmationDialog,
+                                       final DecisionNavigatorPresenter decisionNavigatorPresenter) {
         super(view, containerView);
         this.stunnerEditor = stunnerEditor;
         this.sessionManager = sessionManager;
@@ -163,6 +166,7 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
         this.guidedTourBridgeInitializer = guidedTourBridgeInitializer;
         this.drdNameChanger = drdNameChanger;
         this.confirmationDialog = confirmationDialog;
+        this.decisionNavigatorPresenter = decisionNavigatorPresenter;
     }
 
     public void onStartup(final PlaceRequest place) {
@@ -251,6 +255,7 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
         final AbstractSession currentSession = stunnerEditor.isClosed()
                 ? null
                 : (AbstractSession) stunnerEditor.getSession();
+        decisionNavigatorPresenter.setIsRefreshComponentsViewSuspended(true);
         stunnerEditor.open(diagram, getSessionPresenterCallback(diagram, callback, currentSession));
     }
 
@@ -281,10 +286,13 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
                 if (null != currentSession) {
                     currentSession.close();
                 }
+                decisionNavigatorPresenter.setIsRefreshComponentsViewSuspended(false);
+                decisionNavigatorPresenter.refreshComponentsView();
             }
 
             @Override
             public void onError(final ClientRuntimeError error) {
+                decisionNavigatorPresenter.setIsRefreshComponentsViewSuspended(false);
                 callback.onError(error);
             }
         };

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -29,6 +29,7 @@ import elemental2.promise.Promise;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.common.KogitoChannelHelper;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
+import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.included.IncludedModelsPage;
@@ -103,7 +104,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final ReadOnlyProvider readOnlyProvider,
                             final LazyCanvasFocusUtils lazyCanvasFocusUtils,
                             final EditorSessionCommands commands,
-                            final ConfirmationDialog confirmationDialog) {
+                            final ConfirmationDialog confirmationDialog,
+                            final DecisionNavigatorPresenter decisionNavigatorPresenter) {
         super(view,
               containerView,
               stunnerEditor,
@@ -128,7 +130,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               kogitoChannelHelper,
               guidedTourBridgeInitializer,
               drdNameChanger,
-              confirmationDialog);
+              confirmationDialog,
+              decisionNavigatorPresenter);
         this.readOnlyProvider = readOnlyProvider;
         this.lazyCanvasFocusUtils = lazyCanvasFocusUtils;
         this.commands = commands;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -34,6 +34,7 @@ import elemental2.promise.Promise;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.common.KogitoChannelHelper;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
+import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorPresenter;
 import org.kie.workbench.common.dmn.client.docks.navigator.common.LazyCanvasFocusUtils;
 import org.kie.workbench.common.dmn.client.editors.drd.DRDNameChanger;
 import org.kie.workbench.common.dmn.client.editors.expressions.ExpressionEditorView;
@@ -106,7 +107,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final LazyCanvasFocusUtils lazyCanvasFocusUtils,
                             final EditorSessionCommands commands,
                             final FEELDemoEditor feelDemoEditor,
-                            final ConfirmationDialog confirmationDialog) {
+                            final ConfirmationDialog confirmationDialog,
+                            final DecisionNavigatorPresenter decisionNavigatorPresenter) {
         super(view,
               containerView,
               stunnerEditor,
@@ -131,7 +133,8 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
               kogitoChannelHelper,
               guidedTourBridgeInitializer,
               drdNameChanger,
-              confirmationDialog);
+              confirmationDialog,
+              decisionNavigatorPresenter);
         this.readOnlyProvider = readOnlyProvider;
         this.lazyCanvasFocusUtils = lazyCanvasFocusUtils;
         this.commands = commands;


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/KOGITO-7067

**The issue:**

Running a profiling tool, I found out that the event RefreshDecisionComponents is fired [here](https://github.com/kiegroup/kie-tools/blob/main/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/graph/DMNElementsSynchronizer.java#L81) for every loaded node.

This event is handled [here](https://github.com/kiegroup/kie-tools/blob/4466b9cd1ea5eb9869fbbba3270e2e3b805cbc7c/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java#L112).

It means that for every node inserted on the canvas, during the loading process, the [refreshComponentsView()](https://github.com/kiegroup/kie-tools/blob/4466b9cd1ea5eb9869fbbba3270e2e3b805cbc7c/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/docks/navigator/DecisionNavigatorPresenter.java#L148)is performed.

The Decision Components panel contains all the nodes in the canvas or imported from another model, so they can be duplicated.

This event is used to refresh the Decision Components with the changes every time a node is update.

**The fix:**
During the loading process of the model, we don't need to handle the RefreshDecisionComponents for each node. We only need a single refresh at the end of the loading process.
This PR suspend the refresh during the loading process and resumes it after the loading is done.

**The result:**
Doing that change I reduced the load of a large DMN file from 3:53 (3 minutes and 53 seconds) to 0:33 (33 seconds) in my local machine.