### PR TITLE
Improve `EnvelopeMapping`

### DIFF
--- a/examples/base64png-editor-chrome-extension/src/contentscript.ts
+++ b/examples/base64png-editor-chrome-extension/src/contentscript.ts
@@ -33,11 +33,11 @@ startExtension({
   extensionIconUrl: chrome.extension.getURL("/resources/kie_icon_rgb_fullcolor_default.svg"),
   githubAuthTokenCookieName: "github-oauth-token-base64-editors",
   editorEnvelopeLocator: new EditorEnvelopeLocator(window.location.origin, [
-    new EnvelopeMapping(
-      "base64png",
-      "**/*.base64png",
-      `${resourcesPathPrefix}/dist/`,
-      `${resourcesPathPrefix}/dist/envelope/index.html`
-    ),
+    new EnvelopeMapping({
+      type: "base64png",
+      filePathGlob: "**/*.base64png",
+      resourcesPathPrefix: `${resourcesPathPrefix}/dist/`,
+      envelopePath: `${resourcesPathPrefix}/dist/envelope/index.html`,
+    }),
   ]),
 });

--- a/examples/base64png-editor-vscode-extension/src/extension.ts
+++ b/examples/base64png-editor-vscode-extension/src/extension.ts
@@ -48,7 +48,12 @@ export function activate(context: vscode.ExtensionContext) {
     generateSvgCommandId: "extension.kogito.getPreviewSvg",
     silentlyGenerateSvgCommandId: "",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping("base64png", "**/*.base64png", `dist/`, `dist/envelope/index.js`),
+      new EnvelopeMapping({
+        type: "base64png",
+        filePathGlob: "**/*.base64png",
+        resourcesPathPrefix: "dist/",
+        envelopePath: "dist/envelope/index.js",
+      }),
     ]),
     backendProxy: backendProxy,
   });

--- a/examples/webapp/src/Pages/Base64Png/Base64PngGallery.tsx
+++ b/examples/webapp/src/Pages/Base64Png/Base64PngGallery.tsx
@@ -40,6 +40,7 @@ export function Base64PngGallery(props: { setFile: React.Dispatch<EmbeddedEditor
       fileExtension: "base64png",
       fileName: fileName,
       getFileContents: () => fetch(filePath).then((response) => response.text()),
+      path: filePath,
     });
   }, []);
 

--- a/examples/webapp/src/Pages/Base64Png/Base64PngPage.tsx
+++ b/examples/webapp/src/Pages/Base64Png/Base64PngPage.tsx
@@ -37,6 +37,7 @@ export function Base64PngPage() {
     fileExtension: "base64png",
     getFileContents: () => Promise.resolve(""),
     isReadOnly: false,
+    path: "new-file.base64png",
   });
 
   /**
@@ -45,7 +46,12 @@ export function Base64PngPage() {
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("base64png", "**/*.base64png", `envelope/`, `envelope/base64-editor.html`),
+        new EnvelopeMapping({
+          type: "base64png",
+          filePathGlob: "**/*.base64png",
+          resourcesPathPrefix: "envelope/",
+          envelopePath: "envelope/base64-editor.html",
+        }),
       ]),
     [file]
   );

--- a/examples/webapp/src/Pages/KogitoEditors/BpmnPage.tsx
+++ b/examples/webapp/src/Pages/KogitoEditors/BpmnPage.tsx
@@ -41,6 +41,7 @@ export function BpmnPage() {
     fileExtension: "bpmn",
     getFileContents: () => Promise.resolve(""),
     isReadOnly: false,
+    path: "new-file.bpmn",
   });
 
   /**
@@ -49,18 +50,12 @@ export function BpmnPage() {
    */
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(() => {
     return new EditorEnvelopeLocator(window.location.origin, [
-      new EnvelopeMapping(
-        "bpmn",
-        "**/*.bpmn",
-        "https://kiegroup.github.io/kogito-online/editors/latest/bpmn",
-        "https://kiegroup.github.io/kogito-online/bpmn-envelope.html"
-      ),
-      new EnvelopeMapping(
-        "bpmn",
-        "**/*.bpmn2",
-        "https://kiegroup.github.io/kogito-online/editors/latest/bpmn",
-        "https://kiegroup.github.io/kogito-online/bpmn-envelope.html"
-      ),
+      new EnvelopeMapping({
+        type: "bpmn",
+        filePathGlob: "**/*.bpmn?(2)",
+        resourcesPathPrefix: "https://kiegroup.github.io/kogito-online/editors/latest/bpmn",
+        envelopePath: "https://kiegroup.github.io/kogito-online/bpmn-envelope.html",
+      }),
     ]);
   }, []);
 

