### PR TITLE
KOGITO-7577: SWF Editor - Parameter named 'uuid' should be not null

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/Workflow.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/definition/Workflow.java
@@ -60,6 +60,12 @@ public class Workflow {
     public String id;
 
     /**
+     *  Domain-specific workflow identifier
+     */
+    @Property
+    public String key;
+
+    /**
      * Workflow name.
      */
     @Property(meta = PropertyMetaTypes.NAME)
@@ -91,6 +97,15 @@ public class Workflow {
 
     public Workflow setId(String id) {
         this.id = id;
+        return this;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Workflow setKey(String key) {
+        this.key = key;
         return this;
     }
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Marshaller.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Marshaller.java
@@ -143,7 +143,8 @@ public class Marshaller {
         HashMap<String, String> previousNameToUUIDBindings = null;
         try {
             // TODO: Use dedicated factory instead.
-            graph = GraphImpl.build(workflow.id);
+            String workflowId = workflow.id != null ? workflow.id : workflow.key;
+            graph = GraphImpl.build(workflowId);
             final Index index = new MapIndexBuilder().build(graph);
 
             // Keep UUIDs when reloading

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/WorkflowMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/WorkflowMarshalling.java
@@ -23,6 +23,8 @@ import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
+import org.kie.workbench.common.stunner.core.util.UUID;
 import org.kie.workbench.common.stunner.sw.definition.End;
 import org.kie.workbench.common.stunner.sw.definition.Start;
 import org.kie.workbench.common.stunner.sw.definition.StartTransition;
@@ -84,7 +86,12 @@ public interface WorkflowMarshalling {
 
     NodeUnmarshaller<Workflow> WORKFLOW_UNMARSHALLER =
             (context, workflow) -> {
-                Node<View<Workflow>, Edge> workflowNode = context.addNodeByUUID(workflow.name, workflow);
+                String workflowId = workflow.id != null ? workflow.id : workflow.key;
+                if (StringUtils.isEmpty(workflowId)) {
+                    workflowId = UUID.uuid();
+                    workflow.id = workflowId;
+                }
+                Node<View<Workflow>, Edge> workflowNode = context.addNodeByUUID(workflowId, workflow);
                 workflowNode.getContent().setBounds(Bounds.create(0, 0, 950, 950));
 
                 // Set workflow node into the context state.

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/EmptyWorkflowNameTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/EmptyWorkflowNameTest.java
@@ -1,0 +1,38 @@
+package org.kie.workbench.common.stunner.sw.marshall;
+
+import org.junit.Test;
+import org.kie.workbench.common.stunner.sw.definition.OperationState;
+import org.kie.workbench.common.stunner.sw.definition.State;
+import org.kie.workbench.common.stunner.sw.definition.Workflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EmptyWorkflowNameTest extends BaseMarshallingTest {
+
+    @Override
+    protected Workflow createWorkflow() {
+        return new Workflow()
+                .setId("workflow1")
+                .setStart("State1")
+                .setStates(new State[]{
+                        new OperationState()
+                                .setName("State1")
+                                .setEnd(true)
+                });
+    }
+
+    @Test
+    public void testUnmarshallWorkflow() {
+        unmarshallWorkflow();
+        assertDefinitionReferencedInNode(workflow, "workflow1");
+        assertEquals(3, countChildren("workflow1"));
+        OperationState state = (OperationState) workflow.states[0];
+        assertDefinitionReferencedInNode(state, "State1");
+        assertParentOf("workflow1", "State1");
+        assertTrue(hasIncomingEdges("State1"));
+        assertTrue(hasOutgoingEdges("State1"));
+        assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));
+        assertTrue(hasOutgoingEdgeTo("State1", Marshaller.STATE_END));
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/FilledKeyNullIdWorkflowTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/FilledKeyNullIdWorkflowTest.java
@@ -1,0 +1,38 @@
+package org.kie.workbench.common.stunner.sw.marshall;
+
+import org.junit.Test;
+import org.kie.workbench.common.stunner.sw.definition.OperationState;
+import org.kie.workbench.common.stunner.sw.definition.State;
+import org.kie.workbench.common.stunner.sw.definition.Workflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FilledKeyNullIdWorkflowTest extends BaseMarshallingTest {
+
+    @Override
+    protected Workflow createWorkflow() {
+        return new Workflow()
+                .setKey("workflow1")
+                .setStart("State1")
+                .setStates(new State[]{
+                        new OperationState()
+                                .setName("State1")
+                                .setEnd(true)
+                });
+    }
+
+    @Test
+    public void testUnmarshallWorkflow() {
+        unmarshallWorkflow();
+        assertDefinitionReferencedInNode(workflow, "workflow1");
+        assertEquals(3, countChildren("workflow1"));
+        OperationState state = (OperationState) workflow.states[0];
+        assertDefinitionReferencedInNode(state, "State1");
+        assertParentOf("workflow1", "State1");
+        assertTrue(hasIncomingEdges("State1"));
+        assertTrue(hasOutgoingEdges("State1"));
+        assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));
+        assertTrue(hasOutgoingEdgeTo("State1", Marshaller.STATE_END));
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/NullKeyNullIdWorkflowTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/NullKeyNullIdWorkflowTest.java
@@ -1,0 +1,33 @@
+package org.kie.workbench.common.stunner.sw.marshall;
+
+import org.junit.Test;
+import org.kie.workbench.common.stunner.sw.definition.OperationState;
+import org.kie.workbench.common.stunner.sw.definition.State;
+import org.kie.workbench.common.stunner.sw.definition.Workflow;
+
+import static org.junit.Assert.assertTrue;
+
+public class NullKeyNullIdWorkflowTest extends BaseMarshallingTest {
+
+    @Override
+    protected Workflow createWorkflow() {
+        return new Workflow()
+                .setStart("State1")
+                .setStates(new State[]{
+                        new OperationState()
+                                .setName("State1")
+                                .setEnd(true)
+                });
+    }
+
+    @Test
+    public void testUnmarshallWorkflow() {
+        unmarshallWorkflow();
+        OperationState state = (OperationState) workflow.states[0];
+        assertDefinitionReferencedInNode(state, "State1");
+        assertTrue(hasIncomingEdges("State1"));
+        assertTrue(hasOutgoingEdges("State1"));
+        assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));
+        assertTrue(hasOutgoingEdgeTo("State1", Marshaller.STATE_END));
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/OperationStateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/OperationStateMarshallingTest.java
@@ -28,11 +28,13 @@ import static org.junit.Assert.assertTrue;
 
 public class OperationStateMarshallingTest extends BaseMarshallingTest {
 
+    private static final String WORKFLOW_ID = "workflow1";
+    private static final String WORKFLOW_NAME = "Workflow1";
     @Override
     protected Workflow createWorkflow() {
         return new Workflow()
-                .setId("workflow1")
-                .setName("Workflow1")
+                .setId(WORKFLOW_ID)
+                .setName(WORKFLOW_NAME)
                 .setStart("State1")
                 .setStates(new State[]{
                         new OperationState()
@@ -50,11 +52,11 @@ public class OperationStateMarshallingTest extends BaseMarshallingTest {
     @Test
     public void testUnmarshallWorkflow() {
         unmarshallWorkflow();
-        assertDefinitionReferencedInNode(workflow, "Workflow1");
-        assertEquals(4, countChildren("Workflow1"));
+        assertDefinitionReferencedInNode(workflow, WORKFLOW_ID);
+        assertEquals(4, countChildren(WORKFLOW_ID));
         OperationState state = (OperationState) workflow.states[0];
         assertDefinitionReferencedInNode(state, "State1");
-        assertParentOf("Workflow1", "State1");
+        assertParentOf(WORKFLOW_ID, "State1");
         assertTrue(hasIncomingEdges("State1"));
         assertTrue(hasOutgoingEdges("State1"));
         assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StateMarshallingTest.java
@@ -37,11 +37,14 @@ import static org.mockito.Mockito.when;
 
 public class StateMarshallingTest extends BaseMarshallingTest {
 
+    private static final String WORKFLOW_ID = "workflow1";
+    private static final String WORKFLOW_NAME = "Workflow1";
+
     @Override
     protected Workflow createWorkflow() {
         return new Workflow()
-                .setId("workflow1")
-                .setName("Workflow1")
+                .setId(WORKFLOW_ID)
+                .setName(WORKFLOW_NAME)
                 .setStates(new State[]{
                         new State()
                                 .setName("State1")
@@ -75,8 +78,8 @@ public class StateMarshallingTest extends BaseMarshallingTest {
         injectState.setUsedForCompensation(true);
 
         Workflow workflow = new Workflow()
-                .setId("workflow1")
-                .setName("Workflow1")
+                .setId(WORKFLOW_ID)
+                .setName(WORKFLOW_NAME)
                 .setStates(new State[]{
                         injectState
                 });
@@ -89,10 +92,10 @@ public class StateMarshallingTest extends BaseMarshallingTest {
     @Test
     public void testUnmarshallWorkflow() {
         unmarshallWorkflow();
-        assertDefinitionReferencedInNode(workflow, "Workflow1");
+        assertDefinitionReferencedInNode(workflow, WORKFLOW_ID);
         assertDefinitionReferencedInNode(workflow.states[0], "State1");
-        assertEquals(2, countChildren("Workflow1"));
-        assertParentOf("Workflow1", "State1");
+        assertEquals(2, countChildren(WORKFLOW_ID));
+        assertParentOf(WORKFLOW_ID, "State1");
         assertTrue(hasIncomingEdges("State1"));
         assertFalse(hasOutgoingEdges("State1"));
     }
@@ -101,7 +104,7 @@ public class StateMarshallingTest extends BaseMarshallingTest {
     public void testUnmarshallStartState() {
         workflow.setStart("State1");
         unmarshallWorkflow();
-        assertEquals(3, countChildren("Workflow1"));
+        assertEquals(3, countChildren(WORKFLOW_ID));
         assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));
     }
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StatesFlowMarshallingTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/marshall/StatesFlowMarshallingTest.java
@@ -25,11 +25,14 @@ import static org.junit.Assert.assertTrue;
 
 public class StatesFlowMarshallingTest extends BaseMarshallingTest {
 
+    private static final String WORKFLOW_ID = "workflow1";
+    private static final String WORKFLOW_NAME = "Workflow1";
+
     @Override
     protected Workflow createWorkflow() {
         return new Workflow()
-                .setId("workflow1")
-                .setName("Workflow1")
+                .setId(WORKFLOW_ID)
+                .setName(WORKFLOW_NAME)
                 .setStart("State1")
                 .setStates(new State[]{
                         new State()
@@ -47,20 +50,20 @@ public class StatesFlowMarshallingTest extends BaseMarshallingTest {
     @Test
     public void testUnmarshallWorkflow() {
         unmarshallWorkflow();
-        assertDefinitionReferencedInNode(workflow, "Workflow1");
-        assertEquals(5, countChildren("Workflow1"));
+        assertDefinitionReferencedInNode(workflow, WORKFLOW_ID);
+        assertEquals(5, countChildren(WORKFLOW_ID));
         assertDefinitionReferencedInNode(workflow.states[0], "State1");
-        assertParentOf("Workflow1", "State1");
+        assertParentOf(WORKFLOW_ID, "State1");
         assertTrue(hasIncomingEdges("State1"));
         assertTrue(hasIncomingEdgeFrom("State1", Marshaller.STATE_START));
         assertTrue(hasOutgoingEdges("State1"));
         assertDefinitionReferencedInNode(workflow.states[1], "State2");
-        assertParentOf("Workflow1", "State2");
+        assertParentOf(WORKFLOW_ID, "State2");
         assertTrue(hasIncomingEdges("State2"));
         assertTrue(hasIncomingEdgeFrom("State2", "State1"));
         assertTrue(hasOutgoingEdges("State2"));
         assertDefinitionReferencedInNode(workflow.states[2], "State3");
-        assertParentOf("Workflow1", "State3");
+        assertParentOf(WORKFLOW_ID, "State3");
         assertTrue(hasIncomingEdges("State3"));
         assertTrue(hasIncomingEdgeFrom("State3", "State2"));
         assertTrue(hasOutgoingEdges("State3"));


### PR DESCRIPTION
Hi @romartin, @ricardozanini,

The issue was that if Workflow missing name, diagram wasn't shown since Stunner uses Workflow name as a UUID for the root node.

The fix consist of two parts:
1. Workflow ID is used as UUID instead of Workflow Name
2. If Workflow ID is missing, than generate some random value to use it as UUID.

Please, tell me if it is OK to use Workflow ID as UUID and it will not break any backward compatibility (like automated tests or something else).

If you think it's better to keep Workflow Name as UUID of the root diagram node, I will revert this change and keep only second point (If Workflow Name is missing, generate some randome value to use it as UUID).

[VSIX for local tests](https://drive.google.com/file/d/1erUT_bBreE7Bi0Lr_Fb6H6GvTx0p8Tdz/view?usp=sharing)

Thank you!
