### PR TITLE
Configure concurrency for Staging Publish workflow

### DIFF
--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ["**-prerelease"]
 
+concurrency:
+  group: staging-publish
+  cancel-in-progress: true
+
 jobs:
   create_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Running jobs for `Staging :: Publish` will be canceled when a new one is started.
This is useful when we sequentially push fixes into pre-release branches.