### PR TITLE
Separating `CI :: Code formatting` and `CI :: Dependency consistency` checks for PRs

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -1,0 +1,41 @@
+name: "Bootstrap KIE Tools"
+description: ""
+
+inputs:
+  path:
+    description: "kie-tools path"
+    required: false
+    default: "."
+  pnpm_filter_string:
+    description: "pnpm filter string to choose what to bootstrap"
+    required: false
+    default: ""
+
+outputs:
+  pnpm_filter_string:
+    description: "Same as the input"
+    value: ${{ inputs.pnpm_filter_string }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Print storage usage (before bootstrap)"
+      shell: bash
+      run: |
+        echo "STEP: Print storage usage (before bootstrap)"
+        cd ${{ inputs.path }}
+        du -sh .
+
+    - name: "Bootstrap"
+      shell: bash
+      run: |
+        echo "STEP: Bootstrap"
+        cd ${{ inputs.path }}
+        pnpm bootstrap ${{ inputs.pnpm_filter_string }}
+
+    - name: "Print storage usage (after bootstrap)"
+      shell: bash
+      run: |
+        echo "STEP: Print storage usage (after bootstrap)"
+        cd ${{ inputs.path }}
+        du -sh .

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,14 +9,6 @@ inputs:
     description: "kie-tools path"
     required: false
     default: "."
-  partial:
-    description: "If true, only installs dependencies for affected packages."
-    required: false
-    default: "false"
-  base_sha:
-    description: "If `partial` is true, `base_sha` is used to determine the affected packages."
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -63,36 +55,6 @@ runs:
         pnpm -r exec 'bash' '-c' 'mkdir .mvn'
         pnpm -r exec 'bash' '-c' 'echo -B -ntp > .mvn/maven.config'
         pnpm -r exec 'bash' '-c' 'echo -Xmx2g > .mvn/jvm.config'
-
-    - name: "Bootstrap (full)"
-      if: inputs.partial == 'false'
-      shell: bash
-      run: |
-        echo "STEP: Bootstrap (full)"
-        cd ${{ inputs.path }}
-        pnpm bootstrap
-
-    - name: "Bootstrap (partial)"
-      if: inputs.partial == 'true'
-      shell: bash
-      run: |
-        echo "STEP: Bootstrap (partial)"
-        cd ${{ inputs.path }}
-        pnpm bootstrap -F "...[${{ inputs.base_sha }}]..."
-
-    - name: "Check dependencies mismatches"
-      shell: bash
-      run: |
-        echo "STEP: Check dependencies mismatches"
-        cd ${{ inputs.path }}
-        npx --yes syncpack@6.2.0 list-mismatches
-
-    - name: "Check format"
-      shell: bash
-      run: |
-        echo "STEP: Check format"
-        cd ${{ inputs.path }}
-        pnpm format:check
 
     - name: "Start Xvfb (Ubuntu only)"
       shell: bash

--- a/.github/workflows/check_code_formatting.yml
+++ b/.github/workflows/check_code_formatting.yml
@@ -1,0 +1,38 @@
+name: "CI :: Code formatting"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: "**"
+
+concurrency:
+  group: ${{ github.event.pull_request && format('check-code-formatting-pr-{0}', github.event.pull_request.number) || format('check-code-formatting-push-main-{0}', github.sha) }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.base_ref }}
+
+      - name: "Setup kie-tools-bot"
+        uses: ./.github/actions/setup-kie-tools-bot
+
+      - name: "Merge PR changes"
+        uses: ./.github/actions/merge-pr-changes
+
+      - name: "Setup environment"
+        uses: ./.github/actions/setup-env
+        with:
+          os: ubuntu-latest
+
+      - name: "Check code formatting"
+        shell: bash
+        run: |
+          pnpm install-dependencies -F .
+          pnpm format:check

--- a/.github/workflows/check_dependencies_consistency.yaml
+++ b/.github/workflows/check_dependencies_consistency.yaml
@@ -1,0 +1,38 @@
+name: "CI :: Dependencies consistency"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: "**"
+
+concurrency:
+  group: ${{ github.event.pull_request && format('check-dependencies-consistency-pr-{0}', github.event.pull_request.number) || format('check-dependencies-consistency-push-main-{0}', github.sha) }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.base_ref }}
+
+      - name: "Setup kie-tools-bot"
+        uses: ./.github/actions/setup-kie-tools-bot
+
+      - name: "Merge PR changes"
+        uses: ./.github/actions/merge-pr-changes
+
+      - name: "Setup environment"
+        uses: ./.github/actions/setup-env
+        with:
+          os: ubuntu-latest
+
+      - name: "Check dependencies mismatches"
+        shell: bash
+        run: |
+          pnpm install-dependencies -F .
+          npx --yes syncpack@6.2.0 list-mismatches

