### PR TITLE
Bump up Golang version to 1.19

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -43,10 +43,10 @@ runs:
       with:
         java-version: 11
 
-    - name: "Set up GOLANG 1.17"
-      uses: actions/setup-go@v2
+    - name: "Set up GOLANG 1.19"
+      uses: actions/setup-go@v3
       with:
-        go-version: "1.17"
+        go-version: "1.19"
 
     - name: "Setup Yarn"
       shell: bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start building the KIE Tools project, you're going to need:
 - pnpm `7.0.0` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Maven `3.8.1`
 - Java `11`
-- Go `1.17` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.19` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 \*nix users will also need:
 

--- a/packages/extended-services/go.mod
+++ b/packages/extended-services/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiegroup/kie-tools/extended-services
 
-go 1.17
+go 1.19
 
 require (
 	github.com/getlantern/systray v1.1.0

--- a/packages/extended-services/package.json
+++ b/packages/extended-services/package.json
@@ -29,6 +29,7 @@
     "copy-jitexecutor:darwin": "cp ./node_modules/@kie-tools/jitexecutor-native/dist/darwin/jitexecutor jitexecutor && chmod +x jitexecutor",
     "copy-jitexecutor:linux": "cp ./node_modules/@kie-tools/jitexecutor-native/dist/linux/jitexecutor jitexecutor && chmod +x jitexecutor",
     "copy-jitexecutor:win32": "COPY /B /Y .\\node_modules\\@kie-tools\\jitexecutor-native\\dist\\win32\\jitexecutor.exe jitexecutor",
+    "install": "go mod tidy",
     "pack-app": "run-script-os",
     "pack-app:darwin": "cd ./scripts/macos && ./build.sh",
     "pack-app:linux": "cd ./dist/linux && tar -pcvzf kie_sandbox_extended_services.tar.gz kie_sandbox_extended_services",

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -12,7 +12,7 @@ All the commands in this section should be performed in the monorepo root.
 
 - Node `>= 16.13.2` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
 - pnpm `7.0.0` _(To install, follow these instructions: https://pnpm.io/installation)_
-- Go `1.17` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.19` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 ### Installing and linking dependencies
 

--- a/packages/kn-plugin-workflow/go.mod
+++ b/packages/kn-plugin-workflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/kiegroup/kie-tools/packages/kn-plugin-workflow
 
-go 1.17
+go 1.19
 
 require (
 	github.com/briandowns/spinner v1.18.1


### PR DESCRIPTION
With the Golang 1.19 release, the 1.17 version has reached EOL. (https://go.dev/doc/devel/release)