### PR TITLE
KOGITO-7519: Bump `monaco-yaml` version to fix API incompatibility

### DIFF
--- a/packages/chrome-extension-serverless-workflow-editor/package.json
+++ b/packages/chrome-extension-serverless-workflow-editor/package.json
@@ -18,7 +18,7 @@
     "@kie-tools-core/webpack-base": "0.0.0",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1"
+    "monaco-yaml": "^4.0.0"
   },
   "scripts": {
     "lint": "pnpm run-script-if --bool \"$(build-env global.build.lint)\" --then \"pnpm eslint ./src --ext .ts,.tsx\"",

--- a/packages/chrome-extension-serverless-workflow-editor/webpack.config.js
+++ b/packages/chrome-extension-serverless-workflow-editor/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = async (env) => {
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/dashbuilder-editor/dev-webapp/webpack.config.js
+++ b/packages/dashbuilder-editor/dev-webapp/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = (env) =>
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/dashbuilder-editor/package.json
+++ b/packages/dashbuilder-editor/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.2",
     "@kie-tools/dashbuilder-client": "0.0.0",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1"
+    "monaco-yaml": "^4.0.0"
   },
   "scripts": {
     "lint": "pnpm run-script-if --bool \"$(build-env global.build.lint)\" --then \"pnpm eslint ./src --ext .ts,.tsx\"",

--- a/packages/serverless-workflow-editor/dev-webapp/webpack.config.js
+++ b/packages/serverless-workflow-editor/dev-webapp/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = (env) =>
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/serverless-workflow-editor/package.json
+++ b/packages/serverless-workflow-editor/package.json
@@ -43,7 +43,7 @@
     "csstype": "^3.0.11",
     "mermaid": "^9.0.0",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1",
+    "monaco-yaml": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "vscode-languageserver-types": "^3.16.0",

--- a/packages/vscode-extension-serverless-workflow-editor/package.json
+++ b/packages/vscode-extension-serverless-workflow-editor/package.json
@@ -37,7 +37,7 @@
     "@kie-tools/serverless-workflow-service-catalog": "0.0.0",
     "@rhoas/registry-instance-sdk": "^0.34.1",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1",
+    "monaco-yaml": "^4.0.0",
     "openapi-types": "^7.0.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",

--- a/packages/vscode-extension-serverless-workflow-editor/webpack.config.js
+++ b/packages/vscode-extension-serverless-workflow-editor/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = async (env) => [
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/vscode-extension-yard-editor/package.json
+++ b/packages/vscode-extension-yard-editor/package.json
@@ -33,7 +33,7 @@
     "@kie-tools-core/workspace": "0.0.0",
     "@kie-tools/yard-editor": "0.0.0",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1",
+    "monaco-yaml": "^4.0.0",
     "openapi-types": "^7.0.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",

--- a/packages/vscode-extension-yard-editor/webpack.config.js
+++ b/packages/vscode-extension-yard-editor/webpack.config.js
@@ -59,7 +59,7 @@ module.exports = async (env) => [
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/yard-editor/dev-webapp/webpack.config.js
+++ b/packages/yard-editor/dev-webapp/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = (env) =>
             entry: ["monaco-yaml", "vs/basic-languages/yaml/yaml.contribution"],
             worker: {
               id: "monaco-yaml/yamlWorker",
-              entry: "monaco-yaml/lib/esm/yaml.worker",
+              entry: "monaco-yaml/yaml.worker.js",
             },
           },
         ],

--- a/packages/yard-editor/package.json
+++ b/packages/yard-editor/package.json
@@ -37,7 +37,7 @@
     "@patternfly/react-icons": "^4.11.17",
     "csstype": "^3.0.11",
     "monaco-editor": "^0.33.0",
-    "monaco-yaml": "^3.2.1",
+    "monaco-yaml": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "json-schema": "^0.4.0"

--- a/packages/yard-editor/src/editor/YardEditor.tsx
+++ b/packages/yard-editor/src/editor/YardEditor.tsx
@@ -16,12 +16,21 @@
 import * as React from "react";
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
 import {
+  Button,
   Drawer,
   DrawerContent,
   DrawerContentBody,
   DrawerPanelBody,
   DrawerPanelContent,
-} from "@patternfly/react-core/dist/js/components/Drawer";
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Tab,
+  Tabs,
+  TabTitleText,
+  Title,
+} from "@patternfly/react-core";
+import { CubesIcon } from "@patternfly/react-icons";
 import { KogitoEdit } from "@kie-tools-core/workspace/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { YardTextEditorApi, YardTextEditorOperation } from "../textEditor/YardTextEditorController";
@@ -184,10 +193,49 @@ const RefForwardingYardEditor: React.ForwardRefRenderFunction<YardEditorRef | un
     [initialContent, props.channelType, onContentChanged, setValidationErrors, props.isReadOnly]
   );
 
