### PR TITLE
KOGITO-7150: Treat `pnpm-lock.yaml` to not include duplicate dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6436,11 +6436,7 @@ packages:
 
   /axios/0.27.2:
     resolution:
-      {
-        integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz,
-      }
+      { integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ== }
     dependencies:
       follow-redirects: 1.14.9
       form-data: 4.0.0
@@ -7276,11 +7272,7 @@ packages:
 
   /big.js/5.2.2:
     resolution:
-      {
-        integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz,
-      }
+      { integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ== }
     dev: true
 
   /binary-extensions/2.2.0:
@@ -10105,11 +10097,7 @@ packages:
 
   /emojis-list/3.0.0:
     resolution:
-      {
-        integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz,
-      }
+      { integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q== }
     engines: { node: ">= 4" }
     dev: true
 
@@ -11380,11 +11368,7 @@ packages:
 
   /form-data/4.0.0:
     resolution:
-      {
-        integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz,
-      }
+      { integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww== }
     engines: { node: ">= 6" }
     dependencies:
       asynckit: 0.4.0
@@ -13713,22 +13697,13 @@ packages:
     resolution: { integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus= }
 
   /json5/0.5.1:
-    resolution:
-      {
-        integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz,
-      }
+    resolution: { integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE= }
     hasBin: true
     dev: true
 
   /json5/1.0.1:
     resolution:
-      {
-        integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz,
-      }
+      { integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow== }
     hasBin: true
     dependencies:
       minimist: 1.2.6
@@ -15096,11 +15071,7 @@ packages:
 
   /monaco-editor-webpack-plugin/7.0.1_4era6pk35okdbgphw4rwgut7wu:
     resolution:
-      {
-        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
-      }
+      { integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw== }
     peerDependencies:
       monaco-editor: ">= 0.31.0"
       monaco-yaml: "*"
@@ -15113,11 +15084,7 @@ packages:
 
   /monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm:
     resolution:
-      {
-        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
-      }
+      { integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw== }
     peerDependencies:
       monaco-editor: ">= 0.31.0"
       monaco-yaml: "*"
@@ -15851,11 +15818,7 @@ packages:
 
   /openapi-types/7.2.3:
     resolution:
-      {
-        integrity: sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.yarnpkg.com/openapi-types/-/openapi-types-7.2.3.tgz,
-      }
+      { integrity: sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA== }
     dev: false
 
   /optionator/0.8.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,7 +489,7 @@ importers:
       "@kie-tools-core/i18n": link:../i18n
       "@kie-tools-core/notifications": link:../notifications
       "@kie-tools-core/workspace": link:../workspace
-      axios: registry.npmjs.org/axios/0.27.2
+      axios: 0.27.2
       fast-xml-parser: 3.17.4
       portfinder: 1.0.28
     devDependencies:
@@ -642,7 +642,7 @@ importers:
       "@kie-tools/build-env": link:../build-env
       "@kie-tools/serverless-workflow-editor": link:../serverless-workflow-editor
       monaco-editor: 0.33.0
-      monaco-editor-webpack-plugin: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm
+      monaco-editor-webpack-plugin: 7.0.1_xaucyy2rqq33fyrllhuadbirwm
       monaco-yaml: 3.2.1_monaco-editor@0.33.0
 
   packages/cors-proxy-image:
@@ -701,7 +701,7 @@ importers:
     devDependencies:
       "@kie-tools-core/run-script-if": link:../run-script-if
       "@kie-tools/build-env": link:../build-env
-      monaco-editor-webpack-plugin: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_4era6pk35okdbgphw4rwgut7wu
+      monaco-editor-webpack-plugin: 7.0.1_4era6pk35okdbgphw4rwgut7wu
       vscode-json-languageservice: 4.2.1
 
   packages/dashbuilder-images:
@@ -1199,11 +1199,11 @@ importers:
       "@kie-tools/kie-bc-editors": link:../kie-bc-editors
       "@kie-tools/stunner-editors": link:../stunner-editors
       "@types/minimatch": 3.0.4
-      "@types/react-router-dom": registry.npmjs.org/@types/react-router-dom/5.1.7
+      "@types/react-router-dom": 5.1.7
       minimatch: 3.0.5
-      react: registry.npmjs.org/react/17.0.2
-      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-      react-router-dom: registry.npmjs.org/react-router-dom/5.3.0_react@17.0.2
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-router-dom: 5.3.0_react@17.0.2
 
   packages/kie-sandbox-extended-services-image:
     specifiers:
@@ -1573,7 +1573,7 @@ importers:
       "@kie-tools/build-env": link:../build-env
       "@types/json-schema": 7.0.11
       "@types/mermaid": 8.2.9
-      monaco-editor-webpack-plugin: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm
+      monaco-editor-webpack-plugin: 7.0.1_xaucyy2rqq33fyrllhuadbirwm
       vscode-json-languageservice: 4.2.1
 
   packages/serverless-workflow-language-service:
@@ -1605,7 +1605,7 @@ importers:
       "@kie-tools-core/envelope-bus": link:../envelope-bus
       "@types/js-yaml": 4.0.5
       js-yaml: 4.1.0
-      openapi-types: registry.npmjs.org/openapi-types/7.2.3
+      openapi-types: 7.2.3
     devDependencies:
       "@kie-tools-core/run-script-if": link:../run-script-if
       "@kie-tools/build-env": link:../build-env
@@ -2024,8 +2024,8 @@ importers:
       "@kie-tools/serverless-workflow-service-catalog": link:../serverless-workflow-service-catalog
       axios: 0.27.2
       monaco-editor: 0.33.0
-      monaco-yaml: registry.npmjs.org/monaco-yaml/3.2.1_monaco-editor@0.33.0
-      openapi-types: registry.npmjs.org/openapi-types/7.2.3
+      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      openapi-types: 7.2.3
       vscode-languageserver-textdocument: 1.0.4
       vscode-languageserver-types: 3.16.0
       yaml: 2.0.1
@@ -2033,7 +2033,7 @@ importers:
       "@kie-tools-core/run-script-if": link:../run-script-if
       "@kie-tools-core/webpack-base": link:../webpack-base
       "@kie-tools/build-env": link:../build-env
-      monaco-editor-webpack-plugin: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm
+      monaco-editor-webpack-plugin: 7.0.1_xaucyy2rqq33fyrllhuadbirwm
 
   packages/vscode-java-code-completion:
     specifiers:
@@ -2214,7 +2214,7 @@ packages:
       webpack-merge: 5.8.0
       webpack-subresource-integrity: 5.1.0_webpack@5.70.0
     optionalDependencies:
-      esbuild: registry.npmjs.org/esbuild/0.14.22
+      esbuild: 0.14.22
     transitivePeerDependencies:
       - "@swc/core"
       - "@types/express"
@@ -3868,7 +3868,7 @@ packages:
     hasBin: true
     dependencies:
       exec-sh: 0.3.4
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
     dev: true
 
   /@csstools/postcss-progressive-custom-properties/1.3.0_postcss@8.4.5:
@@ -3934,8 +3934,8 @@ packages:
       semver: 6.3.0
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: registry.npmjs.org/global-agent/2.2.0
-      global-tunnel-ng: registry.npmjs.org/global-tunnel-ng/2.7.1
+      global-agent: 2.2.0
+      global-tunnel-ng: 2.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4121,7 +4121,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -4137,7 +4137,7 @@ packages:
       terminal-link: 2.1.1
       v8-to-istanbul: 7.1.2
     optionalDependencies:
-      node-notifier: registry.npmjs.org/node-notifier/8.0.2
+      node-notifier: 8.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4148,8 +4148,8 @@ packages:
     engines: { node: ">= 10.14.2" }
     dependencies:
       callsites: 3.1.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
-      source-map: registry.npmjs.org/source-map/0.6.1
+      graceful-fs: 4.2.10
+      source-map: 0.6.1
     dev: true
 
   /@jest/test-result/26.6.2:
@@ -4169,7 +4169,7 @@ packages:
     engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/test-result": 26.6.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
@@ -4192,7 +4192,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
@@ -4797,7 +4797,7 @@ packages:
     engines: { node: ">=8", npm: ">=6", yarn: ">=1" }
     dependencies:
       "@babel/runtime": 7.16.7
-      "@types/testing-library__jest-dom": registry.npmjs.org/@types/testing-library__jest-dom/5.9.5
+      "@types/testing-library__jest-dom": 5.9.5
       aria-query: 5.0.0
       chalk: 3.0.0
       css: 3.0.0
@@ -5475,6 +5475,15 @@ packages:
       "@types/yargs-parser": 15.0.0
     dev: true
 
+  /@types/yauzl/2.9.1:
+    resolution:
+      { integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA== }
+    requiresBuild: true
+    dependencies:
+      "@types/node": 17.0.12
+    dev: true
+    optional: true
+
   /@typescript-eslint/eslint-plugin/4.24.0_geldymnpyfy2fejyq4g6bajrxq:
     resolution:
       { integrity: sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw== }
