### PR TITLE
SW-EDITOR: Add ELK license header

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/resources/org/kie/workbench/common/stunner/sw/autolayout/elkjs/elk.bundled.js
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/resources/org/kie/workbench/common/stunner/sw/autolayout/elkjs/elk.bundled.js
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Kiel University and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 (function (f) {
   if (typeof exports === "object" && typeof module !== "undefined") {
     module.exports = f();


### PR DESCRIPTION
Hey @romartin,

Could you pease review this PR?

Just adding manually the license header to elk.bundled.js file.  
It is not being added by their build scripts.  

Thanks!