### PR TITLE
KOGITO-7195: SWF Viewer - Fix issue with empty Json

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/services/ClientDiagramService.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/services/ClientDiagramService.java
@@ -35,6 +35,7 @@ import org.kie.workbench.common.stunner.core.diagram.MetadataImpl;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.sw.Definitions;
 import org.kie.workbench.common.stunner.sw.factory.DiagramFactory;
+import org.kie.workbench.common.stunner.sw.marshall.Context;
 import org.kie.workbench.common.stunner.sw.marshall.Marshaller;
 import org.uberfire.client.promise.Promises;
 
@@ -162,8 +163,13 @@ public class ClientDiagramService {
 
     private void updateClientMetadata(final Diagram diagram) {
         final Metadata metadata = diagram.getMetadata();
-        String rootUUID = marshaller.getContext().getWorkflowRootNode().getUUID();
-        metadata.setCanvasRootUUID(rootUUID);
+
+        Context context = marshaller.getContext();
+        if (context != null) {
+            String rootUUID = context.getWorkflowRootNode().getUUID();
+            metadata.setCanvasRootUUID(rootUUID);
+        }
+
         if (isEmpty(metadata.getShapeSetId())) {
             final String sId = shapeManager.getDefaultShapeSet(metadata.getDefinitionSetId()).getId();
             metadata.setShapeSetId(sId);


### PR DESCRIPTION
**JIRA:** [KOGITO-7195 - SWF Viewer : Fix issue with empty Json](https://issues.redhat.com/browse/KOGITO-7195)

The context is created only after loading content. What this fix does is still load the diagram and show the graph even if there is no context available.