@@ -6119,7 +6128,7 @@ packages:
     engines: { node: ">= 6" }
     dependencies:
       glob: 7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       lazystream: 1.0.0
       lodash.defaults: 4.2.0
       lodash.difference: 4.5.0
@@ -6294,7 +6303,7 @@ packages:
       glob: 7.2.0
       minimatch: 3.0.5
     optionalDependencies:
-      "@types/glob": registry.npmjs.org/@types/glob/7.1.3
+      "@types/glob": 7.1.3
     dev: true
 
   /asn1/0.2.4:
@@ -6427,7 +6436,11 @@ packages:
 
   /axios/0.27.2:
     resolution:
-      { integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ== }
+      {
+        integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz,
+      }
     dependencies:
       follow-redirects: 1.14.9
       form-data: 4.0.0
@@ -6467,7 +6480,7 @@ packages:
       babylon: 6.18.0
       convert-source-map: 1.7.0
       debug: 2.6.9
-      json5: registry.npmjs.org/json5/0.5.1
+      json5: 0.5.1
       lodash: 4.17.21
       minimatch: 3.0.5
       path-is-absolute: 1.0.1
@@ -6486,7 +6499,7 @@ packages:
       detect-indent: 4.0.0
       jsesc: 1.3.0
       lodash: 4.17.21
-      source-map: registry.npmjs.org/source-map/0.5.7
+      source-map: 0.5.7
       trim-right: 1.0.1
     dev: true
 
@@ -6622,7 +6635,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 26.6.2_@babel+core@7.16.12
       chalk: 4.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -7261,6 +7274,15 @@ packages:
     engines: { node: ">=0.6" }
     dev: true
 
+  /big.js/5.2.2:
+    resolution:
+      {
+        integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz,
+      }
+    dev: true
+
   /binary-extensions/2.2.0:
     resolution:
       { integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA== }
@@ -7777,7 +7799,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: true
 
   /chownr/1.1.4:
@@ -7929,7 +7951,7 @@ packages:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
-      colors: registry.npmjs.org/colors/1.4.0
+      colors: 1.4.0
     dev: true
 
   /cli-truncate/2.1.0:
@@ -9842,7 +9864,7 @@ packages:
       { integrity: sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ== }
     dependencies:
       "@babel/runtime": 7.16.7
-      csstype: registry.npmjs.org/csstype/3.0.11
+      csstype: 3.0.11
     dev: false
 
   /dom-serialize/2.2.1:
@@ -9990,7 +10012,7 @@ packages:
       compare-version: 0.1.2
       debug: 2.6.9
       isbinaryfile: 3.0.3
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
       plist: 3.0.5
     dev: true
 
@@ -10081,9 +10103,28 @@ packages:
     resolution:
       { integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A== }
 
+  /emojis-list/3.0.0:
+    resolution:
+      {
+        integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz,
+      }
+    engines: { node: ">= 4" }
+    dev: true
+
   /encodeurl/1.0.2:
     resolution: { integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k= }
     engines: { node: ">= 0.8" }
+
+  /encoding/0.1.13:
+    resolution:
+      { integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A== }
+    requiresBuild: true
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+    optional: true
 
   /end-of-stream/1.4.4:
     resolution:
@@ -10178,6 +10219,16 @@ packages:
       { integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA== }
     dev: true
 
+  /errno/0.1.8:
+    resolution:
+      { integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A== }
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      prr: 1.0.1
+    dev: true
+    optional: true
+
   /error-ex/1.3.2:
     resolution:
       { integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g== }
@@ -10238,12 +10289,231 @@ packages:
       es6-promise: 4.2.8
     dev: true
 
