### PR TITLE
Fix for `windows-ci-workflows`

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Support longpaths"
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: git config --system core.longpaths true
 
       - name: "Checkout"

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Support longpaths"
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2019'
         run: git config --system core.longpaths true
 
       - name: "Checkout"


### PR DESCRIPTION
It seems that using `windows-lastest` as OS build results in build instability.
Recently, `windows-latest` was updated to `window-2022` os.
Forcing the previous one, `windows-2019` should remove the instability

References: https://github.com/hashicorp/terraform-cdk/issues/1564