### PR TITLE
Ignoring non-source paths on CI

### DIFF
--- a/.github/supporting-files/ci/non-source-paths.txt
+++ b/.github/supporting-files/ci/non-source-paths.txt
@@ -1,0 +1,12 @@
+*.md
+*.icns
+*.ico
+*.gif
+*.jpg
+*.jpeg
+*.png
+*.svg
+docs
+gifs
+repo
+.github/CODEOWNERS

--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  monorepo-pr-ci:
+  ci:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -38,18 +38,28 @@ jobs:
         id: check_diff_paths
         shell: bash
         run: |
-          # If there are no changed files in dirs that are not `packages` or `examples`,
-          # it means that all changed files are in either `packages` or `examples`, so we should run the normal CI.
+          export NON_SOURCE_PATHS=$(cat ./.github/supporting-files/ci/non-source-paths.txt | xargs -n1 -I{} echo -n "'"':!'"{}""' ")
+          echo "Non-source paths:"
+          echo $NON_SOURCE_PATHS
 
-          read -r -a DIFF_PATHS <<< $(git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- ':!packages' ':!examples')
-          echo $DIFF_PATHS
+          # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
+          IFS=
+          export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
+          echo "Changed source paths:"
+          echo $CHANGED_SOURCE_PATHS
 
-          if [ ${#DIFF_PATHS[@]} -eq 0 ]; then
-            echo '`CI` will run.'
-            echo "::set-output name=should_run::true"
-          else
-            echo '`CI :: Full` is already running, no need to run this one.'
+          if [ ${#CHANGED_SOURCE_PATHS[@]} -eq 0 ]; then
+            echo 'No source files changed; `CI :: Monorepo` will not run.'
             echo "::set-output name=should_run::false"
+          else
+            export CHANGED_SRC_PATHS_IN_ROOT=$(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples" )
+            if [ ${#CHANGED_SRC_PATHS_IN_ROOT[@]} -eq 0 ]; then
+              echo 'No source files changed in root; `CI :: Monorepo` will run.'
+              echo "::set-output name=should_run::true"
+            else
+              echo 'Source files changed in root; `CI :: Monorepo` will not run.'
+              echo "::set-output name=should_run::false"
+            fi
           fi
 
           echo "Done"

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  monorepo-pr-ci-full:
+  ci-full:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -40,21 +40,28 @@ jobs:
         id: check_diff_paths
         shell: bash
         run: |
-          # If there are no changed files outside `packages` or `examples`,
-          # we don't need to run the full CI.
+          export NON_SOURCE_PATHS=$(cat ./.github/supporting-files/ci/non-source-paths.txt | xargs -n1 -I{} echo -n "'"':!'"{}""' ")
+          echo "Non-source paths:"
+          echo $NON_SOURCE_PATHS
 
-          read -r -a DIFF_PATHS <<< $(git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- ':!packages' ':!examples')
-          echo $DIFF_PATHS
+          # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
+          IFS=
+          export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
+          echo "Changed source paths:"
+          echo $CHANGED_SOURCE_PATHS
 
-          if [ ! ${{ github.event.pull_request }} ]; then
-            echo 'Push to the main branch happened, should run'
-            echo "::set-output name=should_run::true"
-          elif [ ${#DIFF_PATHS[@]} -eq 0 ]; then
-            echo '`CI` is already running, no need to run this one.'
+          if [ ${#CHANGED_SOURCE_PATHS[@]} -eq 0 ]; then
+            echo 'No source files changed; `CI :: Monorepo (full)` will not run.'
             echo "::set-output name=should_run::false"
           else
-            echo '`CI :: Full` will run.'
-            echo "::set-output name=should_run::true"
+            export CHANGED_SRC_PATHS_IN_ROOT=$(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples" )
+            if [ ${#CHANGED_SRC_PATHS_IN_ROOT[@]} -eq 0 ]; then
+              echo 'No source files changed in root; `CI :: Monorepo (full)` will not run.'
+              echo "::set-output name=should_run::false"
+            else
+              echo 'Source files changed in root; `CI :: Monorepo (full)` will run.'
+              echo "::set-output name=should_run::true"
+            fi
           fi
 
           echo "Done"


### PR DESCRIPTION
This PR creates a mechanism to exclude non-source files and paths from the changes detection on our CI workflows.

The goal here is to encourage people to edit `README.md` files, update icons, images, and other non-source-related things that improve our code. People doing these kind of contributions should not be penalized with a useless build that takes hours to complete.

Here's is how it works:

- If only non-source files change on a PR, neither CIs will run, and we'll save a lot of time and resources.

- If source files change exclusively inside `packages` or `examples`, `CI :: Monorepo` will run, which will build only the affected packages.

- If at least one source file change at the root of the monorepo, only `CI :: Monorepo (full)` will run.