+  const EmptyStep = ({
+    emptyStateBodyText,
+    emptyStateTitleText,
+  }: {
+    emptyStateBodyText: string;
+    emptyStateTitleText: string;
+  }) => {
+    return (
+      <EmptyState>
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title headingLevel={"h6"} size={"md"}>
+          {emptyStateTitleText}
+        </Title>
+        <EmptyStateBody>{emptyStateBodyText}</EmptyStateBody>
+      </EmptyState>
+    );
+  };
+
+  const onNewElementButtonClicked = useCallback(() => {
+    window.alert("Not yet implemented");
+  }, []);
+
   const yardUIContainer = (
-    <>
-      <p>Future UI here</p>
-    </>
+    <Tabs isBox={false} aria-label="Tabs in the default example">
+      <Tab eventKey={0} title={<TabTitleText>Decision Elements</TabTitleText>}>
+        <div style={{ padding: 10 }}>
+          <Button variant="primary" onClick={onNewElementButtonClicked}>
+            New Element
+          </Button>{" "}
+          <Button variant="danger" isDisabled={true}>
+            Delete Element
+          </Button>
+        </div>
+        <div style={{ padding: 10 }}>
+          <EmptyStep
+            emptyStateTitleText="No decision elements"
+            emptyStateBodyText="Your yard file doesn't have any Decision element. Please add a new element"
+          ></EmptyStep>
+        </div>
+      </Tab>
+      <Tab eventKey={1} title={<TabTitleText>Decision Inputs</TabTitleText>}></Tab>
+      <Tab eventKey={2} title={<TabTitleText>General</TabTitleText>}></Tab>
+    </Tabs>
   );
 
   return (
@@ -197,7 +245,7 @@ const RefForwardingYardEditor: React.ForwardRefRenderFunction<YardEditorRef | un
           <DrawerContent
             panelContent={
               <DrawerPanelContent isResizable={true} defaultSize={"50%"}>
-                <DrawerPanelBody>{yardUIContainer}</DrawerPanelBody>
+                <DrawerPanelBody style={{ padding: 5 }}>{yardUIContainer}</DrawerPanelBody>
               </DrawerPanelContent>
             }
           >

--- a/packages/yard-editor/src/editor/YardEditor.tsx
+++ b/packages/yard-editor/src/editor/YardEditor.tsx
@@ -16,21 +16,12 @@
 import * as React from "react";
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
 import {
-  Button,
   Drawer,
   DrawerContent,
   DrawerContentBody,
   DrawerPanelBody,
   DrawerPanelContent,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Tab,
-  Tabs,
-  TabTitleText,
-  Title,
-} from "@patternfly/react-core";
-import { CubesIcon } from "@patternfly/react-icons";
+} from "@patternfly/react-core/dist/js/components/Drawer";
 import { KogitoEdit } from "@kie-tools-core/workspace/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { YardTextEditorApi, YardTextEditorOperation } from "../textEditor/YardTextEditorController";
@@ -193,49 +184,10 @@ const RefForwardingYardEditor: React.ForwardRefRenderFunction<YardEditorRef | un
     [initialContent, props.channelType, onContentChanged, setValidationErrors, props.isReadOnly]
   );
 
