### PR TITLE
KOGITO-7534: Cursor moves to start of name field

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoMultipleSelectionControl.java
@@ -110,7 +110,7 @@ public class LienzoMultipleSelectionControl<H extends AbstractCanvasHandler>
                 getSelectionControl().deselect(deselectList);
                 List<String> selectList = new ArrayList<>(shapesToIdentifiers(changedItems.getAddedShapes().toList()));
                 selectList.addAll(shapesToIdentifiers(changedItems.getAddedConnectors().toList()));
-                getSelectionControl().select(selectList);
+                getSelectionControl().select(selectList, true);
                 defaultSelectionListener.onChanged(selectedItems);
 
                 if (getSelectionControl().getSelectedItems().isEmpty()) {

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoSelectionControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/LienzoSelectionControl.java
@@ -96,7 +96,7 @@ public class LienzoSelectionControl<H extends AbstractCanvasHandler>
         if (!getSelectedItems().isEmpty()) {
             clearSelection();
         }
-        select(element.getUUID());
+        select(element.getUUID(), true);
     }
 
     @Override

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/SelectionControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/SelectionControl.java
@@ -30,7 +30,7 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 public interface SelectionControl<C extends CanvasHandler, E extends Element>
         extends CanvasControl<C> {
 
-    SelectionControl<C, E> select(String itemId);
+    SelectionControl<C, E> select(String itemId, boolean fireEvents);
 
     SelectionControl<C, E> deselect(String itemId);
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/AbstractSelectionControl.java
@@ -97,8 +97,8 @@ public abstract class AbstractSelectionControl<H extends AbstractCanvasHandler>
     }
 
     @Override
