### PR TITLE
Fix non-sources detection on PRs

### DIFF
--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -42,15 +42,12 @@ jobs:
           echo "Non-source paths:"
           echo $NON_SOURCE_PATHS
 
-          # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
-          IFS_BKP=$IFS
-          IFS=
-          export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
+          export CHANGED_SOURCE_PATHS=($(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS"))
           echo "Changed source paths:"
-          echo $CHANGED_SOURCE_PATHS
-          IFS=$IFS_BKP
+          echo ${#CHANGED_SOURCE_PATHS[@]}
+          printf '%s\n' "${CHANGED_SOURCE_PATHS[@]}"
 
-          export CHANGED_SOURCE_PATHS_IN_ROOT=($(echo "$CHANGED_SOURCE_PATHS" | grep -v -e "^packages" -e "^examples"))
+          export CHANGED_SOURCE_PATHS_IN_ROOT=($(printf '%s\n' "${CHANGED_SOURCE_PATHS[@]}" | grep -v -e "^packages" -e "^examples"))
           echo "Changed source paths in root:"
           echo ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]}
           printf '%s\n' "${CHANGED_SOURCE_PATHS_IN_ROOT[@]}"

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -44,15 +44,12 @@ jobs:
           echo "Non-source paths:"
           echo $NON_SOURCE_PATHS
 
-          # Setting IFS to empty string will preserve new lines on CHANGED_SOURCE_PATHS
-          IFS_BKP=$IFS
-          IFS=
-          export CHANGED_SOURCE_PATHS=$(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS")
+          export CHANGED_SOURCE_PATHS=($(eval "git diff --name-only ${{ steps.merge_changes.outputs.base_sha }} ${{ steps.merge_changes.outputs.head_sha }} -- $NON_SOURCE_PATHS"))
           echo "Changed source paths:"
-          echo $CHANGED_SOURCE_PATHS
-          IFS=$IFS_BKP
+          echo ${#CHANGED_SOURCE_PATHS[@]}
+          printf '%s\n' "${CHANGED_SOURCE_PATHS[@]}"
 
-          export CHANGED_SOURCE_PATHS_IN_ROOT=($(echo "$CHANGED_SOURCE_PATHS" | grep -v -e "^packages" -e "^examples"))
+          export CHANGED_SOURCE_PATHS_IN_ROOT=($(printf '%s\n' "${CHANGED_SOURCE_PATHS[@]}" | grep -v -e "^packages" -e "^examples"))
           echo "Changed source paths in root:"
           echo ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]}
           printf '%s\n' "${CHANGED_SOURCE_PATHS_IN_ROOT[@]}"


### PR DESCRIPTION
Bash scripts fail me once again...

....anyway 😅 .... `CHANGED_SOURCE_PATHS` was not being treated as an array. So even if it was an empty string of a bunch of changed files, its size was always equal to 1, which never made the PR skip for non-source-only PRs.