### PR TITLE
KOGITO-8063: [SWF Editor] Disable cross-language autocompletion in YAML

### DIFF
--- a/packages/serverless-workflow-language-service/src/channel/SwfJsonLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfJsonLanguageService.ts
@@ -19,7 +19,13 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { CodeLens, CompletionItem, CompletionItemKind, Position, Range } from "vscode-languageserver-types";
 import { FileLanguage } from "../api";
 import { SwfLanguageService, SwfLanguageServiceArgs } from "./SwfLanguageService";
-import { CodeCompletionStrategy, ShouldCompleteArgs, SwfLsNode, TranslateArgs } from "./types";
+import {
+  ShouldCreateCodelensArgs,
+  CodeCompletionStrategy,
+  ShouldCompleteArgs,
+  SwfLsNode,
+  TranslateArgs,
+} from "./types";
 
 export class SwfJsonLanguageService {
   private readonly ls: SwfLanguageService;
@@ -93,5 +99,9 @@ export class JsonCodeCompletionStrategy implements CodeCompletionStrategy {
   public shouldComplete(args: ShouldCompleteArgs): boolean {
     const cursorJsonLocation = jsonc.getLocation(args.content, args.cursorOffset);
     return cursorJsonLocation.matches(args.path) && cursorJsonLocation.path.length === args.path.length;
+  }
+
+  public shouldCreateCodelens(_args: ShouldCreateCodelensArgs): boolean {
+    return true;
   }
 }

--- a/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
@@ -32,7 +32,12 @@ import {
   Position,
   Range,
 } from "vscode-languageserver-types";
-import { FileLanguage, SwfLanguageServiceCommandArgs, SwfLanguageServiceCommandExecution } from "../api";
+import {
+  FileLanguage,
+  SwfLanguageServiceCommandArgs,
+  SwfLanguageServiceCommandExecution,
+  SwfLanguageServiceCommandTypes,
+} from "../api";
 import { SW_SPEC_WORKFLOW_SCHEMA } from "../schemas";
 import { findNodesAtLocation } from "./findNodesAtLocation";
 import * as swfModelQueries from "./modelQueries";
@@ -213,7 +218,12 @@ export class SwfLanguageService {
       jsonPath: ["functions"],
       positionLensAt: "begin",
       commandDelegates: ({ node }) => {
-        if (node.type !== "array") {
+        const commandName: SwfLanguageServiceCommandTypes = "swf.ls.commands.OpenFunctionsCompletionItems";
+
+        if (
+          node.type !== "array" ||
+          !args.codeCompletionStrategy.shouldCreateCodelens({ node, commandName, content: args.content })
+        ) {
           return [];
         }
 
@@ -221,11 +231,9 @@ export class SwfLanguageService {
 
         return [
           {
-            name: "swf.ls.commands.OpenFunctionsCompletionItems",
+            name: commandName,
             title: "+ Add function...",
-            args: [
-              { newCursorPosition } as SwfLanguageServiceCommandArgs["swf.ls.commands.OpenFunctionsCompletionItems"],
-            ],
+            args: [{ newCursorPosition } as SwfLanguageServiceCommandArgs[typeof commandName]],
           },
         ];
       },
@@ -237,19 +245,21 @@ export class SwfLanguageService {
       jsonPath: ["functions"],
       positionLensAt: "begin",
       commandDelegates: ({ position, node }) => {
-        if (node.type !== "array") {
-          return [];
-        }
+        const commandName: SwfLanguageServiceCommandTypes = "swf.ls.commands.OpenServiceRegistriesConfig";
 
-        if (!this.args.config.shouldConfigureServiceRegistries()) {
+        if (
+          node.type !== "array" ||
+          !args.codeCompletionStrategy.shouldCreateCodelens({ node, commandName, content: args.content }) ||
+          !this.args.config.shouldConfigureServiceRegistries()
+        ) {
           return [];
         }
 
         return [
           {
-            name: "swf.ls.commands.OpenServiceRegistriesConfig",
+            name: commandName,
             title: "↪ Setup Service Registries...",
-            args: [{ position } as SwfLanguageServiceCommandArgs["swf.ls.commands.OpenServiceRegistriesConfig"]],
+            args: [{ position } as SwfLanguageServiceCommandArgs[typeof commandName]],
           },
         ];
       },
@@ -261,23 +271,22 @@ export class SwfLanguageService {
       jsonPath: ["functions"],
       positionLensAt: "begin",
       commandDelegates: ({ position, node }) => {
-        if (node.type !== "array") {
-          return [];
-        }
+        const commandName: SwfLanguageServiceCommandTypes = "swf.ls.commands.LogInServiceRegistries";
 
-        if (this.args.config.shouldConfigureServiceRegistries()) {
-          return [];
-        }
-
-        if (!this.args.config.shouldServiceRegistriesLogIn()) {
+        if (
+          node.type !== "array" ||
+          !args.codeCompletionStrategy.shouldCreateCodelens({ node, commandName, content: args.content }) ||
+          this.args.config.shouldConfigureServiceRegistries() ||
+          !this.args.config.shouldServiceRegistriesLogIn()
+        ) {
           return [];
         }
 
         return [
           {
-            name: "swf.ls.commands.LogInServiceRegistries",
+            name: commandName,
             title: "↪ Log in Service Registries...",
-            args: [{ position } as SwfLanguageServiceCommandArgs["swf.ls.commands.LogInServiceRegistries"]],
+            args: [{ position } as SwfLanguageServiceCommandArgs[typeof commandName]],
           },
         ];
       },
@@ -289,23 +298,22 @@ export class SwfLanguageService {
       jsonPath: ["functions"],
       positionLensAt: "begin",
       commandDelegates: ({ position, node }) => {
-        if (node.type !== "array") {
-          return [];
-        }
+        const commandName: SwfLanguageServiceCommandTypes = "swf.ls.commands.RefreshServiceRegistries";
 
-        if (this.args.config.shouldConfigureServiceRegistries()) {
-          return [];
-        }
-
-        if (!this.args.config.canRefreshServices()) {
+        if (
+          node.type !== "array" ||
+          !args.codeCompletionStrategy.shouldCreateCodelens({ node, commandName, content: args.content }) ||
+          this.args.config.shouldConfigureServiceRegistries() ||
+          !this.args.config.canRefreshServices()
+        ) {
           return [];
         }
 
         return [
           {
-            name: "swf.ls.commands.RefreshServiceRegistries",
+            name: commandName,
             title: "↺ Refresh Service Registries...",
-            args: [{ position } as SwfLanguageServiceCommandArgs["swf.ls.commands.RefreshServiceRegistries"]],
+            args: [{ position } as SwfLanguageServiceCommandArgs[typeof commandName]],
           },
         ];
       },

--- a/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfLanguageService.ts
@@ -344,19 +344,13 @@ export class SwfLanguageService {
       const serviceFileName = posixPath.basename(func.source.serviceFileAbsolutePath);
       const serviceFileRelativePosixPath = posixPath.join(specsDirRelativePosixPath, serviceFileName);
       return `${serviceFileRelativePosixPath}#${func.name}`;
-    }
-
-    //
-    else if (
+    } else if (
       (await this.args.config.shouldReferenceServiceRegistryFunctionsWithUrls()) &&
       containingService.source.type === SwfServiceCatalogServiceSourceType.SERVICE_REGISTRY &&
       func.source.type === SwfServiceCatalogFunctionSourceType.SERVICE_REGISTRY
     ) {
       return `${containingService.source.url}#${func.name}`;
-    }
-
-    //
-    else if (
+    } else if (
       containingService.source.type === SwfServiceCatalogServiceSourceType.SERVICE_REGISTRY &&
       func.source.type === SwfServiceCatalogFunctionSourceType.SERVICE_REGISTRY
     ) {
@@ -366,10 +360,7 @@ export class SwfLanguageService {
       );
       const serviceFileRelativePosixPath = posixPath.join(specsDirRelativePosixPath, serviceFileName);
       return `${serviceFileRelativePosixPath}#${func.name}`;
-    }
-
-    //
-    else {
+    } else {
       throw new Error("Unknown Service Catalog function source type");
     }
   }

--- a/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
@@ -27,6 +27,7 @@ import {
   YAMLScalar,
   YAMLSequence,
 } from "yaml-language-server-parser";
+import { getNodeFormat } from "./getNodeFormat";
 import { FileLanguage } from "../api";
 import { indentText } from "./indentText";
 import { matchNodeWithLocation } from "./matchNodeWithLocation";
@@ -214,6 +215,17 @@ export class YamlCodeCompletionStrategy implements CodeCompletionStrategy {
   }
 
   public shouldComplete(args: ShouldCompleteArgs): boolean {
+    if (
+      !args.root ||
+      !args.node ||
+      (["object", "array"].includes(args.node.type) && getNodeFormat(args.content, args.node) === FileLanguage.JSON) ||
+      (["string", "number", "boolean"].includes(args.node.type) &&
+        args.node.parent &&
+        getNodeFormat(args.content, args.node.parent) === FileLanguage.JSON)
+    ) {
+      return false;
+    }
+
     return matchNodeWithLocation(args.root, args.node, args.path);
   }
 }

--- a/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
@@ -32,7 +32,13 @@ import { FileLanguage } from "../api";
 import { indentText } from "./indentText";
 import { matchNodeWithLocation } from "./matchNodeWithLocation";
 import { findNodeAtOffset, SwfLanguageService, SwfLanguageServiceArgs } from "./SwfLanguageService";
-import { CodeCompletionStrategy, ShouldCompleteArgs, SwfLsNode, TranslateArgs } from "./types";
+import {
+  ShouldCreateCodelensArgs,
+  CodeCompletionStrategy,
+  ShouldCompleteArgs,
+  SwfLsNode,
+  TranslateArgs,
+} from "./types";
 
 export class SwfYamlLanguageService {
   private readonly ls: SwfLanguageService;
@@ -227,5 +233,12 @@ export class YamlCodeCompletionStrategy implements CodeCompletionStrategy {
     }
 
     return matchNodeWithLocation(args.root, args.node, args.path);
+  }
+
+  public shouldCreateCodelens(args: ShouldCreateCodelensArgs): boolean {
+    return (
+      args.commandName !== "swf.ls.commands.OpenFunctionsCompletionItems" ||
+      getNodeFormat(args.content, args.node) !== FileLanguage.JSON
+    );
   }
 }

--- a/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
+++ b/packages/serverless-workflow-language-service/src/channel/SwfYamlLanguageService.ts
@@ -131,7 +131,11 @@ export const isNodeUncompleted = (args: {
 
   const nodeAtPrevOffset = findNodeAtOffset(args.rootNode, args.cursorOffset - 1, true);
 
-  return nodeAtPrevOffset?.colonOffset === args.cursorOffset - 1;
+  if (!nodeAtPrevOffset) {
+    return false;
+  }
+
+  return nodeAtPrevOffset.offset + nodeAtPrevOffset.length === args.cursorOffset - 1;
 };
 
 const astConvert = (node: YAMLNode, parentNode?: SwfLsNode): SwfLsNode => {
@@ -139,7 +143,6 @@ const astConvert = (node: YAMLNode, parentNode?: SwfLsNode): SwfLsNode => {
     type: "object",
     offset: node.startPosition,
     length: node.endPosition - node.startPosition,
-    colonOffset: node.endPosition,
     parent: parentNode,
   };
 
@@ -159,6 +162,7 @@ const astConvert = (node: YAMLNode, parentNode?: SwfLsNode): SwfLsNode => {
       ...(convertedNode.value ? [astConvert(yamlMapping.value, convertedNode)] : []),
     ];
     convertedNode.type = "property";
+    convertedNode.colonOffset = yamlMapping.key.endPosition;
   } else if (node.kind === Kind.SEQ) {
     convertedNode.children = (node as YAMLSequence).items
       .filter((item) => item)

--- a/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
+++ b/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
@@ -20,7 +20,7 @@ import { SwfLsNode } from "./types";
 import { FileLanguage } from "../api";
 
 /**
- * Detected the format of a node's content.
+ * Detect the format of a node's content.
  * Note: for strings in double quotes and boolean values it's not able to distinguish between JSON and YAML. JSON will be returned in those cases.
  *
  * @param content the content

--- a/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
+++ b/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
@@ -25,7 +25,7 @@ import { FileLanguage } from "../api";
  *
  * @param content the content
  * @param node the node
- * @returns the FileLanguage, null if unrecognized
+ * @returns the FileLanguage, undefined if unrecognized
  */
 export function getNodeFormat(content: string, node: SwfLsNode): FileLanguage | undefined {
   const nodeContent = content.slice(node.offset, node.offset + node.length);

--- a/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
+++ b/packages/serverless-workflow-language-service/src/channel/getNodeFormat.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as jsonc from "jsonc-parser";
+import { load } from "yaml-language-server-parser";
+import { SwfLsNode } from "./types";
+import { FileLanguage } from "../api";
+
+/**
+ * Detected the format of a node's content.
+ * Note: for strings in double quotes and boolean values it's not able to distinguish between JSON and YAML. JSON will be returned in those cases.
+ *
+ * @param content the content
+ * @param node the node
+ * @returns the FileLanguage, null if unrecognized
+ */
+export function getNodeFormat(content: string, node: SwfLsNode): FileLanguage | undefined {
+  const nodeContent = content.slice(node.offset, node.offset + node.length);
+
+  if (jsonc.parseTree(nodeContent) !== undefined) {
+    return FileLanguage.JSON;
+  }
+
+  const yamlAST = load(nodeContent);
+
+  if (node.type === "array" && node.parent && nodeContent.slice(0, 1) == "-") {
+    // if the node is an array and starts with "-", use the parent to have a valid YAML string
+    return getNodeFormat(content, node.parent);
+  }
+
+  if (yamlAST && !yamlAST.errors.length) {
+    return FileLanguage.YAML;
+  }
+
+  return;
+}

--- a/packages/serverless-workflow-language-service/src/channel/index.ts
+++ b/packages/serverless-workflow-language-service/src/channel/index.ts
@@ -23,3 +23,4 @@ export * from "./refValidation";
 export * from "./nodeUpUntilType";
 export * from "./types";
 export * from "./indentText";
+export * from "./getNodeFormat";

--- a/packages/serverless-workflow-language-service/src/channel/matchNodeWithLocation.ts
+++ b/packages/serverless-workflow-language-service/src/channel/matchNodeWithLocation.ts
@@ -39,7 +39,7 @@ export function matchNodeWithLocation(
   const nodeToMatch = nodeUpUntilType(node, ["object", "property"]);
   const starSelector = path[path.length - 1] === "*";
 
-  if (starSelector && node.type === "array" && node?.children) {
+  if (starSelector && node.type === "array" && node.children) {
     return matchNodeWithLocation(root, node, path.slice(0, -1));
   }
 

--- a/packages/serverless-workflow-language-service/src/channel/types.ts
+++ b/packages/serverless-workflow-language-service/src/channel/types.ts
@@ -16,6 +16,7 @@
 
 import { Position, TextDocument } from "vscode-languageserver-textdocument";
 import { CompletionItemKind, Range } from "vscode-languageserver-types";
+import { SwfLanguageServiceCommandTypes } from "../api";
 
 // types SwfJsonPath, SwfLsNode, SwfLsNodeType need to be compatible with jsonc types
 export declare type SwfJsonPath = (string | number)[];
@@ -42,6 +43,12 @@ export interface ShouldCompleteArgs {
   cursorOffset: number;
 }
 
+export interface ShouldCreateCodelensArgs {
+  content: string;
+  node: SwfLsNode;
+  commandName: SwfLanguageServiceCommandTypes;
+}
+
 export interface TranslateArgs {
   completion: object | string;
   completionItemKind: CompletionItemKind;
@@ -53,4 +60,5 @@ export interface CodeCompletionStrategy {
   formatLabel(label: string, completionItemKind: CompletionItemKind): string;
   shouldComplete(args: ShouldCompleteArgs): boolean;
   getStartNodeValuePosition(document: TextDocument, node: SwfLsNode): Position | undefined;
+  shouldCreateCodelens(_args: ShouldCreateCodelensArgs): boolean;
 }

--- a/packages/serverless-workflow-language-service/src/channel/types.ts
+++ b/packages/serverless-workflow-language-service/src/channel/types.ts
@@ -60,5 +60,5 @@ export interface CodeCompletionStrategy {
   formatLabel(label: string, completionItemKind: CompletionItemKind): string;
   shouldComplete(args: ShouldCompleteArgs): boolean;
   getStartNodeValuePosition(document: TextDocument, node: SwfLsNode): Position | undefined;
-  shouldCreateCodelens(_args: ShouldCreateCodelensArgs): boolean;
+  shouldCreateCodelens(args: ShouldCreateCodelensArgs): boolean;
 }

--- a/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfJsonLanguageService.test.ts
@@ -25,7 +25,7 @@ import {
   testRelativeFunction1,
   testRelativeService1,
 } from "./SwfLanguageServiceConfigs";
-import { codeCompletionTester, getStartNodeValuePositionTester, trim } from "./testUtils";
+import { codeCompletionTester, ContentWithCursor, getStartNodeValuePositionTester, trim } from "./testUtils";
 
 const documentUri = "test.sw.json";
 
@@ -397,16 +397,13 @@ describe("SWF LS JSON", () => {
     });
 
     describe("function completion", () => {
-      test("empty completion items", async () => {
-        const { completionItems } = await codeCompletionTester(
-          ls,
-          documentUri,
-          `{
-  "functions": [
-    {🎯}
-  ]
-}`
-        );
+      test.each([
+        ["empty completion items", `{ "functions": [ {🎯} ] }`],
+        ["pointing before the array of functions", `{ "functions":🎯 [] }`],
+        ["pointing before the array of functions / with extra space after ':'", `{ "functions": 🎯 [] }`],
+        ["pointing after the array of functions", `{ "functions": []🎯 }`],
+      ])("%s", async (_description, content: ContentWithCursor) => {
+        let { completionItems } = await codeCompletionTester(ls, documentUri, content, false);
 
         expect(completionItems).toHaveLength(0);
       });

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -1145,7 +1145,7 @@ states:
         } as CompletionItem);
       });
 
-      test.skip("using JSON format", async () => {
+      test("using JSON format", async () => {
         const { completionItems, cursorPosition } = await codeCompletionTester(
           ls,
           documentUri,
@@ -1162,21 +1162,7 @@ states:
   - functionRef: {🎯}`
         );
 
-        expect(completionItems).toHaveLength(1);
-        expect(completionItems[0]).toStrictEqual({
-          kind: CompletionItemKind.Module,
-          label: "testRelativeFunction1",
-          detail: "specs/testRelativeService1.yml#testRelativeFunction1",
-          sortText: "testRelativeFunction1",
-          textEdit: {
-            newText: `{
-  "refName": "testRelativeFunction1",
-  "arguments": {\n    "argString": "\${1:}",\n    "argNumber": "\${2:}",\n    "argBoolean": "\${3:}"\n  }
-}`,
-            range: { start: cursorPosition, end: cursorPosition },
-          },
-          insertTextFormat: InsertTextFormat.Snippet,
-        } as CompletionItem);
+        expect(completionItems).toHaveLength(0);
       });
     });
 
@@ -1567,7 +1553,7 @@ states:
         } as CompletionItem);
       });
 
-      test.skip("using JSON format", async () => {
+      test("using JSON format", async () => {
         const { completionItems, cursorPosition } = await codeCompletionTester(
           ls,
           documentUri,
@@ -1587,22 +1573,7 @@ states:
       arguments: {🎯}`
         );
 
-        expect(completionItems).toHaveLength(1);
-        expect(completionItems[0]).toStrictEqual({
-          kind: CompletionItemKind.Module,
-          label: `'testRelativeFunction1' arguments`,
-          detail: "specs/testRelativeService1.yml#testRelativeFunction1",
-          sortText: `'testRelativeFunction1' arguments`,
-          textEdit: {
-            newText: `{
-  "argString": "\${1:}",
-  "argNumber": "\${2:}",
-  "argBoolean": "\${3:}"
-}`,
-            range: { start: cursorPosition, end: cursorPosition },
-          },
-          insertTextFormat: InsertTextFormat.Snippet,
-        } as CompletionItem);
+        expect(completionItems).toHaveLength(0);
       });
     });
   });

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -870,13 +870,6 @@ functions: []
           "pointing inside an object of the array of functions / using JSON format",
           `functions: [ {🎯 "name":"getGreetingFunction", "operation":"openapi.yml#getGreeting"}]`,
         ],
-      ])("%s", async (_description, content: ContentWithCursor) => {
-        let { completionItems } = await codeCompletionTester(ls, documentUri, content, false);
-
-        expect(completionItems).toHaveLength(0);
-      });
-
-      test.each([
         ["using JSON format", `functions: [🎯]`],
         [
           "using JSON format / before a function",
@@ -887,42 +880,9 @@ functions: []
           `functions: [{ "name": "getGreetingFunction", "operation": "openapi.yml#getGreeting" },🎯]`,
         ],
       ])("%s", async (_description, content: ContentWithCursor) => {
-        let { completionItems, cursorPosition } = await codeCompletionTester(ls, documentUri, content, false);
+        let { completionItems } = await codeCompletionTester(ls, documentUri, content, false);
 
-        expect(completionItems).toHaveLength(1);
-        expect(completionItems[0]).toStrictEqual({
-          kind: CompletionItemKind.Reference,
-          label: "specs»testRelativeService1.yml#testRelativeFunction1",
-          detail: "specs/testRelativeService1.yml#testRelativeFunction1",
-          textEdit: {
-            range: { start: cursorPosition, end: cursorPosition },
-            newText: `{
-    "name": "\${1:testRelativeFunction1}",
-    "operation": "specs/testRelativeService1.yml#testRelativeFunction1",
-    "type": "rest"
-  }`,
-          },
-          snippet: true,
-          insertTextFormat: InsertTextFormat.Snippet,
-          command: {
-            command: "swf.ls.commands.ImportFunctionFromCompletionItem",
-            title: "Import function from completion item",
-            arguments: [
-              {
-                documentUri,
-                containingService: {
-                  ...testRelativeService1,
-                  functions: [
-                    {
-                      ...testRelativeFunction1,
-                      operation: "specs/testRelativeService1.yml#testRelativeFunction1",
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        } as CompletionItem);
+        expect(completionItems).toHaveLength(0);
       });
 
       test.each([
@@ -1013,6 +973,15 @@ functions:
 
     describe("operation completion", () => {
       test.each([
+        ["using JSON format", `functions: [{"name": "getGreetingFunction", "operation": 🎯 }]`],
+        ["using JSON format", `functions: [{\n      "name": "getGreetingFunction",\n      "operation": "🎯"\n      }]`],
+      ])("%s", async (_description, content: ContentWithCursor) => {
+        let { completionItems, cursorPosition } = await codeCompletionTester(ls, documentUri, content, false);
+
+        expect(completionItems).toHaveLength(0);
+      });
+
+      test.each([
         [
           "not in quotes / without space after property name",
           `functions:\n- name: testRelativeFunction1\n  operation: 🎯`,
@@ -1021,8 +990,6 @@ functions:
           "not in quotes / with same level content after",
           `functions:\n- name: testRelativeFunction1\n  operation: 🎯\n  type: rest`,
         ],
-        ["using JSON format", `functions: [{"name": "getGreetingFunction", "operation": 🎯 }]`],
-        ["using JSON format", `functions: [{\n      "name": "getGreetingFunction",\n      "operation": ""\n      }]`],
       ])("%s", async (_description, content: ContentWithCursor) => {
         let { completionItems, cursorPosition } = await codeCompletionTester(ls, documentUri, content, false);
 

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -1408,7 +1408,7 @@ states:
     });
 
     describe("functionRef arguments completion", () => {
-      test("without any function to complete", async () => {
+      test("without any function arguments to complete", async () => {
         const testRelativeService1WithEmptyFunctionArgs = {
           ...testRelativeService1,
           functions: [{ ...testRelativeFunction1, arguments: {} }],

--- a/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
+++ b/packages/serverless-workflow-language-service/tests/SwfYamlLanguageService.test.ts
@@ -699,15 +699,7 @@ functions: [] `);
 
       const codeLenses = await ls.getCodeLenses({ uri: documentUri, content });
 
-      expect(codeLenses).toHaveLength(1);
-      expect(codeLenses[0]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
-        command: {
-          title: "+ Add function...",
-          command: "swf.ls.commands.OpenFunctionsCompletionItems",
-          arguments: [{ newCursorPosition: { character: 12, line: 1 } }],
-        },
-      } as CodeLens);
+      expect(codeLenses).toHaveLength(0);
     });
 
     test("service registries integration disabled", async () => {
@@ -725,18 +717,18 @@ functions: [] `);
 
       const { content } = trim(`
 ---
-functions: []
-`);
+functions: 
+- name: getGreetingFunction `);
 
       const codeLenses = await ls.getCodeLenses({ uri: documentUri, content });
 
       expect(codeLenses).toHaveLength(1);
       expect(codeLenses[0]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           title: "+ Add function...",
           command: "swf.ls.commands.OpenFunctionsCompletionItems",
-          arguments: [{ newCursorPosition: { character: 12, line: 1 } }],
+          arguments: [{ newCursorPosition: { character: 0, line: 2 } }],
         },
       } as CodeLens);
     });
@@ -750,26 +742,26 @@ functions: []
 
       const { content } = trim(`
 ---
-functions: []
-`);
+functions: 
+- name: getGreetingFunction `);
 
       const codeLenses = await ls.getCodeLenses({ uri: documentUri, content });
 
       expect(codeLenses).toHaveLength(2);
       expect(codeLenses[0]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           command: "swf.ls.commands.LogInServiceRegistries",
           title: "↪ Log in Service Registries...",
-          arguments: [{ position: { character: 11, line: 1 } }],
+          arguments: [{ position: { character: 0, line: 2 } }],
         },
       });
       expect(codeLenses[1]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           title: "+ Add function...",
           command: "swf.ls.commands.OpenFunctionsCompletionItems",
-          arguments: [{ newCursorPosition: { character: 12, line: 1 } }],
+          arguments: [{ newCursorPosition: { character: 0, line: 2 } }],
         },
       } as CodeLens);
     });
@@ -786,26 +778,26 @@ functions: []
 
       const { content } = trim(`
 ---
-functions: []
-`);
+functions: 
+- name: getGreetingFunction `);
 
       const codeLenses = await ls.getCodeLenses({ uri: documentUri, content });
 
       expect(codeLenses).toHaveLength(2);
       expect(codeLenses[0]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           command: "swf.ls.commands.OpenServiceRegistriesConfig",
           title: "↪ Setup Service Registries...",
-          arguments: [{ position: { character: 11, line: 1 } }],
+          arguments: [{ position: { character: 0, line: 2 } }],
         },
       });
       expect(codeLenses[1]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           title: "+ Add function...",
           command: "swf.ls.commands.OpenFunctionsCompletionItems",
-          arguments: [{ newCursorPosition: { character: 12, line: 1 } }],
+          arguments: [{ newCursorPosition: { character: 0, line: 2 } }],
         },
       } as CodeLens);
     });
@@ -822,26 +814,26 @@ functions: []
 
       const { content } = trim(`
 ---
-functions: []
-`);
+functions: 
+- name: getGreetingFunction `);
 
       const codeLenses = await ls.getCodeLenses({ uri: documentUri, content });
 
       expect(codeLenses).toHaveLength(2);
       expect(codeLenses[0]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           command: "swf.ls.commands.RefreshServiceRegistries",
           title: "↺ Refresh Service Registries...",
-          arguments: [{ position: { character: 11, line: 1 } }],
+          arguments: [{ position: { character: 0, line: 2 } }],
         },
       });
       expect(codeLenses[1]).toStrictEqual({
-        range: { start: { line: 1, character: 11 }, end: { line: 1, character: 11 } },
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
         command: {
           title: "+ Add function...",
           command: "swf.ls.commands.OpenFunctionsCompletionItems",
-          arguments: [{ newCursorPosition: { character: 12, line: 1 } }],
+          arguments: [{ newCursorPosition: { character: 0, line: 2 } }],
         },
       } as CodeLens);
     });

--- a/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
+++ b/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileLanguage } from "@kie-tools/serverless-workflow-language-service/dist/api";
+import {
+  findNodeAtOffset,
+  getNodeFormat,
+  SwfJsonLanguageService,
+  SwfYamlLanguageService,
+} from "@kie-tools/serverless-workflow-language-service/dist/channel";
+import { Position } from "vscode-languageserver-types";
+import { defaultConfig, defaultServiceCatalogConfig } from "./SwfLanguageServiceConfigs";
+import { ContentWithCursor, treat } from "./testUtils";
+
+describe("getNodeFormat", () => {
+  const getNodeFormatTester = (args: {
+    content: ContentWithCursor;
+    ls: SwfJsonLanguageService | SwfYamlLanguageService;
+  }): Position | undefined => {
+    const { content, cursorOffset } = treat(args.content);
+    const root = args.ls.parseContent(content);
+    const node = findNodeAtOffset(root!, cursorOffset);
+
+    return getNodeFormat(content, node);
+  };
+
+  describe("JSON format", () => {
+    const ls = new SwfJsonLanguageService({
+      fs: {},
+      serviceCatalog: defaultServiceCatalogConfig,
+      config: defaultConfig,
+    });
+
+    test("string value", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `{
+          "name": "🎯Greeting workflow"
+        }`,
+          ls,
+        })
+      ).toBe(FileLanguage.JSON);
+    });
+
+    test("boolean value", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `{
+          "end": tru🎯e
+        }`,
+          ls,
+        })
+      ).toBe(FileLanguage.JSON);
+    });
+
+    describe("arrays", () => {
+      test("single line declaration", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+          "functions": [🎯]
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("two lines declaration", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+          "functions": 
+          [🎯]
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("single line declaration / with one function / with content before and after", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+          "name": "Greeting workflow",
+          "functions": [
+           🎯 {
+                "name": "getGreetingFunction",
+                "operation": "openapi.yml#getGreeting"
+              }
+          ],
+          "states": []
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+    });
+
+    describe("objects", () => {
+      test("single line declaration", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+          "data": {🎯}
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("two lines declaration", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+            "data": 
+            {🎯
+              "language": "Portuguese"
+            }
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("single line declaration / with one attribute / with content before and after", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+            "name": "GreetInPortuguese",
+            "data": {🎯
+              "language": "Portuguese",
+              "message": "Hello"
+            },
+            "transition": "GetGreeting"
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+    });
+  });
+
+  describe("YAML format", () => {
+    const ls = new SwfYamlLanguageService({
+      fs: {},
+      serviceCatalog: defaultServiceCatalogConfig,
+      config: defaultConfig,
+    });
+
+    test("string value", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `name: 🎯Greeting workflow`,
+          ls,
+        })
+      ).toBe(FileLanguage.YAML);
+    });
+
+    test("boolean value / JSON format", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `end: 🎯true`,
+          ls,
+        })
+      ).toBe(FileLanguage.JSON);
+    });
+
+    test("boolean value", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `end: 🎯True`,
+          ls,
+        })
+      ).toBe(FileLanguage.YAML);
+    });
+
+    describe("arrays", () => {
+      test("single line declaration / JSON format", async () => {
+        expect(getNodeFormatTester({ content: `functions: [🎯]`, ls })).toBe(FileLanguage.JSON);
+      });
+
+      test("two lines declaration / JSON format", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `functions: 
+            [🎯]`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("YAML format / with two functions / with content before and after", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `---
+            name: Greeting workflow
+            functions:
+            🎯- name: getGreetingFunction
+              operation: openapi.yml#getGreeting
+            - name: greetFunction
+              type: custom
+              operation: sysout
+            states: [] `,
+            ls,
+          })
+        ).toBe(FileLanguage.YAML);
+      });
+    });
+
+    describe("objects", () => {
+      test("single line declaration / JSON format", async () => {
+        expect(getNodeFormatTester({ content: `data: {🎯}`, ls })).toBe(FileLanguage.JSON);
+      });
+
+      test("two lines declaration / JSON format", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `{
+            data: 
+            {🎯
+              "language": "Portuguese"
+            }
+        }`,
+            ls,
+          })
+        ).toBe(FileLanguage.JSON);
+      });
+
+      test("YAML format / with content before and after", async () => {
+        expect(
+          getNodeFormatTester({
+            content: `---
+            name: GreetInPortuguese
+            data:
+            🎯  language: Portuguese
+              message: Hello
+            transition: GetGreeting `,
+            ls,
+          })
+        ).toBe(FileLanguage.YAML);
+      });
+    });
+  });
+});