-    public SelectionControl<H, Element> select(final String uuid) {
-        selectionControl.select(uuid);
+    public SelectionControl<H, Element> select(final String uuid, boolean fireEvents) {
+        selectionControl.select(uuid, fireEvents);
         onSelect(Collections.singletonList(uuid));
         return this;
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControl.java
@@ -117,8 +117,8 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
     }
 
     @Override
-    public SelectionControl<H, Element> select(final String uuid) {
-        return select(Collections.singletonList(uuid));
+    public SelectionControl<H, Element> select(final String uuid, boolean fireEvents) {
+        return select(Collections.singletonList(uuid), fireEvents);
     }
 
     @Override
@@ -188,12 +188,14 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
         this.readonly = readonly;
     }
 
-    public SelectionControl<H, Element> select(final Collection<String> uuids) {
+    public SelectionControl<H, Element> select(final Collection<String> uuids, boolean fireEvents) {
         uuids.stream()
                 .filter(itemsRegistered())
                 .forEach(uuid -> items.put(uuid, true));
         updateViewShapesState(getSelectedItems());
-        fireSelectedItemsEvent();
+        if (fireEvents) {
+            fireSelectedItemsEvent();
+        }
         return this;
     }
 
@@ -269,8 +271,8 @@ public final class MapSelectionControl<H extends AbstractCanvasHandler>
                 .map(Map.Entry::getKey)
                 .anyMatch(uuid -> event.getIdentifiers().contains(uuid));
         if (isSameCtxt && !isCanvasRoot && !equals) {
-            this.clearSelection(false);
-            select(event.getIdentifiers());
+            this.clearSelection(true);
+            select(event.getIdentifiers(), true);
         }
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/select/MapSelectionControlTest.java
@@ -221,7 +221,7 @@ public class MapSelectionControlTest {
     public void testSelect() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         assertEquals(1, tested.getSelectedItems().size());
         assertEquals(ELEMENT_UUID, tested.getSelectedItems().iterator().next());
         verify(shape, times(1)).applyState(ShapeState.SELECTED);
@@ -242,8 +242,8 @@ public class MapSelectionControlTest {
     public void testSelectOnlyOnce() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
+        tested.select(element.getUUID(), true);
 
         assertEquals(1, tested.getSelectedItems().size());
         assertEquals(ELEMENT_UUID, tested.getSelectedItems().iterator().next());
@@ -267,7 +267,7 @@ public class MapSelectionControlTest {
         tested.init(canvasHandler);
         tested.register(element);
         tested.setReadonly(true);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         verify(shape, never()).applyState(ShapeState.SELECTED);
         verify(shape, never()).applyState(ShapeState.NONE);
         verify(shape, never()).applyState(ShapeState.INVALID);
@@ -279,7 +279,7 @@ public class MapSelectionControlTest {
     public void testDeselect() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         tested.deselect(element.getUUID());
         assertTrue(tested.getSelectedItems().isEmpty());
         verify(shape, times(1)).applyState(ShapeState.SELECTED);
@@ -292,7 +292,7 @@ public class MapSelectionControlTest {
     public void testClearSelection() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         tested.clearSelection();
         assertTrue(tested.getSelectedItems().isEmpty());
         verify(shape, times(1)).applyState(ShapeState.SELECTED);
@@ -328,7 +328,7 @@ public class MapSelectionControlTest {
     public void testGetSelectedItemDefinitionWithOneItemSelected() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
 
         when(index.get(ELEMENT_UUID)).thenReturn(element);
 
@@ -342,7 +342,7 @@ public class MapSelectionControlTest {
         tested.init(canvasHandler);
         tested.register(element);
         tested.register(rootElement);
-        tested.select(Stream.of(ROOT_UUID, ELEMENT_UUID).collect(Collectors.toSet()));
+        tested.select(Stream.of(ROOT_UUID, ELEMENT_UUID).collect(Collectors.toSet()), true);
 
         when(index.get(ELEMENT_UUID)).thenReturn(element);
         when(index.get(ROOT_UUID)).thenReturn(rootElement);
@@ -356,7 +356,7 @@ public class MapSelectionControlTest {
     public void testOnShapeRemovedEvent() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         CanvasShapeRemovedEvent shapeRemovedEvent = new CanvasShapeRemovedEvent(canvas,
                                                                                 shape);
         tested.onShapeRemoved(shapeRemovedEvent);
@@ -368,7 +368,7 @@ public class MapSelectionControlTest {
     public void testOnClearSelectionEvent() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         CanvasClearSelectionEvent event = new CanvasClearSelectionEvent(canvasHandler);
         tested.onCanvasClearSelection(event);
         assertTrue(tested.getSelectedItems().isEmpty());
@@ -406,7 +406,7 @@ public class MapSelectionControlTest {
     public void testClear() {
         tested.init(canvasHandler);
         tested.register(element);
-        tested.select(element.getUUID());
+        tested.select(element.getUUID(), true);
         tested.clear();
         assertTrue(tested.getSelectedItems().isEmpty());
         verify(clearSelectionEvent,

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
@@ -270,7 +270,7 @@ public class DiagramEditor {
         while (iterator.hasNext()) {
             final Node<View<?>, Edge> node = (Node<View<?>, Edge>) iterator.next();
             if (selection.contains(node.getUUID())) {
-                session.getSelectionControl().select(node.getUUID());
+                session.getSelectionControl().select(node.getUUID(), false);
             }
         }
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
@@ -347,7 +347,7 @@ public class DiagramEditorTest {
         verify(selectionControl, times(1)).clear();
         verify(commandManager, times(1)).execute(eq(canvasHandler2), any(ClearAllCommand.class));
         // Keep selection
-        verify(selectionControl, times(1)).select("uuid");
+        verify(selectionControl, times(1)).select("uuid", false);
         // Center selected node
         verify(jsCanvas, times(1)).centerNode("uuid");
     }


### PR DESCRIPTION
**JIRA:** [KOGITO-7534 - Cursor moves to start of name field](https://issues.redhat.com/browse/KOGITO-7534)

When updating the diagram, selection events are not fired. This prevents the error from happening.

**VS Code Extension:** [Serveless Workflow Editor](https://drive.google.com/file/d/1dx8tPmvJuqjpgWRmAEI604K9JA4ZuizL/view?usp=sharing)