### PR TITLE
KOGITO-7623: Specs folder is not detected in Windows on SWF VSCode Extension

### DIFF
--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/configuration.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/configuration.ts
@@ -17,8 +17,10 @@
 import {
   configurationTokenKeys,
   getInterpolatedConfigurationValue,
+  definitelyPosixPath,
 } from "@kie-tools-core/vscode-extension/dist/ConfigurationInterpolation";
 import * as vscode from "vscode";
+import * as path from "path";
 import { SwfServiceRegistriesSettings } from "@kie-tools/serverless-workflow-service-catalog/dist/api";
 
 export const WEBVIEW_EDITOR_VIEW_TYPE = "kieKogitoWebviewEditorsServerlessWorkflow";
@@ -85,13 +87,13 @@ export class SwfVsCodeExtensionConfiguration {
 
     await vscode.workspace
       .getConfiguration()
-      .update(CONFIGURATION_SECTIONS.automaticallyOpenDiagramEditorAlongsideTextEditor, picked);
+      .update(CONFIGURATION_SECTIONS.automaticallyOpenDiagramEditorAlongsideTextEditor, picked, true);
   }
 
   public getConfiguredSpecsDirPath() {
     return vscode.workspace
       .getConfiguration()
-      .get(CONFIGURATION_SECTIONS.specsStoragePath, `${configurationTokenKeys["${fileDirname}"]}/specs`);
+      .get(CONFIGURATION_SECTIONS.specsStoragePath, path.join(configurationTokenKeys["${fileDirname}"], "/specs"));
   }
 
   public getConfiguredFlagShouldReferenceServiceRegistryFunctionsWithUrls() {
@@ -101,9 +103,13 @@ export class SwfVsCodeExtensionConfiguration {
   }
 
   public getInterpolatedSpecsDirAbsolutePosixPath(args: { baseFileAbsolutePosixPath: string }) {
+    console.log({
+      value: vscode.Uri.parse(this.getConfiguredSpecsDirPath()).path,
+      config: this.getConfiguredSpecsDirPath(),
+    });
     return getInterpolatedConfigurationValue({
       currentFileAbsolutePosixPath: args.baseFileAbsolutePosixPath,
-      value: this.getConfiguredSpecsDirPath(),
+      value: definitelyPosixPath(this.getConfiguredSpecsDirPath()),
     });
   }
 

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/configuration.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/configuration.ts
@@ -103,10 +103,6 @@ export class SwfVsCodeExtensionConfiguration {
   }
 
   public getInterpolatedSpecsDirAbsolutePosixPath(args: { baseFileAbsolutePosixPath: string }) {
-    console.log({
-      value: vscode.Uri.parse(this.getConfiguredSpecsDirPath()).path,
-      config: this.getConfiguredSpecsDirPath(),
-    });
     return getInterpolatedConfigurationValue({
       currentFileAbsolutePosixPath: args.baseFileAbsolutePosixPath,
       value: definitelyPosixPath(this.getConfiguredSpecsDirPath()),

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/languageService/VsCodeSwfLanguageService.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/languageService/VsCodeSwfLanguageService.ts
@@ -18,7 +18,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import * as vscode from "vscode";
 import { SwfVsCodeExtensionConfiguration } from "../configuration";
 import { SwfServiceCatalogStore } from "../serviceCatalog/SwfServiceCatalogStore";
-import { posix as posixPath } from "path";
+import * as path from "path";
 import {
   SwfJsonLanguageService,
   SwfLanguageServiceArgs,
@@ -27,6 +27,7 @@ import {
 import { FileLanguage } from "@kie-tools/serverless-workflow-language-service/dist/api";
 import { FsWatchingServiceCatalogRelativeStore } from "../serviceCatalog/fs";
 import { getServiceFileNameFromSwfServiceCatalogServiceId } from "../serviceCatalog/serviceRegistry";
+import { definitelyPosixPath } from "@kie-tools-core/vscode-extension/dist/ConfigurationInterpolation";
 
 export class VsCodeSwfLanguageService {
   private readonly jsonLs: SwfJsonLanguageService;
@@ -59,7 +60,7 @@ export class VsCodeSwfLanguageService {
         },
         relative: {
           getServices: async (textDocument) => {
-            const specsDirAbsolutePosixPath = this.getSpecsDirPosixPaths(textDocument).specsDirAbsolutePosixPath;
+            const { specsDirAbsolutePosixPath } = this.getSpecsDirPosixPaths(textDocument);
             let swfServiceCatalogRelativeStore = this.fsWatchingSwfServiceCatalogStore.get(specsDirAbsolutePosixPath);
             if (swfServiceCatalogRelativeStore) {
               return swfServiceCatalogRelativeStore.getServices();
@@ -107,13 +108,14 @@ export class VsCodeSwfLanguageService {
   private getSpecsDirPosixPaths(document: TextDocument) {
     const baseFileAbsolutePosixPath = vscode.Uri.parse(document.uri).path;
 
-    const specsDirAbsolutePosixPath = this.args.configuration.getInterpolatedSpecsDirAbsolutePosixPath({
-      baseFileAbsolutePosixPath,
-    });
+    const specsDirAbsolutePosixPath = definitelyPosixPath(
+      this.args.configuration.getInterpolatedSpecsDirAbsolutePosixPath({
+        baseFileAbsolutePosixPath,
+      })
+    );
 
-    const specsDirRelativePosixPath = posixPath.relative(
-      posixPath.dirname(baseFileAbsolutePosixPath),
-      specsDirAbsolutePosixPath
+    const specsDirRelativePosixPath = definitelyPosixPath(
+      path.relative(path.dirname(baseFileAbsolutePosixPath), specsDirAbsolutePosixPath)
     );
 
     return { specsDirRelativePosixPath, specsDirAbsolutePosixPath };

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/SwfServiceCatalogSupportActions.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/SwfServiceCatalogSupportActions.ts
@@ -52,7 +52,6 @@ export class SwfServiceCatalogSupportActions {
     });
 
     const serviceFileAbsolutePosixPath = posixPath.join(specsDirAbsolutePosixPath, serviceFileName);
-    console.log({ specsDirAbsolutePosixPath, serviceFileAbsolutePosixPath });
     vscode.workspace.fs.writeFile(
       vscode.Uri.parse(serviceFileAbsolutePosixPath),
       encoder.encode(args.containingService.rawContent)

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/SwfServiceCatalogSupportActions.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/SwfServiceCatalogSupportActions.ts
@@ -52,6 +52,7 @@ export class SwfServiceCatalogSupportActions {
     });
 
     const serviceFileAbsolutePosixPath = posixPath.join(specsDirAbsolutePosixPath, serviceFileName);
+    console.log({ specsDirAbsolutePosixPath, serviceFileAbsolutePosixPath });
     vscode.workspace.fs.writeFile(
       vscode.Uri.parse(serviceFileAbsolutePosixPath),
       encoder.encode(args.containingService.rawContent)

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/fs/FsWatchingServiceCatalogRelativeStore.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/serviceCatalog/fs/FsWatchingServiceCatalogRelativeStore.ts
@@ -61,7 +61,7 @@ export class FsWatchingServiceCatalogRelativeStore {
 
   private setupFsWatcher(args: { specsDirAbsolutePosixPath: string }): vscode.Disposable {
     const fsWatcher = vscode.workspace.createFileSystemWatcher(
-      `${vscode.Uri.parse(args.specsDirAbsolutePosixPath).path}/*.{json,yaml,yml}`,
+      new vscode.RelativePattern(vscode.Uri.parse(args.specsDirAbsolutePosixPath), "*.{json,yaml,yml}"),
       false,
       false,
       false

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/setupDiagramEditorControls.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/setupDiagramEditorControls.ts
@@ -78,8 +78,10 @@ export async function setupDiagramEditorControls(args: {
       }
 
       if (
-        args.configuration.shouldAutomaticallyOpenDiagramEditorAlongsideTextEditor() ===
-        ShouldOpenDiagramEditorAutomaticallyConfiguration.OPEN_AUTOMATICALLY
+        [
+          ShouldOpenDiagramEditorAutomaticallyConfiguration.OPEN_AUTOMATICALLY,
+          ShouldOpenDiagramEditorAutomaticallyConfiguration.ASK,
+        ].includes(args.configuration.shouldAutomaticallyOpenDiagramEditorAlongsideTextEditor())
       ) {
         args.kieToolsEditorStore.openEditors.forEach((kieToolsEditor) => {
           if (textEditor?.document.uri.toString() !== kieToolsEditor.document.document.uri.toString()) {
@@ -89,6 +91,10 @@ export async function setupDiagramEditorControls(args: {
       }
 
       if (!textEditor) {
+        return;
+      }
+
+      if (!isSwf(textEditor.document)) {
         return;
       }
 

--- a/packages/vscode-extension-yard-editor/.vscode/launch.json
+++ b/packages/vscode-extension-yard-editor/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    },
+    {
+      "name": "Run Extension (web)",
+      "type": "pwa-extensionHost",
+      "debugWebWorkerHost": true,
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionDevelopmentKind=web"],
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/packages/vscode-extension-yard-editor/.vscode/settings.json
+++ b/packages/vscode-extension-yard-editor/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "files.exclude": {
+    "out": false
+  },
+  "search.exclude": {
+    "out": true
+  },
+  "typescript.tsc.autoDetect": "off"
+}

--- a/packages/vscode-extension-yard-editor/.vscode/tasks.json
+++ b/packages/vscode-extension-yard-editor/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/packages/vscode-extension-yard-editor/src/extension/configuration.ts
+++ b/packages/vscode-extension-yard-editor/src/extension/configuration.ts
@@ -70,6 +70,6 @@ export class YardVsCodeExtensionConfiguration {
 
     await vscode.workspace
       .getConfiguration()
-      .update(CONFIGURATION_SECTIONS.automaticallyOpenDiagramEditorAlongsideTextEditor, picked);
+      .update(CONFIGURATION_SECTIONS.automaticallyOpenDiagramEditorAlongsideTextEditor, picked, true);
   }
 }

--- a/packages/vscode-extension-yard-editor/src/extension/setupDiagramEditorControls.ts
+++ b/packages/vscode-extension-yard-editor/src/extension/setupDiagramEditorControls.ts
@@ -74,8 +74,10 @@ export async function setupDiagramEditorControls(args: {
       }
 
       if (
-        args.configuration.shouldAutomaticallyOpenDiagramEditorAlongsideTextEditor() ===
-        ShouldOpenDiagramEditorAutomaticallyConfiguration.OPEN_AUTOMATICALLY
+        [
+          ShouldOpenDiagramEditorAutomaticallyConfiguration.OPEN_AUTOMATICALLY,
+          ShouldOpenDiagramEditorAutomaticallyConfiguration.ASK,
+        ].includes(args.configuration.shouldAutomaticallyOpenDiagramEditorAlongsideTextEditor())
       ) {
         args.kieToolsEditorStore.openEditors.forEach((kieToolsEditor) => {
           if (textEditor?.document.uri.toString() !== kieToolsEditor.document.document.uri.toString()) {
@@ -85,6 +87,10 @@ export async function setupDiagramEditorControls(args: {
       }
 
       if (!textEditor) {
+        return;
+      }
+
+      if (!isYard(textEditor.document)) {
         return;
       }
 

--- a/packages/vscode-extension/src/ConfigurationInterpolation.tsx
+++ b/packages/vscode-extension/src/ConfigurationInterpolation.tsx
@@ -35,6 +35,15 @@ export const configurationTokenKeys: Record<
   "${fileBasenameNoExtension}": "${fileBasenameNoExtension}",
 };
 
+export const definitelyPosixPath = (filePath: string) => {
+  let result = filePath;
+  // Prepend / to Windows drive letters, from C:\foo to /C:\foo, resulting in /C:/foo.
+  if (/^(\w:\\)/.test(filePath)) {
+    result = `/${filePath}`;
+  }
+  return result.split(path.sep).join(path.posix.sep);
+};
+
 export function doInterpolation(tokens: Record<string, string>, value: string) {
   return Object.entries(tokens).reduce(
     (result, [tokenName, tokenValue]) => result.replaceAll(tokenName, tokenValue),
@@ -43,10 +52,10 @@ export function doInterpolation(tokens: Record<string, string>, value: string) {
 }
 
 export function getInterpolatedConfigurationValue(args: { currentFileAbsolutePosixPath: string; value: string }) {
-  const parsedPath = path.parse(path.normalize(args.currentFileAbsolutePosixPath));
+  const parsedPath = path.posix.parse(args.currentFileAbsolutePosixPath);
   const workspace = vscode.workspace.workspaceFolders?.length
     ? vscode.workspace.workspaceFolders.find((workspace) => {
-        const relative = path.relative(workspace.uri.path, args.currentFileAbsolutePosixPath);
+        const relative = path.posix.relative(workspace.uri.path, args.currentFileAbsolutePosixPath);
         return relative && !relative.startsWith("..") && !path.isAbsolute(relative);
       })
     : undefined;

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -21,7 +21,11 @@ import { WorkspaceApi } from "@kie-tools-core/workspace/dist/api";
 import { VsCodeI18n } from "./i18n";
 import { I18n } from "@kie-tools-core/i18n/dist/core";
 import { EditorEnvelopeLocator } from "@kie-tools-core/editor/dist/api";
-import { configurationTokenKeys, getInterpolatedConfigurationValue } from "./ConfigurationInterpolation";
+import {
+  configurationTokenKeys,
+  definitelyPosixPath,
+  getInterpolatedConfigurationValue,
+} from "./ConfigurationInterpolation";
 
 const encoder = new TextEncoder();
 
@@ -68,15 +72,16 @@ export async function generateSvg(args: {
   }
 
   const svgFileName = getInterpolatedConfigurationValue({
-    currentFileAbsolutePosixPath: editor.document.document.uri.fsPath,
-    value: svgFilenameTemplate || `${configurationTokenKeys["${fileBasenameNoExtension}"]}-svg.svg`,
+    currentFileAbsolutePosixPath: editor.document.document.uri.path,
+    value:
+      definitelyPosixPath(svgFilenameTemplate) || `${configurationTokenKeys["${fileBasenameNoExtension}"]}-svg.svg`,
   });
   const svgFilePath = getInterpolatedConfigurationValue({
-    currentFileAbsolutePosixPath: editor.document.document.uri.fsPath,
-    value: svgFilePathTemplate || `${configurationTokenKeys["${fileDirname}"]}`,
+    currentFileAbsolutePosixPath: editor.document.document.uri.path,
+    value: definitelyPosixPath(svgFilePathTemplate) || `${configurationTokenKeys["${fileDirname}"]}`,
   });
 
-  const svgUri = editor.document.document.uri.with({ path: __path.resolve(svgFilePath, svgFileName) });
+  const svgUri = editor.document.document.uri.with({ path: __path.posix.resolve(svgFilePath, svgFileName) });
 
   await vscode.workspace.fs.writeFile(svgUri, encoder.encode(previewSvg));
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/KOGITO-7623
Fixes https://github.com/kiegroup/kie-tools/issues/1113
___

- Parse all files and directories paths as POSIX;
- Fix FsWatcher for specs files;
- Saves `kogito.yard.automaticallyOpenDiagramEditorAlongsideTextEditor` and `kogito.swf.automaticallyOpenDiagramEditorAlongsideTextEditor` settings to the user's `settings.json` file;
- Only show prompt for automatic opening diagram view for SWF or Yard files;