### PR TITLE
Fix deploy without kogito.yml file

### DIFF
--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -110,9 +110,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		fmt.Println("✅ Knative Eventing bindings successfully created")
-	} else if err != nil {
-		fmt.Println("Check the full logs with the -v | --verbose option")
-		return err
 	}
 
 	finish := time.Since(start)


### PR DESCRIPTION
Remove the requirement of a kogito.yml file to deploy the service.