### PR TITLE
Fix changes detection on CI

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -43,17 +43,23 @@ jobs:
           echo $NON_SOURCE_PATHS
 
           # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
+          IFS_BKP=$IFS
           IFS=
           export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
           echo "Changed source paths:"
           echo $CHANGED_SOURCE_PATHS
+          IFS=$IFS_BKP
+
+          export CHANGED_SOURCE_PATHS_IN_ROOT=($(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples"))
+          echo "Changed source paths in root:"
+          echo ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]}
+          printf '%s\n' "${CHANGED_SOURCE_PATHS_IN_ROOT[@]}"
 
           if [ ${#CHANGED_SOURCE_PATHS[@]} -eq 0 ]; then
             echo 'No source files changed; `CI :: Monorepo` will not run.'
             echo "::set-output name=should_run::false"
           else
-            export CHANGED_SRC_PATHS_IN_ROOT=$(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples" )
-            if [ ${#CHANGED_SRC_PATHS_IN_ROOT[@]} -eq 0 ]; then
+            if [ ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]} -eq 0 ]; then
               echo 'No source files changed in root; `CI :: Monorepo` will run.'
               echo "::set-output name=should_run::true"
             else

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -45,17 +45,23 @@ jobs:
           echo $NON_SOURCE_PATHS
 
           # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
+          IFS_BKP=$IFS
           IFS=
           export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
           echo "Changed source paths:"
           echo $CHANGED_SOURCE_PATHS
+          IFS=$IFS_BKP
+
+          export CHANGED_SOURCE_PATHS_IN_ROOT=($(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples"))
+          echo "Changed source paths in root:"
+          echo ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]}
+          printf '%s\n' "${CHANGED_SOURCE_PATHS_IN_ROOT[@]}"
 
           if [ ${#CHANGED_SOURCE_PATHS[@]} -eq 0 ]; then
             echo 'No source files changed; `CI :: Monorepo (full)` will not run.'
             echo "::set-output name=should_run::false"
           else
-            export CHANGED_SRC_PATHS_IN_ROOT=$(echo $CHANGED_SOURCE_PATHS | grep -v -e "^packages" -e "^examples" )
-            if [ ${#CHANGED_SRC_PATHS_IN_ROOT[@]} -eq 0 ]; then
+            if [ ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]} -eq 0 ]; then
               echo 'No source files changed in root; `CI :: Monorepo (full)` will not run.'
               echo "::set-output name=should_run::false"
             else


### PR DESCRIPTION
The changed source paths in root always had a length >=1, as it was not being treated as an array. This PR fixes it and prints the length of the array.