### PR TITLE
KOGITO-8043 Jenkins node master -> built-in

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem8g && !master'
+        label 'kie-rhel7 && kie-mem8g && !built-in'
     }
     tools {
         maven 'kie-maven-3.6.3'

--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -4,7 +4,7 @@ settingsXMLId = 'kie-tools-prod'
 
 pipeline {
     agent {
-        label 'kie-rhel8 && kie-mem16g && !master'
+        label 'kie-rhel8 && kie-mem16g && !built-in'
     }
     tools {
         nodejs "nodejs-16.2.0"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8043

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/631
- https://github.com/kiegroup/drools/pull/4723
- https://github.com/kiegroup/kogito-runtimes/pull/2525
- https://github.com/kiegroup/kogito-apps/pull/1483
- https://github.com/kiegroup/kogito-examples/pull/1423
- https://github.com/kiegroup/kogito-images/pull/1342
- https://github.com/kiegroup/kogito-operator/pull/1293
- https://github.com/kiegroup/kogito-docs/pull/218
- https://github.com/kiegroup/kie-tools/pull/1249
- https://github.com/kiegroup/optaplanner/pull/2219
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/760
- https://github.com/kiegroup/optaplanner-quickstarts/pull/415