### PR TITLE
[0.19.2-prerelease] Cherry-pick: Bump `jdt.ls` assets (#1024)

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -60,7 +60,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.11.0/repository/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>
@@ -89,7 +89,6 @@
           </target>
           <resolver>p2</resolver>
           <pomDependencies>consider</pomDependencies>
-          <ignoreTychoRepositories>true</ignoreTychoRepositories>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
cherry-picks #1024 to `0.19.2-prerelease`