### PR TITLE
Bring back JSON Schema to SWF Editor VS Code Extension

### DIFF
--- a/packages/serverless-logic-sandbox/src/editor/api/SandboxSwfJsonLanguageService.ts
+++ b/packages/serverless-logic-sandbox/src/editor/api/SandboxSwfJsonLanguageService.ts
@@ -35,6 +35,7 @@ export class SandboxSwfJsonLanguageService extends SwfJsonLanguageService {
       },
       config: {
         shouldDisplayServiceRegistriesIntegration: async () => false,
+        shouldIncludeJsonSchemaDiagnostics: async () => true,
         shouldReferenceServiceRegistryFunctionsWithUrls: async () => true,
         getSpecsDirPosixPaths: async (_textDocument) => ({
           specsDirRelativePosixPath: "",

--- a/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
@@ -66,6 +66,7 @@ const defaultConfig: SwfLanguageServiceConfig = {
   getSpecsDirPosixPaths: async () => ({ specsDirRelativePosixPath: "specs", specsDirAbsolutePosixPath: "" }),
   shouldDisplayServiceRegistriesIntegration: async () => true,
   shouldReferenceServiceRegistryFunctionsWithUrls: async () => false,
+  shouldIncludeJsonSchemaDiagnostics: async () => true,
 };
 
 describe("SWF LS JSON", () => {

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -66,6 +66,7 @@ const defaultConfig: SwfLanguageServiceConfig = {
   getSpecsDirPosixPaths: async () => ({ specsDirRelativePosixPath: "specs", specsDirAbsolutePosixPath: "" }),
   shouldDisplayServiceRegistriesIntegration: async () => true,
   shouldReferenceServiceRegistryFunctionsWithUrls: async () => false,
+  shouldIncludeJsonSchemaDiagnostics: async () => true,
 };
 
 describe("SWF LS YAML", () => {

--- a/packages/serverless-workflow-language-service/tests/refValidations.test.ts
+++ b/packages/serverless-workflow-language-service/tests/refValidations.test.ts
@@ -488,6 +488,7 @@ describe("test YAML refValidation method against source and target paths", () =>
     getSpecsDirPosixPaths: async () => ({ specsDirRelativePosixPath: "specs", specsDirAbsolutePosixPath: "" }),
     shouldDisplayServiceRegistriesIntegration: async () => true,
     shouldReferenceServiceRegistryFunctionsWithUrls: async () => false,
+    shouldIncludeJsonSchemaDiagnostics: async () => true,
   };
 
   const defaultServiceCatalogConfig = {

--- a/packages/vscode-extension-serverless-workflow-editor/package.json
+++ b/packages/vscode-extension-serverless-workflow-editor/package.json
@@ -255,6 +255,12 @@
         "scopeName": "source.yaml"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": "**/*.sw.json",
+        "url": "https://serverlessworkflow.io/schemas/0.8/workflow.json"
+      }
+    ],
     "keybindings": [
       {
         "command": "extension.kogito.swf.openAsDiagram",

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/ServerlessWorkflowEditorChannelApiProducer.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/ServerlessWorkflowEditorChannelApiProducer.ts
@@ -29,7 +29,6 @@ import { SwfVsCodeExtensionConfiguration } from "./configuration";
 import { SwfServiceCatalogSupportActions } from "./serviceCatalog/SwfServiceCatalogSupportActions";
 import { SwfLanguageServiceChannelApiImpl } from "./languageService/SwfLanguageServiceChannelApiImpl";
 import { VsCodeSwfLanguageService } from "./languageService/VsCodeSwfLanguageService";
-import { getFileLanguageOrThrow } from "@kie-tools/serverless-workflow-language-service/dist/api";
 
 export class ServerlessWorkflowEditorChannelApiProducer implements VsCodeKieEditorChannelApiProducer {
   constructor(
@@ -49,9 +48,6 @@ export class ServerlessWorkflowEditorChannelApiProducer implements VsCodeKieEdit
     viewType: string,
     i18n: I18n<VsCodeI18n>
   ): KogitoEditorChannelApi {
-    const fileLanguage = getFileLanguageOrThrow(editor.document.document.uri.path);
-    const ls = this.args.vsCodeSwfLanguageService.getLs(fileLanguage);
-
     return new ServerlessWorkflowEditorChannelApiImpl(
       editor,
       resourceContentService,
@@ -66,7 +62,9 @@ export class ServerlessWorkflowEditorChannelApiProducer implements VsCodeKieEdit
         configuration: this.args.configuration,
         swfServiceCatalogSupportActions: this.args.swfServiceCatalogSupportActions,
       }),
-      new SwfLanguageServiceChannelApiImpl({ ls })
+      new SwfLanguageServiceChannelApiImpl({
+        ls: this.args.vsCodeSwfLanguageService.getLsForDiagramEditor(editor.document.document),
+      })
     );
   }
 }


### PR DESCRIPTION
For the `Serverless Workflow (JSON)` and `Serverless Workflow (YAML)` languages, SWF LS JSON Schema diagnostics should be enabled, but for the `JSON` and `YAML` languages, we use VS Code's built-in JSON Schema capabilities (though the YAML extension for the `YAML` language), it shouldn't, or otherwise it would result in duplication of validation messages.

`JSON` and `YAML` continue to be the preferred languages, but the `Serverless Workflow (JSON)` and `Serverless Workflow (YAML)` languages keep us aware of the capabilities that are exclusive to the SWF LS.

After #1102, `getLsForDiagramEditor` won't be necessary anymore, as we're gonna have a better separation between Text and Diagram editors for SWF.

Also note that although the VS Code Extension contribution point is called `jsonValidation`, it enables full JSON Schema capabilities on the built-in VS Code text editor, such as auto-complete, outlines, etc etc, that's why it's important that we keep it.