### PR TITLE
Build `dashbuilder-runtime-client` on `build:dev` as well

### DIFF
--- a/packages/dashbuilder/package.json
+++ b/packages/dashbuilder/package.json
@@ -16,8 +16,11 @@
     "**/dist/*"
   ],
   "scripts": {
-    "build:dev": "run-script-os",
+    "build:dev": "run-script-os && pnpm copy:components && pnpm build:dev:runtime",
     "build:dev:linux:darwin": "mvn clean install -DskipTests -Dgwt.compiler.skip=true",
+    "build:dev:runtime": "run-script-os",
+    "build:dev:runtime:linux:darwin": "cd ./dashbuilder-runtime-parent/dashbuilder-runtime-client/ && mvn clean install -Psources -DskipTests",
+    "build:dev:runtime:win32": "echo \"Build not supported on Windows\"",
     "build:dev:win32": "pnpm powershell \"mvn clean install `-DskipTests `-Dgwt.compiler.skip=true\"",
     "build:prod": "pnpm copy:components && pnpm lint && run-script-os && pnpm build:prod:authoring && pnpm build:prod:runtime && pnpm dist && pnpm delete:components",
     "build:prod:authoring": "run-script-os",


### PR DESCRIPTION
I took these changes from this open PR [1] to unblock other PRs. See [2].

[1] https://github.com/kiegroup/kie-tools/pull/1235
[2] https://github.com/kiegroup/kie-tools/pull/1240#issuecomment-1261301231