### PR TITLE
Serverless Logic Web Tools: Fix `terminate` value on Greetings sample

### DIFF
--- a/packages/serverless-logic-sandbox/static/samples/greetings/greetings.sw.json
+++ b/packages/serverless-logic-sandbox/static/samples/greetings/greetings.sw.json
@@ -60,7 +60,7 @@
         }
       ],
       "end": {
-        "terminate": "true"
+        "terminate": true
       }
     }
   ]


### PR DESCRIPTION
Type should be `boolean`, not `string`.