### PR TITLE
KOGITO-7491: Setting SVG commands ID as optional at Editor creation

### DIFF
--- a/packages/vscode-extension-pmml-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-pmml-editor/src/extension/extension.ts
@@ -38,8 +38,6 @@ export function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-pmml-editor",
     context: context,
     viewType: "kieKogitoWebviewEditorsPmml",
-    generateSvgCommandId: "",
-    silentlyGenerateSvgCommandId: "",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
       new EnvelopeMapping("pmml", "**/*.pmml", "dist/webview/PmmlEditorEnvelopeApp.js", "dist/webview/editors/pmml"),
     ]),

--- a/packages/vscode-extension-yard-editor/src/extension/commandIds.ts
+++ b/packages/vscode-extension-yard-editor/src/extension/commandIds.ts
@@ -15,8 +15,6 @@
  */
 
 export const COMMAND_IDS = {
-  getPreviewSvg: "extension.kogito.yard.getPreviewSvg",
-  silentlyGetPreviewSvg: "extension.kogito.yard.silentlyGenerateSvg",
   openAsDiagram: "extension.kogito.yard.openAsDiagram",
   openAsSource: "extension.kogito.yard.openAsSource",
   setupAutomaticallyOpenDiagramEditorAlongsideTextEditor:

--- a/packages/vscode-extension-yard-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-yard-editor/src/extension/extension.ts
@@ -42,8 +42,6 @@ export async function activate(context: vscode.ExtensionContext) {
     extensionName: "kie-group.vscode-extension-yard-editor",
     context: context,
     viewType: WEBVIEW_EDITOR_VIEW_TYPE,
-    generateSvgCommandId: COMMAND_IDS.getPreviewSvg,
-    silentlyGenerateSvgCommandId: COMMAND_IDS.silentlyGetPreviewSvg,
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
       new EnvelopeMapping(
         "yard",

--- a/packages/vscode-extension/src/index.ts
+++ b/packages/vscode-extension/src/index.ts
@@ -45,8 +45,8 @@ export async function startExtension(args: {
   extensionName: string;
   context: vscode.ExtensionContext;
   viewType: string;
-  generateSvgCommandId: string;
-  silentlyGenerateSvgCommandId: string;
+  generateSvgCommandId?: string;
+  silentlyGenerateSvgCommandId?: string;
   editorEnvelopeLocator: EditorEnvelopeLocator;
   backendProxy: VsCodeBackendProxy;
   channelApiProducer?: KogitoEditorChannelApiProducer;
@@ -116,29 +116,33 @@ export async function startExtension(args: {
     throw new Error("Type not supported");
   }
 
-  args.context.subscriptions.push(
-    vscode.commands.registerCommand(args.generateSvgCommandId, () =>
-      generateSvg({
-        editorStore: editorStore,
-        workspaceApi: workspaceApi,
-        vsCodeI18n: vsCodeI18n,
-        displayNotification: true,
-        editorEnvelopeLocator: args.editorEnvelopeLocator,
-      })
-    )
-  );
+  if (args.generateSvgCommandId !== undefined) {
+    args.context.subscriptions.push(
+      vscode.commands.registerCommand(args.generateSvgCommandId, () =>
+        generateSvg({
+          editorStore: editorStore,
+          workspaceApi: workspaceApi,
+          vsCodeI18n: vsCodeI18n,
+          displayNotification: true,
+          editorEnvelopeLocator: args.editorEnvelopeLocator,
+        })
+      )
+    );
+  }
 
-  args.context.subscriptions.push(
-    vscode.commands.registerCommand(args.silentlyGenerateSvgCommandId, () =>
-      generateSvg({
-        editorStore: editorStore,
-        workspaceApi: workspaceApi,
-        vsCodeI18n: vsCodeI18n,
-        displayNotification: false,
-        editorEnvelopeLocator: args.editorEnvelopeLocator,
-      })
-    )
-  );
+  if (args.silentlyGenerateSvgCommandId !== undefined) {
+    args.context.subscriptions.push(
+      vscode.commands.registerCommand(args.silentlyGenerateSvgCommandId, () =>
+        generateSvg({
+          editorStore: editorStore,
+          workspaceApi: workspaceApi,
+          vsCodeI18n: vsCodeI18n,
+          displayNotification: false,
+          editorEnvelopeLocator: args.editorEnvelopeLocator,
+        })
+      )
+    );
+  }
 
   return editorStore;
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-7491

Currently `startExtension` requires SVG commands ID. These are useful in case the editor supports SVG creation. `yard` doesn't require it, so I put these as optional parameters.