### PR TITLE
upgrade gson to version 2.8.9

### DIFF
--- a/packages/stunner-editors/errai-bom/pom.xml
+++ b/packages/stunner-editors/errai-bom/pom.xml
@@ -80,7 +80,7 @@
 
     <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
+    <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
     <version.com.google.jsinterop>2.0.0</version.com.google.jsinterop>
     <!-- 3.18+ breaks GWT compilation -->
     <version.org.eclipse.jdt.ecj>3.17.0</version.org.eclipse.jdt.ecj>


### PR DESCRIPTION
com.google.code.gson:gson before 2.8.9 is vulnerable to Deserialization of Untrusted Data via the
writeReplace() method in internal classes, which may lead to DoS attacks.