--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -1,15 +1,15 @@
-name: "CI :: Monorepo"
+name: "CI :: Build"
 
 on:
   pull_request:
     branches: "**"
 
 concurrency:
-  group: monorepo-pr-ci-${{ github.event.pull_request.number }}
+  group: ci-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  ci:
+  run:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -68,13 +68,18 @@ jobs:
 
           echo "Done"
 
-      - name: "Setup environment (partial)"
+      - name: "Setup environment"
         if: steps.check_diff_paths.outputs.should_run == 'true'
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
-          partial: true
-          base_sha: ${{ steps.merge_changes.outputs.base_sha }}
+
+      - name: "Bootstrap"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F "...[${{ steps.merge_changes.outputs.base_sha }}]..."
 
       - name: "Build dependencies"
         if: steps.check_diff_paths.outputs.should_run == 'true'

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -1,4 +1,4 @@
-name: "CI :: Monorepo (full)"
+name: "CI :: Build (full)"
 
 on:
   push:
@@ -7,11 +7,11 @@ on:
     branches: "**"
 
 concurrency:
-  group: ${{ github.event.pull_request && format('monorepo-pr-ci-full-{0}', github.event.pull_request.number) || format('monorepo-ci-full-push-main-{0}', github.sha) }}
+  group: ${{ github.event.pull_request && format('ci-build-full-pr-{0}', github.event.pull_request.number) || format('ci-build-full-push-main-{0}', github.sha) }}
   cancel-in-progress: true
 
 jobs:
-  ci-full:
+  run:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -78,6 +78,10 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
+
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
 
       - name: "Build"
         if: steps.check_diff_paths.outputs.should_run == 'true'

--- a/.github/workflows/publish_daily_dev_version.yml
+++ b/.github/workflows/publish_daily_dev_version.yml
@@ -85,6 +85,12 @@ jobs:
           os: ${{ matrix.os }}
           path: kie-tools
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+
       - name: "Build kie-tools"
         env:
           WEBPACK__minimize: "true"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -161,14 +161,21 @@ jobs:
           restore-keys: ${{ runner.os }}-dmn-dev-sandbox-deployment-base-image-m2
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/dmn-dev-sandbox-deployment-base-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/dmn-dev-sandbox-deployment-base-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Push dmn-dev-sandbox-deployment-base-image to quay.io"
         if: ${{ !inputs.dry_run }}
@@ -219,14 +226,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/kie-sandbox-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/kie-sandbox-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Push kie-sandbox-image to quay.io"
         if: ${{ !inputs.dry_run }}
@@ -288,14 +302,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/kie-sandbox-extended-services-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/kie-sandbox-extended-services-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Push kie-sandbox-extended-services-image to quay.io"
         if: ${{ !inputs.dry_run }}
@@ -349,14 +370,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/cors-proxy-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/cors-proxy-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Push cors-proxy-image to quay.io"
         if: ${{ !inputs.dry_run }}
@@ -435,15 +463,23 @@ jobs:
           restore-keys: ${{ runner.os }}-release-m2
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./kie-tools/.github/actions/setup-env
         with:
           path: kie-tools
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+          pnpm_filter_string: -F @kie-tools/online-editor...
+
       - name: "Build"
         working-directory: ${{ github.workspace }}/kie-tools
         run: |
-          pnpm -F @kie-tools/online-editor... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Deploy to GitHub Pages (kogito-online)"
         if: ${{ !inputs.dry_run }}
@@ -485,10 +521,9 @@ jobs:
       SWF_CHROME_EXTENSION__routerTargetOrigin: "https://kiegroup.github.io"
       SWF_CHROME_EXTENSION__routerRelativePath: "kogito-online/swf-chrome-extension/${{ inputs.tag }}"
       SWF_CHROME_EXTENSION__manifestFile: "manifest.prod.json"
-
-    if: ${{ always() && needs.extract_runners.outputs.chrome_extensions == 'true' && (needs.online_editor.result == 'success' || needs.online_editor.result == 'skipped') }}
+    if: ${{ always() && needs.extract_runners.outputs.chrome_extensions == 'true' && (needs.extended_services.result == 'success' || needs.extended_services.result == 'skipped') && (needs.dmn_dev_sandbox_image.result == 'success' || needs.dmn_dev_sandbox_image.result == 'skipped') && (needs.online_editor.result == 'success' || needs.online_editor.result == 'skipped') }}
     runs-on: ubuntu-latest
-    needs: [extract_runners, online_editor]
+    needs: [extract_runners, dmn_dev_sandbox_image, extended_services, online_editor]
     steps:
       - name: "Checkout kie-tools"
         uses: actions/checkout@v2