--- a/examples/webapp/src/Pages/KogitoEditors/DmnPage.tsx
+++ b/examples/webapp/src/Pages/KogitoEditors/DmnPage.tsx
@@ -38,6 +38,7 @@ export function DmnPage() {
     fileExtension: "dmn",
     getFileContents: () => Promise.resolve(""),
     isReadOnly: false,
+    path: "new-file.dmn",
   });
 
   /**
@@ -46,7 +47,12 @@ export function DmnPage() {
    */
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(() => {
     return new EditorEnvelopeLocator(window.location.origin, [
-      new EnvelopeMapping("dmn", "**/*.dmn", "../dmn-editor/dmn/", "envelope/dmn-editor.html"),
+      new EnvelopeMapping({
+        type: "dmn",
+        filePathGlob: "**/*.dmn",
+        resourcesPathPrefix: "../dmn-editor/dmn/",
+        envelopePath: "envelope/dmn-editor.html",
+      }),
     ]);
   }, []);
 

--- a/examples/webapp/src/Pages/KogitoEditors/Sidebar.tsx
+++ b/examples/webapp/src/Pages/KogitoEditors/Sidebar.tsx
@@ -88,6 +88,7 @@ export function Sidebar(props: Props) {
       fileExtension: props.fileExtension,
       fileName: "new-file",
       getFileContents: () => Promise.resolve(""),
+      path: `new-file.${props.fileExtension}`,
     });
   }, []);
 
@@ -98,6 +99,7 @@ export function Sidebar(props: Props) {
       fileExtension: props.fileExtension,
       fileName: "sample",
       getFileContents: () => fetch(`examples/sample.${props.fileExtension}`).then((response) => response.text()),
+      path: `sample.${props.fileExtension}`,
     });
   }, []);
 
