### PR TITLE
KOGITO-7567 - SWF Editor is duplicating actions in worklow after getContent()

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Parser.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Parser.java
@@ -209,10 +209,10 @@ public class Parser {
         ActionNode action = null;
         if (null != jso.functionRef) {
             action = parse(CallFunctionAction.class, jso);
-            action.setName(jso.functionRef);
+            action.setFunctionRef(jso.functionRef);
         } else if (null != jso.subFlowRef) {
             action = parse(CallSubflowAction.class, jso);
-            action.setName(jso.subFlowRef);
+            action.setSubFlowRef(jso.subFlowRef);
         }
         return action;
     }


### PR DESCRIPTION
**JIRA:** [KOGITO-7567 - SWF Editor is duplicating actions in worklow after getContent()](https://issues.redhat.com/browse/KOGITO-7567)

The parser was setting the wrong fields. This fixes the problem.

**VS Code Extension:** [Serveless Workflow Editor](https://drive.google.com/file/d/10h4gXCfMY9l_-VbhGWJB4dNs4fP9idFU/view?usp=sharing)