### PR TITLE
KOGITO-7331, KOGITO-7332 : Missing data when the serverless workflow definition is unmarshalled, Editor adds non-required attribute to serverless workflow definition

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/InjectState.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/InjectState.java
@@ -50,7 +50,6 @@ public class InjectState extends State {
 
     public InjectState() {
         this.type = TYPE_INJECT;
-        usedForCompensation = false;
     }
 
     public String getData() {

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/OperationState.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/OperationState.java
@@ -56,7 +56,6 @@ public class OperationState extends State {
 
     public OperationState() {
         this.type = TYPE_OPERATION;
-        this.usedForCompensation = false;
     }
 
     public String getActionMode() {

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/SwitchState.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/SwitchState.java
@@ -61,7 +61,6 @@ public class SwitchState extends State {
 
     public SwitchState() {
         this.type = TYPE_SWITCH;
-        this.usedForCompensation = false;
     }
 
     public DefaultConditionTransition getDefaultCondition() {

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshalling.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
-import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.sw.definition.ActionNode;

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshalling.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.relationship.Dock;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
 import org.kie.workbench.common.stunner.sw.definition.ActionNode;
@@ -118,7 +119,6 @@ public interface StateMarshalling {
 
                 // TODO: Clear states here or on each marshaller?
                 state.transition = null;
-                state.end = false;
                 state.compensatedBy = null;
                 state.eventTimeout = null;
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
@@ -61,7 +61,11 @@ public interface TransitionMarshalling {
                         Object targetDef = getElementDefinition(targetNode);
                         if (targetDef instanceof End) {
                             sourceState.transition = null;
-                            sourceState.end = true;
+
+                            if (sourceState.end instanceof Boolean) {
+                                sourceState.end = true;
+                            } // else is Object
+
                         } else {
                             sourceState.transition = getStateNodeName(targetNode);
                             sourceState.end = false;

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.sw.marshall.Marshaller.unmarshallNode;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class StateMarshallingTest extends BaseMarshallingTest {
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
@@ -51,10 +51,10 @@ public class StateMarshallingTest extends BaseMarshallingTest {
     @Test
     public void testEndObject() {
         JsPropertyMap<Object> endObject = mock(JsPropertyMap.class);
-        when(endObject.get("terminate")).thenReturn(true);
-        when(endObject.get("continueAs")).thenReturn("{}");
-        when(endObject.get("compensate")).thenReturn(false);
-        when(endObject.get("produceEvents")).thenReturn("[]");
+        endObject.set("terminate", true);
+        endObject.set("continueAs", "{}");
+        endObject.set("compensate", false);
+        endObject.set("produceEvents","[]");
         workflow.states[0].setEnd(endObject);
         unmarshallWorkflow();
         assertTrue(hasOutgoingEdges("State1"));

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
@@ -18,9 +18,11 @@ package org.kie.workbench.common.stunner.sw.marshall;
 
 import java.util.Optional;
 
+import jsinterop.base.JsPropertyMap;
 import org.junit.Test;
 import org.kie.workbench.common.stunner.sw.definition.End;
 import org.kie.workbench.common.stunner.sw.definition.ErrorTransition;
+import org.kie.workbench.common.stunner.sw.definition.InjectState;
 import org.kie.workbench.common.stunner.sw.definition.State;
 import org.kie.workbench.common.stunner.sw.definition.Workflow;
 
@@ -29,6 +31,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.stunner.sw.marshall.Marshaller.unmarshallNode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StateMarshallingTest extends BaseMarshallingTest {
 
@@ -41,6 +46,44 @@ public class StateMarshallingTest extends BaseMarshallingTest {
                         new State()
                                 .setName("State1")
                 });
+    }
+
+    @Test
+    public void testEndObject() {
+        JsPropertyMap<Object> endObject = mock(JsPropertyMap.class);
+        when(endObject.get("terminate")).thenReturn(true);
+        when(endObject.get("continueAs")).thenReturn("{}");
+        when(endObject.get("compensate")).thenReturn(false);
+        when(endObject.get("produceEvents")).thenReturn("[]");
+        workflow.states[0].setEnd(endObject);
+        unmarshallWorkflow();
+        assertTrue(hasOutgoingEdges("State1"));
+        assertTrue(hasOutgoingEdgeTo("State1", Marshaller.STATE_END));
+        assertTrue(workflow.states[0].end instanceof JsPropertyMap);
+        final JsPropertyMap end = (JsPropertyMap) workflow.states[0].end;
+        assertTrue((Boolean) end.get("terminate"));
+        assertTrue(end.get("continueAs").equals("{}"));
+        assertTrue(!((Boolean) end.get("compensate")));
+        assertTrue(end.get("produceEvents").equals("[]"));
+    }
+
+    @Test
+    public void testUnsetCompensatedBy() {
+        InjectState injectState = new InjectState();
+
+        injectState.setName("Inject State");
+        injectState.setUsedForCompensation(true);
+
+        Workflow workflow = new Workflow()
+                .setId("workflow1")
+                .setName("Workflow1")
+                .setStates(new State[]{
+                        injectState
+                });
+
+        unmarshallNode(builderContext, workflow);
+        assertEquals(injectState.usedForCompensation, true);
+        // specific case when usedForCompensation is equals to Js.undefined cannot be tested since value defaults to false
     }
 
     @Test

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.workbench.common.stunner.sw.marshall.Marshaller.unmarshallNode;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StateMarshallingTest extends BaseMarshallingTest {
 
@@ -50,10 +51,10 @@ public class StateMarshallingTest extends BaseMarshallingTest {
     @Test
     public void testEndObject() {
         JsPropertyMap<Object> endObject = mock(JsPropertyMap.class);
-        endObject.set("terminate", true);
-        endObject.set("continueAs", "{}");
-        endObject.set("compensate", false);
-        endObject.set("produceEvents","[]");
+        when(endObject.get("terminate")).thenReturn(true);
+        when(endObject.get("continueAs")).thenReturn("{}");
+        when(endObject.get("compensate")).thenReturn(false);
+        when(endObject.get("produceEvents")).thenReturn("[]");
         workflow.states[0].setEnd(endObject);
         unmarshallWorkflow();
         assertTrue(hasOutgoingEdges("State1"));


### PR DESCRIPTION
Hi @romartin can you review this PR?