### PR TITLE
[NOISSUE] Correctly use config and live setting for insecureSkipVerify

### DIFF
--- a/packages/extended-services/main.go
+++ b/packages/extended-services/main.go
@@ -32,6 +32,7 @@ func main() {
 	var config config.Config
 	conf := config.GetConfig()
 	port := flag.Int("p", conf.Proxy.Port, "KIE Sandbox Extended Services Port")
+	insecureSkipVerify := conf.Proxy.InsecureSkipVerify
 	flag.Parse()
-	kogito.Systray(*port, jitexecutor)
+	kogito.Systray(*port, jitexecutor, insecureSkipVerify)
 }

--- a/packages/extended-services/package.json
+++ b/packages/extended-services/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@kie-tools/build-env": "0.0.0",
-    "@kie-tools-core/run-script-if": "0.0.0"
+    "@kie-tools-core/run-script-if": "0.0.0",
+    "cross-env": "^5.2.1"
   }
 }

--- a/packages/extended-services/package.json
+++ b/packages/extended-services/package.json
@@ -27,7 +27,7 @@
     "pack-app:win32": "echo 'Nothing to do'",
     "build:dev": "rimraf dist jitexecutor && pnpm copy-jitexecutor && pnpm build",
     "build:prod": "rimraf dist jitexecutor && pnpm copy-jitexecutor && pnpm build && pnpm pack-app",
-    "start": "ENV=dev go run main.go"
+    "start": "cross-env ENV=dev go run main.go"
   },
   "dependencies": {
     "@kie-tools/jitexecutor-native": "1.12.0-Final"

--- a/packages/extended-services/pkg/kogito/main.go
+++ b/packages/extended-services/pkg/kogito/main.go
@@ -16,8 +16,8 @@
 
 package kogito
 
-func Systray(port int, jitexecutor []byte) {
-	proxy := NewProxy(port, jitexecutor)
+func Systray(port int, jitexecutor []byte, insecureSkipVerify bool) {
+	proxy := NewProxy(port, jitexecutor, insecureSkipVerify)
 	proxy.view = &KogitoSystray{}
 	proxy.view.controller = proxy
 	proxy.view.Run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,11 +1135,13 @@ importers:
       "@kie-tools-core/run-script-if": 0.0.0
       "@kie-tools/build-env": 0.0.0
       "@kie-tools/jitexecutor-native": 1.12.0-Final
+      cross-env: ^5.2.1
     dependencies:
       "@kie-tools/jitexecutor-native": 1.12.0-Final
     devDependencies:
       "@kie-tools-core/run-script-if": link:../run-script-if
       "@kie-tools/build-env": link:../build-env
+      cross-env: 5.2.1
 
   packages/feel-input-component:
     specifiers:
@@ -15868,6 +15870,7 @@ packages:
     resolution:
       { integrity: sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q== }
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
Extended Services app was only reading the `insecureSkipVerify` flag from the config file, not the live setting (from the systray menu). 

Now it correctly reflects both, by starting the proxy with the config from the yaml file, then reading the live setting from the systray menu.