### PR TITLE
KOGITO-7666: kn workflow ignores the flag "--image" when building and append quay.io in the generated knative.yml file

### DIFF
--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -21,7 +21,7 @@
     "build:darwin:arm": "make build-darwin-arm64",
     "build:win32": "make build-win32",
     "build:dev": "rimraf dist && pnpm build",
-    "build:prod": "rimraf dist && pnpm test && pnpm build:all",
+    "build:prod": "rimraf dist && pnpm build:all && pnpm test",
     "test": "go test ./..."
   },
   "devDependencies": {

--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -21,7 +21,7 @@
     "build:darwin:arm": "make build-darwin-arm64",
     "build:win32": "make build-win32",
     "build:dev": "rimraf dist && pnpm build",
-    "build:prod": "rimraf dist && pnpm build:all",
+    "build:prod": "rimraf dist && pnpm test && pnpm build:all",
     "test": "go test ./..."
   },
   "devDependencies": {

--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -21,7 +21,8 @@
     "build:darwin:arm": "make build-darwin-arm64",
     "build:win32": "make build-win32",
     "build:dev": "rimraf dist && pnpm build",
-    "build:prod": "rimraf dist && pnpm build:all"
+    "build:prod": "rimraf dist && pnpm build:all",
+    "test": "go test ./..."
   },
   "devDependencies": {
     "@kie-tools/build-env": "0.0.0"

--- a/packages/kn-plugin-workflow/pkg/command/build.go
+++ b/packages/kn-plugin-workflow/pkg/command/build.go
@@ -263,12 +263,12 @@ func runBuildImage(cfg BuildCmdConfig) (out string, err error) {
 		return
 	}
 
-	if cfg.Push {
-		fmt.Printf("Created and pushed an image to registry: %s\n", getImage(registry, repository, name, tag))
-	} else {
-		fmt.Printf("Created a local image: %s\n", getImage(registry, repository, name, tag))
-	}
 	out = getImage(registry, repository, name, tag)
+	if cfg.Push {
+		fmt.Printf("Created and pushed an image to registry: %s\n", out)
+	} else {
+		fmt.Printf("Created a local image: %s\n", out)
+	}
 
 	fmt.Println("✅ Build success")
 	return
@@ -293,18 +293,16 @@ func getImageConfig(cfg BuildCmdConfig) (string, string, string, string) {
 	imageTagArray := strings.Split(cfg.Image, ":")
 	imageArray := strings.SplitN(imageTagArray[0], "/", 3)
 
-	var registry = common.DEFAULT_REGISTRY
+	var registry = ""
 	if len(cfg.Registry) > 0 {
 		registry = cfg.Registry
-	} else if len(imageArray) > 2 {
+	} else if len(imageArray) > 1 {
 		registry = imageArray[0]
 	}
 
 	var repository = ""
 	if len(cfg.Repository) > 0 {
 		repository = cfg.Repository
-	} else if len(imageArray) == 2 {
-		repository = imageArray[0]
 	} else if len(imageArray) == 3 {
 		repository = imageArray[1]
 	}
@@ -331,7 +329,9 @@ func getImageConfig(cfg BuildCmdConfig) (string, string, string, string) {
 }
 
 func getImage(registry string, repository string, name string, tag string) string {
-	if len(repository) == 0 {
+	if len(registry) == 0 && len(repository) == 0 {
+		return fmt.Sprintf("%s:%s", name, tag)
+	} else if len(registry) == 0 || len(repository) == 0 {
 		return fmt.Sprintf("%s/%s:%s", registry, name, tag)
 	}
 	return fmt.Sprintf("%s/%s/%s:%s", registry, repository, name, tag)

--- a/packages/kn-plugin-workflow/pkg/command/build.go
+++ b/packages/kn-plugin-workflow/pkg/command/build.go
@@ -275,7 +275,7 @@ func runBuildImage(cfg BuildCmdConfig) (out string, err error) {
 }
 
 func checkImageName(name string) (err error) {
-	matched, err := regexp.MatchString("[a-z]([-a-z0-9]*[a-z0-9])?", name)
+	matched, err := regexp.MatchString("^[a-z]([-a-z0-9]*[a-z0-9])?$", name)
 	if !matched {
 		fmt.Println(`
 ERROR: Image name should match [a-z]([-a-z0-9]*[a-z0-9])?
@@ -331,7 +331,9 @@ func getImageConfig(cfg BuildCmdConfig) (string, string, string, string) {
 func getImage(registry string, repository string, name string, tag string) string {
 	if len(registry) == 0 && len(repository) == 0 {
 		return fmt.Sprintf("%s:%s", name, tag)
-	} else if len(registry) == 0 || len(repository) == 0 {
+	} else if len(registry) == 0 {
+		return fmt.Sprintf("%s/%s:%s", repository, name, tag)
+	} else if len(repository) == 0 {
 		return fmt.Sprintf("%s/%s:%s", registry, name, tag)
 	}
 	return fmt.Sprintf("%s/%s/%s:%s", registry, repository, name, tag)

--- a/packages/kn-plugin-workflow/pkg/command/build_test.go
+++ b/packages/kn-plugin-workflow/pkg/command/build_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/common"
+)
+
+var imageName = []string{
+	"quay.io/test:latest",
+	"docker.io/test:latest",
+	"docker.io/repo/test:latest",
+	"quay.io/repo/test:0.0.0",
+}
+
+var cfg = []BuildCmdConfig{
+	{Image: "test"},
+	{Image: "docker.io/test:latest"},
+	{Image: "docker.io/repo/test:latest"},
+	{Image: "quay.io/repo/test:0.0.0"},
+}
+
+func fakeExecCommand(helperIndex string) func(command string, args ...string) *exec.Cmd {
+	return func(command string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", command}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{fmt.Sprintf("GO_WANT_HELPER_PROCESS=%s", helperIndex)}
+		return cmd
+	}
+
+}
+
+func TestRunBuildImage(t *testing.T) {
+	common.ExecCommand = fakeExecCommand("0")
+	defer func() { common.ExecCommand = exec.Command }()
+
+	out, err := runBuildImage(cfg[0])
+	if err != nil {
+		t.Errorf("Expected nil error, got %#v", err)
+	}
+
+	if string(out) != imageName[0] {
+		t.Errorf("Expected %q, got %q", imageName[0], out)
+	}
+}
+
+func TestRunBuildImage1(t *testing.T) {
+	common.ExecCommand = fakeExecCommand("1")
+	defer func() { common.ExecCommand = exec.Command }()
+
+	out, err := runBuildImage(cfg[1])
+	if err != nil {
+		t.Errorf("Expected nil error, got %#v", err)
+	}
+
+	if string(out) != imageName[1] {
+		t.Errorf("Expected %q, got %q", imageName[1], out)
+	}
+}
+
+func TestRunBuildImage2(t *testing.T) {
+	common.ExecCommand = fakeExecCommand("2")
+	defer func() { common.ExecCommand = exec.Command }()
+
+	out, err := runBuildImage(cfg[2])
+	if err != nil {
+		t.Errorf("Expected nil error, got %#v", err)
+	}
+
+	if string(out) != imageName[2] {
+		t.Errorf("Expected %q, got %q", imageName[2], out)
+	}
+}
+
+func TestRunBuildImage3(t *testing.T) {
+	common.ExecCommand = fakeExecCommand("3")
+	defer func() { common.ExecCommand = exec.Command }()
+
+	out, err := runBuildImage(cfg[3])
+	if err != nil {
+		t.Errorf("Expected nil error, got %#v", err)
+	}
+
+	if string(out) != imageName[3] {
+		t.Errorf("Expected %q, got %q", imageName[3], out)
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "0" {
+		fmt.Fprintf(os.Stdout, imageName[0])
+		os.Exit(0)
+	} else if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		fmt.Fprintf(os.Stdout, imageName[1])
+		os.Exit(0)
+	} else if os.Getenv("GO_WANT_HELPER_PROCESS") == "2" {
+		fmt.Fprintf(os.Stdout, imageName[2])
+		os.Exit(0)
+	} else if os.Getenv("GO_WANT_HELPER_PROCESS") == "3" {
+		fmt.Fprintf(os.Stdout, imageName[3])
+		os.Exit(0)
+	} else {
+		return
+	}
+
+}

--- a/packages/kn-plugin-workflow/pkg/command/build_test.go
+++ b/packages/kn-plugin-workflow/pkg/command/build_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var imageName = []string{
-	"quay.io/test:latest",
+	"test:latest",
 	"docker.io/test:latest",
 	"docker.io/repo/test:latest",
 	"quay.io/repo/test:0.0.0",

--- a/packages/kn-plugin-workflow/pkg/command/config.go
+++ b/packages/kn-plugin-workflow/pkg/command/config.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/common"
 	"github.com/ory/viper"
@@ -95,7 +94,7 @@ func runConfig(cmd *cobra.Command, args []string, dependenciesVersion common.Dep
 		return err
 	}
 
-	updateProjectVersion := exec.Command("mvn",
+	updateProjectVersion := common.ExecCommand("mvn",
 		"versions:set-property",
 		"-Dproperty=quarkus.platform.version",
 		fmt.Sprintf("-DnewVersion=%s", quarkusVersion))

--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/common"
@@ -96,7 +95,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	create := exec.Command(
+	create := common.ExecCommand(
 		"mvn",
 		fmt.Sprintf("io.quarkus.platform:quarkus-maven-plugin:%s:create", cfg.QuarkusVersion),
 		"-DprojectGroupId=org.acme",

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -85,7 +85,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	createService := exec.Command("kubectl", "apply", "-f", fmt.Sprintf("%s/knative.yml", cfg.Path))
+	createService := common.ExecCommand("kubectl", "apply", "-f", fmt.Sprintf("%s/knative.yml", cfg.Path))
 	if err := common.RunCommand(
 		createService,
 		cfg.Verbose,
@@ -99,7 +99,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	// Check if kogito.yml file exists
 	if exists, err := checkIfKogitoFileExists(cfg); exists && err == nil {
-		deploy := exec.Command("kubectl", "apply", "-f", fmt.Sprintf("%s/kogito.yml", cfg.Path))
+		deploy := common.ExecCommand("kubectl", "apply", "-f", fmt.Sprintf("%s/kogito.yml", cfg.Path))
 		if err := common.RunCommand(
 			deploy,
 			cfg.Verbose,

--- a/packages/kn-plugin-workflow/pkg/common/checks.go
+++ b/packages/kn-plugin-workflow/pkg/common/checks.go
@@ -19,7 +19,6 @@ package common
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -36,7 +35,7 @@ func CheckJavaDependencies() error {
 }
 
 func checkJava() error {
-	javaCheck := exec.Command("java", "-version")
+	javaCheck := ExecCommand("java", "-version")
 	version, err := javaCheck.CombinedOutput()
 	if err != nil {
 		fmt.Println("ERROR: Java not found")
@@ -59,7 +58,7 @@ func checkJava() error {
 }
 
 func checkMaven() error {
-	mavenCheck := exec.Command("mvn", "--version")
+	mavenCheck := ExecCommand("mvn", "--version")
 	version, err := mavenCheck.CombinedOutput()
 	if err != nil {
 		fmt.Println("ERROR: Maven not found")
@@ -84,7 +83,7 @@ func checkMaven() error {
 
 func CheckDocker() error {
 	fmt.Println("✅ Checking if Docker is available...")
-	dockerCheck := exec.Command("docker", "stats", "--no-stream")
+	dockerCheck := ExecCommand("docker", "stats", "--no-stream")
 	if err := dockerCheck.Run(); err != nil {
 		fmt.Println("ERROR: Docker not found.")
 		fmt.Println("Download from https://docs.docker.com/get-docker/")
@@ -98,7 +97,7 @@ func CheckDocker() error {
 
 func CheckPodman() error {
 	fmt.Println("✅ Checking if Docker is available...")
-	dockerCheck := exec.Command("podman", "stats", "--no-stream")
+	dockerCheck := ExecCommand("podman", "stats", "--no-stream")
 	if err := dockerCheck.Run(); err != nil {
 		fmt.Println("ERROR: Podman not found.")
 		fmt.Println("Download from https://docs.podman.io/en/latest/")

--- a/packages/kn-plugin-workflow/pkg/common/constants.go
+++ b/packages/kn-plugin-workflow/pkg/common/constants.go
@@ -36,8 +36,7 @@ const (
 	MAVEN_MINOR_VERSION = 8
 
 	// Default values
-	DEFAULT_REGISTRY = "quay.io"
-	DEFAULT_TAG      = "latest"
+	DEFAULT_TAG = "latest"
 
 	// Filenames
 	WORKFLOW_CONFIG_YML = "workflow.config.yml"

--- a/packages/kn-plugin-workflow/pkg/common/exec.go
+++ b/packages/kn-plugin-workflow/pkg/common/exec.go
@@ -1,0 +1,5 @@
+package common
+
+import "os/exec"
+
+var ExecCommand = exec.Command

--- a/packages/kn-plugin-workflow/pkg/common/exec.go
+++ b/packages/kn-plugin-workflow/pkg/common/exec.go
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package common
 
 import "os/exec"
 
+// Make it a global var so it can be overrided in tests
 var ExecCommand = exec.Command

--- a/packages/kn-plugin-workflow/pkg/common/helper.go
+++ b/packages/kn-plugin-workflow/pkg/common/helper.go
@@ -92,7 +92,7 @@ func UpdateProjectExtensionsVersions(verbose bool, friendlyMessages []string, ex
 }
 
 func RunExtensionCommand(verbose bool, extensionCommand string, friendlyMessages []string, extensions string) error {
-	command := exec.Command("mvn", extensionCommand, fmt.Sprintf("-Dextensions=%s", extensions))
+	command := ExecCommand("mvn", extensionCommand, fmt.Sprintf("-Dextensions=%s", extensions))
 	if err := RunCommand(command, verbose, extensionCommand, friendlyMessages); err != nil {
 		fmt.Println("ERROR: It wasn't possible to add Quarkus extension in your pom.xml.")
 		return err


### PR DESCRIPTION
## Jira
https://issues.redhat.com/browse/KOGITO-7666

## On this PR
- Remove quay.io default value
- Add tests to check generated image name