### PR TITLE
Configure Buildkite to keep track of our Integration Tests results

### DIFF
--- a/.github/actions/setup-ci-patterns/action.yml
+++ b/.github/actions/setup-ci-patterns/action.yml
@@ -86,6 +86,7 @@ runs:
           core.setOutput(
             "integration_tests_reports_patterns_for_find", 
             prefixWithRoots(fs.readFileSync("./.github/supporting-files/ci/integration-tests-reports-patterns.txt", "utf-8"))
+              .split("\n")
               .map(p => `-path '${p}'`)
               .join(" -o ")
           );

--- a/.github/actions/setup-ci-patterns/action.yml
+++ b/.github/actions/setup-ci-patterns/action.yml
@@ -32,6 +32,9 @@ outputs:
   build_artifacts_patterns:
     description: ""
     value: ${{ steps.ci_patterns.outputs.build_artifacts_patterns }}
+  integration_tests_reports_patterns_for_find:
+    description: ""
+    value: ${{ steps.ci_patterns.outputs.integration_tests_reports_patterns_for_find }}
 
 runs:
   using: "composite"
@@ -80,6 +83,13 @@ runs:
           await outputPatternsPrefixedWithRoots("integration_tests_artifacts_patterns", path.join(cwd, "./.github/supporting-files/ci/integration-tests-artifacts-patterns.txt"));
           await outputPatternsPrefixedWithRoots("build_artifacts_patterns", path.join(cwd, "./.github/supporting-files/ci/build-artifacts-patterns.txt"));
 
+          core.setOutput(
+            "integration_tests_reports_patterns_for_find", 
+            prefixWithRoots(fs.readFileSync("./.github/supporting-files/ci/integration-tests-reports-patterns.txt", "utf-8"))
+              .map(p => `-path '${p}'`)
+              .join(" -o ")
+          );
+
     - name: "Print CI patterns"
       shell: bash
       run: |
@@ -91,3 +101,4 @@ runs:
         echo "${{ steps.ci_patterns.outputs.integration_tests_reports_patterns }}" 
         echo "${{ steps.ci_patterns.outputs.integration_tests_artifacts_patterns }}" 
         echo "${{ steps.ci_patterns.outputs.build_artifacts_patterns }}"
+        echo "${{ steps.ci_patterns.outputs.integration_tests_reports_patterns_for_find }}"

--- a/.github/workflows/monorepo_pr_ci.yml
+++ b/.github/workflows/monorepo_pr_ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout @ GitHub default"
         uses: actions/checkout@v3
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         id: checkout_pr
         uses: ./.github/actions/checkout-pr
         with:

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: "Upload integration tests results to Buildkite"
         if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true' && !github.event.pull_request
+        shell: bash
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILDKITE_BUILD_ID: ${{ github.run_id }}

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: "Start telemetry service (`main` only)"
         if: steps.check_diff_paths.outputs.should_run == 'true' && !github.event.pull_request
-        uses: runforesight/workflow-telemetry-action@7771f879afebe55ef1009a49f0b8a5d9089d8bc7
+        uses: runforesight/workflow-telemetry-action@93f572a11871f543b083e0695ddfcefba32d07bd
 
       - name: "Setup environment"
         if: steps.check_diff_paths.outputs.should_run == 'true'

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   run:
+    environment: ci
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -116,6 +117,36 @@ jobs:
       - name: "Upload reports and artifacts"
         if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         uses: ./.github/actions/upload-ci-reports-and-artifacts
+
+      - name: "Upload integration tests results to Buildkite"
+        if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true' && !github.event.pull_request
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+          BUILDKITE_BUILD_ID: ${{ github.run_id }}
+          BUILDKITE_BUILD_NUMBER: ${{ github.run_attempt }}
+          BUILDKITE_JOB_ID: ${{ github.run_id }}
+          BUILDKITE_BRANCH: main
+          BUILDKITE_COMMIT: ${{ github.sha }}
+          BUILDKITE_MESSAGE: ${{ github.event.commits[0].message }}
+          BUILDKITE_BUILD_URL: ${{ github.event.html_url }}/actions/runs/${{ github.run_id }}
+          INTEGRATION_TESTS_PATTERNS: >-
+            ${{ steps.ci_patterns.outputs.integration_tests_reports_patterns }}
+        run: |
+          echo $INTEGRATION_TESTS_PATTERNS
+          echo ${INTEGRATION_TESTS_PATTERNS[@]}
+          find $INTEGRATION_TESTS_PATTERNS | xargs -I{} curl -X POST \
+            -H "Authorization: Token token=$BUILDKITE_ANALYTICS_TOKEN" \
+            -F "format=junit" \
+            -F "data=@{}" \
+            -F "run_env[CI]=buildkite" \
+            -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+            -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+            -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+            -F "run_env[branch]=$BUILDKITE_BRANCH" \
+            -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+            -F "run_env[message]=$BUILDKITE_MESSAGE" \
+            -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+            https://analytics-api.buildkite.com/v1/uploads
 
       - name: "Print storage usage (after build)"
         shell: bash

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -118,7 +118,7 @@ jobs:
         if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true'
         uses: ./.github/actions/upload-ci-reports-and-artifacts
 
