### PR TITLE
KOGITO-7070: Check Dashbuilder security alerts on kie-tools repository

### DIFF
--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -94,7 +94,7 @@
     <!-- database testing -->
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
     <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
-    <version.org.postgres-driver>42.2.14</version.org.postgres-driver>
+    <version.org.postgres-driver>42.3.3</version.org.postgres-driver>
 
     <version.org.arquillian.cube>1.15.3</version.org.arquillian.cube>
 

--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -93,7 +93,7 @@
 
     <!-- database testing -->
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
-    <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
+    <version.org.mysql-driver>8.0.16</version.org.mysql-driver>
     <version.org.postgres-driver>42.3.3</version.org.postgres-driver>
 
     <version.org.arquillian.cube>1.15.3</version.org.arquillian.cube>

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
@@ -28,10 +28,6 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>

--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -68,7 +68,6 @@
     <version.jakarta.activation-api>1.2.2</version.jakarta.activation-api>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
     <version.com.google.jsinterop.annotations>2.0.0</version.com.google.jsinterop.annotations>
-    <version.com.thoughtworks.xstream>1.4.17</version.com.thoughtworks.xstream>
     <version.org.apache.tomcat.tomcat-dbcp>9.0.21</version.org.apache.tomcat.tomcat-dbcp>
     <version.org.jboss.narayana.tomcat>5.9.0.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
@@ -426,16 +425,6 @@
         <groupId>org.jboss.xnio</groupId>
         <artifactId>xnio-nio</artifactId>
         <version>${version.org.jboss.xnio}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${version.com.thoughtworks.xstream}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream-hibernate</artifactId>
-        <version>${version.com.thoughtworks.xstream}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
Updating libraries and removing unused xstream to get rid of security vulnerabilities.