### PR TITLE
Fix staging `kn-plugin-workflow` artifacts upload

### DIFF
--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -561,7 +561,7 @@ jobs:
           username: "${{ env.DASHBUILDER__baseImageAccount }}"
           password: "${{ secrets.quay_registry_password }}"
 
-      - name: "STAGING: Upload Knative CLI Workflow Plugin for Linux"
+      - name: "STAGING: Upload Knative CLI Workflow Plugin for Linux (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -572,7 +572,7 @@ jobs:
           asset_name: STAGING__kn-workflow-linux-amd64-${{ inputs.tag }}
           asset_content_type: application/octet-stream
 
-      - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS"
+      - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
@@ -583,7 +583,7 @@ jobs:
           asset_name: STAGING__kn-workflow-darwin-amd64-${{ inputs.tag }}
           asset_content_type: application/octet-stream
 
-      - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS M1"
+      - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS M1 (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
@@ -594,7 +594,7 @@ jobs:
           asset_name: STAGING__kn-workflow-darwin-arm64-${{ inputs.tag }}
           asset_content_type: application/octet-stream
 
-      - name: "STAGING: Knative CLI Workflow Plugin for Windows"
+      - name: "STAGING: Knative CLI Workflow Plugin for Windows (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -562,7 +562,7 @@ jobs:
           password: "${{ secrets.quay_registry_password }}"
 
       - name: "STAGING: Upload Knative CLI Workflow Plugin for Linux"
-        if: ${{ !inputs.dry_run }}
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -573,7 +573,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS"
-        if: ${{ !inputs.dry_run }}
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -584,7 +584,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: "STAGING: Upload Knative CLI Workflow Plugin for macOS M1"
-        if: ${{ !inputs.dry_run }}
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -595,7 +595,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: "STAGING: Knative CLI Workflow Plugin for Windows"
-        if: ${{ !inputs.dry_run }}
+        if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}


### PR DESCRIPTION
The staging `kn-plugin-workflow` artifacts are being uploaded by all OS builds. This fix makes them being uploaded only by the Ubuntu build.
