### PR TITLE
Update `greetings` sample on Serverless Logic Sandbox to use `jq` + some CI fixes

### DIFF
--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -80,6 +80,7 @@ jobs:
           os: ${{ matrix.os }}
 
       - name: "Bootstrap"
+        if: steps.check_diff_paths.outputs.should_run == 'true'
         id: bootstrap
         uses: ./.github/actions/bootstrap
 

--- a/packages/serverless-logic-sandbox/static/samples/greetings/greetings.sw.json
+++ b/packages/serverless-logic-sandbox/static/samples/greetings/greetings.sw.json
@@ -2,7 +2,6 @@
   "id": "jsongreet",
   "version": "1.0",
   "name": "Greeting workflow",
-  "expressionLang": "jsonpath",
   "description": "JSON based greeting workflow",
   "start": "ChooseOnLanguage",
   "functions": [
@@ -18,11 +17,11 @@
       "type": "switch",
       "dataConditions": [
         {
-          "condition": "${ $.[?(@.language  == 'English')] }",
+          "condition": "${ .language == \"English\" }",
           "transition": "GreetInEnglish"
         },
         {
-          "condition": "${ $.[?(@.language  == 'Spanish')] }",
+          "condition": "${ .language == \"Spanish\" }",
           "transition": "GreetInSpanish"
         }
       ],
@@ -55,13 +54,13 @@
           "functionRef": {
             "refName": "greetFunction",
             "arguments": {
-              "message": "$.greeting $.name"
+              "message": ".greeting+.name"
             }
           }
         }
       ],
       "end": {
-        "terminate": true
+        "terminate": "true"
       }
     }
   ]

--- a/packages/serverless-workflow-diagram-editor/package.json
+++ b/packages/serverless-workflow-diagram-editor/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build:dev": "run-script-os",
     "build:dev:linux:darwin": "mvn clean install -DskipTests -DskipITs -Pno-showcase && pnpm dist",
-    "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-DskipITs `-Pno-showcase && pnpm dist\"",
+    "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-DskipITs `-Pno-showcase\" && pnpm dist",
     "build:prod": "run-script-os",
     "build:prod:linux:darwin": "pnpm lint && mvn clean install -DskipTests=$(build-env global.build.test --not) -DskipITs -Pno-showcase && pnpm dist",
     "build:prod:win32": "pnpm lint && pnpm powershell \"mvn clean install `-DskipTests=$(build-env global.build.test --not) `-DskipITs `-Pno-showcase\" && pnpm dist",

--- a/packages/stunner-editors/package.json
+++ b/packages/stunner-editors/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build:dev": "run-script-os",
     "build:dev:linux:darwin": "mvn clean install -DskipTests -DskipITs -Pno-showcase && pnpm dist",
-    "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-DskipITs `-Pno-showcase && pnpm dist\"",
+    "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-DskipITs `-Pno-showcase\" && pnpm dist",
     "build:prod": "run-script-os",
     "build:prod:linux:darwin": "pnpm lint && mvn clean install -DskipTests=$(build-env global.build.test --not) -DskipITs=$(build-env global.build.testIT --not) -Pno-showcase && pnpm dist",
     "build:prod:win32": "pnpm lint && pnpm powershell \"mvn clean install `-DskipTests=$(build-env global.build.test --not) `-DskipITs `-Pno-showcase\" && pnpm dist",


### PR DESCRIPTION
I didn't change the svgs because that would require a manual update, and this is a small change. 

Either way, soon we will have to update all svgs to use stunner as default.