### PR TITLE
Use our deployed cors-proxy as default value

### DIFF
--- a/packages/kie-sandbox-image/README.md
+++ b/packages/kie-sandbox-image/README.md
@@ -53,10 +53,10 @@ Runtime environment variables can be passed to the containerized KIE Sandbox.
 
 Currently, the following environment variables are supported:
 
-|                Name                 |                              Description                              | Default                         |
-| :---------------------------------: | :-------------------------------------------------------------------: | ------------------------------- |
-| `KIE_SANDBOX_EXTENDED_SERVICES_URL` |       The URL that points to the KIE Sandbox Extended Services        | http://localhost:21345          |
-|          `CORS_PROXY_URL`           | The URL that points to the cors-proxy for the interaction with GitHub | https://cors.isomorphic-git.org |
+|                Name                 |                              Description                              | Default                                                                                                               |
+| :---------------------------------: | :-------------------------------------------------------------------: | --------------------------------------------------------------------------------------------------------------------- |
+| `KIE_SANDBOX_EXTENDED_SERVICES_URL` |       The URL that points to the KIE Sandbox Extended Services        | http://localhost:21345                                                                                                |
+|          `CORS_PROXY_URL`           | The URL that points to the cors-proxy for the interaction with GitHub | https://cors-proxy-kie-sandbox.rhba-cluster-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud |
 
 There are three options to set custom values. Check out the examples below.
 

--- a/packages/online-editor/src/env/EnvContext.tsx
+++ b/packages/online-editor/src/env/EnvContext.tsx
@@ -23,7 +23,8 @@ export type EnvVars = Record<EnvVarNames, string>;
 
 export const DEFAULT_KIE_SANDBOX_EXTENDED_SERVICES_HOST = "http://localhost";
 export const DEFAULT_KIE_SANDBOX_EXTENDED_SERVICES_PORT = "21345";
-export const DEFAULT_CORS_PROXY_URL = "https://cors.isomorphic-git.org";
+export const DEFAULT_CORS_PROXY_URL =
+  "https://cors-proxy-kie-sandbox.rhba-cluster-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud";
 
 export const DEFAULT_ENV_VARS: EnvVars = {
   KIE_SANDBOX_EXTENDED_SERVICES_URL: `${DEFAULT_KIE_SANDBOX_EXTENDED_SERVICES_HOST}:${DEFAULT_KIE_SANDBOX_EXTENDED_SERVICES_PORT}`,


### PR DESCRIPTION
Replacing since https://cors.isomorphic-git.org does not work anymore.