### PR TITLE
KOGITO-7230: Upgrade dependencies with reported vulnerabilities

### DIFF
--- a/packages/stunner-editors/errai-bom/pom.xml
+++ b/packages/stunner-editors/errai-bom/pom.xml
@@ -78,9 +78,9 @@
 
     <sonar.skip>true</sonar.skip>
 
-    <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.code.gson>2.8.9</version.com.google.code.gson>
+    <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
     <version.com.google.jsinterop>2.0.0</version.com.google.jsinterop>
     <!-- 3.18+ breaks GWT compilation -->
     <version.org.eclipse.jdt.ecj>3.17.0</version.org.eclipse.jdt.ecj>
@@ -141,7 +141,7 @@
     <version.org.slf4j>1.7.26</version.org.slf4j>
     <version.org.wildfly>19.1.0.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-    <version.org.wildfly.core>11.1.1.Final</version.org.wildfly.core>
+    <version.org.wildfly.core>18.1.1.Final</version.org.wildfly.core>
     <version.xml-apis>1.4.01</version.xml-apis>
   </properties>
 


### PR DESCRIPTION
…ilities

Cherry-picks KOGITO-7230 into stunner-editors package

See #1003 for original PR.