### PR TITLE
Bump `jdt.ls` assets

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -35,7 +35,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.12.0.20220601164340</jdt.ls.version>
+    <jdt.ls.version>1.11.0.20220505143732</jdt.ls.version>
 
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
@@ -60,7 +60,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.12.0/repository/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.11.0/repository/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -35,7 +35,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.11.0.20220505143732</jdt.ls.version>
+    <jdt.ls.version>1.12.0.20220601164340</jdt.ls.version>
 
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
@@ -60,7 +60,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.12.0/repository/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>
@@ -89,7 +89,6 @@
           </target>
           <resolver>p2</resolver>
           <pomDependencies>consider</pomDependencies>
-          <ignoreTychoRepositories>true</ignoreTychoRepositories>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The scope of this PR is:
- Fixing compile error  reported in `vscode-java-code-completion-extension-plugin`: 
`[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: vscode-java-code-completion-extension-plugin-core 0.0.0
[ERROR]   Missing requirement: org.eclipse.jdt.ls.core 1.13.0.202206080005 requires 'osgi.ee; (&(osgi.ee=JavaSE)(version=17))' but it could not be found
[ERROR]   Cannot satisfy dependency: vscode-java-code-completion-extension-plugin-core 0.0.0 depends on: osgi.bundle; org.eclipse.jdt.ls.core 0.0.0
`
To fix this, I changed the repository used to retrieve `jdt.ls` dependencies from the `snapshots` one to the `milestone/{current_version}` (currently `1.11.0`) repo. In this way, we rely on tagged and fixed dependencies and no more on snapshots which can change every day introducing nondeterministic status (like what happened today)