### PR TITLE
KOGITO-7748: Integration tests of `stunner-editors` are not parametrized to `build-env` settings

### DIFF
--- a/packages/stunner-editors/package.json
+++ b/packages/stunner-editors/package.json
@@ -22,7 +22,7 @@
     "build:dev:linux:darwin": "mvn clean install -DskipTests -DskipITs -Pno-showcase && pnpm dist",
     "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-DskipITs `-Pno-showcase && pnpm dist\"",
     "build:prod": "run-script-os",
-    "build:prod:linux:darwin": "pnpm lint && mvn clean install -DskipTests=$(build-env global.build.test --not) -Pno-showcase && pnpm dist",
+    "build:prod:linux:darwin": "pnpm lint && mvn clean install -DskipTests=$(build-env global.build.test --not) -DskipITs=$(build-env global.build.testIT --not) -Pno-showcase && pnpm dist",
     "build:prod:win32": "pnpm lint && pnpm powershell \"mvn clean install `-DskipTests=$(build-env global.build.test --not) `-DskipITs `-Pno-showcase\" && pnpm dist",
     "dist": "rimraf dist && mkdir dist && pnpm dist:bpmn && pnpm dist:dmn && pnpm dist:scesim",
     "dist:bpmn": "symlink-dir kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/target/kie-wb-common-stunner-bpmn-kogito-runtime ./dist/bpmn",


### PR DESCRIPTION
@tiagobento let me know if this is OK,  @LuboTerifaj please review

This will allow people to skipITs as intended by the build-env package.