### PR TITLE
Specify types of pull_request events that should trigger the CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: "**"
+    types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
   group: ${{ github.event.pull_request && format('ci-build-full-pr-{0}', github.event.pull_request.number) || format('ci-build-full-push-main-{0}', github.sha) }}


### PR DESCRIPTION
The CI was not being ran when a PR was marked for review (after being a draft PR).