### PR TITLE
KOGITO-7227: SWF Viewer - Error Handling

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -150,23 +150,25 @@ public class StunnerEditor {
 
     public void handleError(final ClientRuntimeError error) {
         final Throwable e = error.getThrowable();
+        final String message;
         if (e instanceof DiagramParsingException) {
             final DiagramParsingException dpe = (DiagramParsingException) e;
-            close();
             parsingExceptionProcessor.accept(dpe);
-            view.setWidget(errorPage);
+            message = e.toString();
+        } else if (e instanceof DefinitionNotFoundException) {
+            final DefinitionNotFoundException dnfe = (DefinitionNotFoundException) e;
+            message = translationService.getValue(CoreTranslationMessages.DIAGRAM_LOAD_FAIL_UNSUPPORTED_ELEMENTS,
+                                                  dnfe.getDefinitionId());
         } else {
-            String message = null;
-            if (e instanceof DefinitionNotFoundException) {
-                final DefinitionNotFoundException dnfe = (DefinitionNotFoundException) e;
-                message = translationService.getValue(CoreTranslationMessages.DIAGRAM_LOAD_FAIL_UNSUPPORTED_ELEMENTS,
-                                                      dnfe.getDefinitionId());
-            } else {
-                message = error.getThrowable() != null ?
-                        error.getThrowable().getMessage() : error.getMessage();
-            }
-            showError(message);
             exceptionProcessor.accept(error.getThrowable());
+            message = error.getThrowable() != null ? error.getThrowable().getMessage() : error.getMessage();
+        }
+
+        if ((diagramPresenter != null) &&
+                (diagramPresenter.getView() != null)) {
+            showError(message);
+        } else {
+            view.setWidget(errorPage);
         }
     }
 
@@ -211,10 +213,21 @@ public class StunnerEditor {
     }
 
     public void showMessage(String message) {
-        diagramPresenter.getView().showMessage(message);
+        if (!isClosed()) {
+            diagramPresenter.getView().showMessage(message);
+        }
+    }
+
+    public void showWarning(String message) {
+        if (!isClosed()) {
+            diagramPresenter.getView().showWarning(message);
+        }
     }
 
     public void showError(String message) {
+        if (!isClosed()) {
+            diagramPresenter.getView().showError(message);
+        }
     }
 
     public IsWidget getView() {

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
@@ -41,7 +41,6 @@ import org.kie.workbench.common.stunner.core.client.service.ServiceCallback;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
 import org.kie.workbench.common.stunner.core.client.util.WindowJSType;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
-import org.kie.workbench.common.stunner.core.diagram.DiagramParsingException;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.sw.client.services.ClientDiagramService;
 import org.kie.workbench.common.stunner.sw.client.services.IncrementalMarshaller;
@@ -112,7 +111,6 @@ public class DiagramEditor {
     }
 
     public Promise<Void> setContent(final String path, final String value) {
-        close();
         return promises.create((success, failure) -> {
             diagramService.transform(path,
                                      value,
@@ -158,7 +156,7 @@ public class DiagramEditor {
 
                                          @Override
                                          public void onError(final ClientRuntimeError error) {
-                                             stunnerEditor.handleError(new ClientRuntimeError(new DiagramParsingException()));
+                                             stunnerEditor.handleError(error);
                                              failure.onInvoke(error);
                                          }
                                      });

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/services/ClientDiagramService.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/services/ClientDiagramService.java
@@ -83,7 +83,6 @@ public class ClientDiagramService {
     private void doTransform(final String fileName,
                              final String xml,
                              final ServiceCallback<Diagram> callback) {
-
         if (Objects.isNull(xml) || xml.isEmpty()) {
             Diagram newDiagram = createNewDiagram(fileName);
             callback.onSuccess(newDiagram);


### PR DESCRIPTION
**JIRA:** [KOGITO-7227 - SWF Viewer: Error Handling](https://issues.redhat.com/browse/KOGITO-7227)

The error page is not shown after the canvas is loaded.
Marshaller errors are now caught and properly treated.
Error messages are shown in the editor for proper clarification.