-  const EmptyStep = ({
-    emptyStateBodyText,
-    emptyStateTitleText,
-  }: {
-    emptyStateBodyText: string;
-    emptyStateTitleText: string;
-  }) => {
-    return (
-      <EmptyState>
-        <EmptyStateIcon icon={CubesIcon} />
-        <Title headingLevel={"h6"} size={"md"}>
-          {emptyStateTitleText}
-        </Title>
-        <EmptyStateBody>{emptyStateBodyText}</EmptyStateBody>
-      </EmptyState>
-    );
-  };
-
-  const onNewElementButtonClicked = useCallback(() => {
-    window.alert("Not yet implemented");
-  }, []);
-
   const yardUIContainer = (
-    <Tabs isBox={false} aria-label="Tabs in the default example">
-      <Tab eventKey={0} title={<TabTitleText>Decision Elements</TabTitleText>}>
-        <div style={{ padding: 10 }}>
-          <Button variant="primary" onClick={onNewElementButtonClicked}>
-            New Element
-          </Button>{" "}
-          <Button variant="danger" isDisabled={true}>
-            Delete Element
-          </Button>
-        </div>
-        <div style={{ padding: 10 }}>
-          <EmptyStep
-            emptyStateTitleText="No decision elements"
-            emptyStateBodyText="Your yard file doesn't have any Decision element. Please add a new element"
-          ></EmptyStep>
-        </div>
-      </Tab>
-      <Tab eventKey={1} title={<TabTitleText>Decision Inputs</TabTitleText>}></Tab>
-      <Tab eventKey={2} title={<TabTitleText>General</TabTitleText>}></Tab>
-    </Tabs>
+    <>
+      <p>Future UI here</p>
+    </>
   );
 
   return (
@@ -245,7 +197,7 @@ const RefForwardingYardEditor: React.ForwardRefRenderFunction<YardEditorRef | un
           <DrawerContent
             panelContent={
               <DrawerPanelContent isResizable={true} defaultSize={"50%"}>
-                <DrawerPanelBody style={{ padding: 5 }}>{yardUIContainer}</DrawerPanelBody>
+                <DrawerPanelBody>{yardUIContainer}</DrawerPanelBody>
               </DrawerPanelContent>
             }
           >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22076,3 +22076,11 @@ packages:
       monaco-editor: ">=0.30.0"
     dependencies:
       monaco-editor: 0.33.0
+
+  /monaco-worker-manager/2.0.1_monaco-editor@0.33.0:
+    resolution:
+      { integrity: sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg== }
+    peerDependencies:
+      monaco-editor: ">=0.30.0"
+    dependencies:
+      monaco-editor: 0.33.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21911,10 +21911,6 @@ packages:
     resolution:
       { integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A== }
 
-  /yaml-language-server-parser/0.1.3:
-    resolution:
-      { integrity: sha512-xD2I+6M/vqQvcy4ded8JpXUaDHXmZMdhIO3OpuiFxstutwnW4whrfDzNcrsfXVdgMWqOUpdv3747Q081PFN1+g== }
-
   /yaml/1.10.2:
     resolution:
       { integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg== }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,7 +646,7 @@ importers:
       "@kie-tools/serverless-workflow-editor": 0.0.0
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
     devDependencies:
       "@kie-tools-core/chrome-extension": link:../chrome-extension
       "@kie-tools-core/editor": link:../editor
@@ -657,7 +657,7 @@ importers:
       "@kie-tools/serverless-workflow-editor": link:../serverless-workflow-editor
       monaco-editor: 0.33.0
       monaco-editor-webpack-plugin: 7.0.1_xaucyy2rqq33fyrllhuadbirwm
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
 
   packages/cors-proxy-image:
     specifiers:
@@ -926,7 +926,7 @@ importers:
       "@patternfly/react-icons": ^4.11.17
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
       react: ^17.0.2
       react-dom: ^17.0.2
       vscode-json-languageservice: ^4.2.1
@@ -941,7 +941,7 @@ importers:
       "@patternfly/react-core": 4.168.8_sfoxds7t5ydpegc3knd667wn6m
       "@patternfly/react-icons": 4.19.8_sfoxds7t5ydpegc3knd667wn6m
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -1805,7 +1805,7 @@ importers:
       mermaid: ^9.0.0
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
       react: ^17.0.2
       react-dom: ^17.0.2
       vscode-json-languageservice: ^4.2.1
@@ -1826,7 +1826,7 @@ importers:
       json-schema: 0.4.0
       mermaid: 9.0.0
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       vscode-languageserver-types: 3.16.0
@@ -2282,7 +2282,7 @@ importers:
       "@rhoas/registry-instance-sdk": ^0.34.1
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
       openapi-types: ^7.0.1
       vscode-languageserver-textdocument: ^1.0.4
       vscode-languageserver-types: ^3.16.0
@@ -2303,7 +2303,7 @@ importers:
       "@kie-tools/serverless-workflow-service-catalog": link:../serverless-workflow-service-catalog
       "@rhoas/registry-instance-sdk": 0.34.1
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
       openapi-types: 7.2.3
       vscode-languageserver-textdocument: 1.0.4
       vscode-languageserver-types: 3.16.0
@@ -2332,7 +2332,7 @@ importers:
       "@kie-tools/yard-editor": 0.0.0
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
       openapi-types: ^7.0.1
       vscode-languageserver-textdocument: ^1.0.4
       vscode-languageserver-types: ^3.16.0
@@ -2350,7 +2350,7 @@ importers:
       "@kie-tools-core/workspace": link:../workspace
       "@kie-tools/yard-editor": link:../yard-editor
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
       openapi-types: 7.2.3
       vscode-languageserver-textdocument: 1.0.4
       vscode-languageserver-types: 3.16.0
@@ -2420,7 +2420,7 @@ importers:
       json-schema: ^0.4.0
       monaco-editor: ^0.33.0
       monaco-editor-webpack-plugin: ^7.0.1
-      monaco-yaml: ^3.2.1
+      monaco-yaml: ^4.0.0
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
@@ -2436,7 +2436,7 @@ importers:
       csstype: 3.0.11
       json-schema: 0.4.0
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -15508,7 +15508,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       monaco-editor: 0.33.0
-      monaco-yaml: 3.2.1_monaco-editor@0.33.0
+      monaco-yaml: 4.0.0_monaco-editor@0.33.0
     dev: true
 
   /monaco-editor/0.23.0:
@@ -15536,20 +15536,23 @@ packages:
       - typescript
     dev: true
 
-  /monaco-yaml/3.2.1_monaco-editor@0.33.0:
+  /monaco-yaml/4.0.0_monaco-editor@0.33.0:
     resolution:
-      { integrity: sha512-2geAd5I7H1SMgwTHBuyPAPK9WTAzxbl9XwDl5h6NY6n9j4qnlLLQKK1i0P9cAmUiV2uaiViz69RLNWqVU5BVsg== }
+      { integrity: sha512-7/CbvZIHE1iOQF6ny+uPclcsrBnkK54lcZugIB9SzqADljhb3TliJyYs7vouaGNDF73RWvrtZrMsWCC5N/GW+g== }
     peerDependencies:
-      monaco-editor: ">=0.22"
+      monaco-editor: ">=0.30"
     dependencies:
       "@types/json-schema": 7.0.11
-      js-yaml: 4.1.0
+      jsonc-parser: 3.0.0
       monaco-editor: 0.33.0
+      monaco-marker-data-provider: 1.1.0_monaco-editor@0.33.0
+      monaco-worker-manager: 2.0.1_monaco-editor@0.33.0
       path-browserify: 1.0.1
-      prettier: 2.0.5
+      prettier: 2.3.0
       vscode-languageserver-textdocument: 1.0.4
       vscode-languageserver-types: 3.16.0
-      yaml-language-server-parser: 0.1.3
+      vscode-uri: 3.0.3
+      yaml: 2.0.1
 
   /mongo-object/0.1.4:
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22072,3 +22072,11 @@ packages:
     resolution:
       { integrity: sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ== }
     dev: true
+
+  /monaco-marker-data-provider/1.1.0_monaco-editor@0.33.0:
+    resolution:
+      { integrity: sha512-g5YH4FLItl3usf0Qxr1Td/vCd4XZmPOFh+dFpo8d+Q5mp8nJZTPFMVA7kwz0vWAy0zBd7bzQYUmfdvHfR1ETBw== }
+    peerDependencies:
+      monaco-editor: ">=0.30.0"
+    dependencies:
+      monaco-editor: 0.33.0


### PR DESCRIPTION
During `yard` development, I noticed this runtime error in the console:
![Screenshot from 2022-07-07 15-11-06](https://user-images.githubusercontent.com/16005046/177951667-f1f25f90-aece-4c42-8d46-2263c92c9cba.png)
I checked, and the current `monaco-yaml` `3.2.1` relies on an old  `monaco-editor` version with a different API.
Version `4.0.0` added compatibility with `monaco-editor` `0.33.0` and [fixes the above error](https://github.com/remcohaszing/monaco-yaml/commit/f3decc20dd9b7e8b59ac07bc731a026489eabfff#diff-ea95b2efb3fd38940772369b9ec8a70e76d7a0f40d570f1056a4a054eccfb951R72)

yaml worker location has changed, thus I updated the path in all the projects.