--- a/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
+++ b/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
@@ -141,7 +141,7 @@ describe("getNodeFormat", () => {
             "name": "GreetInPortuguese",
             "data": {🎯
               "language": "Portuguese",
-              "message": "Hello"
+              "message": "Olá"
             },
             "transition": "GetGreeting"
         }`,

--- a/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
+++ b/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
@@ -21,7 +21,6 @@ import {
   SwfJsonLanguageService,
   SwfYamlLanguageService,
 } from "@kie-tools/serverless-workflow-language-service/dist/channel";
-import { Position } from "vscode-languageserver-types";
 import { defaultConfig, defaultServiceCatalogConfig } from "./SwfLanguageServiceConfigs";
 import { ContentWithCursor, treat } from "./testUtils";
 
@@ -29,12 +28,12 @@ describe("getNodeFormat", () => {
   const getNodeFormatTester = (args: {
     content: ContentWithCursor;
     ls: SwfJsonLanguageService | SwfYamlLanguageService;
-  }): Position | undefined => {
+  }): FileLanguage | undefined => {
     const { content, cursorOffset } = treat(args.content);
     const root = args.ls.parseContent(content);
     const node = findNodeAtOffset(root!, cursorOffset);
 
-    return getNodeFormat(content, node);
+    return node ? getNodeFormat(content, node) : undefined;
   };
 
   describe("JSON format", () => {

--- a/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
+++ b/packages/serverless-workflow-language-service/tests/getNodeFormat.test.ts
@@ -168,6 +168,15 @@ describe("getNodeFormat", () => {
       ).toBe(FileLanguage.YAML);
     });
 
+    test("string value / JSON format", async () => {
+      expect(
+        getNodeFormatTester({
+          content: `name: "🎯Greeting workflow"`,
+          ls,
+        })
+      ).toBe(FileLanguage.JSON);
+    });
+
     test("boolean value / JSON format", async () => {
       expect(
         getNodeFormatTester({
@@ -194,8 +203,10 @@ describe("getNodeFormat", () => {
       test("two lines declaration / JSON format", async () => {
         expect(
           getNodeFormatTester({
-            content: `functions: 
-            [🎯]`,
+            content: `functions: [🎯    {
+        "name": "getGreetingFunction",
+        "operation": "openapi.yml#getGreeting"
+      }]`,
             ls,
           })
         ).toBe(FileLanguage.JSON);
@@ -205,14 +216,14 @@ describe("getNodeFormat", () => {
         expect(
           getNodeFormatTester({
             content: `---
-            name: Greeting workflow
-            functions:
-            🎯- name: getGreetingFunction
-              operation: openapi.yml#getGreeting
-            - name: greetFunction
-              type: custom
-              operation: sysout
-            states: [] `,
+name: Greeting workflow
+functions:
+🎯- name: getGreetingFunction
+  operation: openapi.yml#getGreeting
+- name: greetFunction
+  type: custom
+  operation: sysout
+states: [] `,
             ls,
           })
         ).toBe(FileLanguage.YAML);
