### PR TITLE
KOGITO-7587: [SWF Editor] Code lenses stop working on a specific scenario

### DIFF
--- a/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
@@ -129,23 +129,6 @@ export class SwfLanguageService {
 
     const nodeAtOffset = findNodeAtOffset(args.rootNode, cursorOffset);
 
-    console.log("7578 getCompletionItems", {
-      ce: completions.entries(),
-      nodeAtOffset,
-      cursorOffset,
-      strAtOffset: args.content.slice(cursorOffset, cursorOffset + 10),
-      result: Array.from(completions.entries()).filter(([path, _]) => {
-        path.toString() == "functions,*" &&
-          console.log("7578 filter", {
-            path: path.toString(),
-            nodeAtOffset,
-            rootNode: args.rootNode,
-            result: matchNodeWithLocation(args.rootNode, nodeAtOffset, path),
-          });
-        return matchNodeWithLocation(args.rootNode, nodeAtOffset, path);
-      }),
-    });
-
     const result = await Promise.all(
       Array.from(completions.entries())
         .filter(([path, _]) => matchNodeWithLocation(args.rootNode, nodeAtOffset, path))
@@ -684,13 +667,8 @@ export function matchNodeWithLocation(
   if (nodesAtLocation.some((currentNode) => currentNode === node)) {
     return true;
   }
-  if (path[path.length - 1] === "*") {
-    if (node.type == "array" && node.children) {
-      return matchNodeWithLocation(root, node, path.slice(0, -1));
-    }
-    // if (!nodesAtLocation.length) {
-    //   return matchNodeWithLocation(root, node, path.slice(0, -1));
-    // }
+  if (path[path.length - 1] === "*" && node.type == "array" && node.children) {
+    return matchNodeWithLocation(root, node, path.slice(0, -1));
   }
 
   return false;

--- a/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
@@ -129,6 +129,23 @@ export class SwfLanguageService {
 
     const nodeAtOffset = findNodeAtOffset(args.rootNode, cursorOffset);
 
+    console.log("7578 getCompletionItems", {
+      ce: completions.entries(),
+      nodeAtOffset,
+      cursorOffset,
+      strAtOffset: args.content.slice(cursorOffset, cursorOffset + 10),
+      result: Array.from(completions.entries()).filter(([path, _]) => {
+        path.toString() == "functions,*" &&
+          console.log("7578 filter", {
+            path: path.toString(),
+            nodeAtOffset,
+            rootNode: args.rootNode,
+            result: matchNodeWithLocation(args.rootNode, nodeAtOffset, path),
+          });
+        return matchNodeWithLocation(args.rootNode, nodeAtOffset, path);
+      }),
+    });
+
     const result = await Promise.all(
       Array.from(completions.entries())
         .filter(([path, _]) => matchNodeWithLocation(args.rootNode, nodeAtOffset, path))
@@ -666,8 +683,14 @@ export function matchNodeWithLocation(
 
   if (nodesAtLocation.some((currentNode) => currentNode === node)) {
     return true;
-  } else if (path[path.length - 1] === "*" && !nodesAtLocation.length) {
-    return matchNodeWithLocation(root, node, path.slice(0, -1));
+  }
+  if (path[path.length - 1] === "*") {
+    if (node.type == "array" && node.children) {
+      return matchNodeWithLocation(root, node, path.slice(0, -1));
+    }
+    // if (!nodesAtLocation.length) {
+    //   return matchNodeWithLocation(root, node, path.slice(0, -1));
+    // }
   }
 
   return false;

--- a/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
@@ -30,7 +30,6 @@ import {
 import { CodeLens, CompletionItem, CompletionItemKind, InsertTextFormat } from "vscode-languageserver-types";
 import { SwfLanguageServiceConfig } from "../src/channel";
 import { trim, treat } from "./testUtils";
-import * as jsonc from "jsonc-parser";
 
 const testRelativeFunction1: SwfServiceCatalogFunction = {
   name: "testRelativeFunction1",
@@ -516,66 +515,5 @@ describe("SWF LS JSON", () => {
       },
       insertTextFormat: InsertTextFormat.Snippet,
     } as CompletionItem);
-  });
-});
-
-describe("findNodeAtOffset", () => {
-  test("with newline after functions", () => {
-    const ls = new SwfJsonLanguageService({
-      fs: {},
-      serviceCatalog: defaultServiceCatalogConfig,
-      config: defaultConfig,
-    });
-    const content = `{
-  "functions": [
-    {
-      "name": "function1",
-      "operation": "openapi.yml#getGreeting"
-    },
-    {
-      "name": "function2",
-      "operation": "openapi.yml#getGreeting"
-    },
-    {
-      "name": "function3",
-      "operation": "openapi.yml#getGreeting"
-    }
-}`;
-    const cursorOffset = content.indexOf("[");
-    const root = ls.parseContent(content);
-    const node = jsonc.findNodeAtOffset(root!, cursorOffset);
-
-    expect(node).not.toBeUndefined();
-    expect(node?.type).toBe("array");
-    expect(node?.children?.length).toBe(3);
-  });
-
-  test("without newline after functions", () => {
-    const ls = new SwfJsonLanguageService({
-      fs: {},
-      serviceCatalog: defaultServiceCatalogConfig,
-      config: defaultConfig,
-    });
-    const content = `{
-  "functions": [{
-      "name": "function1",
-      "operation": "openapi.yml#getGreeting"
-    },
-    {
-      "name": "function2",
-      "operation": "openapi.yml#getGreeting"
-    },
-    {
-      "name": "function3",
-      "operation": "openapi.yml#getGreeting"
-    }
-}`;
-    const cursorOffset = content.indexOf("[");
-    const root = ls.parseContent(content);
-    const node = jsonc.findNodeAtOffset(root!, cursorOffset);
-
-    expect(node).not.toBeUndefined();
-    expect(node?.type).toBe("array");
-    expect(node?.children?.length).toBe(3);
   });
 });

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -27,7 +27,6 @@ import {
   SwfServiceCatalogServiceSourceType,
   SwfServiceCatalogServiceType,
 } from "@kie-tools/serverless-workflow-service-catalog/dist/api";
-import { TextDocument } from "vscode-languageserver-textdocument";
 import { CodeLens, CompletionItem, CompletionItemKind, InsertTextFormat } from "vscode-languageserver-types";
 import { SwfLanguageServiceConfig } from "../src/channel";
 import { trim, treat } from "./testUtils";
@@ -367,6 +366,27 @@ functions: [🎯]`);
       expect(matchNodeWithLocation(root!, node!, ["functions", "*"])).toBeTruthy();
       expect(matchNodeWithLocation(root!, node!, ["functions"])).toBeTruthy();
       expect(matchNodeWithLocation(root!, node!, ["functions", "none"])).toBeFalsy();
+    });
+
+    describe("matching functions array with 1 function", () => {
+      // NOTE: despite JSON in YAML there is no need to test the case without newline after "functions:"
+      test("with cursorOffset at the first function", () => {
+        const ls = new SwfYamlLanguageService({
+          fs: {},
+          serviceCatalog: defaultServiceCatalogConfig,
+          config: defaultConfig,
+        });
+        let { content, cursorOffset } = treat(`
+---
+functions:
+🎯- name: function1
+  operation: openapi.yml#getGreeting`);
+        const root = ls.parseContent(content);
+        const node = findNodeAtOffset(root!, cursorOffset);
+
+        expect(matchNodeWithLocation(root!, node!, ["functions", "*"])).toBeTruthy();
+        expect(matchNodeWithLocation(root!, node!, ["functions"])).toBeTruthy();
+      });
     });
 
     test("matching refName", () => {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/KOGITO-7587

Please note: in the recording, when there is a newline after `functions: [`, there is a completion with `{}`. That completion comes from VSCode, not from our extension. Is that an issue? 

![KOGITO-7578](https://user-images.githubusercontent.com/17780574/179752714-5ce594b4-e661-43b5-8509-33d84ac04585.gif)


**What caused the issue**
1st case
```
"functions": [
    {
      "name": "function1",
      "operation": "openapi.yml#getGreeting"
    },
    {
      "name": "function2",
      "operation": "openapi.yml#getGreeting"
    },
    {
      "name": "function3",
      "operation": "openapi.yml#getGreeting"
    }
  ],
````
2nd case:
```
"functions": [{
      "name": "function1",
      "operation": "openapi.yml#getGreeting"
    },
    {
      "name": "function2",
      "operation": "openapi.yml#getGreeting"
    },
    {
      "name": "function3",
      "operation": "openapi.yml#getGreeting"
    }
  ],
````

In the 1st case `getCompletion()` was receiving the offset, from VSCode, at the chat "\n" after "[" and pointing to the array.
Iin the 2nd case was receiving the offset at the char "{" of the first node and pointing to the first node.

**Adopted solution**
Now `matchNodeWithLocation()`, when compares the JSONPath "["functions", "*"] with an array of children, returns true