### PR TITLE
KOGITO-7530: SWF Viewer can't visualize the workflow when transition is broken

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/autolayout/AutoLayout.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/autolayout/AutoLayout.java
@@ -219,6 +219,10 @@ public class AutoLayout {
 
             @Override
             public void startEdgeTraversal(Edge<View<?>, Node> edge) {
+                if (edge.getSourceNode() == null || edge.getTargetNode() == null) {
+                    return;
+                }
+
                 final ELKEdge elkEdge = new ELKEdge(edge.getUUID(),
                                                     edge.getSourceNode().getUUID(),
                                                     edge.getTargetNode().getUUID());

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Context.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Context.java
@@ -16,7 +16,9 @@
 
 package org.kie.workbench.common.stunner.sw.marshall;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
@@ -33,6 +35,7 @@ public class Context {
     // TODO: Need to keep a ref to the whole graph?
     final Index<?, ?> graphIndex;
     private Node workflowRootNode;
+    private final List<Message> messages = new ArrayList<>();
 
     public Context(Index<?, ?> graphIndex) {
         this.graphIndex = graphIndex;
@@ -92,5 +95,17 @@ public class Context {
 
     static String generateUUID() {
         return UUID.uuid();
+    }
+
+    public Message[] getMessages() {
+        return messages.toArray(new Message[0]);
+    }
+
+    public void addMessage(Message message) {
+        messages.add(message);
+    }
+
+    public void clearMessages() {
+        messages.clear();
     }
 }

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Message.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/Message.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.sw.marshall;
+
+public class Message {
+
+    private final String messageCode;
+
+    private final String value;
+
+    public Message(String messageCode, String value) {
+        this.messageCode = messageCode;
+        this.value = value;
+    }
+
+    public String getMessageCode() {
+        return messageCode;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return messageCode.replaceAll("%s", value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Message)) {
+            return false;
+        }
+
+        Message message = (Message) o;
+
+        if (getMessageCode() != null ? !getMessageCode().equals(message.getMessageCode()) : message.getMessageCode() != null) {
+            return false;
+        }
+        return getValue() != null ? getValue().equals(message.getValue()) : message.getValue() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getMessageCode() != null ? getMessageCode().hashCode() : 0;
+        result = 31 * result + (getValue() != null ? getValue().hashCode() : 0);
+        return result;
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/MessageCode.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/MessageCode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.sw.marshall;
+
+// Message codes done in Interfaces instead of Enums for easier I18n later.
+public interface MessageCode {
+
+    String INVALID_TARGET_NAME = "Transition %s has invalid target.";
+
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/MessageCode.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/MessageCode.java
@@ -19,6 +19,6 @@ package org.kie.workbench.common.stunner.sw.marshall;
 // Message codes done in Interfaces instead of Enums for easier I18n later.
 public interface MessageCode {
 
-    String INVALID_TARGET_NAME = "Transition %s has invalid target.";
+    String INVALID_TARGET_NAME = "Transition from %s has invalid target.";
 
 }

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/ParseResult.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/ParseResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.sw.marshall;
+
+import org.kie.workbench.common.stunner.core.diagram.Diagram;
+
+public class ParseResult {
+
+    private final Diagram diagram;
+
+    private final Message[] messages;
+
+    public ParseResult(Diagram diagram, Message[] messages) {
+        this.diagram = diagram;
+        this.messages = messages;
+    }
+
+    public Diagram getDiagram() {
+        return diagram;
+    }
+
+    public Message[] getMessages() {
+        return messages;
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
@@ -65,7 +65,6 @@ public interface TransitionMarshalling {
                             if (sourceState.end instanceof Boolean) {
                                 sourceState.end = true;
                             } // else is Object
-
                         } else {
                             sourceState.transition = getStateNodeName(targetNode);
                             sourceState.end = false;
@@ -221,7 +220,6 @@ public interface TransitionMarshalling {
                 return edge;
             };
 
-
     EdgeMarshaller<EventConditionTransition> EVENT_CONDITION_TRANSITION_MARSHALLER =
             (context, edge) -> {
                 Node sourceNode = edge.getSourceNode();
@@ -269,5 +267,4 @@ public interface TransitionMarshalling {
                 // TODO: Update StartTransition.transition ?
                 return edge;
             };
-
 }

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/autolayout/AutoLayoutBrokenTransitionTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/autolayout/AutoLayoutBrokenTransitionTest.java
@@ -1,0 +1,119 @@
+package org.kie.workbench.common.stunner.sw.autolayout;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import elemental2.core.JsArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.TestingGraphMockHandler;
+import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.content.view.View;
+import org.kie.workbench.common.stunner.core.rule.RuleViolation;
+import org.kie.workbench.common.stunner.sw.autolayout.elkjs.ELKNode;
+import org.kie.workbench.common.stunner.sw.definition.State;
+import org.kie.workbench.common.stunner.sw.definition.Workflow;
+import org.kie.workbench.common.stunner.sw.marshall.BaseMarshallingTest;
+import org.kie.workbench.common.stunner.sw.marshall.BuilderContext;
+import org.kie.workbench.common.stunner.sw.marshall.Context;
+import org.kie.workbench.common.stunner.sw.marshall.Marshaller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class AutoLayoutBrokenTransitionTest extends BaseMarshallingTest {
+
+    @Override
+    protected Workflow createWorkflow() {
+        return new Workflow()
+                .setId("workflow1")
+                .setName("Workflow1")
+                .setStart("State1")
+                .setStates(new State[]{
+                        new State()
+                                .setName("State1")
+                                .setTransition("State 2"), // Broken Transition
+                        new State()
+                                .setName("State2")
+                                .setTransition("State3"),
+                        new State()
+                                .setName("State3")
+                                .setEnd(true)
+                });
+    }
+
+    @Before
+    @Override
+    public void setUp() {
+        graphHandler = new TestingGraphMockHandler();
+        context = new Context(graphHandler.graphIndex);
+        builderContext = new BuilderContext(context,
+                                            graphHandler.getDefinitionManager(),
+                                            graphHandler.getFactoryManager());
+        workflow = createWorkflow();
+        Marshaller.LOAD_DETAILS = true;
+
+        unmarshallWorkflow();
+    }
+
+    @Test
+    @SuppressWarnings("all")
+    public void testUpdateNodesPosition() {
+        final Graph<?, ?> graph = getGraph();
+        final Object parentLayout = mock(Object.class);
+        final Object nestedLayout = mock(Object.class);
+        final CompositeCommand.Builder layoutCommands = new CompositeCommand.Builder();
+        final ELKNode elkRootNode = AutoLayout.buildElkInputNode(graph,
+                                                                 context.getWorkflowRootNode(),
+                                                                 parentLayout,
+                                                                 nestedLayout,
+                                                                 false);
+
+        simulateProcessedELKEResult(elkRootNode);
+
+        AutoLayout.updateGraphNodeSizes(elkRootNode, graph);
+        AutoLayout.updateNodesPosition(elkRootNode, graph, layoutCommands);
+
+        final CompositeCommand<GraphCommandExecutionContext, RuleViolation> all =
+                new CompositeCommand.Builder<>()
+                        .addCommand(layoutCommands.build())
+                        .build();
+
+        all.execute(builderContext.buildExecutionContext());
+
+        for (int i = 0; i < elkRootNode.getChildren().length; i++) {
+            final ELKNode childElkNode = elkRootNode.getChildren().getAt(i);
+            final Node<View, Edge> node = graph.getNode(childElkNode.getId());
+            assertEquals(childElkNode.getX(), node.getContent().getBounds().getX(), 0);
+            assertEquals(childElkNode.getY(), node.getContent().getBounds().getY(), 0);
+        }
+    }
+
+    private static void simulateProcessedELKEResult(ELKNode elkRootNode) {
+        // Node size and location
+        for (int i = 0; i < elkRootNode.getChildren().length; i++) {
+            ELKNode childElkNode = elkRootNode.getChildren().getAt(i);
+
+            childElkNode.setWidth(childElkNode.getWidth() + 5d);
+            childElkNode.setHeight(childElkNode.getHeight() + 5d);
+            childElkNode.setX(300);
+            childElkNode.setY(i * 100);
+        }
+
+        // BendPoints
+        for (int i = 1; i <= elkRootNode.getEdges().length; i++) {
+            final Point2D p0 = new Point2D(310, i * 50);
+            final Point2D p1 = new Point2D(310, i * 55);
+            final Point2D p2 = new Point2D(310, i * 50);
+            final JsArray<Point2D> point2DJsArray = new JsArray<>();
+            point2DJsArray.push(p0, p1, p2);
+            elkRootNode.getEdges().getAt(i - 1).setBendPoints(point2DJsArray);
+        }
+    }
+
+}


### PR DESCRIPTION
It worked fine when transition where missing, but can't visualize if transition was incorrect.

Now it can load the process and shows incorrect transition pointing to the top-left corner of the diagram.

Jira issue for further UX improvements: [KOGITO-7634](https://issues.redhat.com/browse/KOGITO-7634)

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/1477262/180787196-d20071e9-2433-4ca5-9a13-8cb0d4349a9a.png">
