### PR TITLE
Bump `flatten-maven-plugin` to `1.3.0`

### DIFF
--- a/packages/backend-extended-services/pom.xml
+++ b/packages/backend-extended-services/pom.xml
@@ -101,7 +101,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -1295,7 +1295,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/dmn-dev-sandbox-quarkus/pom.xml
+++ b/packages/dmn-dev-sandbox-quarkus/pom.xml
@@ -147,7 +147,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -800,7 +800,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -810,7 +810,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -97,7 +97,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.7</version>
+        <version>1.3.0</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>


### PR DESCRIPTION
This fixes an issue first reported by @hasys, where he could not run `mvn gwt:run` on `packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app`.

We found out this issue was a bug (https://github.com/mojohaus/flatten-maven-plugin/issues/100) on `flatten-maven-plugin`, which was clashing with `shade-maven-plugin`, leaving the installed POM with a reference to the CI friendly version `${revision}`.

We contacted the maintainers of `flatten-maven-plugin` through this issue https://github.com/mojohaus/flatten-maven-plugin/issues/292 and they kindly released a new version containing the fix (https://github.com/mojohaus/flatten-maven-plugin/pull/281) right away. (Thanks a lot, @slawekjaranowski 🎉)

