### PR TITLE
Fix deploy without kogito.yml file

### DIFF
--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -580,7 +580,7 @@ jobs:
         with:
           upload_url: ${{ inputs.upload_asset_url }}
           asset_path: ${{ github.workspace }}/kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-darwin-amd64
-          asset_name: STAGING__kie_sandbox_kn-workflow-darwin-amd64-${{ inputs.tag }}
+          asset_name: STAGING__kn-workflow-darwin-amd64-${{ inputs.tag }}
           asset_content_type: application/octet-stream
 
       - name: "STAGING: Knative CLI Workflow Plugin for Windows (Windows only)"
@@ -591,5 +591,5 @@ jobs:
         with:
           upload_url: ${{ inputs.upload_asset_url }}
           asset_path: "${{ github.workspace }}/kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-windows-amd64.exe"
-          asset_name: "STAGING__kie_sandbox_kn-workflow-windows-amd64-${{ inputs.tag }}.exe"
+          asset_name: "STAGING__kn-workflow-windows-amd64-${{ inputs.tag }}.exe"
           asset_content_type: application/octet-stream

--- a/packages/kn-plugin-workflow/pkg/command/build.go
+++ b/packages/kn-plugin-workflow/pkg/command/build.go
@@ -19,6 +19,7 @@ package command
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -176,7 +177,7 @@ func runBuildConfig(cmd *cobra.Command) (cfg BuildConfig, err error) {
 func runAddExtension(cfg BuildConfig) error {
 	var addExtension *exec.Cmd
 
-	osCommand := common.GetOsCommand("mvnw")
+	osCommand := getMavenCommand()
 	if cfg.Jib || cfg.JibPodman {
 		fmt.Printf(" - Adding Quarkus Jib extension\n")
 		addExtension = exec.Command(osCommand, "quarkus:add-extension",
@@ -204,7 +205,7 @@ func runBuildImage(cfg BuildConfig) error {
 	builderConfig := getBuilderConfig(cfg)
 	executableName := getExecutableNameConfig(cfg)
 
-	osCommand := common.GetOsCommand("mvnw")
+	osCommand := getMavenCommand()
 	build := exec.Command(osCommand, "package",
 		"-Dquarkus.kubernetes.deployment-target=knative",
 		fmt.Sprintf("-Dquarkus.knative.name=%s", name),
@@ -310,6 +311,13 @@ func getExecutableNameConfig(cfg BuildConfig) string {
 		executableName += "docker"
 	}
 	return executableName
+}
+
+func getMavenCommand() string {
+	if runtime.GOOS == "windows" {
+		return common.GetOsCommand("mvnw.cmd")
+	}
+	return common.GetOsCommand("mvnw")
 }
 
 func getAddExtensionFriendlyMessages() []string {

--- a/packages/kn-plugin-workflow/pkg/command/build.go
+++ b/packages/kn-plugin-workflow/pkg/command/build.go
@@ -175,16 +175,17 @@ func runBuildConfig(cmd *cobra.Command) (cfg BuildConfig, err error) {
 
 func runAddExtension(cfg BuildConfig) error {
 	var addExtension *exec.Cmd
+
+	osCommand := common.GetOsCommand("mvnw")
 	if cfg.Jib || cfg.JibPodman {
 		fmt.Printf(" - Adding Quarkus Jib extension\n")
-		addExtension = exec.Command("./mvnw", "quarkus:add-extension",
+		addExtension = exec.Command(osCommand, "quarkus:add-extension",
 			"-Dextensions=container-image-jib")
 	} else {
 		fmt.Printf(" - Adding Quarkus Docker extension\n")
-		addExtension = exec.Command("./mvnw", "quarkus:add-extension",
+		addExtension = exec.Command(osCommand, "quarkus:add-extension",
 			"-Dextensions=container-image-docker")
 	}
-
 	if err := common.RunCommand(
 		addExtension,
 		cfg.Verbose,
@@ -203,7 +204,8 @@ func runBuildImage(cfg BuildConfig) error {
 	builderConfig := getBuilderConfig(cfg)
 	executableName := getExecutableNameConfig(cfg)
 
-	build := exec.Command("./mvnw", "package",
+	osCommand := common.GetOsCommand("mvnw")
+	build := exec.Command(osCommand, "package",
 		"-Dquarkus.kubernetes.deployment-target=knative",
 		fmt.Sprintf("-Dquarkus.knative.name=%s", name),
 		"-Dquarkus.container-image.build=true",

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -110,9 +110,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		fmt.Println("✅ Knative Eventing bindings successfully created")
-	} else if err != nil {
-		fmt.Println("Check the full logs with the -v | --verbose option")
-		return err
 	}
 
 	finish := time.Since(start)

--- a/packages/kn-plugin-workflow/pkg/common/helper.go
+++ b/packages/kn-plugin-workflow/pkg/common/helper.go
@@ -28,14 +28,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func GetOsCommand(command string) string {
-	var osCommand = "./" + command
-	if runtime.GOOS == "windows" {
-		osCommand = ".\\" + command
-	}
-	return osCommand
-}
-
 func RunCommand(command *exec.Cmd, verbose bool, commandName string, friendlyMessages []string) error {
 	stdout, _ := command.StdoutPipe()
 	stderr, _ := command.StderrPipe()
@@ -108,4 +100,12 @@ func DefaultTemplatedHelp(cmd *cobra.Command, args []string) {
 	if err := tpl.Execute(cmd.OutOrStdout(), data); err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "unable to display help text: %v", err)
 	}
+}
+
+func GetOsCommand(command string) string {
+	var osCommand = "./" + command
+	if runtime.GOOS == "windows" {
+		osCommand = ".\\" + command
+	}
+	return osCommand
 }

--- a/packages/kn-plugin-workflow/pkg/common/helper.go
+++ b/packages/kn-plugin-workflow/pkg/common/helper.go
@@ -21,11 +21,20 @@ import (
 	"fmt"
 	"html/template"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 )
+
+func GetOsCommand(command string) string {
+	var osCommand = "./" + command
+	if runtime.GOOS == "windows" {
+		osCommand = ".\\" + command
+	}
+	return osCommand
+}
 
 func RunCommand(command *exec.Cmd, verbose bool, commandName string, friendlyMessages []string) error {
 	stdout, _ := command.StdoutPipe()


### PR DESCRIPTION
- Remove the requirement of a kogito.yml file to deploy the service.
- Fix the Windows file paths.
- Remove the "kie-sandbox" from the Staging Knative Workflow plugins artifacts.
