### PR TITLE
Update default git author details on Sandboxes

### DIFF
--- a/packages/online-editor/src/workspace/WorkspacesContextProvider.tsx
+++ b/packages/online-editor/src/workspace/WorkspacesContextProvider.tsx
@@ -40,6 +40,10 @@ import { DEFAULT_CORS_PROXY_URL, useEnv } from "../env/EnvContext";
 
 const MAX_NEW_FILE_INDEX_ATTEMPTS = 10;
 const NEW_FILE_DEFAULT_NAME = "Untitled";
+const GIT_USER_DEFAULT = {
+  name: "KIE Sandbox",
+  email: "",
+};
 
 interface Props {
   children: React.ReactNode;
@@ -131,8 +135,8 @@ export function WorkspacesContextProvider(props: Props) {
         dir: service.getAbsolutePath({ workspaceId: args.workspaceId }),
         ref: workspace.origin.branch,
         author: {
-          name: args.gitConfig?.name ?? "Unknown",
-          email: args.gitConfig?.email ?? "unknown@email.com",
+          name: args.gitConfig?.name ?? GIT_USER_DEFAULT.name,
+          email: args.gitConfig?.email ?? GIT_USER_DEFAULT.email,
         },
         authInfo: args.authInfo,
       });
@@ -184,8 +188,8 @@ export function WorkspacesContextProvider(props: Props) {
         targetBranch: descriptor.origin.branch,
         message: "Changes from KIE Sandbox",
         author: {
-          name: args.gitConfig?.name ?? "Unknown",
-          email: args.gitConfig?.email ?? "unknown@email.com",
+          name: args.gitConfig?.name ?? GIT_USER_DEFAULT.name,
+          email: args.gitConfig?.email ?? GIT_USER_DEFAULT.email,
         },
       });
 
@@ -251,8 +255,8 @@ export function WorkspacesContextProvider(props: Props) {
             message: "Initial commit from KIE Sandbox",
             targetBranch: GIT_DEFAULT_BRANCH,
             author: {
-              name: args.gitConfig?.name ?? "Unknown",
-              email: args.gitConfig?.email ?? "unknown@email.com",
+              name: args.gitConfig?.name ?? GIT_USER_DEFAULT.name,
+              email: args.gitConfig?.email ?? GIT_USER_DEFAULT.email,
             },
           });
 

--- a/packages/serverless-logic-sandbox/src/workspace/WorkspacesContextProvider.tsx
+++ b/packages/serverless-logic-sandbox/src/workspace/WorkspacesContextProvider.tsx
@@ -42,6 +42,10 @@ import { decoder, encoder } from "./commonServices/BaseFile";
 
 const MAX_NEW_FILE_INDEX_ATTEMPTS = 10;
 const NEW_FILE_DEFAULT_NAME = "Untitled";
+const GIT_USER_DEFAULT = {
+  name: "Serverless Logic Web Tools",
+  email: "",
+};
 
 interface Props {
   children: React.ReactNode;
@@ -130,8 +134,8 @@ export function WorkspacesContextProvider(props: Props) {
         dir: service.getAbsolutePath({ descriptorId: args.workspaceId }),
         ref: workspace.origin.branch,
         author: {
-          name: args.gitConfig?.name ?? "Unknown",
-          email: args.gitConfig?.email ?? "unknown@email.com",
+          name: args.gitConfig?.name ?? GIT_USER_DEFAULT.name,
+          email: args.gitConfig?.email ?? GIT_USER_DEFAULT.email,
         },
         authInfo: args.authInfo,
       });
@@ -183,8 +187,8 @@ export function WorkspacesContextProvider(props: Props) {
         targetBranch: descriptor.origin.branch,
         message: "Changes from Serverless Logic Web Tools",
         author: {
-          name: args.gitConfig?.name ?? "Unknown",
-          email: args.gitConfig?.email ?? "unknown@email.com",
+          name: args.gitConfig?.name ?? GIT_USER_DEFAULT.name,
+          email: args.gitConfig?.email ?? GIT_USER_DEFAULT.email,
         },
       });
 
@@ -245,8 +249,8 @@ export function WorkspacesContextProvider(props: Props) {
             message: "Initial commit from Serverless Logic Web Tools",
             targetBranch: GIT_DEFAULT_BRANCH,
             author: {
-              name: settings.github.user?.name ?? "Unknown",
-              email: settings.github.user?.email ?? "unknown@email.com",
+              name: settings.github.user?.name ?? GIT_USER_DEFAULT.name,
+              email: settings.github.user?.email ?? GIT_USER_DEFAULT.email,
             },
           });
 


### PR DESCRIPTION
We cannot use `unknown@email.com` as a default `email` for the commit author information because it maps to a real Github user. So I'm leaving it empty when this case is reached. I've also improved the default value for `name` to something more meaningful.