### PR TITLE
Rename from Sandbox to Serverless Logic Web Tools

### DIFF
--- a/packages/serverless-logic-sandbox/src/editor/EditorToolbar.tsx
+++ b/packages/serverless-logic-sandbox/src/editor/EditorToolbar.tsx
@@ -441,7 +441,7 @@ export function EditorToolbar(props: Props) {
         files: {
           "README.md": {
             content: `
-This Gist was created from KIE Sandbox.
+This Gist was created from Serverless Logic Web Tools.
 
 This file is temporary and you should not be seeing it.
 If you are, it means that creating this Gist failed and it can safely be deleted.

--- a/packages/serverless-logic-sandbox/src/pageTemplate/OnlineEditorPage.tsx
+++ b/packages/serverless-logic-sandbox/src/pageTemplate/OnlineEditorPage.tsx
@@ -50,7 +50,7 @@ export function OnlineEditorPage(props: { children?: React.ReactNode }) {
                 style={{ textDecoration: "none" }}
               >
                 <TextContent>
-                  <Text component={TextVariants.h1}>Serverless Logic Sandbox</Text>
+                  <Text component={TextVariants.h1}>Serverless Logic Web Tools</Text>
                 </TextContent>
               </MastheadBrand>
             </PageHeaderToolsItem>

--- a/packages/serverless-logic-sandbox/src/settings/extendedServices/KieSandboxExtendedServicesSettingsTab.tsx
+++ b/packages/serverless-logic-sandbox/src/settings/extendedServices/KieSandboxExtendedServicesSettingsTab.tsx
@@ -118,9 +118,9 @@ export function KieSandboxExtendedServicesSettingsTab() {
                 </TextContent>
                 <TextContent>
                   <Text component={TextVariants.small}>
-                    Data you provide here is necessary for proxying Sandbox requests to OpenShift, thus making it
-                    possible to deploy models. All information is locally stored in your browser and never shared with
-                    anyone.
+                    Data you provide here is necessary for proxying Serverless Logic Web Tools requests to OpenShift,
+                    thus making it possible to deploy models. All information is locally stored in your browser and
+                    never shared with anyone.
                   </Text>
                 </TextContent>
                 <FormGroup

--- a/packages/serverless-logic-sandbox/src/settings/serviceRegistry/ServiceRegistrySettingsTab.tsx
+++ b/packages/serverless-logic-sandbox/src/settings/serviceRegistry/ServiceRegistrySettingsTab.tsx
@@ -145,7 +145,11 @@ export function ServiceRegistrySettingsTab() {
               <FormGroup
                 label={"Name"}
                 labelIcon={
-                  <Popover bodyContent={"Name to identify your Service Registry instance across the Sandbox."}>
+                  <Popover
+                    bodyContent={
+                      "Name to identify your Service Registry instance across the Serverless Logic Web Tools."
+                    }
+                  >
                     <button
                       type="button"
                       aria-label="More info for name field"

--- a/packages/serverless-logic-sandbox/src/workspace/WorkspacesContextProvider.tsx
+++ b/packages/serverless-logic-sandbox/src/workspace/WorkspacesContextProvider.tsx
@@ -181,7 +181,7 @@ export function WorkspacesContextProvider(props: Props) {
         fs: args.fs,
         dir: workspaceRootDirPath,
         targetBranch: descriptor.origin.branch,
-        message: "Changes from KIE Sandbox",
+        message: "Changes from Serverless Logic Web Tools",
         author: {
           name: args.gitConfig?.name ?? "Unknown",
           email: args.gitConfig?.email ?? "unknown@email.com",
@@ -242,7 +242,7 @@ export function WorkspacesContextProvider(props: Props) {
           await gitService.commit({
             fs: fs,
             dir: workspaceRootDirPath,
-            message: "Initial commit from KIE Sandbox",
+            message: "Initial commit from Serverless Logic Web Tools",
             targetBranch: GIT_DEFAULT_BRANCH,
             author: {
               name: settings.github.user?.name ?? "Unknown",

--- a/packages/serverless-logic-sandbox/static/index.html
+++ b/packages/serverless-logic-sandbox/static/index.html
@@ -18,7 +18,7 @@
 <html lang="en" class="pf-m-redhat-font">
   <head>
     <!-- gtm:header -->
-    <title>Serverless Logic Sandbox</title>
+    <title>Serverless Logic Web Tools</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/packages/serverless-logic-sandbox/webpack.config.js
+++ b/packages/serverless-logic-sandbox/webpack.config.js
@@ -182,10 +182,10 @@ function getServerlessLogicSandboxBaseImageArgs() {
   const baseImageName = buildEnv.serverlessLogicSandboxBaseImageEnv.name;
   const baseImageTag = buildEnv.serverlessLogicSandbox.baseImage.tag;
 
-  console.info("Serverless Logic Sandbox :: Base Image Registry: " + baseImageRegistry);
-  console.info("Serverless Logic Sandbox :: Base Image Account: " + baseImageAccount);
-  console.info("Serverless Logic Sandbox :: Base Image Name: " + baseImageName);
-  console.info("Serverless Logic Sandbox :: Base Image Tag: " + baseImageTag);
+  console.info("Serverless Logic Web Tools :: Base Image Registry: " + baseImageRegistry);
+  console.info("Serverless Logic Web Tools :: Base Image Account: " + baseImageAccount);
+  console.info("Serverless Logic Web Tools :: Base Image Name: " + baseImageName);
+  console.info("Serverless Logic Web Tools :: Base Image Tag: " + baseImageTag);
 
   return [baseImageRegistry, baseImageAccount, baseImageName, baseImageTag];
 }
@@ -196,10 +196,10 @@ function getServerlessLogicSandboxOpenJdk11MvnImageArgs() {
   const openJdk11MvnImageName = buildEnv.openJdk11MvnImageEnv.name;
   const openJdk11MvnImageTag = buildEnv.serverlessLogicSandbox.openJdk11MvnImage.tag;
 
-  console.info("Serverless Logic Sandbox :: OpenJDK 11 + Maven Image Registry: " + openJdk11MvnImageRegistry);
-  console.info("Serverless Logic Sandbox :: OpenJDK 11 + Maven Image Account: " + openJdk11MvnImageAccount);
-  console.info("Serverless Logic Sandbox :: OpenJDK 11 + Maven Image Name: " + openJdk11MvnImageName);
-  console.info("Serverless Logic Sandbox :: OpenJDK 11 + Maven Image Tag: " + openJdk11MvnImageTag);
+  console.info("Serverless Logic Web Tools :: OpenJDK 11 + Maven Image Registry: " + openJdk11MvnImageRegistry);
+  console.info("Serverless Logic Web Tools :: OpenJDK 11 + Maven Image Account: " + openJdk11MvnImageAccount);
+  console.info("Serverless Logic Web Tools :: OpenJDK 11 + Maven Image Name: " + openJdk11MvnImageName);
+  console.info("Serverless Logic Web Tools :: OpenJDK 11 + Maven Image Tag: " + openJdk11MvnImageTag);
 
   return [openJdk11MvnImageRegistry, openJdk11MvnImageAccount, openJdk11MvnImageName, openJdk11MvnImageTag];
 }


### PR DESCRIPTION
Other projects use the Sandbox name at Red Hat, so I've renamed our tools to 'Serverless Logic Web Tools' to avoid confusion.

Later, we should rename packages and, more importantly, the extended services binary.