### PR TITLE
KOGITO-7375: [DMN Designer] Import Java Classes Fix cases with special characters in PATH

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
@@ -13,8 +13,9 @@
 
   <properties>
     <version.org.freemarker>2.3.31</version.org.freemarker>
+    <version.org.assertj>3.23.1</version.org.assertj>
     <version.org.junit.jupiter>5.8.2</version.org.junit.jupiter>
-    <version.org.assertj>3.22.0</version.org.assertj>
+    <version.org.mockito>4.6.1</version.org.mockito>
   </properties>
 
   <dependencyManagement>
@@ -34,6 +35,11 @@
         <artifactId>assertj-core</artifactId>
         <version>${version.org.assertj}</version>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${version.org.mockito}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -49,6 +55,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
@@ -19,6 +19,7 @@ package org.kogito.core.internal.engine;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -27,7 +28,7 @@ import org.kogito.core.internal.util.WorkspaceUtil;
 public class ActivationChecker {
 
     private final WorkspaceUtil workspaceUtil;
-    private String activatorUri = "";
+    private String activatorPath = "";
     private boolean present = false;
 
     public ActivationChecker(WorkspaceUtil workspaceUtil) {
@@ -43,7 +44,7 @@ public class ActivationChecker {
         }
         this.present = visitor.isPresent();
         if (this.present) {
-            this.activatorUri = visitor.getActivatorFile().toAbsolutePath().toString();
+            this.activatorPath = visitor.getActivatorFile().toAbsolutePath().toString();
         }
     }
 
@@ -52,8 +53,8 @@ public class ActivationChecker {
     }
 
     public String getActivatorUri() {
-        if (this.existActivator() && this.activatorUri != null && !this.activatorUri.isEmpty()) {
-            return "file://" + this.activatorUri;
+        if (this.existActivator() && this.activatorPath != null && !this.activatorPath.isEmpty()) {
+            return Path.of(this.activatorPath).toUri().toASCIIString();
         } else {
             throw new ActivationCheckerException("Activator URI is not present");
         }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.kogito.core.internal.engine;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kogito.core.internal.util.WorkspaceUtil;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public class ActivationCheckerTest {
+
+    private WorkspaceUtil workspaceUtilMock;
+
+    private ActivationChecker activationChecker;
+
+    @BeforeEach
+    public void setup() {
+        workspaceUtilMock = Mockito.mock(WorkspaceUtil.class);
+        this.activationChecker = new ActivationChecker(workspaceUtilMock);
+    }
+
+    @Test
+    public void getActivatorPathWithoutSpecialChars() {
+        when(workspaceUtilMock.getWorkspace()).thenReturn("src/test/resources/testProject/");
+        activationChecker.check();
+        var activatorUri = activationChecker.getActivatorUri();
+        Assertions.assertNotNull(activatorUri);
+        Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
+    }
+
+    @Test
+    public void getActivatorPathWithSpecialChars() {
+        when(workspaceUtilMock.getWorkspace()).thenReturn("src/test/resources/test projéct");
+        activationChecker.check();
+        var activatorUri = activationChecker.getActivatorUri();
+        Assertions.assertTrue(activatorUri.contains("test%20proj%C3%A9ct"));
+        Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
+    }
+
+}

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mockito;
 
 import static org.mockito.Mockito.when;
 
-public class ActivationCheckerTest {
+class ActivationCheckerTest {
 
     private WorkspaceUtil workspaceUtilMock;
 
@@ -46,7 +46,7 @@ public class ActivationCheckerTest {
     }
 
     @Test
-    public void getActivatorPathWithSpecialChars() {
+    void getActivatorPathWithSpecialChars() {
         when(workspaceUtilMock.getWorkspace()).thenReturn("src/test/resources/test projéct");
         activationChecker.check();
         var activatorUri = activationChecker.getActivatorUri();

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/Activator.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/Activator.java
@@ -1,0 +1,8 @@
+package org.kogito.test.project;
+
+import org.kie.api.project.KieActivator;
+
+@KieActivator
+public class Activator {
+
+}

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/RandomClass.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/RandomClass.java
@@ -1,0 +1,14 @@
+package org.kogito.test.project;
+
+public class RandomClass {
+
+    private int number;
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public int getNumber() {
+        return this.number;
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7375

In case the project path contains special characters, like an empty space, (eg. `/home/user/my project/src/ ...`), the project path is fetched with an error. To fix this, I converted the string value of the path to a `Path`, to an `Uri` and returns `.toASCIIString()`, which encodes special char (eg." " is encoded as "%20")