### PR TITLE
Save storage space on GitHub Actions workflows and other minor improvements

### DIFF
--- a/.github/actions/merge-pr-changes/action.yml
+++ b/.github/actions/merge-pr-changes/action.yml
@@ -29,7 +29,7 @@ runs:
 
           echo "Merge changes from $user/${{ github.head_ref }}"
           git remote add $user https://github.com/$user/kie-tools.git
-          git fetch $user
+          git fetch $user ${{ github.head_ref }} 
 
           echo "Before merging..."
           git log -n 1

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,10 +9,25 @@ inputs:
     description: "kie-tools path"
     required: false
     default: "."
+  sparse:
+    description: "If true, only installs dependencies for affected packages."
+    required: false
+    default: "false"
+  base_sha:
+    description: "If `sparse` is true, `base_sha` is used to determine the affected packages."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
+    - name: "Print storage usage (before setup)"
+      shell: bash
+      run: |
+        echo "STEP: Print storage usage (before setup)"
+        cd ${{ inputs.path }}
+        du -sh .
+
     - name: "Setup pnpm"
       uses: pnpm/action-setup@v2.0.1
       with:
@@ -33,13 +48,6 @@ runs:
       with:
         go-version: "1.16"
 
-    - name: "Fetch Git tags"
-      shell: bash
-      run: |
-        echo "STEP: Fetch Git tags"
-        cd ${{ inputs.path }}
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-
     - name: "Setup Yarn and Lerna"
       shell: bash
       run: |
@@ -57,12 +65,21 @@ runs:
         pnpm -r exec 'bash' '-c' 'echo -B -ntp > .mvn/maven.config'
         pnpm -r exec 'bash' '-c' 'echo -Xmx2g > .mvn/jvm.config'
 
-    - name: "Bootstrap"
+    - name: "Bootstrap (full)"
+      if: inputs.sparse == 'false'
       shell: bash
       run: |
-        echo "STEP: Bootstrap"
+        echo "STEP: Bootstrap (full)"
         cd ${{ inputs.path }}
-        pnpm bootstrap --frozen-lockfile
+        pnpm bootstrap
+
+    - name: "Bootstrap (sparse)"
+      if: inputs.sparse == 'true'
+      shell: bash
+      run: |
+        echo "STEP: Bootstrap (sparse)"
+        cd ${{ inputs.path }}
+        pnpm install-dependencies -F "...[${{ inputs.base_sha }}]..." -F . && pnpm link-packages-with-self && pnpm generate-packages-graph && pnpm check-cli-tools
 
     - name: "Check dependencies mismatches"
       shell: bash
@@ -117,3 +134,10 @@ runs:
           libappindicator3-dev \
           gir1.2-appindicator3-0.1
         fi
+
+    - name: "Print storage usage (after setup)"
+      shell: bash
+      run: |
+        echo "STEP: Print storage usage (after setup)"
+        cd ${{ inputs.path }}
+        du -sh .

--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -59,6 +59,8 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
+          sparse: true
+          base_sha: ${{ steps.merge_changes.outputs.base_sha }}
 
       - name: "Build dependencies"
         if: steps.check_diff_paths.outputs.should_run == 'true'
@@ -92,6 +94,11 @@ jobs:
         run: |
           git diff
           [ "0" == "$(git diff | wc -l | tr -d ' ')" ]
+
+      - name: "Print storage usage (after build)"
+        shell: bash
+        run: |
+          du -sh .
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -7,7 +7,7 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.event.pull_request && format('monorepo-pr-ci-full-{0}', github.event.pull_request.number) || 'monorepo-pr-ci-full-push-main' }}
+  group: ${{ github.event.pull_request && format('monorepo-pr-ci-full-{0}', github.event.pull_request.number) || format('monorepo-ci-full-push-main-{0}', github.sha) }}
   cancel-in-progress: true
 
 jobs:
@@ -86,6 +86,11 @@ jobs:
         run: |
           git diff
           [ "0" == "$(git diff | wc -l | tr -d ' ')" ]
+
+      - name: "Print storage usage (after build)"
+        shell: bash
+        run: |
+          du -sh .
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -22,7 +22,6 @@ jobs:
       - name: "Checkout kogito-apps"
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
           repository: kiegroup/kogito-apps
           ref: ${{ github.event.inputs.kogito_runtime_version }}
 
@@ -101,8 +100,6 @@ jobs:
     steps:
       - name: "Checkout kie-tools"
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: "Download Windows binary"
         uses: actions/download-artifact@v2

--- a/scripts/link_packages_with_self.js
+++ b/scripts/link_packages_with_self.js
@@ -20,8 +20,10 @@ const path = require("path");
 
 function main() {
   getPackagesSync().forEach((pkg) => {
-    const isScopedPackage = pkg.name.includes("@");
+    // always create node_modules. this fixes the case where we don't install dependencies for every package.
+    fs.mkdirSync(path.join(pkg.location, "node_modules"), { recursive: true });
 
+    const isScopedPackage = pkg.name.includes("@");
     if (isScopedPackage) {
       const [pkgScope, pkgSimpleName] = pkg.name.split("/");
       fs.mkdirSync(path.join(pkg.location, "node_modules", pkgScope), { recursive: true });
@@ -39,13 +41,13 @@ function main() {
 
 function selfLink(pkg, selfLinkPath) {
   const relTargetPath = path.relative(path.dirname(selfLinkPath), pkg.location);
+  console.info(
+    `[link-packages-with-self] Linking '${pkg.name}'. ${path.relative(pkg.location, selfLinkPath)} -> ${relTargetPath}`
+  );
   if (fs.existsSync(selfLinkPath)) {
     fs.unlinkSync(selfLinkPath);
   }
   fs.symlinkSync(relTargetPath, selfLinkPath);
-  console.info(
-    `[link-packages-with-self] Linking '${pkg.name}'. ${path.relative(pkg.location, selfLinkPath)} -> ${relTargetPath}`
-  );
 }
 
 main();


### PR DESCRIPTION
## On this PR:
- Not checking out all branches of the fork's PR, to save space and time.
- Only installing the necessary dependencies for `CI :: Monorepo`, to save space and time.
- The CI on the `main` branch now doesn't cancel when a new commit is done. Although this uses more resources, it's important for us to know which PR broke the build, if many are merged in a short period of time.
- Fixed `scripts/link_packages_with_self.js` to work even when their `node_modules` directory doesn't exist.
- Printing storage usage in key places for monitoring.


## Next steps:
- Stop checking out the complete history of the base branch of PRs.
- Remove dependencies from the root package.json. This will save space and time during sparse installs.
- Maybe have a daemon running that outputs information about the CPU and Memory usage during the build?