@@ -117,6 +119,7 @@ export function Sidebar(props: Props) {
       isReadOnly: false,
       fileExtension: extractFileExtension(currentFile.name)!,
       fileName: removeFileExtension(currentFile.name),
+      path: currentFile.name,
       getFileContents: () =>
         new Promise<string | undefined>((resolve) => {
           const reader = new FileReader();

--- a/packages/chrome-extension-pack-kogito-kie-editors/src/github-content-script.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/src/github-content-script.ts
@@ -32,18 +32,23 @@ startExtension({
     },
   },
   editorEnvelopeLocator: new EditorEnvelopeLocator(window.location.origin, [
-    new EnvelopeMapping(
-      "bpmn",
-      "**/*.bpmn?(2)",
-      `${resourcesPathPrefix}/bpmn`,
-      `${resourcesPathPrefix}/bpmn-envelope.html`
-    ),
-    new EnvelopeMapping("dmn", "**/*.dmn", `${resourcesPathPrefix}/dmn`, `${resourcesPathPrefix}/dmn-envelope.html`),
-    new EnvelopeMapping(
-      "scesim",
-      "**/*.scesim",
-      `${resourcesPathPrefix}/scesim`,
-      `${resourcesPathPrefix}/scesim-envelope.html`
-    ),
+    new EnvelopeMapping({
+      type: "bpmn",
+      filePathGlob: "**/*.bpmn?(2)",
+      resourcesPathPrefix: `${resourcesPathPrefix}/bpmn`,
+      envelopePath: `${resourcesPathPrefix}/bpmn-envelope.html`,
+    }),
+    new EnvelopeMapping({
+      type: "dmn",
+      filePathGlob: "**/*.dmn",
+      resourcesPathPrefix: `${resourcesPathPrefix}/dmn`,
+      envelopePath: `${resourcesPathPrefix}/dmn-envelope.html`,
+    }),
+    new EnvelopeMapping({
+      type: "scesim",
+      filePathGlob: "**/*.scesim",
+      resourcesPathPrefix: `${resourcesPathPrefix}/scesim`,
+      envelopePath: `${resourcesPathPrefix}/scesim-envelope.html`,
+    }),
   ]),
 });

--- a/packages/chrome-extension-serverless-workflow-editor/src/github-content-script.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/src/github-content-script.ts
@@ -24,11 +24,11 @@ startExtension({
   extensionIconUrl: chrome.runtime.getURL("/resources/kie_icon_rgb_fullcolor_default.svg"),
   githubAuthTokenCookieName: "github-oauth-token-kie-editors",
   editorEnvelopeLocator: new EditorEnvelopeLocator(window.location.origin, [
-    new EnvelopeMapping(
-      "swf",
-      "**/*.sw.+(json|yml|yaml)",
-      `${resourcesPathPrefix}`,
-      `${resourcesPathPrefix}/serverless-workflow-combined-editor-envelope.html`
-    ),
+    new EnvelopeMapping({
+      type: "swf",
+      filePathGlob: "**/*.sw.+(json|yml|yaml)",
+      resourcesPathPrefix: `${resourcesPathPrefix}`,
+      envelopePath: `${resourcesPathPrefix}/serverless-workflow-combined-editor-envelope.html`,
+    }),
   ]),
 });

--- a/packages/chrome-extension/tests/testing_utils.tsx
+++ b/packages/chrome-extension/tests/testing_utils.tsx
@@ -37,7 +37,12 @@ import { ChromeExtensionI18n } from "@kie-tools-core/chrome-extension/dist/app/i
 
 export function usingTestingGlobalContext(children: React.ReactElement, ctx?: Partial<GlobalContextType>) {
   const editorEnvelopeLocator = new EditorEnvelopeLocator("localhost:8888", [
-    new EnvelopeMapping("txt", "**/*.txt", "envelope", "chrome-testing://https://my-url.com/"),
+    new EnvelopeMapping({
+      type: "txt",
+      filePathGlob: "**/*.txt",
+      resourcesPathPrefix: "envelope",
+      envelopePath: "chrome-testing://https://my-url.com/",
+    }),
   ]);
 
   const usedCtx: GlobalContextType = {

--- a/packages/dashbuilder-editor/dev-webapp/App.tsx
+++ b/packages/dashbuilder-editor/dev-webapp/App.tsx
@@ -44,7 +44,12 @@ export const App = () => {
   const editorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("dash", "**/*.dash.+(yml|yaml)", "", "dashbuilder-editor-envelope.html"),
+        new EnvelopeMapping({
+          type: "dash",
+          filePathGlob: "**/*.dash.+(yml|yaml)",
+          resourcesPathPrefix: "",
+          envelopePath: "dashbuilder-editor-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/desktop/src/__tests__/testing_utils.tsx
+++ b/packages/desktop/src/__tests__/testing_utils.tsx
@@ -24,7 +24,12 @@ import { DesktopI18n } from "../webview/common/i18n";
 export function usingTestingGlobalContext(children: React.ReactElement, ctx?: Partial<GlobalContextType>) {
   const usedCtx: GlobalContextType = {
     editorEnvelopeLocator: new EditorEnvelopeLocator(window.location.origin, [
-      new EnvelopeMapping("dmn", "**/*.dmn", "", "envelope/envelope.html"),
+      new EnvelopeMapping({
+        type: "dmn",
+        filePathGlob: "**/*.dmn",
+        resourcesPathPrefix: "",
+        envelopePath: "envelope/envelope.html",
+      }),
     ]),
     file: { fileName: "test", fileExtension: "dmn", getFileContents: () => Promise.resolve(""), isReadOnly: false },
     ...ctx,

--- a/packages/desktop/src/webview/App.tsx
+++ b/packages/desktop/src/webview/App.tsx
@@ -68,8 +68,18 @@ export function App() {
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("bpmn", "**/*.bpmn?(2)", "../gwt-editors/bpmn", "envelope/bpmn-envelope.html"),
-        new EnvelopeMapping("dmn", "**/*.dmn", "../gwt-editors/dmn", "envelope/dmn-envelope.html"),
+        new EnvelopeMapping({
+          type: "bpmn",
+          filePathGlob: "**/*.bpmn?(2)",
+          resourcesPathPrefix: "../gwt-editors/bpmn",
+          envelopePath: "envelope/bpmn-envelope.html",
+        }),
+        new EnvelopeMapping({
+          type: "dmn",
+          filePathGlob: "**/*.dmn",
+          resourcesPathPrefix: "../gwt-editors/dmn",
+          envelopePath: "envelope/dmn-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/editor/src/api/EditorEnvelopeLocator.ts
+++ b/packages/editor/src/api/EditorEnvelopeLocator.ts
@@ -20,12 +20,25 @@ export class EnvelopeMapping {
   public matcher: IMinimatch;
 
   constructor(
-    public readonly type: string,
-    public readonly filePathGlob: string,
-    public readonly resourcesPathPrefix: string,
-    public readonly envelopePath: string
+    private readonly args: { type: string; filePathGlob: string; resourcesPathPrefix: string; envelopePath: string }
   ) {
-    this.matcher = new Minimatch(filePathGlob, { nocase: true, dot: true });
+    this.matcher = new Minimatch(args.filePathGlob, { nocase: true, dot: true });
+  }
+
+  get type(): string {
+    return this.args.type;
+  }
+
+  get filePathGlob(): string {
+    return this.args.filePathGlob;
+  }
+
+  get resourcesPathPrefix(): string {
+    return this.args.resourcesPathPrefix;
+  }
+
+  get envelopePath(): string {
+    return this.args.envelopePath;
   }
 }
 

--- a/packages/editor/tests/embedded/embedded/EmbeddedEditor.test.tsx
+++ b/packages/editor/tests/embedded/embedded/EmbeddedEditor.test.tsx
@@ -32,7 +32,12 @@ describe("EmbeddedEditor::ONLINE", () => {
   };
 
   const editorEnvelopeLocator = new EditorEnvelopeLocator("localhost:8888", [
-    new EnvelopeMapping("dmn", "**/*.dmn", "envelope", "envelope/envelope.html"),
+    new EnvelopeMapping({
+      type: "dmn",
+      filePathGlob: "**/*.dmn",
+      resourcesPathPrefix: "envelope",
+      envelopePath: "envelope/envelope.html",
+    }),
   ]);
 
   const channelType = ChannelType.ONLINE;

--- a/packages/editor/tests/embedded/embedded/EmbeddedViewer.test.tsx
+++ b/packages/editor/tests/embedded/embedded/EmbeddedViewer.test.tsx
@@ -32,7 +32,12 @@ describe("EmbeddedViewer::ONLINE", () => {
   };
 
   const editorEnvelopeLocator = new EditorEnvelopeLocator("localhost:8888", [
-    new EnvelopeMapping("dmn", "**/*.dmn", "envelope", "envelope/envelope.html"),
+    new EnvelopeMapping({
+      type: "dmn",
+      filePathGlob: "**/*.dmn",
+      resourcesPathPrefix: "envelope",
+      envelopePath: "envelope/envelope.html",
+    }),
   ]);
 
   const channelType = ChannelType.ONLINE;

--- a/packages/online-editor/src/envelopeLocator/EditorEnvelopeLocatorContext.tsx
+++ b/packages/online-editor/src/envelopeLocator/EditorEnvelopeLocatorContext.tsx
@@ -26,9 +26,24 @@ export function EditorEnvelopeLocatorContextProvider(props: { children: React.Re
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("bpmn", "**/*.bpmn?(2)", "gwt-editors/bpmn", "bpmn-envelope.html"),
-        new EnvelopeMapping("dmn", "**/*.dmn", "gwt-editors/dmn", "dmn-envelope.html"),
-        new EnvelopeMapping("pmml", "**/*.pmml", "", "pmml-envelope.html"),
+        new EnvelopeMapping({
+          type: "bpmn",
+          filePathGlob: "**/*.bpmn?(2)",
+          resourcesPathPrefix: "gwt-editors/bpmn",
+          envelopePath: "bpmn-envelope.html",
+        }),
+        new EnvelopeMapping({
+          type: "dmn",
+          filePathGlob: "**/*.dmn",
+          resourcesPathPrefix: "gwt-editors/dmn",
+          envelopePath: "dmn-envelope.html",
+        }),
+        new EnvelopeMapping({
+          type: "pmml",
+          filePathGlob: "**/*.pmml",
+          resourcesPathPrefix: "",
+          envelopePath: "pmml-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/serverless-logic-sandbox/src/envelopeLocator/EditorEnvelopeLocatorContext.tsx
+++ b/packages/serverless-logic-sandbox/src/envelopeLocator/EditorEnvelopeLocatorContext.tsx
@@ -25,9 +25,24 @@ export function EditorEnvelopeLocatorContextProvider(props: { children: React.Re
   const editorEnvelopeLocator: EditorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("swf", GLOB_PATTERN.sw, ".", "serverless-workflow-combined-editor-envelope.html"),
-        new EnvelopeMapping("dash", GLOB_PATTERN.dash, "", "dashbuilder-editor-envelope.html"),
-        new EnvelopeMapping("text", GLOB_PATTERN.all, "", "text-editor-envelope.html"),
+        new EnvelopeMapping({
+          type: "swf",
+          filePathGlob: GLOB_PATTERN.sw,
+          resourcesPathPrefix: ".",
+          envelopePath: "serverless-workflow-combined-editor-envelope.html",
+        }),
+        new EnvelopeMapping({
+          type: "dash",
+          filePathGlob: GLOB_PATTERN.dash,
+          resourcesPathPrefix: "",
+          envelopePath: "dashbuilder-editor-envelope.html",
+        }),
+        new EnvelopeMapping({
+          type: "text",
+          filePathGlob: GLOB_PATTERN.all,
+          resourcesPathPrefix: "",
+          envelopePath: "text-editor-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/serverless-workflow-combined-editor/dev-webapp/App.tsx
+++ b/packages/serverless-workflow-combined-editor/dev-webapp/App.tsx
@@ -34,7 +34,12 @@ export const App = () => {
   const editorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("swf", "**/*.sw.+(json|yml|yaml)", "", "serverless-workflow-combined-editor-envelope.html"),
+        new EnvelopeMapping({
+          type: "swf",
+          filePathGlob: "**/*.sw.+(json|yml|yaml)",
+          resourcesPathPrefix: "",
+          envelopePath: "serverless-workflow-combined-editor-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -99,12 +99,12 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
   const textEditorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(targetOrigin, [
-        new EnvelopeMapping(
-          ENVELOPE_LOCATOR_TYPE,
-          "**/*.sw.+(json|yml|yaml)",
-          props.resourcesPathPrefix + "/text",
-          props.resourcesPathPrefix + "/serverless-workflow-text-editor-envelope.html"
-        ),
+        new EnvelopeMapping({
+          type: ENVELOPE_LOCATOR_TYPE,
+          filePathGlob: "**/*.sw.+(json|yml|yaml)",
+          resourcesPathPrefix: props.resourcesPathPrefix + "/text",
+          envelopePath: props.resourcesPathPrefix + "/serverless-workflow-text-editor-envelope.html",
+        }),
       ]),
     [props.resourcesPathPrefix, targetOrigin]
   );
@@ -120,18 +120,18 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
           envelopePath: props.resourcesPathPrefix + "/serverless-workflow-mermaid-viewer-envelope.html",
         };
     return new EditorEnvelopeLocator(targetOrigin, [
-      new EnvelopeMapping(
-        ENVELOPE_LOCATOR_TYPE,
-        "**/*.sw.json",
-        diagramEnvelopeMappingConfig.resourcesPathPrefix,
-        diagramEnvelopeMappingConfig.envelopePath
-      ),
-      new EnvelopeMapping(
-        ENVELOPE_LOCATOR_TYPE,
-        "**/*.sw.+(yml|yaml)",
-        props.resourcesPathPrefix + "/mermaid",
-        props.resourcesPathPrefix + "/serverless-workflow-mermaid-viewer-envelope.html"
-      ),
+      new EnvelopeMapping({
+        type: ENVELOPE_LOCATOR_TYPE,
+        filePathGlob: "**/*.sw.json",
+        resourcesPathPrefix: diagramEnvelopeMappingConfig.resourcesPathPrefix,
+        envelopePath: diagramEnvelopeMappingConfig.envelopePath,
+      }),
+      new EnvelopeMapping({
+        type: ENVELOPE_LOCATOR_TYPE,
+        filePathGlob: "**/*.sw.+(yml|yaml)",
+        resourcesPathPrefix: props.resourcesPathPrefix + "/mermaid",
+        envelopePath: props.resourcesPathPrefix + "/serverless-workflow-mermaid-viewer-envelope.html",
+      }),
     ]);
   }, [featureToggle, props.resourcesPathPrefix, targetOrigin]);
 

--- a/packages/serverless-workflow-mermaid-viewer/dev-webapp/App.tsx
+++ b/packages/serverless-workflow-mermaid-viewer/dev-webapp/App.tsx
@@ -34,7 +34,12 @@ export const App = () => {
   const editorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("swf", "**/*.sw.+(json|yml|yaml)", "", "serverless-workflow-mermaid-viewer-envelope.html"),
+        new EnvelopeMapping({
+          type: "swf",
+          filePathGlob: "**/*.sw.+(json|yml|yaml)",
+          resourcesPathPrefix: "",
+          envelopePath: "serverless-workflow-mermaid-viewer-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/serverless-workflow-text-editor/dev-webapp/App.tsx
+++ b/packages/serverless-workflow-text-editor/dev-webapp/App.tsx
@@ -34,7 +34,12 @@ export const App = () => {
   const editorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("swf", "**/*.sw.+(json|yml|yaml)", "", "serverless-workflow-text-editor-envelope.html"),
+        new EnvelopeMapping({
+          type: "swf",
+          filePathGlob: "**/*.sw.+(json|yml|yaml)",
+          resourcesPathPrefix: "",
+          envelopePath: "serverless-workflow-text-editor-envelope.html",
+        }),
       ]),
     []
   );

--- a/packages/vscode-extension-bpmn-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-bpmn-editor/src/extension/extension.ts
@@ -36,12 +36,12 @@ export function activate(context: vscode.ExtensionContext) {
     generateSvgCommandId: "extension.kogito.getPreviewSvgBpmn",
     silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvgBpmn",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping(
-        "bpmn",
-        "**/*.bpmn?(2)",
-        "dist/webview/BpmnEditorEnvelopeApp.js",
-        "dist/webview/editors/bpmn"
-      ),
+      new EnvelopeMapping({
+        type: "bpmn",
+        filePathGlob: "**/*.bpmn?(2)",
+        resourcesPathPrefix: "dist/webview/editors/bpmn",
+        envelopePath: "dist/webview/BpmnEditorEnvelopeApp.js",
+      }),
     ]),
     backendProxy: backendProxy,
   });

--- a/packages/vscode-extension-dmn-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-dmn-editor/src/extension/extension.ts
@@ -36,13 +36,18 @@ export function activate(context: vscode.ExtensionContext) {
     generateSvgCommandId: "extension.kogito.getPreviewSvgDmn",
     silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvgDmn",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping("dmn", "**/*.dmn", "dist/webview/DmnEditorEnvelopeApp.js", "dist/webview/editors/dmn"),
-      new EnvelopeMapping(
-        "scesim",
-        "**/*.scesim",
-        "dist/webview/SceSimEditorEnvelopeApp.js",
-        "dist/webview/editors/scesim"
-      ),
+      new EnvelopeMapping({
+        type: "dmn",
+        filePathGlob: "**/*.dmn",
+        resourcesPathPrefix: "dist/webview/editors/dmn",
+        envelopePath: "dist/webview/DmnEditorEnvelopeApp.js",
+      }),
+      new EnvelopeMapping({
+        type: "scesim",
+        filePathGlob: "**/*.scesim",
+        resourcesPathPrefix: "dist/webview/editors/scesim",
+        envelopePath: "dist/webview/SceSimEditorEnvelopeApp.js",
+      }),
     ]),
     backendProxy: backendProxy,
   });

--- a/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
+++ b/packages/vscode-extension-pack-kogito-kie-editors/src/extension/extension.ts
@@ -49,20 +49,30 @@ export async function activate(context: vscode.ExtensionContext) {
     generateSvgCommandId: "extension.kogito.getPreviewSvg",
     silentlyGenerateSvgCommandId: "extension.kogito.silentlyGenerateSvg",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping(
-        "bpmn",
-        "**/*.bpmn?(2)",
-        "dist/webview/BpmnEditorEnvelopeApp.js",
-        "dist/webview/editors/bpmn"
-      ),
-      new EnvelopeMapping("dmn", "**/*.dmn", "dist/webview/DmnEditorEnvelopeApp.js", "dist/webview/editors/dmn"),
-      new EnvelopeMapping(
-        "scesim",
-        "**/*.scesim",
-        "dist/webview/SceSimEditorEnvelopeApp.js",
-        "dist/webview/editors/scesim"
-      ),
-      new EnvelopeMapping("pmml", "**/*.pmml", "dist/webview/PMMLEditorEnvelopeApp.js", "dist/webview/editors/pmml"),
+      new EnvelopeMapping({
+        type: "bpmn",
+        filePathGlob: "**/*.bpmn?(2)",
+        resourcesPathPrefix: "dist/webview/editors/bpmn",
+        envelopePath: "dist/webview/BpmnEditorEnvelopeApp.js",
+      }),
+      new EnvelopeMapping({
+        type: "dmn",
+        filePathGlob: "**/*.dmn",
+        resourcesPathPrefix: "dist/webview/editors/dmn",
+        envelopePath: "dist/webview/DmnEditorEnvelopeApp.js",
+      }),
+      new EnvelopeMapping({
+        type: "scesim",
+        filePathGlob: "**/*.scesim",
+        resourcesPathPrefix: "dist/webview/editors/scesim",
+        envelopePath: "dist/webview/SceSimEditorEnvelopeApp.js",
+      }),
+      new EnvelopeMapping({
+        type: "pmml",
+        filePathGlob: "**/*.pmml",
+        resourcesPathPrefix: "dist/webview/editors/pmml",
+        envelopePath: "dist/webview/PMMLEditorEnvelopeApp.js",
+      }),
     ]),
     backendProxy: backendProxy,
   });

--- a/packages/vscode-extension-pmml-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-pmml-editor/src/extension/extension.ts
@@ -39,7 +39,12 @@ export function activate(context: vscode.ExtensionContext) {
     context: context,
     viewType: "kieKogitoWebviewEditorsPmml",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping("pmml", "**/*.pmml", "dist/webview/PmmlEditorEnvelopeApp.js", "dist/webview/editors/pmml"),
+      new EnvelopeMapping({
+        type: "pmml",
+        filePathGlob: "**/*.pmml",
+        resourcesPathPrefix: "dist/webview/editors/pmml",
+        envelopePath: "dist/webview/PmmlEditorEnvelopeApp.js",
+      }),
     ]),
     backendProxy: backendProxy,
   });

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/extension.ts
@@ -93,18 +93,18 @@ export async function activate(context: vscode.ExtensionContext) {
     generateSvgCommandId: COMMAND_IDS.getPreviewSvg,
     silentlyGenerateSvgCommandId: COMMAND_IDS.silentlyGetPreviewSvg,
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping(
-        swEnvelopeType,
-        "**/*.sw.json",
-        diagramEnvelopeMappingConfig.envelopePath,
-        diagramEnvelopeMappingConfig.resourcesPathPrefix
-      ),
-      new EnvelopeMapping(
-        swEnvelopeType,
-        "**/*.sw.+(yml|yaml)",
-        baseEnvelopePath + "/serverless-workflow-mermaid-viewer-envelope.js",
-        baseEnvelopePath
-      ),
+      new EnvelopeMapping({
+        type: swEnvelopeType,
+        filePathGlob: "**/*.sw.json",
+        resourcesPathPrefix: diagramEnvelopeMappingConfig.resourcesPathPrefix,
+        envelopePath: diagramEnvelopeMappingConfig.envelopePath,
+      }),
+      new EnvelopeMapping({
+        type: swEnvelopeType,
+        filePathGlob: "**/*.sw.+(yml|yaml)",
+        resourcesPathPrefix: baseEnvelopePath,
+        envelopePath: baseEnvelopePath + "/serverless-workflow-mermaid-viewer-envelope.js",
+      }),
     ]),
     channelApiProducer: new ServerlessWorkflowEditorChannelApiProducer({
       configuration,

--- a/packages/vscode-extension-yard-editor/src/extension/extension.ts
+++ b/packages/vscode-extension-yard-editor/src/extension/extension.ts
@@ -43,12 +43,12 @@ export async function activate(context: vscode.ExtensionContext) {
     context: context,
     viewType: WEBVIEW_EDITOR_VIEW_TYPE,
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
-      new EnvelopeMapping(
-        "yard",
-        "**/*.yard.+(json|yml|yaml)",
-        "dist/webview/YardEditorEnvelopeApp.js",
-        "dist/webview/editors/yard"
-      ),
+      new EnvelopeMapping({
+        type: "yard",
+        filePathGlob: "**/*.yard.+(json|yml|yaml)",
+        resourcesPathPrefix: "dist/webview/editors/yard",
+        envelopePath: "dist/webview/YardEditorEnvelopeApp.js",
+      }),
     ]),
     backendProxy,
   });

--- a/packages/vscode-extension/src/VsCodeKieEditorControllerFactory.ts
+++ b/packages/vscode-extension/src/VsCodeKieEditorControllerFactory.ts
@@ -118,12 +118,12 @@ export class VsCodeKieEditorControllerFactory {
       this.editorEnvelopeLocator.targetOrigin,
       [...this.editorEnvelopeLocator.envelopeMappings].reduce((envelopeMappings, mapping) => {
         envelopeMappings.push(
-          new EnvelopeMapping(
-            mapping.type,
-            mapping.filePathGlob,
-            this.getWebviewPath(webview, mapping.envelopePath),
-            this.getWebviewPath(webview, mapping.resourcesPathPrefix)
-          )
+          new EnvelopeMapping({
+            type: mapping.type,
+            filePathGlob: mapping.filePathGlob,
+            resourcesPathPrefix: this.getWebviewPath(webview, mapping.resourcesPathPrefix),
+            envelopePath: this.getWebviewPath(webview, mapping.envelopePath),
+          })
         );
         return envelopeMappings;
       }, [] as EnvelopeMapping[])

--- a/packages/yard-editor/dev-webapp/App.tsx
+++ b/packages/yard-editor/dev-webapp/App.tsx
@@ -34,7 +34,12 @@ export const App = () => {
   const editorEnvelopeLocator = useMemo(
     () =>
       new EditorEnvelopeLocator(window.location.origin, [
-        new EnvelopeMapping("yard", "**/*.yard.+(yml|yaml|json)", "", "yard-editor-envelope.html"),
+        new EnvelopeMapping({
+          type: "yard",
+          filePathGlob: "**/*.yard.+(yml|yaml|json)",
+          resourcesPathPrefix: "",
+          envelopePath: "yard-editor-envelope.html",
+        }),
       ]),
     []
   );


### PR DESCRIPTION
There is confusion when setting `resourcesPathPrefix` and `envelopePath` for `EnvelopeMapping`s on each `extension.ts` (VS Code channel) file. Although this confusion is "undone" in `VsCodeKieEditorControllerFactory` and no issues are seen, this is still incorrect.

To avoid such confusion, I'm adding an `args` object to the `EnvelopeMapping` constructor so that auto-completion can guide with named parameters when creating `EnvelopeMapping`s.


I also fixed the `@kie-tools-examples/webapp` during the validation of these changes.
We should probably revisit [1] because this is another potential point for confusion.

[1] https://github.com/kiegroup/kie-tools/blob/main/packages/editor/src/embedded/embedded/EmbeddedEditor.tsx#L89