@@ -227,12 +238,8 @@ describe("getNodeFormat", () => {
       test("two lines declaration / JSON format", async () => {
         expect(
           getNodeFormatTester({
-            content: `{
-            data: 
-            {🎯
-              "language": "Portuguese"
-            }
-        }`,
+            content: `data: {🎯
+              "language": "Portuguese" }`,
             ls,
           })
         ).toBe(FileLanguage.JSON);
@@ -242,11 +249,11 @@ describe("getNodeFormat", () => {
         expect(
           getNodeFormatTester({
             content: `---
-            name: GreetInPortuguese
-            data:
-            🎯  language: Portuguese
-              message: Hello
-            transition: GetGreeting `,
+name: GreetInPortuguese
+data:
+🎯  language: Portuguese
+  message: Hello
+transition: GetGreeting `,
             ls,
           })
         ).toBe(FileLanguage.YAML);

--- a/packages/serverless-workflow-language-service/tests/testUtils.ts
+++ b/packages/serverless-workflow-language-service/tests/testUtils.ts
@@ -40,8 +40,8 @@ export function getLineFromOffset(fullText: string, offset: number | undefined, 
 
 export type ContentWithCursor = `${string}🎯${string}`;
 
-export function treat(content: ContentWithCursor) {
-  const trimmedContent = content.trim();
+export function treat(content: ContentWithCursor, trimContent = true) {
+  const trimmedContent = trimContent ? content.trim() : content;
   const treatedContent = trimmedContent.replace("🎯", "");
   const doc = TextDocument.create("", "json", 0, trimmedContent);
   const cursorOffset = trimmedContent.indexOf("🎯");

--- a/packages/serverless-workflow-language-service/tests/testUtils.ts
+++ b/packages/serverless-workflow-language-service/tests/testUtils.ts
@@ -63,9 +63,10 @@ export function trim(content: string) {
 export async function codeCompletionTester(
   ls: SwfJsonLanguageService | SwfYamlLanguageService,
   documentUri: DocumentUri,
-  contentToParse: ContentWithCursor
+  contentToParse: ContentWithCursor,
+  trimContent = true
 ): Promise<{ completionItems: CompletionItem[]; cursorPosition: Position }> {
-  const { content, cursorPosition } = treat(contentToParse);
+  const { content, cursorPosition } = treat(contentToParse, trimContent);
 
   return {
     completionItems: await ls.getCompletionItems({


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/KOGITO-8063

"Trying the autocompletion in the current version, with just this YAML: `functions: []`, there are bugs in the position of the completion and in the format of the snippet, because the value is written in JSON.

Please, disable the autocompletion only for the cross-language nodes."

Please note: that because the code completion is disabled in cross-language YAML, in this PR I also hide the "+Add function..." CodeLens, which would have nothing to suggest.

![KOGITO-8063](https://user-images.githubusercontent.com/17780574/194084374-611fb75c-076f-4f01-bde2-708672b1cf73.gif)