@@ -516,15 +551,23 @@ jobs:
           ref: gh-pages
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./kie-tools/.github/actions/setup-env
         with:
           path: kie-tools
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+          pnpm_filter_string: -F chrome-extension-pack-kogito-kie-editors... -F chrome-extension-serverless-workflow-editor...
+
       - name: "Build Chrome Extensions"
         working-directory: ${{ github.workspace }}/kie-tools
         run: |
-          pnpm -F chrome-extension-pack-kogito-kie-editors... -F chrome-extension-serverless-workflow-editor... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload Chrome Extension for Kogito KIE Editors"
         if: ${{ !inputs.dry_run }}
@@ -660,13 +703,20 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F vscode-extension-pack-kogito-kie-editors... -F vscode-extension-backend...
+
       - name: "Build"
         run: |
-          pnpm -F vscode-extension-pack-kogito-kie-editors... -F vscode-extension-backend... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload VS Code Extension (dev) (Ubuntu only)"
         if: ${{ !inputs.dry_run }}
@@ -708,21 +758,27 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: >-
+            -F vscode-extension-bpmn-editor...
+            -F vscode-extension-dmn-editor...
+            -F vscode-extension-pmml-editor...
+            -F vscode-extension-kogito-bundle...
+            -F vscode-extension-red-hat-business-automation-bundle...
+            -F vscode-extension-serverless-workflow-editor...
+            -F vscode-extension-kie-ba-bundle...
+
       - name: "Build"
         run: |
-          pnpm \
-            -F vscode-extension-bpmn-editor... \
-            -F vscode-extension-dmn-editor... \
-            -F vscode-extension-pmml-editor... \
-            -F vscode-extension-kogito-bundle... \
-            -F vscode-extension-red-hat-business-automation-bundle... \
-            -F vscode-extension-serverless-workflow-editor... \
-            -F vscode-extension-kie-ba-bundle... \
-            build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload VS Code Extension - BPMN Editor (prod)"
         if: ${{ !inputs.dry_run }}
@@ -826,14 +882,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/desktop...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/desktop... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload Desktop App for Linux (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
@@ -890,15 +953,27 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Create pnpm filter for building"
+        id: create_pnpm_filter_string_for_building
+        run: |
+          export PNPM_FILTER_STRING_FOR_BUILDING=$(pnpm -r exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json) PKG_IS_PVT=$(jq -r ".private" package.json); if [ "$PKG_IS_PVT" != "true" ]; then echo "-F $PKG_NAME..."; fi')
+          echo $PNPM_FILTER_STRING_FOR_BUILDING
+          echo ::set-output name=filter::$PNPM_FILTER_STRING_FOR_BUILDING
+
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: ${{ steps.create_pnpm_filter_string_for_building.outputs.filter }}
+
       - name: "Build"
         run: |
-          export FILTER=$(pnpm -r exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json) PKG_IS_PVT=$(jq -r ".private" package.json); if [ "$PKG_IS_PVT" != "true" ]; then echo "-F $PKG_NAME..."; fi')
-          echo $FILTER
-          pnpm $FILTER build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Publish packages to the NPM registry"
         if: ${{ !inputs.dry_run }}
@@ -906,14 +981,14 @@ jobs:
           NPM_TOKEN: ${{ secrets.kiegroup_npm_token }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          export FILTER=$(pnpm -r exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json) PKG_IS_PVT=$(jq -r ".private" package.json); if [ "$PKG_IS_PVT" != "true" ]; then echo "-F $PKG_NAME"; fi')
-          echo $FILTER
-          pnpm $FILTER exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json); NPM_PKG_INFO=$(npm view $PKG_NAME@${{ inputs.tag }} name || echo ""); if [ -z $NPM_PKG_INFO ]; then pnpm publish --access public; fi'
+          export PNPM_FILTER_STRING_FOR_PUBLISHING=$(pnpm -r exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json) PKG_IS_PVT=$(jq -r ".private" package.json); if [ "$PKG_IS_PVT" != "true" ]; then echo "-F $PKG_NAME"; fi')
+          echo $PNPM_FILTER_STRING_FOR_PUBLISHING
+          pnpm $PNPM_FILTER_STRING_FOR_PUBLISHING exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json); NPM_PKG_INFO=$(npm view $PKG_NAME@${{ inputs.tag }} name || echo ""); if [ -z $NPM_PKG_INFO ]; then pnpm publish --access public; fi'
 
   standalone_editors_cdn:
-    if: ${{ always() && needs.extract_runners.outputs.standalone_editors_cdn == 'true' && (needs.chrome_extensions.result == 'success' || needs.chrome_extensions.result == 'skipped') }}
+    if: ${{ always() && needs.extract_runners.outputs.standalone_editors_cdn == 'true' && (needs.extended_services.result == 'success' || needs.extended_services.result == 'skipped') && (needs.dmn_dev_sandbox_image.result == 'success' || needs.dmn_dev_sandbox_image.result == 'skipped') && (needs.online_editor.result == 'success' || needs.online_editor.result == 'skipped') && (needs.chrome_extensions.result == 'success' || needs.chrome_extensions.result == 'skipped') }}
     runs-on: ubuntu-latest
