### PR TITLE
Temporarily removing Java from CodeQL build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "java", "javascript"]
+        language: ["go", "javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
As we use a custom java build process, we need to configure CodeQL to make it work.

This PR temporarily removes CodeQL java analysis from our build, and I've created this [issue](https://issues.redhat.com/browse/KOGITO-7079) to fix it.