### PR TITLE
Point cors-proxy URLs to the new cluster

### DIFF
--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -22,7 +22,7 @@ jobs:
       DMN_DEV_SANDBOX__baseImageTag: "daily-dev"
       DMN_DEV_SANDBOX__baseImageBuildTags: "daily-dev"
       DMN_DEV_SANDBOX__onlineEditorUrl: "https://kiegroup.github.io/kogito-online/dev"
-      ONLINE_EDITOR__corsProxyUrl: "https://cors.isomorphic-git.org"
+      ONLINE_EDITOR__corsProxyUrl: "https://daily-dev-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
 
       KIE_SANDBOX__imageRegistry: "quay.io"
       KIE_SANDBOX__imageAccount: "kie-tools"
@@ -54,7 +54,7 @@ jobs:
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageName: "openjdk11-mvn-image"
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageTag: "daily-dev"
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageBuildTags: "daily-dev"
-      SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://cors.isomorphic-git.org"
+      SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://daily-dev-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
 
     steps:
       - name: "Support longpaths (Windows only)"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -394,7 +394,7 @@ jobs:
       ONLINE_EDITOR__kieSandboxExtendedServicesDownloadUrlWindows: "https://github.com/kiegroup/kie-tools/releases/download/${{ inputs.tag }}/kie_sandbox_extended_services_windows_${{ inputs.tag }}.exe"
       ONLINE_EDITOR__kieSandboxExtendedServicesCompatibleVersion: "${{ inputs.tag }}"
       ONLINE_EDITOR__gtmId: "GTM-PQGMKNW"
-      ONLINE_EDITOR__corsProxyUrl: "https://cors.isomorphic-git.org"
+      ONLINE_EDITOR__corsProxyUrl: "https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
       DMN_DEV_SANDBOX__baseImageRegistry: "quay.io"
       DMN_DEV_SANDBOX__baseImageAccount: "kie-tools"
       DMN_DEV_SANDBOX__baseImageName: "dmn-dev-sandbox-deployment-base-image"
@@ -1341,7 +1341,7 @@ jobs:
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageAccount: "kie-tools"
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageName: "openjdk11-mvn-image"
       SERVERLESS_LOGIC_SANDBOX__openJdk11MvnImageTag: "${{ inputs.tag }}"
-      SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://cors.isomorphic-git.org"
+      SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
 
     if: ${{ always() && needs.extract_runners.outputs.serverless_logic_sandbox == 'true' && (needs.extended_services.result == 'success' || needs.extended_services.result == 'skipped') && (needs.serverless_logic_sandbox_base_image.result == 'success' || needs.serverless_logic_sandbox_base_image.result == 'skipped') && (needs.openjdk11_mvn_image.result == 'success' || needs.openjdk11_mvn_image.result == 'skipped') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -168,7 +168,7 @@ jobs:
           ONLINE_EDITOR__kieSandboxExtendedServicesDownloadUrlWindows: "${{ inputs.download_asset_url }}/STAGING__kie_sandbox_extended_services_windows_${{ inputs.tag }}.exe"
           ONLINE_EDITOR__kieSandboxExtendedServicesCompatibleVersion: "${{ inputs.tag }}"
           ONLINE_EDITOR__gtmId: ""
-          ONLINE_EDITOR__corsProxyUrl: "https://cors.isomorphic-git.org"
+          ONLINE_EDITOR__corsProxyUrl: "https://staging-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
           DMN_DEV_SANDBOX__gtmId: ""
           DMN_DEV_SANDBOX__onlineEditorUrl: "https://kiegroup.github.io/kogito-online-staging/${{ inputs.tag }}-prerelease"
           SERVERLESS_LOGIC_SANDBOX__buildInfo: "${{ inputs.tag }} (staging) @ ${{ inputs.commit_sha }}"
@@ -176,7 +176,7 @@ jobs:
           SERVERLESS_LOGIC_SANDBOX__kieSandboxExtendedServicesDownloadUrlMacOs: "${{ inputs.download_asset_url }}/STAGING__kie_sandbox_extended_services_macos_${{ inputs.tag }}.dmg"
           SERVERLESS_LOGIC_SANDBOX__kieSandboxExtendedServicesDownloadUrlWindows: "${{ inputs.download_asset_url }}/STAGING__kie_sandbox_extended_services_windows_${{ inputs.tag }}.exe"
           SERVERLESS_LOGIC_SANDBOX__kieSandboxExtendedServicesCompatibleVersion: "${{ inputs.tag }}"
-          SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://cors.isomorphic-git.org"
+          SERVERLESS_LOGIC_SANDBOX__corsProxyUrl: "https://staging-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud"
         run: |
           pnpm -r build:prod
 


### PR DESCRIPTION
Note: Only the URL for `daily-dev` is up at the moment. The others will be created after the next release.