### PR TITLE
KOGITO-7507: Improving `kogito-kie-editors` tests stability

### DIFF
--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -345,7 +345,7 @@ describe("Editors are loading properly", () => {
 
   it("Opens MultipleInstanceSubprocess.bpmn file in BPMN Editor and test Implementation/Execution value change", async function () {
     this.timeout(40000);
-    // Inicialization
+    // Initialization
     webview = await testHelper.openFileFromSidebar(MULTIPLE_INSTANCE_BPMN);
     await testHelper.switchWebviewToFrame(webview);
     const bpmnEditorTester = new BpmnEditorTestHelper(webview);
@@ -413,7 +413,7 @@ describe("Editors are loading properly", () => {
   });
 
   it("Opens UserTask.bpmn file in BPMN Editor and test On Entry and On Exit actions", async function () {
-    this.timeout(20000);
+    this.timeout(40000);
     webview = await testHelper.openFileFromSidebar(USER_TASK_BPMN);
     await testHelper.switchWebviewToFrame(webview);
     const bpmnEditorTester = new BpmnEditorTestHelper(webview);
@@ -502,7 +502,7 @@ describe("Editors are loading properly", () => {
     await webview.switchBack();
   });
 
-  it("Opens ProcessWithGenerics and diplays the generic types", async function () {
+  it("Opens ProcessWithGenerics and displays the generic types", async function () {
     this.timeout(40000);
     webview = await testHelper.openFileFromSidebar("ProcessWithGenerics.bpmn");
     await testHelper.switchWebviewToFrame(webview);

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -413,7 +413,7 @@ describe("Editors are loading properly", () => {
   });
 
   it("Opens UserTask.bpmn file in BPMN Editor and test On Entry and On Exit actions", async function () {
-    this.timeout(40000);
+    this.timeout(30000);
     webview = await testHelper.openFileFromSidebar(USER_TASK_BPMN);
     await testHelper.switchWebviewToFrame(webview);
     const bpmnEditorTester = new BpmnEditorTestHelper(webview);
@@ -422,7 +422,6 @@ describe("Editors are loading properly", () => {
     await explorerPanel.selectDiagramNode("User Task");
 
     let propertiesPanel = await bpmnEditorTester.openDiagramProperties();
-
     await propertiesPanel.expandPropertySection(PropertiesPanelSection.IMPLEMENTATION_EXECUTION);
 
     let onExitActionSection = await propertiesPanel.getProperty("On Exit Action", "div");
@@ -439,7 +438,7 @@ describe("Editors are loading properly", () => {
     await propertiesPanel.changeWidgetedProperty("On Exit Action", newOnExitLanguage, "select");
 
     await bpmnEditorTester.openDiagramExplorer();
-    await bpmnEditorTester.openDiagramProperties();
+    propertiesPanel = await bpmnEditorTester.openDiagramProperties();
     await propertiesPanel.expandPropertySection(PropertiesPanelSection.IMPLEMENTATION_EXECUTION);
 
     // Asserts

--- a/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/it-tests/extension-editors.test.ts
@@ -418,8 +418,8 @@ describe("Editors are loading properly", () => {
     await testHelper.switchWebviewToFrame(webview);
     const bpmnEditorTester = new BpmnEditorTestHelper(webview);
 
-    const explorerPanel = await bpmnEditorTester.openDiagramExplorer();
-    await explorerPanel.selectDiagramNode("User Task");
+    let diagramExplorer = await bpmnEditorTester.openDiagramExplorer();
+    await diagramExplorer.selectDiagramNode("User Task");
 
     let propertiesPanel = await bpmnEditorTester.openDiagramProperties();
     await propertiesPanel.expandPropertySection(PropertiesPanelSection.IMPLEMENTATION_EXECUTION);
@@ -437,7 +437,8 @@ describe("Editors are loading properly", () => {
     await propertiesPanel.changeWidgetedProperty("On Exit Action", newOnExitAction, "textarea");
     await propertiesPanel.changeWidgetedProperty("On Exit Action", newOnExitLanguage, "select");
 
-    await bpmnEditorTester.openDiagramExplorer();
+    diagramExplorer = await bpmnEditorTester.openDiagramExplorer();
+    await diagramExplorer.selectDiagramNode("User Task");
     propertiesPanel = await bpmnEditorTester.openDiagramProperties();
     await propertiesPanel.expandPropertySection(PropertiesPanelSection.IMPLEMENTATION_EXECUTION);
 


### PR DESCRIPTION
In some cases, the test `Opens UserTask.bpmn file in BPMN Editor and test On Entry and On Exit actions` throws this error:
`stale element reference: element is not attached to the page document`
The reason is: `propertiesPanel` requires to be re-instantiated when the test changes the editor status.

A hint to apply when a new `it-tests` is introduced, is to run it locally multiple times. This is because these kinds of failures are not-deterministic.