-      - name: "Upload integration tests results to Buildkite"
+      - name: "Upload integration tests results to Buildkite (`main` only)"
         if: always() && !cancelled() && steps.check_diff_paths.outputs.should_run == 'true' && !github.event.pull_request
         shell: bash
         env:

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -130,12 +130,8 @@ jobs:
           BUILDKITE_COMMIT: ${{ github.sha }}
           BUILDKITE_MESSAGE: ${{ github.event.commits[0].message }}
           BUILDKITE_BUILD_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
-          INTEGRATION_TESTS_PATTERNS: >-
-            ${{ steps.ci_patterns.outputs.integration_tests_reports_patterns }}
         run: |
-          echo $INTEGRATION_TESTS_PATTERNS
-          echo ${INTEGRATION_TESTS_PATTERNS[@]}
-          find $INTEGRATION_TESTS_PATTERNS | xargs -I{} curl -X POST \
+          eval "find -P * -type f ${{ steps.ci_patterns.outputs.integration_tests_reports_patterns_for_find }}" | xargs -I{} curl -X POST \
             -H "Authorization: Token token=$BUILDKITE_ANALYTICS_TOKEN" \
             -F "format=junit" \
             -F "data=@{}" \

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -126,7 +126,7 @@ jobs:
           BUILDKITE_BUILD_ID: ${{ github.run_id }}
           BUILDKITE_BUILD_NUMBER: ${{ github.run_attempt }}
           BUILDKITE_JOB_ID: ${{ github.run_id }}
-          BUILDKITE_BRANCH: main
+          BUILDKITE_BRANCH: ${{ github.ref_name }}
           BUILDKITE_COMMIT: ${{ github.sha }}
           BUILDKITE_MESSAGE: ${{ github.event.commits[0].message }}
           BUILDKITE_BUILD_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Checkout @ GitHub default"
         uses: actions/checkout@v3
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         id: checkout_pr
         uses: ./.github/actions/checkout-pr
         with:

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: "Start telemetry service (`main` only)"
         if: steps.check_diff_paths.outputs.should_run == 'true' && !github.event.pull_request
-        uses: runforesight/workflow-telemetry-action@93f572a11871f543b083e0695ddfcefba32d07bd
+        uses: runforesight/workflow-telemetry-action@f5b7d16a7dd7bbf8c615334fa354a548dadda915
 
       - name: "Setup environment"
         if: steps.check_diff_paths.outputs.should_run == 'true'

--- a/.github/workflows/monorepo_pr_ci_full.yml
+++ b/.github/workflows/monorepo_pr_ci_full.yml
@@ -128,7 +128,7 @@ jobs:
           BUILDKITE_BRANCH: main
           BUILDKITE_COMMIT: ${{ github.sha }}
           BUILDKITE_MESSAGE: ${{ github.event.commits[0].message }}
-          BUILDKITE_BUILD_URL: ${{ github.event.html_url }}/actions/runs/${{ github.run_id }}
+          BUILDKITE_BUILD_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
           INTEGRATION_TESTS_PATTERNS: >-
             ${{ steps.ci_patterns.outputs.integration_tests_reports_patterns }}
         run: |

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -412,7 +412,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}
@@ -502,7 +502,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}
@@ -938,7 +938,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}
@@ -1115,7 +1115,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}
@@ -1352,7 +1352,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           path: kie-tools
 
-      - name: "Checkout @ Simulated squashed merge of PR"
+      - name: "Checkout @ Simulated squashed-merge if PR"
         uses: ./kie-tools/.github/actions/checkout-pr
         with:
           ref: ${{ inputs.base_ref }}


### PR DESCRIPTION
Also:
- Updated workflow-telemetry action to fix a problem on Windows (macOS currently being fixed)
- Fixed some discrepancies in checkout steps names.

The `BUILDKITE_TOKEN` is already configured on the `ci` environment on the repository settings.