+  /esbuild-android-arm64/0.14.22:
+    resolution:
+      { integrity: sha512-k1Uu4uC4UOFgrnTj2zuj75EswFSEBK+H6lT70/DdS4mTAOfs2ECv2I9ZYvr3w0WL0T4YItzJdK7fPNxcPw6YmQ== }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.14.22:
+    resolution:
+      { integrity: sha512-d8Ceuo6Vw6HM3fW218FB6jTY6O3r2WNcTAU0SGsBkXZ3k8SDoRLd3Nrc//EqzdgYnzDNMNtrWegK2Qsss4THhw== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.22:
+    resolution:
+      { integrity: sha512-YAt9Tj3SkIUkswuzHxkaNlT9+sg0xvzDvE75LlBo4DI++ogSgSmKNR6B4eUhU5EUUepVXcXdRIdqMq9ppeRqfw== }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.14.22:
+    resolution:
+      { integrity: sha512-ek1HUv7fkXMy87Qm2G4IRohN+Qux4IcnrDBPZGXNN33KAL0pEJJzdTv0hB/42+DCYWylSrSKxk3KUXfqXOoH4A== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.22:
+    resolution:
+      { integrity: sha512-zPh9SzjRvr9FwsouNYTqgqFlsMIW07O8mNXulGeQx6O5ApgGUBZBgtzSlBQXkHi18WjrosYfsvp5nzOKiWzkjQ== }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.14.22:
+    resolution:
+      { integrity: sha512-SnpveoE4nzjb9t2hqCIzzTWBM0RzcCINDMBB67H6OXIuDa4KqFqaIgmTchNA9pJKOVLVIKd5FYxNiJStli21qg== }
+    engines: { node: ">=12" }
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.22:
+    resolution:
+      { integrity: sha512-Zcl9Wg7gKhOWWNqAjygyqzB+fJa19glgl2JG7GtuxHyL1uEnWlpSMytTLMqtfbmRykIHdab797IOZeKwk5g0zg== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.14.22:
+    resolution:
+      { integrity: sha512-soPDdbpt/C0XvOOK45p4EFt8HbH5g+0uHs5nUKjHVExfgR7du734kEkXR/mE5zmjrlymk5AA79I0VIvj90WZ4g== }
+    engines: { node: ">=12" }
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.22:
+    resolution:
+      { integrity: sha512-8q/FRBJtV5IHnQChO3LHh/Jf7KLrxJ/RCTGdBvlVZhBde+dk3/qS9fFsUy+rs3dEi49aAsyVitTwlKw1SUFm+A== }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.22:
+    resolution:
+      { integrity: sha512-SiNDfuRXhGh1JQLLA9JPprBgPVFOsGuQ0yDfSPTNxztmVJd8W2mX++c4FfLpAwxuJe183mLuKf7qKCHQs5ZnBQ== }
+    engines: { node: ">=12" }
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.22:
+    resolution:
+      { integrity: sha512-6t/GI9I+3o1EFm2AyN9+TsjdgWCpg2nwniEhjm2qJWtJyJ5VzTXGUU3alCO3evopu8G0hN2Bu1Jhz2YmZD0kng== }
+    engines: { node: ">=12" }
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.14.22:
+    resolution:
+      { integrity: sha512-AyJHipZKe88sc+tp5layovquw5cvz45QXw5SaDgAq2M911wLHiCvDtf/07oDx8eweCyzYzG5Y39Ih568amMTCQ== }
+    engines: { node: ">=12" }
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.22:
+    resolution:
+      { integrity: sha512-Sz1NjZewTIXSblQDZWEFZYjOK6p8tV6hrshYdXZ0NHTjWE+lwxpOpWeElUGtEmiPcMT71FiuA9ODplqzzSxkzw== }
+    engines: { node: ">=12" }
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.22:
+    resolution:
+      { integrity: sha512-TBbCtx+k32xydImsHxvFgsOCuFqCTGIxhzRNbgSL1Z2CKhzxwT92kQMhxort9N/fZM2CkRCPPs5wzQSamtzEHA== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.22:
+    resolution:
+      { integrity: sha512-vK912As725haT313ANZZZN+0EysEEQXWC/+YE4rQvOQzLuxAQc2tjbzlAFREx3C8+uMuZj/q7E5gyVB7TzpcTA== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.14.22:
+    resolution:
+      { integrity: sha512-/mbJdXTW7MTcsPhtfDsDyPEOju9EOABvCjeUU2OJ7fWpX/Em/H3WYDa86tzLUbcVg++BScQDzqV/7RYw5XNY0g== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-wasm/0.14.22:
     resolution:
       { integrity: sha512-FOSAM29GN1fWusw0oLMv6JYhoheDIh5+atC72TkJKfIUMID6yISlicoQSd9gsNSFsNBvABvtE2jR4JB1j4FkFw== }
     engines: { node: ">=12" }
     hasBin: true
     dev: true
+
+  /esbuild-windows-32/0.14.22:
+    resolution:
+      { integrity: sha512-1vRIkuvPTjeSVK3diVrnMLSbkuE36jxA+8zGLUOrT4bb7E/JZvDRhvtbWXWaveUc/7LbhaNFhHNvfPuSw2QOQg== }
+    engines: { node: ">=12" }
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.14.22:
+    resolution:
+      { integrity: sha512-AxjIDcOmx17vr31C5hp20HIwz1MymtMjKqX4qL6whPj0dT9lwxPexmLj6G1CpR3vFhui6m75EnBEe4QL82SYqw== }
+    engines: { node: ">=12" }
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.22:
+    resolution:
+      { integrity: sha512-5wvQ+39tHmRhNpu2Fx04l7QfeK3mQ9tKzDqqGR8n/4WUxsFxnVLfDRBGirIfk4AfWlxk60kqirlODPoT5LqMUg== }
+    engines: { node: ">=12" }
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild/0.14.22:
+    resolution:
+      { integrity: sha512-CjFCFGgYtbFOPrwZNJf7wsuzesx8kqwAffOlbYcFDLFuUtP8xloK1GH+Ai13Qr0RZQf9tE7LMTHJ2iVGJ1SKZA== }
+    engines: { node: ">=12" }
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-arm64: 0.14.22
+      esbuild-darwin-64: 0.14.22
+      esbuild-darwin-arm64: 0.14.22
+      esbuild-freebsd-64: 0.14.22
+      esbuild-freebsd-arm64: 0.14.22
+      esbuild-linux-32: 0.14.22
+      esbuild-linux-64: 0.14.22
+      esbuild-linux-arm: 0.14.22
+      esbuild-linux-arm64: 0.14.22
+      esbuild-linux-mips64le: 0.14.22
+      esbuild-linux-ppc64le: 0.14.22
+      esbuild-linux-riscv64: 0.14.22
+      esbuild-linux-s390x: 0.14.22
+      esbuild-netbsd-64: 0.14.22
+      esbuild-openbsd-64: 0.14.22
+      esbuild-sunos-64: 0.14.22
+      esbuild-windows-32: 0.14.22
+      esbuild-windows-64: 0.14.22
+      esbuild-windows-arm64: 0.14.22
+    dev: true
+    optional: true
 
   /escalade/3.1.1:
     resolution:
@@ -10280,7 +10550,7 @@ packages:
       esutils: 2.0.3
       optionator: 0.8.3
     optionalDependencies:
-      source-map: registry.npmjs.org/source-map/0.6.1
+      source-map: 0.6.1
     dev: true
 
   /eslint-config-prettier/8.3.0_eslint@7.26.0:
@@ -10709,7 +10979,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      "@types/yauzl": registry.npmjs.org/@types/yauzl/2.9.1
+      "@types/yauzl": 2.9.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10724,7 +10994,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      "@types/yauzl": registry.npmjs.org/@types/yauzl/2.9.1
+      "@types/yauzl": 2.9.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11110,7 +11380,11 @@ packages:
 
   /form-data/4.0.0:
     resolution:
-      { integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww== }
+      {
+        integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz,
+      }
     engines: { node: ">= 6" }
     dependencies:
       asynckit: 0.4.0
@@ -11227,12 +11501,21 @@ packages:
   /fs.realpath/1.0.0:
     resolution: { integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8= }
 
+  /fsevents/2.3.2:
+    resolution:
+      { integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA== }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fstream/1.0.12:
     resolution:
       { integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg== }
     engines: { node: ">=0.6" }
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       inherits: 2.0.4
       mkdirp: 0.5.5
       rimraf: 2.7.1
@@ -11429,6 +11712,21 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  /global-agent/2.2.0:
+    resolution:
+      { integrity: sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg== }
+    engines: { node: ">=10.0" }
+    requiresBuild: true
+    dependencies:
+      boolean: 3.0.4
+      core-js: 3.20.3
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.3.5
+      serialize-error: 7.0.1
+    optional: true
+
   /global-dirs/3.0.0:
     resolution:
       { integrity: sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA== }
@@ -11436,6 +11734,18 @@ packages:
     dependencies:
       ini: 2.0.0
     dev: true
+
+  /global-tunnel-ng/2.7.1:
+    resolution:
+      { integrity: sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg== }
+    engines: { node: ">=0.10" }
+    requiresBuild: true
+    dependencies:
+      encodeurl: 1.0.2
+      lodash: 4.17.21
+      npm-conf: 1.1.3
+      tunnel: 0.0.6
+    optional: true
 
   /globals/11.12.0:
     resolution:
@@ -12100,6 +12410,14 @@ packages:
       { integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ== }
     engines: { node: ">= 4" }
 
+  /image-size/0.5.5:
+    resolution: { integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w= }
+    engines: { node: ">=0.10.0" }
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /immediate/3.0.6:
     resolution: { integrity: sha1-nbHb0Pr43m++D13V5Wu2BigN5ps= }
 
@@ -12719,7 +13037,7 @@ packages:
     dependencies:
       debug: 4.3.3
       istanbul-lib-coverage: 3.2.0
-      source-map: registry.npmjs.org/source-map/0.6.1
+      source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12800,7 +13118,7 @@ packages:
       chalk: 4.1.2
       deepmerge: 4.2.2
       glob: 7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
@@ -12896,7 +13214,7 @@ packages:
       "@types/node": 17.0.12
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-regex-util: 26.0.0
       jest-serializer: 26.6.2
       jest-util: 26.6.2
@@ -12905,7 +13223,7 @@ packages:
       sane: 4.1.0
       walker: 1.0.7
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/2.3.2
+      fsevents: 2.3.2
     dev: true
 
   /jest-image-snapshot/4.2.0:
@@ -12985,7 +13303,7 @@ packages:
       "@jest/types": 26.6.2
       "@types/stack-utils": 2.0.0
       chalk: 4.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       micromatch: 4.0.4
       pretty-format: 26.6.2
       slash: 3.0.0
@@ -13041,7 +13359,7 @@ packages:
     dependencies:
       "@jest/types": 26.6.2
       chalk: 4.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-pnp-resolver: 1.2.2_jest-resolve@26.6.2
       jest-util: 26.6.2
       read-pkg-up: 7.0.1
@@ -13062,7 +13380,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-config: 26.6.3
       jest-docblock: 26.0.0
       jest-haste-map: 26.6.2
@@ -13102,7 +13420,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-config: 26.6.3
       jest-haste-map: 26.6.2
       jest-message-util: 26.6.2
@@ -13129,7 +13447,7 @@ packages:
     engines: { node: ">= 10.14.2" }
     dependencies:
       "@types/node": 17.0.12
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
     dev: true
 
   /jest-snapshot/26.6.2:
@@ -13143,7 +13461,7 @@ packages:
       "@types/prettier": 2.2.3
       chalk: 4.1.2
       expect: 26.6.2
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       jest-diff: 26.6.2
       jest-get-type: 26.3.0
       jest-haste-map: 26.6.2
@@ -13394,13 +13712,35 @@ packages:
   /json-stringify-safe/5.0.1:
     resolution: { integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus= }
 
+  /json5/0.5.1:
+    resolution:
+      {
+        integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz,
+      }
+    hasBin: true
+    dev: true
+
+  /json5/1.0.1:
+    resolution:
+      {
+        integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz,
+      }
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
+    dev: true
+
   /json5/2.1.2:
     resolution:
       { integrity: sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ== }
     engines: { node: ">=6" }
     hasBin: true
     dependencies:
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
     dev: true
 
   /jsonata/1.8.3:
@@ -13417,7 +13757,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: { integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss= }
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
 
   /jsonfile/6.1.0:
     resolution:
@@ -13425,7 +13765,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonparse/1.3.1:
@@ -13857,13 +14197,13 @@ packages:
       parse-node-version: 1.0.1
       tslib: 2.3.1
     optionalDependencies:
-      errno: registry.npmjs.org/errno/0.1.8
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
-      image-size: registry.npmjs.org/image-size/0.5.5
-      make-dir: registry.npmjs.org/make-dir/2.1.0
-      mime: registry.npmjs.org/mime/1.6.0
-      needle: registry.npmjs.org/needle/2.9.1
-      source-map: registry.npmjs.org/source-map/0.6.1
+      errno: 0.1.8
+      graceful-fs: 4.2.10
+      image-size: 0.5.5
+      make-dir: 2.1.0
+      mime: 1.6.0
+      needle: 2.9.1
+      source-map: 0.6.1
     dev: true
 
   /leven/3.1.0:
@@ -13964,7 +14304,7 @@ packages:
     resolution: { integrity: sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg= }
     engines: { node: ">=4" }
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -13974,7 +14314,7 @@ packages:
     resolution: { integrity: sha1-L19Fq5HjMhYjT9U62rZo607AmTs= }
     engines: { node: ">=4" }
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -14001,9 +14341,9 @@ packages:
       { integrity: sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA== }
     engines: { node: ">=4.0.0" }
     dependencies:
-      big.js: registry.npmjs.org/big.js/5.2.2
-      emojis-list: registry.npmjs.org/emojis-list/3.0.0
-      json5: registry.npmjs.org/json5/1.0.1
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 1.0.1
     dev: true
 
   /loader-utils/2.0.2:
@@ -14011,9 +14351,9 @@ packages:
       { integrity: sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A== }
     engines: { node: ">=8.9.0" }
     dependencies:
-      big.js: registry.npmjs.org/big.js/5.2.2
-      emojis-list: registry.npmjs.org/emojis-list/3.0.0
-      json5: registry.npmjs.org/json5/2.1.2
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 2.1.2
     dev: true
 
   /loader-utils/3.2.0:
@@ -14591,7 +14931,7 @@ packages:
       minipass-sized: 1.0.3
       minizlib: 2.1.2
     optionalDependencies:
-      encoding: registry.npmjs.org/encoding/0.1.13
+      encoding: 0.1.13
     dev: true
 
   /minipass-flush/1.0.5:
@@ -14677,7 +15017,7 @@ packages:
       { integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ== }
     hasBin: true
     dependencies:
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
 
   /mkdirp/1.0.4:
     resolution:
@@ -14753,6 +15093,40 @@ packages:
     resolution:
       { integrity: sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg== }
     dev: false
+
+  /monaco-editor-webpack-plugin/7.0.1_4era6pk35okdbgphw4rwgut7wu:
+    resolution:
+      {
+        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
+      }
+    peerDependencies:
+      monaco-editor: ">= 0.31.0"
+      monaco-yaml: "*"
+      webpack: ^4.5.0 || 5.x
+    dependencies:
+      loader-utils: 2.0.2
+      monaco-editor: 0.23.0
+      monaco-yaml: 3.2.1_monaco-editor@0.23.0
+    dev: true
+
+  /monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm:
+    resolution:
+      {
+        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
+      }
+    peerDependencies:
+      monaco-editor: ">= 0.31.0"
+      monaco-yaml: "*"
+      webpack: ^4.5.0 || 5.x
+    dependencies:
+      loader-utils: 2.0.2
+      monaco-editor: 0.33.0
+      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+    dev: true
 
   /monaco-editor/0.23.0:
     resolution:
@@ -14949,6 +15323,17 @@ packages:
       { integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw== }
     dev: true
 
+  /nice-napi/1.0.2:
+    resolution:
+      { integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA== }
+    os: ["!win32"]
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.3.0
+    dev: true
+    optional: true
+
   /nice-try/1.0.5:
     resolution:
       { integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ== }
@@ -15060,6 +15445,20 @@ packages:
     resolution: { integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA= }
     engines: { node: ">=0.10.0" }
     dev: true
+
+  /node-notifier/8.0.2:
+    resolution:
+      { integrity: sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg== }
+    requiresBuild: true
+    dependencies:
+      growly: 1.3.0
+      is-wsl: 2.2.0
+      semver: 7.3.5
+      shellwords: 0.1.1
+      uuid: 8.3.2
+      which: 2.0.2
+    dev: true
+    optional: true
 
   /node-pre-gyp/0.11.0:
     resolution:
@@ -15449,6 +15848,15 @@ packages:
       is-docker: 2.2.1
       is-wsl: 2.2.0
     dev: true
+
+  /openapi-types/7.2.3:
+    resolution:
+      {
+        integrity: sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA==,
+        registry: https://registry.yarnpkg.com/,
+        tarball: https://registry.yarnpkg.com/openapi-types/-/openapi-types-7.2.3.tgz,
+      }
+    dev: false
 
   /optionator/0.8.3:
     resolution:
@@ -15932,7 +16340,7 @@ packages:
       hdr-histogram-js: 2.0.3
       hdr-histogram-percentiles-obj: 3.0.0
     optionalDependencies:
-      nice-napi: registry.npmjs.org/nice-napi/1.0.2
+      nice-napi: 1.0.2
     dev: true
 
   /pixelmatch/5.2.1:
@@ -16529,7 +16937,7 @@ packages:
       detect-libc: 1.0.3
       expand-template: 2.0.3
       github-from-package: 0.0.0
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
       node-abi: 2.30.1
@@ -16694,7 +17102,7 @@ packages:
     resolution:
       { integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA== }
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       retry: 0.12.0
       signal-exit: 3.0.3
     dev: true
@@ -16924,7 +17332,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
       strip-json-comments: 2.0.1
     dev: true
 
@@ -16962,7 +17370,6 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    dev: false
 
   /react-draggable/4.4.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
@@ -17223,7 +17630,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: false
 
   /read-cache/1.0.0:
     resolution: { integrity: sha1-5mTvMRYRZsl1HNvo28+GtftY93Q= }
@@ -17852,7 +18258,7 @@ packages:
       execa: 1.0.0
       fb-watchman: 2.0.1
       micromatch: 3.1.10
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
       walker: 1.0.7
     dev: true
 
@@ -18322,7 +18728,7 @@ packages:
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
-      source-map: registry.npmjs.org/source-map/0.5.7
+      source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
     dev: true
@@ -19153,7 +19559,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      esbuild: registry.npmjs.org/esbuild/0.14.22
+      esbuild: 0.14.22
       jest-worker: 27.4.6
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
@@ -19944,7 +20350,7 @@ packages:
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.1
       convert-source-map: 1.7.0
-      source-map: registry.npmjs.org/source-map/0.7.3
+      source-map: 0.7.3
     dev: true
 
   /validate-npm-package-license/3.0.4:
@@ -20413,7 +20819,7 @@ packages:
       axios: 0.21.4_debug@4.3.1
       joi: 17.4.0
       lodash: 4.17.21
-      minimist: registry.npmjs.org/minimist/1.2.6
+      minimist: 1.2.6
       rxjs: 6.6.7
     transitivePeerDependencies:
       - debug
@@ -20919,7 +21325,7 @@ packages:
     resolution:
       { integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ== }
     dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       imurmurhash: 0.1.4
       signal-exit: 3.0.3
 
@@ -20938,7 +21344,7 @@ packages:
     engines: { node: ">=6" }
     dependencies:
       detect-indent: 5.0.0
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
+      graceful-fs: 4.2.10
       make-dir: 2.1.0
       pify: 4.0.1
       sort-keys: 2.0.0
@@ -21250,1660 +21656,4 @@ packages:
       { integrity: sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw== }
     dependencies:
       tslib: 2.3.1
-    dev: false
-
-  registry.npmjs.org/@babel/runtime/7.16.7:
-    resolution:
-      {
-        integrity: sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz,
-      }
-    name: "@babel/runtime"
-    version: 7.16.7
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      regenerator-runtime: registry.npmjs.org/regenerator-runtime/0.13.9
-    dev: true
-
-  registry.npmjs.org/@jest/types/26.6.2:
-    resolution:
-      {
-        integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz,
-      }
-    name: "@jest/types"
-    version: 26.6.2
-    engines: { node: ">= 10.14.2" }
-    dependencies:
-      "@types/istanbul-lib-coverage": registry.npmjs.org/@types/istanbul-lib-coverage/2.0.1
-      "@types/istanbul-reports": registry.npmjs.org/@types/istanbul-reports/3.0.0
-      "@types/node": registry.npmjs.org/@types/node/17.0.12
-      "@types/yargs": registry.npmjs.org/@types/yargs/15.0.4
-      chalk: registry.npmjs.org/chalk/4.1.2
-    dev: true
-
-  registry.npmjs.org/@types/glob/7.1.3:
-    resolution:
-      {
-        integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz,
-      }
-    name: "@types/glob"
-    version: 7.1.3
-    requiresBuild: true
-    dependencies:
-      "@types/minimatch": 3.0.4
-      "@types/node": 17.0.12
-    dev: true
-    optional: true
-
-  registry.npmjs.org/@types/history/4.7.5:
-    resolution:
-      {
-        integrity: sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz,
-      }
-    name: "@types/history"
-    version: 4.7.5
-    dev: true
-
-  registry.npmjs.org/@types/istanbul-lib-coverage/2.0.1:
-    resolution:
-      {
-        integrity: sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz,
-      }
-    name: "@types/istanbul-lib-coverage"
-    version: 2.0.1
-    dev: true
-
-  registry.npmjs.org/@types/istanbul-lib-report/3.0.0:
-    resolution:
-      {
-        integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz,
-      }
-    name: "@types/istanbul-lib-report"
-    version: 3.0.0
-    dependencies:
-      "@types/istanbul-lib-coverage": registry.npmjs.org/@types/istanbul-lib-coverage/2.0.1
-    dev: true
-
-  registry.npmjs.org/@types/istanbul-reports/3.0.0:
-    resolution:
-      {
-        integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz,
-      }
-    name: "@types/istanbul-reports"
-    version: 3.0.0
-    dependencies:
-      "@types/istanbul-lib-report": registry.npmjs.org/@types/istanbul-lib-report/3.0.0
-    dev: true
-
-  registry.npmjs.org/@types/jest/26.0.23:
-    resolution:
-      {
-        integrity: sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz,
-      }
-    name: "@types/jest"
-    version: 26.0.23
-    dependencies:
-      jest-diff: registry.npmjs.org/jest-diff/26.6.2
-      pretty-format: registry.npmjs.org/pretty-format/26.6.2
-    dev: true
-
-  registry.npmjs.org/@types/json-schema/7.0.11:
-    resolution:
-      {
-        integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz,
-      }
-    name: "@types/json-schema"
-    version: 7.0.11
-    dev: false
-
-  registry.npmjs.org/@types/node/17.0.12:
-    resolution:
-      {
-        integrity: sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz,
-      }
-    name: "@types/node"
-    version: 17.0.12
-    dev: true
-
-  registry.npmjs.org/@types/prop-types/15.7.3:
-    resolution:
-      {
-        integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz,
-      }
-    name: "@types/prop-types"
-    version: 15.7.3
-    dev: true
-
-  registry.npmjs.org/@types/react-router-dom/5.1.7:
-    resolution:
-      {
-        integrity: sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz,
-      }
-    name: "@types/react-router-dom"
-    version: 5.1.7
-    dependencies:
-      "@types/history": registry.npmjs.org/@types/history/4.7.5
-      "@types/react": registry.npmjs.org/@types/react/17.0.21
-      "@types/react-router": registry.npmjs.org/@types/react-router/5.1.14
-    dev: true
-
-  registry.npmjs.org/@types/react-router/5.1.14:
-    resolution:
-      {
-        integrity: sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz,
-      }
-    name: "@types/react-router"
-    version: 5.1.14
-    dependencies:
-      "@types/history": registry.npmjs.org/@types/history/4.7.5
-      "@types/react": registry.npmjs.org/@types/react/17.0.21
-    dev: true
-
-  registry.npmjs.org/@types/react/17.0.21:
-    resolution:
-      {
-        integrity: sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/react/-/react-17.0.21.tgz,
-      }
-    name: "@types/react"
-    version: 17.0.21
-    dependencies:
-      "@types/prop-types": registry.npmjs.org/@types/prop-types/15.7.3
-      "@types/scheduler": registry.npmjs.org/@types/scheduler/0.16.1
-      csstype: registry.npmjs.org/csstype/3.0.11
-    dev: true
-
-  registry.npmjs.org/@types/scheduler/0.16.1:
-    resolution:
-      {
-        integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz,
-      }
-    name: "@types/scheduler"
-    version: 0.16.1
-    dev: true
-
-  registry.npmjs.org/@types/testing-library__jest-dom/5.9.5:
-    resolution:
-      {
-        integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz,
-      }
-    name: "@types/testing-library__jest-dom"
-    version: 5.9.5
-    dependencies:
-      "@types/jest": registry.npmjs.org/@types/jest/26.0.23
-    dev: true
-
-  registry.npmjs.org/@types/yargs-parser/15.0.0:
-    resolution:
-      {
-        integrity: sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz,
-      }
-    name: "@types/yargs-parser"
-    version: 15.0.0
-    dev: true
-
-  registry.npmjs.org/@types/yargs/15.0.4:
-    resolution:
-      {
-        integrity: sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz,
-      }
-    name: "@types/yargs"
-    version: 15.0.4
-    dependencies:
-      "@types/yargs-parser": registry.npmjs.org/@types/yargs-parser/15.0.0
-    dev: true
-
-  registry.npmjs.org/@types/yauzl/2.9.1:
-    resolution:
-      {
-        integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz,
-      }
-    name: "@types/yauzl"
-    version: 2.9.1
-    requiresBuild: true
-    dependencies:
-      "@types/node": 17.0.12
-    dev: true
-    optional: true
-
-  registry.npmjs.org/ansi-regex/5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz,
-      }
-    name: ansi-regex
-    version: 5.0.1
-    engines: { node: ">=8" }
-    dev: true
-
-  registry.npmjs.org/ansi-styles/4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz,
-      }
-    name: ansi-styles
-    version: 4.3.0
-    engines: { node: ">=8" }
-    dependencies:
-      color-convert: registry.npmjs.org/color-convert/2.0.1
-    dev: true
-
-  registry.npmjs.org/argparse/2.0.1:
-    resolution:
-      {
-        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz,
-      }
-    name: argparse
-    version: 2.0.1
-    dev: false
-
-  registry.npmjs.org/asynckit/0.4.0:
-    resolution:
-      {
-        integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz,
-      }
-    name: asynckit
-    version: 0.4.0
-    dev: false
-
-  registry.npmjs.org/axios/0.27.2:
-    resolution:
-      {
-        integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/axios/-/axios-0.27.2.tgz,
-      }
-    name: axios
-    version: 0.27.2
-    dependencies:
-      follow-redirects: registry.npmjs.org/follow-redirects/1.14.9
-      form-data: registry.npmjs.org/form-data/4.0.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  registry.npmjs.org/big.js/5.2.2:
-    resolution:
-      {
-        integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz,
-      }
-    name: big.js
-    version: 5.2.2
-    dev: true
-
-  registry.npmjs.org/chalk/4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz,
-      }
-    name: chalk
-    version: 4.1.2
-    engines: { node: ">=10" }
-    dependencies:
-      ansi-styles: registry.npmjs.org/ansi-styles/4.3.0
-      supports-color: registry.npmjs.org/supports-color/7.2.0
-    dev: true
-
-  registry.npmjs.org/color-convert/2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz,
-      }
-    name: color-convert
-    version: 2.0.1
-    engines: { node: ">=7.0.0" }
-    dependencies:
-      color-name: registry.npmjs.org/color-name/1.1.4
-    dev: true
-
-  registry.npmjs.org/color-name/1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz,
-      }
-    name: color-name
-    version: 1.1.4
-    dev: true
-
-  registry.npmjs.org/colors/1.4.0:
-    resolution:
-      {
-        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/colors/-/colors-1.4.0.tgz,
-      }
-    name: colors
-    version: 1.4.0
-    engines: { node: ">=0.1.90" }
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/combined-stream/1.0.8:
-    resolution:
-      {
-        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz,
-      }
-    name: combined-stream
-    version: 1.0.8
-    engines: { node: ">= 0.8" }
-    dependencies:
-      delayed-stream: registry.npmjs.org/delayed-stream/1.0.0
-    dev: false
-
-  registry.npmjs.org/csstype/3.0.11:
-    resolution:
-      {
-        integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz,
-      }
-    name: csstype
-    version: 3.0.11
-
-  registry.npmjs.org/delayed-stream/1.0.0:
-    resolution:
-      {
-        integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz,
-      }
-    name: delayed-stream
-    version: 1.0.0
-    engines: { node: ">=0.4.0" }
-    dev: false
-
-  registry.npmjs.org/diff-sequences/26.6.2:
-    resolution:
-      {
-        integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz,
-      }
-    name: diff-sequences
-    version: 26.6.2
-    engines: { node: ">= 10.14.2" }
-    dev: true
-
-  registry.npmjs.org/emojis-list/3.0.0:
-    resolution:
-      {
-        integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz,
-      }
-    name: emojis-list
-    version: 3.0.0
-    engines: { node: ">= 4" }
-    dev: true
-
-  registry.npmjs.org/encoding/0.1.13:
-    resolution:
-      {
-        integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz,
-      }
-    name: encoding
-    version: 0.1.13
-    requiresBuild: true
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: true
-    optional: true
-
-  registry.npmjs.org/errno/0.1.8:
-    resolution:
-      {
-        integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/errno/-/errno-0.1.8.tgz,
-      }
-    name: errno
-    version: 0.1.8
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      prr: 1.0.1
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-android-arm64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-k1Uu4uC4UOFgrnTj2zuj75EswFSEBK+H6lT70/DdS4mTAOfs2ECv2I9ZYvr3w0WL0T4YItzJdK7fPNxcPw6YmQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.22.tgz,
-      }
-    name: esbuild-android-arm64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-darwin-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-d8Ceuo6Vw6HM3fW218FB6jTY6O3r2WNcTAU0SGsBkXZ3k8SDoRLd3Nrc//EqzdgYnzDNMNtrWegK2Qsss4THhw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.22.tgz,
-      }
-    name: esbuild-darwin-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-darwin-arm64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-YAt9Tj3SkIUkswuzHxkaNlT9+sg0xvzDvE75LlBo4DI++ogSgSmKNR6B4eUhU5EUUepVXcXdRIdqMq9ppeRqfw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.22.tgz,
-      }
-    name: esbuild-darwin-arm64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-freebsd-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-ek1HUv7fkXMy87Qm2G4IRohN+Qux4IcnrDBPZGXNN33KAL0pEJJzdTv0hB/42+DCYWylSrSKxk3KUXfqXOoH4A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.22.tgz,
-      }
-    name: esbuild-freebsd-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-freebsd-arm64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-zPh9SzjRvr9FwsouNYTqgqFlsMIW07O8mNXulGeQx6O5ApgGUBZBgtzSlBQXkHi18WjrosYfsvp5nzOKiWzkjQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.22.tgz,
-      }
-    name: esbuild-freebsd-arm64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-32/0.14.22:
-    resolution:
-      {
-        integrity: sha512-SnpveoE4nzjb9t2hqCIzzTWBM0RzcCINDMBB67H6OXIuDa4KqFqaIgmTchNA9pJKOVLVIKd5FYxNiJStli21qg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.22.tgz,
-      }
-    name: esbuild-linux-32
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-Zcl9Wg7gKhOWWNqAjygyqzB+fJa19glgl2JG7GtuxHyL1uEnWlpSMytTLMqtfbmRykIHdab797IOZeKwk5g0zg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.22.tgz,
-      }
-    name: esbuild-linux-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-arm/0.14.22:
-    resolution:
-      {
-        integrity: sha512-soPDdbpt/C0XvOOK45p4EFt8HbH5g+0uHs5nUKjHVExfgR7du734kEkXR/mE5zmjrlymk5AA79I0VIvj90WZ4g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.22.tgz,
-      }
-    name: esbuild-linux-arm
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-arm64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-8q/FRBJtV5IHnQChO3LHh/Jf7KLrxJ/RCTGdBvlVZhBde+dk3/qS9fFsUy+rs3dEi49aAsyVitTwlKw1SUFm+A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.22.tgz,
-      }
-    name: esbuild-linux-arm64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-mips64le/0.14.22:
-    resolution:
-      {
-        integrity: sha512-SiNDfuRXhGh1JQLLA9JPprBgPVFOsGuQ0yDfSPTNxztmVJd8W2mX++c4FfLpAwxuJe183mLuKf7qKCHQs5ZnBQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.22.tgz,
-      }
-    name: esbuild-linux-mips64le
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-ppc64le/0.14.22:
-    resolution:
-      {
-        integrity: sha512-6t/GI9I+3o1EFm2AyN9+TsjdgWCpg2nwniEhjm2qJWtJyJ5VzTXGUU3alCO3evopu8G0hN2Bu1Jhz2YmZD0kng==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.22.tgz,
-      }
-    name: esbuild-linux-ppc64le
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-riscv64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-AyJHipZKe88sc+tp5layovquw5cvz45QXw5SaDgAq2M911wLHiCvDtf/07oDx8eweCyzYzG5Y39Ih568amMTCQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.22.tgz,
-      }
-    name: esbuild-linux-riscv64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-linux-s390x/0.14.22:
-    resolution:
-      {
-        integrity: sha512-Sz1NjZewTIXSblQDZWEFZYjOK6p8tV6hrshYdXZ0NHTjWE+lwxpOpWeElUGtEmiPcMT71FiuA9ODplqzzSxkzw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.22.tgz,
-      }
-    name: esbuild-linux-s390x
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-netbsd-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-TBbCtx+k32xydImsHxvFgsOCuFqCTGIxhzRNbgSL1Z2CKhzxwT92kQMhxort9N/fZM2CkRCPPs5wzQSamtzEHA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.22.tgz,
-      }
-    name: esbuild-netbsd-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-openbsd-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-vK912As725haT313ANZZZN+0EysEEQXWC/+YE4rQvOQzLuxAQc2tjbzlAFREx3C8+uMuZj/q7E5gyVB7TzpcTA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.22.tgz,
-      }
-    name: esbuild-openbsd-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-sunos-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-/mbJdXTW7MTcsPhtfDsDyPEOju9EOABvCjeUU2OJ7fWpX/Em/H3WYDa86tzLUbcVg++BScQDzqV/7RYw5XNY0g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.22.tgz,
-      }
-    name: esbuild-sunos-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-windows-32/0.14.22:
-    resolution:
-      {
-        integrity: sha512-1vRIkuvPTjeSVK3diVrnMLSbkuE36jxA+8zGLUOrT4bb7E/JZvDRhvtbWXWaveUc/7LbhaNFhHNvfPuSw2QOQg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.22.tgz,
-      }
-    name: esbuild-windows-32
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-windows-64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-AxjIDcOmx17vr31C5hp20HIwz1MymtMjKqX4qL6whPj0dT9lwxPexmLj6G1CpR3vFhui6m75EnBEe4QL82SYqw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.22.tgz,
-      }
-    name: esbuild-windows-64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild-windows-arm64/0.14.22:
-    resolution:
-      {
-        integrity: sha512-5wvQ+39tHmRhNpu2Fx04l7QfeK3mQ9tKzDqqGR8n/4WUxsFxnVLfDRBGirIfk4AfWlxk60kqirlODPoT5LqMUg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.22.tgz,
-      }
-    name: esbuild-windows-arm64
-    version: 0.14.22
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/esbuild/0.14.22:
-    resolution:
-      {
-        integrity: sha512-CjFCFGgYtbFOPrwZNJf7wsuzesx8kqwAffOlbYcFDLFuUtP8xloK1GH+Ai13Qr0RZQf9tE7LMTHJ2iVGJ1SKZA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/esbuild/-/esbuild-0.14.22.tgz,
-      }
-    name: esbuild
-    version: 0.14.22
-    engines: { node: ">=12" }
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      esbuild-android-arm64: registry.npmjs.org/esbuild-android-arm64/0.14.22
-      esbuild-darwin-64: registry.npmjs.org/esbuild-darwin-64/0.14.22
-      esbuild-darwin-arm64: registry.npmjs.org/esbuild-darwin-arm64/0.14.22
-      esbuild-freebsd-64: registry.npmjs.org/esbuild-freebsd-64/0.14.22
-      esbuild-freebsd-arm64: registry.npmjs.org/esbuild-freebsd-arm64/0.14.22
-      esbuild-linux-32: registry.npmjs.org/esbuild-linux-32/0.14.22
-      esbuild-linux-64: registry.npmjs.org/esbuild-linux-64/0.14.22
-      esbuild-linux-arm: registry.npmjs.org/esbuild-linux-arm/0.14.22
-      esbuild-linux-arm64: registry.npmjs.org/esbuild-linux-arm64/0.14.22
-      esbuild-linux-mips64le: registry.npmjs.org/esbuild-linux-mips64le/0.14.22
-      esbuild-linux-ppc64le: registry.npmjs.org/esbuild-linux-ppc64le/0.14.22
-      esbuild-linux-riscv64: registry.npmjs.org/esbuild-linux-riscv64/0.14.22
-      esbuild-linux-s390x: registry.npmjs.org/esbuild-linux-s390x/0.14.22
-      esbuild-netbsd-64: registry.npmjs.org/esbuild-netbsd-64/0.14.22
-      esbuild-openbsd-64: registry.npmjs.org/esbuild-openbsd-64/0.14.22
-      esbuild-sunos-64: registry.npmjs.org/esbuild-sunos-64/0.14.22
-      esbuild-windows-32: registry.npmjs.org/esbuild-windows-32/0.14.22
-      esbuild-windows-64: registry.npmjs.org/esbuild-windows-64/0.14.22
-      esbuild-windows-arm64: registry.npmjs.org/esbuild-windows-arm64/0.14.22
-    dev: true
-    optional: true
-
-  registry.npmjs.org/follow-redirects/1.14.9:
-    resolution:
-      {
-        integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz,
-      }
-    name: follow-redirects
-    version: 1.14.9
-    engines: { node: ">=4.0" }
-    peerDependencies:
-      debug: "*"
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
-  registry.npmjs.org/form-data/4.0.0:
-    resolution:
-      {
-        integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz,
-      }
-    name: form-data
-    version: 4.0.0
-    engines: { node: ">= 6" }
-    dependencies:
-      asynckit: registry.npmjs.org/asynckit/0.4.0
-      combined-stream: registry.npmjs.org/combined-stream/1.0.8
-      mime-types: registry.npmjs.org/mime-types/2.1.34
-    dev: false
-
-  registry.npmjs.org/fsevents/2.3.2:
-    resolution:
-      {
-        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz,
-      }
-    name: fsevents
-    version: 2.3.2
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/global-agent/2.2.0:
-    resolution:
-      {
-        integrity: sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/global-agent/-/global-agent-2.2.0.tgz,
-      }
-    name: global-agent
-    version: 2.2.0
-    engines: { node: ">=10.0" }
-    requiresBuild: true
-    dependencies:
-      boolean: 3.0.4
-      core-js: 3.20.3
-      es6-error: 4.1.1
-      matcher: 3.0.0
-      roarr: 2.15.4
-      semver: 7.3.5
-      serialize-error: 7.0.1
-    optional: true
-
-  registry.npmjs.org/global-tunnel-ng/2.7.1:
-    resolution:
-      {
-        integrity: sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz,
-      }
-    name: global-tunnel-ng
-    version: 2.7.1
-    engines: { node: ">=0.10" }
-    requiresBuild: true
-    dependencies:
-      encodeurl: 1.0.2
-      lodash: 4.17.21
-      npm-conf: 1.1.3
-      tunnel: 0.0.6
-    optional: true
-
-  registry.npmjs.org/graceful-fs/4.2.10:
-    resolution:
-      {
-        integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz,
-      }
-    name: graceful-fs
-    version: 4.2.10
-
-  registry.npmjs.org/has-flag/4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz,
-      }
-    name: has-flag
-    version: 4.0.0
-    engines: { node: ">=8" }
-    dev: true
-
-  registry.npmjs.org/history/4.10.1:
-    resolution:
-      {
-        integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/history/-/history-4.10.1.tgz,
-      }
-    name: history
-    version: 4.10.1
-    dependencies:
-      "@babel/runtime": registry.npmjs.org/@babel/runtime/7.16.7
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      resolve-pathname: registry.npmjs.org/resolve-pathname/3.0.0
-      tiny-invariant: registry.npmjs.org/tiny-invariant/1.1.0
-      tiny-warning: registry.npmjs.org/tiny-warning/1.0.3
-      value-equal: registry.npmjs.org/value-equal/1.0.1
-    dev: true
-
-  registry.npmjs.org/hoist-non-react-statics/3.3.2:
-    resolution:
-      {
-        integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz,
-      }
-    name: hoist-non-react-statics
-    version: 3.3.2
-    dependencies:
-      react-is: registry.npmjs.org/react-is/16.13.1
-    dev: true
-
-  registry.npmjs.org/image-size/0.5.5:
-    resolution:
-      {
-        integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz,
-      }
-    name: image-size
-    version: 0.5.5
-    engines: { node: ">=0.10.0" }
-    hasBin: true
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/isarray/0.0.1:
-    resolution:
-      {
-        integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz,
-      }
-    name: isarray
-    version: 0.0.1
-    dev: true
-
-  registry.npmjs.org/jest-diff/26.6.2:
-    resolution:
-      {
-        integrity: sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz,
-      }
-    name: jest-diff
-    version: 26.6.2
-    engines: { node: ">= 10.14.2" }
-    dependencies:
-      chalk: registry.npmjs.org/chalk/4.1.2
-      diff-sequences: registry.npmjs.org/diff-sequences/26.6.2
-      jest-get-type: registry.npmjs.org/jest-get-type/26.3.0
-      pretty-format: registry.npmjs.org/pretty-format/26.6.2
-    dev: true
-
-  registry.npmjs.org/jest-get-type/26.3.0:
-    resolution:
-      {
-        integrity: sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz,
-      }
-    name: jest-get-type
-    version: 26.3.0
-    engines: { node: ">= 10.14.2" }
-    dev: true
-
-  registry.npmjs.org/js-tokens/4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz,
-      }
-    name: js-tokens
-    version: 4.0.0
-    dev: true
-
-  registry.npmjs.org/js-yaml/4.1.0:
-    resolution:
-      {
-        integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz,
-      }
-    name: js-yaml
-    version: 4.1.0
-    hasBin: true
-    dependencies:
-      argparse: registry.npmjs.org/argparse/2.0.1
-    dev: false
-
-  registry.npmjs.org/json5/0.5.1:
-    resolution:
-      {
-        integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/json5/-/json5-0.5.1.tgz,
-      }
-    name: json5
-    version: 0.5.1
-    hasBin: true
-    dev: true
-
-  registry.npmjs.org/json5/1.0.1:
-    resolution:
-      {
-        integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/json5/-/json5-1.0.1.tgz,
-      }
-    name: json5
-    version: 1.0.1
-    hasBin: true
-    dependencies:
-      minimist: registry.npmjs.org/minimist/1.2.6
-    dev: true
-
-  registry.npmjs.org/json5/2.1.2:
-    resolution:
-      {
-        integrity: sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/json5/-/json5-2.1.2.tgz,
-      }
-    name: json5
-    version: 2.1.2
-    engines: { node: ">=6" }
-    hasBin: true
-    dependencies:
-      minimist: registry.npmjs.org/minimist/1.2.6
-    dev: true
-
-  registry.npmjs.org/loader-utils/2.0.2:
-    resolution:
-      {
-        integrity: sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz,
-      }
-    name: loader-utils
-    version: 2.0.2
-    engines: { node: ">=8.9.0" }
-    dependencies:
-      big.js: registry.npmjs.org/big.js/5.2.2
-      emojis-list: registry.npmjs.org/emojis-list/3.0.0
-      json5: registry.npmjs.org/json5/2.1.2
-    dev: true
-
-  registry.npmjs.org/loose-envify/1.4.0:
-    resolution:
-      {
-        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz,
-      }
-    name: loose-envify
-    version: 1.4.0
-    hasBin: true
-    dependencies:
-      js-tokens: registry.npmjs.org/js-tokens/4.0.0
-    dev: true
-
-  registry.npmjs.org/make-dir/2.1.0:
-    resolution:
-      {
-        integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz,
-      }
-    name: make-dir
-    version: 2.1.0
-    engines: { node: ">=6" }
-    requiresBuild: true
-    dependencies:
-      pify: 4.0.1
-      semver: 5.7.1
-    dev: true
-    optional: true
-
-  registry.npmjs.org/mime-db/1.51.0:
-    resolution:
-      {
-        integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz,
-      }
-    name: mime-db
-    version: 1.51.0
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  registry.npmjs.org/mime-types/2.1.34:
-    resolution:
-      {
-        integrity: sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz,
-      }
-    name: mime-types
-    version: 2.1.34
-    engines: { node: ">= 0.6" }
-    dependencies:
-      mime-db: registry.npmjs.org/mime-db/1.51.0
-    dev: false
-
-  registry.npmjs.org/mime/1.6.0:
-    resolution:
-      {
-        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/mime/-/mime-1.6.0.tgz,
-      }
-    name: mime
-    version: 1.6.0
-    engines: { node: ">=4" }
-    hasBin: true
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  registry.npmjs.org/mini-create-react-context/0.4.1_mv67koxdvxhyejehvpcoenu3ai:
-    resolution:
-      {
-        integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz,
-      }
-    id: registry.npmjs.org/mini-create-react-context/0.4.1
-    name: mini-create-react-context
-    version: 0.4.1
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      "@babel/runtime": registry.npmjs.org/@babel/runtime/7.16.7
-      prop-types: registry.npmjs.org/prop-types/15.7.2
-      react: registry.npmjs.org/react/17.0.2
-      tiny-warning: registry.npmjs.org/tiny-warning/1.0.3
-    dev: true
-
-  registry.npmjs.org/minimist/1.2.6:
-    resolution:
-      {
-        integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz,
-      }
-    name: minimist
-    version: 1.2.6
-
-  registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_4era6pk35okdbgphw4rwgut7wu:
-    resolution:
-      {
-        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
-      }
-    id: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1
-    name: monaco-editor-webpack-plugin
-    version: 7.0.1
-    peerDependencies:
-      monaco-editor: ">= 0.31.0"
-      monaco-yaml: "*"
-      webpack: ^4.5.0 || 5.x
-    dependencies:
-      loader-utils: registry.npmjs.org/loader-utils/2.0.2
-      monaco-editor: 0.23.0
-      monaco-yaml: 3.2.1_monaco-editor@0.23.0
-    dev: true
-
-  registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1_xaucyy2rqq33fyrllhuadbirwm:
-    resolution:
-      {
-        integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz,
-      }
-    id: registry.npmjs.org/monaco-editor-webpack-plugin/7.0.1
-    name: monaco-editor-webpack-plugin
-    version: 7.0.1
-    peerDependencies:
-      monaco-editor: ">= 0.31.0"
-      monaco-yaml: "*"
-      webpack: ^4.5.0 || 5.x
-    dependencies:
-      loader-utils: registry.npmjs.org/loader-utils/2.0.2
-      monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
-    dev: true
-
-  registry.npmjs.org/monaco-yaml/3.2.1_monaco-editor@0.33.0:
-    resolution:
-      {
-        integrity: sha512-2geAd5I7H1SMgwTHBuyPAPK9WTAzxbl9XwDl5h6NY6n9j4qnlLLQKK1i0P9cAmUiV2uaiViz69RLNWqVU5BVsg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-3.2.1.tgz,
-      }
-    id: registry.npmjs.org/monaco-yaml/3.2.1
-    name: monaco-yaml
-    version: 3.2.1
-    peerDependencies:
-      monaco-editor: ">=0.22"
-    dependencies:
-      "@types/json-schema": registry.npmjs.org/@types/json-schema/7.0.11
-      js-yaml: registry.npmjs.org/js-yaml/4.1.0
-      monaco-editor: 0.33.0
-      path-browserify: registry.npmjs.org/path-browserify/1.0.1
-      prettier: registry.npmjs.org/prettier/2.0.5
-      vscode-languageserver-textdocument: registry.npmjs.org/vscode-languageserver-textdocument/1.0.4
-      vscode-languageserver-types: registry.npmjs.org/vscode-languageserver-types/3.16.0
-      yaml-language-server-parser: registry.npmjs.org/yaml-language-server-parser/0.1.3
-    dev: false
-
-  registry.npmjs.org/needle/2.9.1:
-    resolution:
-      {
-        integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/needle/-/needle-2.9.1.tgz,
-      }
-    name: needle
-    version: 2.9.1
-    engines: { node: ">= 4.4.x" }
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      debug: 3.2.7
-      iconv-lite: 0.4.24
-      sax: 1.2.4
-    dev: true
-    optional: true
-
-  registry.npmjs.org/nice-napi/1.0.2:
-    resolution:
-      {
-        integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz,
-      }
-    name: nice-napi
-    version: 1.0.2
-    os: ["!win32"]
-    requiresBuild: true
-    dependencies:
-      node-addon-api: 3.2.1
-      node-gyp-build: 4.3.0
-    dev: true
-    optional: true
-
-  registry.npmjs.org/node-notifier/8.0.2:
-    resolution:
-      {
-        integrity: sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz,
-      }
-    name: node-notifier
-    version: 8.0.2
-    requiresBuild: true
-    dependencies:
-      growly: 1.3.0
-      is-wsl: 2.2.0
-      semver: 7.3.5
-      shellwords: 0.1.1
-      uuid: 8.3.2
-      which: 2.0.2
-    dev: true
-    optional: true
-
-  registry.npmjs.org/object-assign/4.1.1:
-    resolution:
-      {
-        integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz,
-      }
-    name: object-assign
-    version: 4.1.1
-    engines: { node: ">=0.10.0" }
-    dev: true
-
-  registry.npmjs.org/openapi-types/7.2.3:
-    resolution:
-      {
-        integrity: sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/openapi-types/-/openapi-types-7.2.3.tgz,
-      }
-    name: openapi-types
-    version: 7.2.3
-    dev: false
-
-  registry.npmjs.org/path-browserify/1.0.1:
-    resolution:
-      {
-        integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz,
-      }
-    name: path-browserify
-    version: 1.0.1
-    dev: false
-
-  registry.npmjs.org/path-to-regexp/1.8.0:
-    resolution:
-      {
-        integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz,
-      }
-    name: path-to-regexp
-    version: 1.8.0
-    dependencies:
-      isarray: registry.npmjs.org/isarray/0.0.1
-    dev: true
-
-  registry.npmjs.org/prettier/2.0.5:
-    resolution:
-      {
-        integrity: sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz,
-      }
-    name: prettier
-    version: 2.0.5
-    engines: { node: ">=10.13.0" }
-    hasBin: true
-    dev: false
-
-  registry.npmjs.org/pretty-format/26.6.2:
-    resolution:
-      {
-        integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz,
-      }
-    name: pretty-format
-    version: 26.6.2
-    engines: { node: ">= 10" }
-    dependencies:
-      "@jest/types": registry.npmjs.org/@jest/types/26.6.2
-      ansi-regex: registry.npmjs.org/ansi-regex/5.0.1
-      ansi-styles: registry.npmjs.org/ansi-styles/4.3.0
-      react-is: registry.npmjs.org/react-is/17.0.2
-    dev: true
-
-  registry.npmjs.org/prop-types/15.7.2:
-    resolution:
-      {
-        integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz,
-      }
-    name: prop-types
-    version: 15.7.2
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-      react-is: registry.npmjs.org/react-is/16.13.1
-    dev: true
-
-  registry.npmjs.org/react-dom/17.0.2_react@17.0.2:
-    resolution:
-      {
-        integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz,
-      }
-    id: registry.npmjs.org/react-dom/17.0.2
-    name: react-dom
-    version: 17.0.2
-    peerDependencies:
-      react: 17.0.2
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-      react: registry.npmjs.org/react/17.0.2
-      scheduler: registry.npmjs.org/scheduler/0.20.2
-    dev: true
-
-  registry.npmjs.org/react-is/16.13.1:
-    resolution:
-      {
-        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz,
-      }
-    name: react-is
-    version: 16.13.1
-    dev: true
-
-  registry.npmjs.org/react-is/17.0.2:
-    resolution:
-      {
-        integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz,
-      }
-    name: react-is
-    version: 17.0.2
-    dev: true
-
-  registry.npmjs.org/react-router-dom/5.3.0_react@17.0.2:
-    resolution:
-      {
-        integrity: sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz,
-      }
-    id: registry.npmjs.org/react-router-dom/5.3.0
-    name: react-router-dom
-    version: 5.3.0
-    peerDependencies:
-      react: ">=15"
-    dependencies:
-      "@babel/runtime": registry.npmjs.org/@babel/runtime/7.16.7
-      history: registry.npmjs.org/history/4.10.1
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      prop-types: registry.npmjs.org/prop-types/15.7.2
-      react: registry.npmjs.org/react/17.0.2
-      react-router: registry.npmjs.org/react-router/5.2.1_react@17.0.2
-      tiny-invariant: registry.npmjs.org/tiny-invariant/1.1.0
-      tiny-warning: registry.npmjs.org/tiny-warning/1.0.3
-    dev: true
-
-  registry.npmjs.org/react-router/5.2.1_react@17.0.2:
-    resolution:
-      {
-        integrity: sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz,
-      }
-    id: registry.npmjs.org/react-router/5.2.1
-    name: react-router
-    version: 5.2.1
-    peerDependencies:
-      react: ">=15"
-    dependencies:
-      "@babel/runtime": registry.npmjs.org/@babel/runtime/7.16.7
-      history: registry.npmjs.org/history/4.10.1
-      hoist-non-react-statics: registry.npmjs.org/hoist-non-react-statics/3.3.2
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      mini-create-react-context: registry.npmjs.org/mini-create-react-context/0.4.1_mv67koxdvxhyejehvpcoenu3ai
-      path-to-regexp: registry.npmjs.org/path-to-regexp/1.8.0
-      prop-types: registry.npmjs.org/prop-types/15.7.2
-      react: registry.npmjs.org/react/17.0.2
-      react-is: registry.npmjs.org/react-is/16.13.1
-      tiny-invariant: registry.npmjs.org/tiny-invariant/1.1.0
-      tiny-warning: registry.npmjs.org/tiny-warning/1.0.3
-    dev: true
-
-  registry.npmjs.org/react/17.0.2:
-    resolution:
-      {
-        integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/react/-/react-17.0.2.tgz,
-      }
-    name: react
-    version: 17.0.2
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: true
-
-  registry.npmjs.org/regenerator-runtime/0.13.9:
-    resolution:
-      {
-        integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz,
-      }
-    name: regenerator-runtime
-    version: 0.13.9
-    dev: true
-
-  registry.npmjs.org/resolve-pathname/3.0.0:
-    resolution:
-      {
-        integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz,
-      }
-    name: resolve-pathname
-    version: 3.0.0
-    dev: true
-
-  registry.npmjs.org/scheduler/0.20.2:
-    resolution:
-      {
-        integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz,
-      }
-    name: scheduler
-    version: 0.20.2
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: true
-
-  registry.npmjs.org/source-map/0.5.7:
-    resolution:
-      {
-        integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz,
-      }
-    name: source-map
-    version: 0.5.7
-    engines: { node: ">=0.10.0" }
-    dev: true
-
-  registry.npmjs.org/source-map/0.6.1:
-    resolution:
-      {
-        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz,
-      }
-    name: source-map
-    version: 0.6.1
-    engines: { node: ">=0.10.0" }
-    dev: true
-
-  registry.npmjs.org/source-map/0.7.3:
-    resolution:
-      {
-        integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz,
-      }
-    name: source-map
-    version: 0.7.3
-    engines: { node: ">= 8" }
-    dev: true
-
-  registry.npmjs.org/supports-color/7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz,
-      }
-    name: supports-color
-    version: 7.2.0
-    engines: { node: ">=8" }
-    dependencies:
-      has-flag: registry.npmjs.org/has-flag/4.0.0
-    dev: true
-
-  registry.npmjs.org/tiny-invariant/1.1.0:
-    resolution:
-      {
-        integrity: sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz,
-      }
-    name: tiny-invariant
-    version: 1.1.0
-    dev: true
-
-  registry.npmjs.org/tiny-warning/1.0.3:
-    resolution:
-      {
-        integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz,
-      }
-    name: tiny-warning
-    version: 1.0.3
-    dev: true
-
-  registry.npmjs.org/value-equal/1.0.1:
-    resolution:
-      {
-        integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz,
-      }
-    name: value-equal
-    version: 1.0.1
-    dev: true
-
-  registry.npmjs.org/vscode-languageserver-textdocument/1.0.4:
-    resolution:
-      {
-        integrity: sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz,
-      }
-    name: vscode-languageserver-textdocument
-    version: 1.0.4
-    dev: false
-
-  registry.npmjs.org/vscode-languageserver-types/3.16.0:
-    resolution:
-      {
-        integrity: sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz,
-      }
-    name: vscode-languageserver-types
-    version: 3.16.0
-    dev: false
-
-  registry.npmjs.org/yaml-language-server-parser/0.1.3:
-    resolution:
-      {
-        integrity: sha512-xD2I+6M/vqQvcy4ded8JpXUaDHXmZMdhIO3OpuiFxstutwnW4whrfDzNcrsfXVdgMWqOUpdv3747Q081PFN1+g==,
-        registry: https://registry.yarnpkg.com/,
-        tarball: https://registry.npmjs.org/yaml-language-server-parser/-/yaml-language-server-parser-0.1.3.tgz,
-      }
-    name: yaml-language-server-parser
-    version: 0.1.3
     dev: false


### PR DESCRIPTION
Some dependencies were duplicated due to us coming from `yarn.lock` previously. This PR removes this duplication.