-    needs: [extract_runners, chrome_extensions]
+    needs: [extract_runners, dmn_dev_sandbox_image, extended_services, online_editor, chrome_extensions]
     steps:
       - name: "Checkout kie-tools"
         uses: actions/checkout@v2
@@ -941,15 +1016,23 @@ jobs:
           ref: gh-pages
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./kie-tools/.github/actions/setup-env
         with:
           path: kie-tools
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+          pnpm_filter_string: -F @kie-tools/kie-editors-standalone...
+
       - name: "Build"
         working-directory: ${{ github.workspace }}/kie-tools
         run: |
-          pnpm -F @kie-tools/kie-editors-standalone... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Deploy to GitHub Pages (kogito-online)"
         if: ${{ !inputs.dry_run }}
@@ -994,14 +1077,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ${{ matrix.os }}
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/extended-services...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/extended-services... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload Extended Services for Linux (Ubuntu only)"
         if: ${{ matrix.os == 'ubuntu-latest' && !inputs.dry_run }}
@@ -1054,14 +1144,21 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/dashbuilder...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/dashbuilder... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Upload DashBuilder Assets"
         if: ${{ !inputs.dry_run }}
@@ -1103,15 +1200,23 @@ jobs:
           path: kie-tools
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./kie-tools/.github/actions/setup-env
         with:
           path: kie-tools
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+          pnpm_filter_string: -F @kie-tools/dashbuilder-images...
+
       - name: "Build Dashbuilder Images"
         working-directory: ${{ github.workspace }}/kie-tools
         run: |
-          pnpm -F @kie-tools/dashbuilder-images... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
       - name: "Push dashbuilder-authoring image to quay.io"
         if: ${{ !inputs.dry_run }}
@@ -1151,14 +1256,22 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/kn-plugin-workflow...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/kn-plugin-workflow... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
+
       - name: "Upload Knative CLI Workflow Plugin for Linux"
         if: ${{ !inputs.dry_run }}
         uses: actions/upload-release-asset@v1.0.2
@@ -1234,14 +1347,21 @@ jobs:
           restore-keys: ${{ runner.os }}-serverless-logic-sandbox-base-image-m2
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/serverless-logic-sandbox-base-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/serverless-logic-sandbox-base-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
       - name: "Push serverless-logic-sandbox-base-image to quay.io"
         if: ${{ !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
@@ -1276,14 +1396,22 @@ jobs:
         uses: ./.github/actions/merge-pr-changes
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./.github/actions/setup-env
         with:
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          pnpm_filter_string: -F @kie-tools/openjdk11-mvn-image...
+
       - name: "Build"
         shell: bash
         run: |
-          pnpm -F @kie-tools/openjdk11-mvn-image... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
+
       - name: "Push openjdk11-mvn-image to quay.io"
         if: ${{ !inputs.dry_run }}
         uses: redhat-actions/push-to-registry@v2
@@ -1348,15 +1476,24 @@ jobs:
           restore-keys: ${{ runner.os }}-serverless-logic-sandbox-m2
 
       - name: "Setup environment"
+        id: setup_env
         uses: ./kie-tools/.github/actions/setup-env
         with:
           path: kie-tools
           os: ubuntu-latest
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+          pnpm_filter_string: -F @kie-tools/serverless-logic-sandbox...
+
       - name: "Build"
         working-directory: ${{ github.workspace }}/kie-tools
         run: |
-          pnpm -F @kie-tools/serverless-logic-sandbox... build:prod
+          pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
+
       - name: "Deploy to GitHub Pages (serverless-logic-sandbox-deployment)"
         if: ${{ !inputs.dry_run }}
         working-directory: ${{ github.workspace }}/serverless-logic-sandbox-deployment

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -145,6 +145,12 @@ jobs:
           os: ${{ matrix.os }}
           path: kie-tools
 
+      - name: "Bootstrap"
+        id: bootstrap
+        uses: ./kie-tools/.github/actions/bootstrap
+        with:
+          path: kie-tools
+
       - name: "Build"
         working-directory: ${{ github.workspace }}/kie-tools
         env:


### PR DESCRIPTION
This PR introduces two new workflows
`CI :: Code formatting`; and
`CI :: Dependencies consistency`.

Those checks were present at the `setup-env` action before.

---

Also on this PR:
- Renaming `CI :: Monorepo (full)` and `CI :: Monorepo` to `CI :: Build (full)` and `CI :: Build`.
- Use filtered bootstraps on Release workflow.