### PR TITLE
Improve KIE Sandbox file lists performance with `react-window`

### DIFF
--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -64,6 +64,8 @@
     "react-dropzone": "^11.4.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.2.1",
+    "react-virtualized-auto-sizer": "^1.0.7",
+    "react-window": "^1.3.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -87,6 +89,8 @@
     "@types/react-dom": "^17.0.5",
     "@types/react-router": "^5.1.14",
     "@types/react-router-dom": "^5.1.7",
+    "@types/react-virtualized-auto-sizer": "^1.0.1",
+    "@types/react-window": "^1.8.5",
     "@types/testing-library__jest-dom": "^5.9.1",
     "@types/testing-library__react": "^9.1.2",
     "@types/uuid": "^8.3.0",

--- a/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDropdownItems.tsx
+++ b/packages/online-editor/src/editor/DmnDevSandbox/DmnDevSandboxDropdownItems.tsx
@@ -29,7 +29,7 @@ import { useSettings, useSettingsDispatch } from "../../settings/SettingsContext
 import { SettingsTabs } from "../../settings/SettingsModalBody";
 import { ActiveWorkspace } from "../../workspace/model/ActiveWorkspace";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
-import { FileLabel } from "../../workspace/components/FileLabel";
+import { FileLabel } from "../../filesList/FileLabel";
 import { OpenshiftIcon } from "@patternfly/react-icons/dist/js/icons/openshift-icon";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";

--- a/packages/online-editor/src/editor/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/EditorToolbar.tsx
@@ -62,7 +62,7 @@ import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { NewFileDropdownMenu } from "./NewFileDropdownMenu";
 import { PageHeaderToolsItem, PageSection } from "@patternfly/react-core/dist/js/components/Page";
-import { FileLabel } from "../workspace/components/FileLabel";
+import { FileLabel } from "../filesList/FileLabel";
 import { useWorkspacePromise } from "../workspace/hooks/WorkspaceHooks";
 import { OutlinedHddIcon } from "@patternfly/react-icons/dist/js/icons/outlined-hdd-icon";
 import { DesktopIcon } from "@patternfly/react-icons/dist/js/icons/desktop-icon";

--- a/packages/online-editor/src/editor/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/FileSwitcher.tsx
@@ -842,6 +842,7 @@ export function FileMenuItem(props: {
 }) {
   return (
     <MenuItem
+      component={props.isEditable ? undefined : "span"}
       onClick={props.onSelectFile}
       style={props.style}
       className={"kie-tools--file-switcher-no-padding-menu-item"}

--- a/packages/online-editor/src/editor/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/FileSwitcher.tsx
@@ -60,7 +60,6 @@ import { EmptyState, EmptyStateIcon } from "@patternfly/react-core/dist/js/compo
 import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { ArrowRightIcon } from "@patternfly/react-icons/dist/js/icons/arrow-right-icon";
 import { ArrowLeftIcon } from "@patternfly/react-icons/dist/js/icons/arrow-left-icon";
-import { WorkspaceLabel } from "../workspace/components/WorkspaceLabel";
 import { useEditorEnvelopeLocator } from "../envelopeLocator/hooks/EditorEnvelopeLocatorContext";
 import { VariableSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -72,7 +71,7 @@ import {
   DataListItemCells,
   DataListItemRow,
 } from "@patternfly/react-core/dist/js/components/DataList";
-import { WorkspaceDescriptorDates } from "../workspace/components/WorkspaceDescriptorDates";
+import { WorkspaceListItem } from "../workspace/components/WorkspaceListItem";
 
 const ROOT_MENU_ID = "rootMenu";
 
@@ -456,41 +455,14 @@ export function WorkspacesMenuItems(props: {
                             <DataListItemCells
                               dataListCells={[
                                 <DataListCell key="link" isFilled={false}>
-                                  <Flex>
-                                    <WorkspaceLabel descriptor={descriptor} />
-                                    <TextContent>
-                                      <Text
-                                        component={TextVariants.small}
-                                        style={{
-                                          whiteSpace: "nowrap",
-                                          overflow: "hidden",
-                                          textOverflow: "ellipsis",
-                                        }}
-                                      >
-                                        {`${workspaceFiles.get(descriptor.workspaceId)!.length} files, ${
-                                          workspaceFiles
-                                            .get(descriptor.workspaceId)!
-                                            .filter((f) => editorEnvelopeLocator.hasMappingFor(f.relativePath)).length
-                                        } models`}
-                                      </Text>
-                                    </TextContent>
-                                  </Flex>
-                                  <br />
-                                  <TextContent>
-                                    <Text
-                                      component={TextVariants.p}
-                                      style={{
-                                        whiteSpace: "nowrap",
-                                        overflow: "hidden",
-                                        textOverflow: "ellipsis",
-                                      }}
-                                    >
-                                      <FolderIcon />
-                                      &nbsp;&nbsp;
-                                      {descriptor.name}
-                                    </Text>
-                                  </TextContent>
-                                  <WorkspaceDescriptorDates workspaceDescriptor={descriptor} />
+                                  <WorkspaceListItem
+                                    isBig={false}
+                                    workspaceDescriptor={descriptor}
+                                    allFiles={workspaceFiles.get(descriptor.workspaceId)!}
+                                    editableFiles={workspaceFiles
+                                      .get(descriptor.workspaceId)!
+                                      .filter((f) => editorEnvelopeLocator.hasMappingFor(f.relativePath))}
+                                  />
                                 </DataListCell>,
                               ]}
                             />

--- a/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useWorkspaces, WorkspaceFile } from "../workspace/WorkspacesContext";
-import { FileLabel } from "../workspace/components/FileLabel";
+import { FileLabel } from "../filesList/FileLabel";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 import {

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkspaceFile } from "../workspace/WorkspacesContext";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
+import { FileLabel } from "./FileLabel";
+import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import * as React from "react";
+import {
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+} from "@patternfly/react-core/dist/js/components/DataList";
+import { Link } from "react-router-dom";
+import { useRoutes } from "../navigation/Hooks";
+
+const heights = {
+  atRoot: 53 + 24,
+  atSubDir: 74 + 24,
+};
+
+export function getFileDataListHeight(file: WorkspaceFile) {
+  return file.relativePath.indexOf("/") >= 0 ? heights.atSubDir : heights.atRoot;
+}
+
+function FileName(props: { file: WorkspaceFile; isEditable: boolean }) {
+  const fileDirPath = props.file.relativeDirPath.split("/").join(" > ");
+  const fileName = props.isEditable ? props.file.nameWithoutExtension : props.file.name;
+  return (
+    <>
+      <Flex flexWrap={{ default: "nowrap" }}>
+        <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
+          <Tooltip content={fileName}>
+            <TextContent>
+              <Text
+                component={TextVariants.p}
+                style={{
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {fileName}
+              </Text>
+            </TextContent>
+          </Tooltip>
+        </FlexItem>
+        <FlexItem>
+          <FileLabel extension={props.file.extension} />
+        </FlexItem>
+      </Flex>
+      <Tooltip content={fileDirPath}>
+        <TextContent>
+          <Text
+            component={TextVariants.small}
+            style={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {fileDirPath}
+          </Text>
+        </TextContent>
+      </Tooltip>
+    </>
+  );
+}
+
+export function FileDataListItem(props: { file: WorkspaceFile; isEditable: boolean }) {
+  return (
+    <DataListItemRow>
+      <DataListItemCells
+        dataListCells={[
+          <DataListCell key="link" isFilled={false}>
+            <FileName file={props.file} isEditable={props.isEditable} />
+          </DataListCell>,
+        ]}
+      />
+    </DataListItemRow>
+  );
+}
+
+export function FileDataList(props: { file: WorkspaceFile; isEditable: boolean; style?: React.CSSProperties }) {
+  const routes = useRoutes();
+
+  return (
+    <DataList aria-label="file-data-list" style={props.style}>
+      <DataListItem style={{ border: 0 }}>
+        {(!props.isEditable && (
+          <FileDataListItem key={props.file.relativePath} file={props.file} isEditable={props.isEditable} />
+        )) || (
+          <Link
+            key={props.file.relativePath}
+            to={routes.workspaceWithFilePath.path({
+              workspaceId: props.file.workspaceId,
+              fileRelativePath: props.file.relativePathWithoutExtension,
+              extension: props.file.extension,
+            })}
+          >
+            <FileDataListItem file={props.file} isEditable={props.isEditable} />
+          </Link>
+        )}
+      </DataListItem>
+    </DataList>
+  );
+}

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -42,7 +42,7 @@ export function getFileDataListHeight(file: WorkspaceFile) {
   return file.relativePath.indexOf("/") >= 0 ? FILE_DATA_LIST_HEIGHTS.atSubDir : FILE_DATA_LIST_HEIGHTS.atRoot;
 }
 
-function FileName(props: { file: WorkspaceFile; isEditable: boolean }) {
+function FileListItem(props: { file: WorkspaceFile; isEditable: boolean }) {
   const fileDirPath = props.file.relativeDirPath.split("/").join(" > ");
   const fileName = props.isEditable ? props.file.nameWithoutExtension : props.file.name;
   return (
@@ -92,7 +92,7 @@ export function FileDataListItem(props: { file: WorkspaceFile; isEditable: boole
       <DataListItemCells
         dataListCells={[
           <DataListCell key="link" isFilled={false}>
-            <FileName file={props.file} isEditable={props.isEditable} />
+            <FileListItem file={props.file} isEditable={props.isEditable} />
           </DataListCell>,
         ]}
       />
@@ -143,32 +143,11 @@ export function SingleFileWorkspaceDataList(props: { workspaceDescriptor: Worksp
             <DataListItemCells
               dataListCells={[
                 <DataListCell key="link" isFilled={false}>
-                  <>
-                    <Flex flexWrap={{ default: "nowrap" }}>
-                      <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
-                        <Tooltip distance={5} position={"top-start"} content={props.file.nameWithoutExtension}>
-                          <TextContent>
-                            <Text
-                              component={TextVariants.p}
-                              style={{
-                                whiteSpace: "nowrap",
-                                overflow: "hidden",
-                                textOverflow: "ellipsis",
-                              }}
-                            >
-                              <TaskIcon />
-                              &nbsp;&nbsp;
-                              {props.file.nameWithoutExtension}
-                            </Text>
-                          </TextContent>
-                        </Tooltip>
-                      </FlexItem>
-                      <FlexItem>
-                        <FileLabel extension={props.file.extension} />
-                      </FlexItem>
-                    </Flex>
-                    <WorkspaceDescriptorDates workspaceDescriptor={props.workspaceDescriptor} />
-                  </>
+                  <SingleFileWorkspaceListItem
+                    isBig={false}
+                    file={props.file}
+                    workspaceDescriptor={props.workspaceDescriptor}
+                  />
                 </DataListCell>,
               ]}
             />
@@ -176,5 +155,40 @@ export function SingleFileWorkspaceDataList(props: { workspaceDescriptor: Worksp
         </Link>
       </DataListItem>
     </DataList>
+  );
+}
+
+export function SingleFileWorkspaceListItem(props: {
+  isBig: boolean;
+  workspaceDescriptor: WorkspaceDescriptor;
+  file: WorkspaceFile;
+}) {
+  return (
+    <>
+      <Flex flexWrap={{ default: "nowrap" }}>
+        <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
+          <Tooltip distance={5} position={"top-start"} content={props.file.nameWithoutExtension}>
+            <TextContent>
+              <Text
+                component={props.isBig ? TextVariants.h3 : TextVariants.p}
+                style={{
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                <TaskIcon />
+                &nbsp;&nbsp;
+                {props.file.nameWithoutExtension}
+              </Text>
+            </TextContent>
+          </Tooltip>
+        </FlexItem>
+        <FlexItem>
+          <FileLabel extension={props.file.extension} />
+        </FlexItem>
+      </Flex>
+      <WorkspaceDescriptorDates workspaceDescriptor={props.workspaceDescriptor} />
+    </>
   );
 }

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -46,7 +46,7 @@ function FileName(props: { file: WorkspaceFile; isEditable: boolean }) {
     <>
       <Flex flexWrap={{ default: "nowrap" }}>
         <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
-          <Tooltip content={fileName}>
+          <Tooltip distance={5} position={"top-start"} content={fileName}>
             <TextContent>
               <Text
                 component={TextVariants.p}
@@ -65,20 +65,20 @@ function FileName(props: { file: WorkspaceFile; isEditable: boolean }) {
           <FileLabel extension={props.file.extension} />
         </FlexItem>
       </Flex>
-      <Tooltip content={fileDirPath}>
-        <TextContent>
-          <Text
-            component={TextVariants.small}
-            style={{
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {fileDirPath}
-          </Text>
-        </TextContent>
-      </Tooltip>
+      <TextContent>
+        <Text
+          component={TextVariants.small}
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          <Tooltip distance={5} position={"top-start"} content={fileDirPath}>
+            <span>{fileDirPath}</span>
+          </Tooltip>
+        </Text>
+      </TextContent>
     </>
   );
 }

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -29,14 +29,17 @@ import {
 } from "@patternfly/react-core/dist/js/components/DataList";
 import { Link } from "react-router-dom";
 import { useRoutes } from "../navigation/Hooks";
+import { TaskIcon } from "@patternfly/react-icons/dist/js/icons/task-icon";
+import { WorkspaceDescriptor } from "../workspace/worker/api/WorkspaceDescriptor";
+import { WorkspaceDescriptorDates } from "../workspace/components/WorkspaceDescriptorDates";
 
-const heights = {
+const FILE_DATA_LIST_HEIGHTS = {
   atRoot: 53 + 24,
   atSubDir: 74 + 24,
 };
 
 export function getFileDataListHeight(file: WorkspaceFile) {
-  return file.relativePath.indexOf("/") >= 0 ? heights.atSubDir : heights.atRoot;
+  return file.relativePath.indexOf("/") >= 0 ? FILE_DATA_LIST_HEIGHTS.atSubDir : FILE_DATA_LIST_HEIGHTS.atRoot;
 }
 
 function FileName(props: { file: WorkspaceFile; isEditable: boolean }) {
@@ -117,6 +120,60 @@ export function FileDataList(props: { file: WorkspaceFile; isEditable: boolean; 
             <FileDataListItem file={props.file} isEditable={props.isEditable} />
           </Link>
         )}
+      </DataListItem>
+    </DataList>
+  );
+}
+
+export function SingleFileWorkspaceDataList(props: { workspaceDescriptor: WorkspaceDescriptor; file: WorkspaceFile }) {
+  const routes = useRoutes();
+
+  return (
+    <DataList aria-label="file-data-list">
+      <DataListItem style={{ border: 0 }}>
+        <Link
+          key={props.file.relativePath}
+          to={routes.workspaceWithFilePath.path({
+            workspaceId: props.file.workspaceId,
+            fileRelativePath: props.file.relativePathWithoutExtension,
+            extension: props.file.extension,
+          })}
+        >
+          <DataListItemRow>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="link" isFilled={false}>
+                  <>
+                    <Flex flexWrap={{ default: "nowrap" }}>
+                      <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
+                        <Tooltip distance={5} position={"top-start"} content={props.file.nameWithoutExtension}>
+                          <TextContent>
+                            <Text
+                              component={TextVariants.p}
+                              style={{
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                              }}
+                            >
+                              <TaskIcon />
+                              &nbsp;&nbsp;
+                              {props.file.nameWithoutExtension}
+                            </Text>
+                          </TextContent>
+                        </Tooltip>
+                      </FlexItem>
+                      <FlexItem>
+                        <FileLabel extension={props.file.extension} />
+                      </FlexItem>
+                    </Flex>
+                    <WorkspaceDescriptorDates workspaceDescriptor={props.workspaceDescriptor} />
+                  </>
+                </DataListCell>,
+              ]}
+            />
+          </DataListItemRow>
+        </Link>
       </DataListItem>
     </DataList>
   );

--- a/packages/online-editor/src/filesList/FileLabel.tsx
+++ b/packages/online-editor/src/filesList/FileLabel.tsx
@@ -25,21 +25,23 @@ const pmmlLabel: LabelColorType = { color: "purple", label: "Scorecard" };
 
 const labelColors = new Map<string, LabelColorType>([
   ["bpmn", bpmnLabel],
-  ["BPMN", bpmnLabel],
   ["bpmn2", bpmnLabel],
-  ["BPMN2", bpmnLabel],
   ["dmn", dmnLabel],
-  ["DMN", dmnLabel],
   ["pmml", pmmlLabel],
-  ["PMML", pmmlLabel],
 ]);
 
 export function FileLabel(props: { style?: LabelProps["style"]; extension: string }) {
+  const label = labelColors.get(props.extension.toLowerCase());
   return (
     <>
-      {props.extension && (
-        <Label style={props.style ?? {}} color={labelColors.get(props.extension)?.color ?? "grey"}>
-          {labelColors.get(props.extension)?.label ?? props.extension.toUpperCase()}
+      {(label && (
+        <Label style={props.style ?? {}} color={label.color ?? "grey"}>
+          {label.label}
+        </Label>
+      )) || (
+        <Label style={{ visibility: "hidden" }}>
+          {/* This is here to make the parent's height not variable. */}
+          {props.extension || "-"}
         </Label>
       )}
     </>

--- a/packages/online-editor/src/filesList/FileLabel.tsx
+++ b/packages/online-editor/src/filesList/FileLabel.tsx
@@ -40,7 +40,7 @@ export function FileLabel(props: { style?: LabelProps["style"]; extension: strin
         </Label>
       )) || (
         <Label style={{ visibility: "hidden" }}>
-          {/* This is here to make the parent's height not variable. */}
+          {/* This is here to make this component's height constant and avoid UI jumps. */}
           {props.extension || "-"}
         </Label>
       )}

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -135,9 +135,9 @@ export function HomePage() {
 
   return (
     <OnlineEditorPage>
-      <PageSection isFilled={false}>
-        <Grid hasGutter>
-          <GridItem sm={12} xl={6}>
+      <PageSection isFilled={false} sticky={"top"} hasOverflowScroll={false} style={{ overflowX: "scroll" }}>
+        <Grid hasGutter style={{ minWidth: "1280px", gridGap: "var(--pf-c-page__main-section--PaddingTop)" }}>
+          <GridItem span={6}>
             <PageSection variant={"light"} isFilled={true} style={{ height: "100%" }}>
               <TextContent>
                 <Text component={TextVariants.h1}>Create</Text>
@@ -146,9 +146,9 @@ export function HomePage() {
               <Divider inset={{ default: "insetXl" }} />
               <Gallery
                 hasGutter={true}
-                // 16px is the "Gutter" width.
-                minWidths={{ sm: "calc(33% - 16px)", default: "100%" }}
-                style={{ height: "calc(100% - 32px)" }}
+                // var(--pf-c-page__main-section--PaddingTop) is the "Gutter" width.
+                minWidths={{ default: "calc(33% - var(--pf-c-page__main-section--PaddingTop))" }}
+                style={{ height: "calc(100% - 32px)", gridAutoFlow: "column" }}
               >
                 <NewModelCard
                   title={"Workflow"}
@@ -168,7 +168,7 @@ export function HomePage() {
               </Gallery>
             </PageSection>
           </GridItem>
-          <GridItem sm={12} xl={6}>
+          <GridItem span={6}>
             <PageSection variant={"light"} isFilled={true} style={{ height: "100%" }}>
               <TextContent>
                 <Text component={TextVariants.h1}>Import</Text>
@@ -177,9 +177,9 @@ export function HomePage() {
               <Divider inset={{ default: "insetXl" }} />
               <Gallery
                 hasGutter={true}
-                // 16px is the "Gutter" width.
-                minWidths={{ sm: "calc(50% - 16px)", default: "100%" }}
-                style={{ height: "calc(100% - 32px)" }}
+                // var(--pf-c-page__main-section--PaddingTop) is the "Gutter" width.
+                minWidths={{ default: "calc(50% - var(--pf-c-page__main-section--PaddingTop))" }}
+                style={{ height: "calc(100% - 32px)", gridAutoFlow: "column" }}
               >
                 <ImportFromUrlCard />
                 <UploadCard expandWorkspace={expandWorkspace} />

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -85,6 +85,7 @@ import { VariableSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Skeleton } from "@patternfly/react-core/dist/js/components/Skeleton";
 import { FileDataList, getFileDataListHeight } from "../filesList/FileDataList";
+import { WorkspaceDescriptorDates } from "../workspace/components/WorkspaceDescriptorDates";
 
 export function HomePage() {
   const routes = useRoutes();
@@ -427,14 +428,7 @@ export function WorkspaceCard(props: { workspaceId: string; isSelected: boolean;
                 </CardActions>
               </CardHeader>
               <CardBody>
-                <TextContent>
-                  <Text component={TextVariants.p}>
-                    <b>{`Created: `}</b>
-                    <RelativeDate date={new Date(workspacePromise.data?.descriptor.createdDateISO ?? "")} />
-                    <b>{`, Last updated: `}</b>
-                    <RelativeDate date={new Date(workspacePromise.data?.descriptor.lastUpdatedDateISO ?? "")} />
-                  </Text>
-                </TextContent>
+                <WorkspaceDescriptorDates workspaceDescriptor={workspacePromise.data?.descriptor} />
               </CardBody>
             </Card>
           )) || (

--- a/packages/online-editor/src/workspace/components/WorkspaceDescriptorDates.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceDescriptorDates.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { WorkspaceDescriptor } from "../worker/api/WorkspaceDescriptor";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { RelativeDate } from "../../dates/RelativeDate";
+
+export function WorkspaceDescriptorDates(props: { workspaceDescriptor: WorkspaceDescriptor | undefined }) {
+  return (
+    <TextContent>
+      <Text component={TextVariants.small}>
+        <b>{`Created: `}</b>
+        <RelativeDate date={new Date(props.workspaceDescriptor?.createdDateISO ?? "-")} />
+        <b>{`, Last updated: `}</b>
+        <RelativeDate date={new Date(props.workspaceDescriptor?.lastUpdatedDateISO ?? "-")} />
+      </Text>
+    </TextContent>
+  );
+}

--- a/packages/online-editor/src/workspace/components/WorkspaceDescriptorDates.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceDescriptorDates.tsx
@@ -21,7 +21,7 @@ import { RelativeDate } from "../../dates/RelativeDate";
 
 export function WorkspaceDescriptorDates(props: { workspaceDescriptor: WorkspaceDescriptor | undefined }) {
   return (
-    <TextContent>
+    <TextContent style={{ marginTop: "6px" }}>
       <Text component={TextVariants.small}>
         <b>{`Created: `}</b>
         <RelativeDate date={new Date(props.workspaceDescriptor?.createdDateISO ?? "-")} />

--- a/packages/online-editor/src/workspace/components/WorkspaceLabel.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceLabel.tsx
@@ -26,6 +26,7 @@ import { WorkspaceDescriptor } from "../worker/api/WorkspaceDescriptor";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 import { CodeIcon } from "@patternfly/react-icons/dist/js/icons/code-icon";
 import { UrlType, useImportableUrl } from "../hooks/ImportableUrlHooks";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 
 export function WorkspaceLabel(props: { descriptor?: WorkspaceDescriptor }) {
   const workspaceImportableUrl = useImportableUrl(props.descriptor?.origin.url?.toString());
@@ -60,46 +61,54 @@ export function WorkspaceLabel(props: { descriptor?: WorkspaceDescriptor }) {
   }, [props.descriptor, workspaceImportableUrl]);
 
   return (
-    <>
+    <Flex wrap={"nowrap"} style={{ display: "inline-flex" }}>
       {props.descriptor?.origin.kind === WorkspaceKind.GIT && (
-        <Tooltip
-          content={`'${
-            props.descriptor?.name
-          }' is linked to a Git Repository. ${props.descriptor?.origin.url.toString()}`}
-          position={"right"}
-        >
-          <>
-            {gitLabel}
-            &nbsp;&nbsp;
-            <Label>
-              <CodeBranchIcon />
-              &nbsp;&nbsp;{props.descriptor?.origin.branch}
-            </Label>
-          </>
-        </Tooltip>
+        <FlexItem>
+          <Tooltip
+            content={`'${
+              props.descriptor?.name
+            }' is linked to a Git Repository. ${props.descriptor?.origin.url.toString()}`}
+            position={"right"}
+          >
+            <>
+              {gitLabel}
+              &nbsp;&nbsp;
+              <Label>
+                <CodeBranchIcon />
+                &nbsp;&nbsp;{props.descriptor?.origin.branch}
+              </Label>
+            </>
+          </Tooltip>
+        </FlexItem>
       )}
       {props.descriptor?.origin.kind === WorkspaceKind.GITHUB_GIST && (
-        <Tooltip
-          content={`'${props.descriptor?.name}' is linked to a GitHub Gist. ${props.descriptor?.origin.url.toString()}`}
-          position={"right"}
-        >
-          <Label>
-            <GithubIcon />
-            &nbsp;&nbsp;Gist
-          </Label>
-        </Tooltip>
+        <FlexItem>
+          <Tooltip
+            content={`'${
+              props.descriptor?.name
+            }' is linked to a GitHub Gist. ${props.descriptor?.origin.url.toString()}`}
+            position={"right"}
+          >
+            <Label>
+              <GithubIcon />
+              &nbsp;&nbsp;Gist
+            </Label>
+          </Tooltip>
+        </FlexItem>
       )}
       {props.descriptor?.origin.kind === WorkspaceKind.LOCAL && (
-        <Tooltip
-          content={`'${props.descriptor?.name}' is saved directly in the browser. Incognito windows don't have access to it.`}
-          position={"right"}
-        >
-          <Label>
-            <PendingIcon />
-            &nbsp;&nbsp;Ephemeral
-          </Label>
-        </Tooltip>
+        <FlexItem>
+          <Tooltip
+            content={`'${props.descriptor?.name}' is saved directly in the browser. Incognito windows don't have access to it.`}
+            position={"right"}
+          >
+            <Label>
+              <PendingIcon />
+              &nbsp;&nbsp;Ephemeral
+            </Label>
+          </Tooltip>
+        </FlexItem>
       )}
-    </>
+    </Flex>
   );
 }

--- a/packages/online-editor/src/workspace/components/WorkspaceListItem.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceListItem.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WorkspaceDescriptor } from "../worker/api/WorkspaceDescriptor";
+import { WorkspaceFile } from "../WorkspacesContext";
+import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
+import { WorkspaceLabel } from "./WorkspaceLabel";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { FolderIcon } from "@patternfly/react-icons/dist/js/icons/folder-icon";
+import { WorkspaceDescriptorDates } from "./WorkspaceDescriptorDates";
+import * as React from "react";
+
+export function WorkspaceListItem(props: {
+  isBig: boolean;
+  workspaceDescriptor: WorkspaceDescriptor;
+  allFiles: WorkspaceFile[];
+  editableFiles: WorkspaceFile[];
+}) {
+  return (
+    <>
+      <Flex>
+        <WorkspaceLabel descriptor={props.workspaceDescriptor} />
+        <TextContent>
+          <Text
+            component={TextVariants.small}
+            style={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {`${props.allFiles.length} files, ${props.editableFiles.length} models`}
+          </Text>
+        </TextContent>
+      </Flex>
+      <br />
+      <TextContent>
+        <Text
+          component={props.isBig ? TextVariants.h3 : TextVariants.p}
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          <FolderIcon />
+          &nbsp;&nbsp;
+          {props.workspaceDescriptor.name}
+        </Text>
+      </TextContent>
+      <WorkspaceDescriptorDates workspaceDescriptor={props.workspaceDescriptor} />
+    </>
+  );
+}

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -674,3 +674,7 @@ section.kie-tools--settings-tab {
 .expression-container .expression-container-box {
   margin-top: -11px;
 }
+
+.kie-tools--file-switcher-no-padding-menu-item {
+  padding: 0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3162,6 +3162,8 @@ importers:
       "@types/react-dom": ^17.0.5
       "@types/react-router": ^5.1.14
       "@types/react-router-dom": ^5.1.7
+      "@types/react-virtualized-auto-sizer": ^1.0.1
+      "@types/react-window": ^1.8.5
       "@types/testing-library__jest-dom": ^5.9.1
       "@types/testing-library__react": ^9.1.2
       "@types/uuid": ^8.3.0
@@ -3189,6 +3191,8 @@ importers:
       react-dropzone: ^11.4.2
       react-router: ^5.2.1
       react-router-dom: ^5.2.1
+      react-virtualized-auto-sizer: ^1.0.7
+      react-window: ^1.3.1
       rimraf: ^3.0.2
       start-server-and-test: ^1.12.1
       ts-jest: ^26.5.6
@@ -3236,6 +3240,8 @@ importers:
       react-dropzone: 11.4.2_react@17.0.2
       react-router: 5.2.1_react@17.0.2
       react-router-dom: 5.3.0_react@17.0.2
+      react-virtualized-auto-sizer: 1.0.7_sfoxds7t5ydpegc3knd667wn6m
+      react-window: 1.8.7_sfoxds7t5ydpegc3knd667wn6m
       uuid: 8.3.2
     devDependencies:
       "@babel/core": 7.16.12
@@ -3258,6 +3264,8 @@ importers:
       "@types/react-dom": 17.0.8
       "@types/react-router": 5.1.14
       "@types/react-router-dom": 5.1.7
+      "@types/react-virtualized-auto-sizer": 1.0.1
+      "@types/react-window": 1.8.5
       "@types/testing-library__jest-dom": 5.9.5
       "@types/testing-library__react": 9.1.3
       "@types/uuid": 8.3.0
@@ -10252,6 +10260,20 @@ packages:
       "@types/react": 17.0.21
     dev: false
 
+  /@types/react-virtualized-auto-sizer/1.0.1:
+    resolution:
+      { integrity: sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong== }
+    dependencies:
+      "@types/react": 17.0.21
+    dev: true
+
+  /@types/react-window/1.8.5:
+    resolution:
+      { integrity: sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw== }
+    dependencies:
+      "@types/react": 17.0.21
+    dev: true
+
   /@types/react/17.0.21:
     resolution:
       { integrity: sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ== }
@@ -15851,7 +15873,7 @@ packages:
       { integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA== }
     engines: { node: ">= 0.4" }
     dependencies:
-      is-callable: 1.2.3
+      is-callable: 1.2.7
       is-date-object: 1.0.2
       is-symbol: 1.0.4
     dev: true
@@ -17231,7 +17253,16 @@ packages:
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
-      has-symbols: 1.0.2
+      has-symbols: 1.0.3
+    dev: true
+
+  /get-intrinsic/1.1.3:
+    resolution:
+      { integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A== }
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.3
     dev: true
 
   /get-npm-tarball-url/2.0.3:
@@ -17629,12 +17660,18 @@ packages:
     engines: { node: ">= 0.4" }
     dev: true
 
+  /has-symbols/1.0.3:
+    resolution:
+      { integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A== }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /has-tostringtag/1.0.0:
     resolution:
       { integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ== }
     engines: { node: ">= 0.4" }
     dependencies:
-      has-symbols: 1.0.2
+      has-symbols: 1.0.3
     dev: true
 
   /has-unicode/2.0.1:
@@ -18224,7 +18261,7 @@ packages:
       { integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA== }
     engines: { node: ">= 0.4" }
     dependencies:
-      get-intrinsic: 1.1.1
+      get-intrinsic: 1.1.3
       has: 1.0.3
       side-channel: 1.0.4
     dev: true
@@ -18335,6 +18372,12 @@ packages:
   /is-callable/1.2.3:
     resolution:
       { integrity: sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ== }
+    engines: { node: ">= 0.4" }
+    dev: true
+
+  /is-callable/1.2.7:
+    resolution:
+      { integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA== }
     engines: { node: ">= 0.4" }
     dev: true
 
@@ -18613,6 +18656,14 @@ packages:
     engines: { node: ">= 0.4" }
     dev: true
 
+  /is-string/1.0.7:
+    resolution:
+      { integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
+
   /is-subdir/1.2.0:
     resolution:
       { integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw== }
@@ -18626,7 +18677,7 @@ packages:
       { integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg== }
     engines: { node: ">= 0.4" }
     dependencies:
-      has-symbols: 1.0.2
+      has-symbols: 1.0.3
     dev: true
 
   /is-typedarray/1.0.0:
@@ -20552,6 +20603,11 @@ packages:
       fs-monkey: 1.0.3
     dev: true
 
+  /memoize-one/5.2.1:
+    resolution:
+      { integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q== }
+    dev: false
+
   /merge-descriptors/1.0.1:
     resolution:
       { integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w== }
@@ -21618,6 +21674,11 @@ packages:
       { integrity: sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw== }
     dev: true
 
+  /object-inspect/1.12.2:
+    resolution:
+      { integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ== }
+    dev: true
+
   /object-is/1.0.2:
     resolution:
       { integrity: sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ== }
@@ -21810,7 +21871,8 @@ packages:
     dev: true
 
   /os-tmpdir/1.0.2:
-    resolution: { integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ= }
+    resolution:
+      { integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g== }
     engines: { node: ">=0.10.0" }
 
   /osenv/0.1.5:
@@ -22357,14 +22419,16 @@ packages:
     engines: { node: ">=6" }
 
   /pinkie-promise/2.0.1:
-    resolution: { integrity: sha1-ITXW36ejWMBprJsXh3YogihFD/o= }
+    resolution:
+      { integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw== }
     engines: { node: ">=0.10.0" }
     dependencies:
       pinkie: 2.0.4
     dev: true
 
   /pinkie/2.0.4:
-    resolution: { integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA= }
+    resolution:
+      { integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg== }
     engines: { node: ">=0.10.0" }
     dev: true
 
@@ -23716,6 +23780,32 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /react-virtualized-auto-sizer/1.0.7_sfoxds7t5ydpegc3knd667wn6m:
+    resolution:
+      { integrity: sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA== }
+    engines: { node: ">8.0.0" }
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
+      react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /react-window/1.8.7_sfoxds7t5ydpegc3knd667wn6m:
+    resolution:
+      { integrity: sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA== }
+    engines: { node: ">8.0.0" }
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      "@babel/runtime": 7.16.7
+      memoize-one: 5.2.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /react/17.0.2:
     resolution:
       { integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA== }
@@ -24830,8 +24920,8 @@ packages:
       { integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw== }
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.1.1
-      object-inspect: 1.10.3
+      get-intrinsic: 1.1.3
+      object-inspect: 1.12.2
     dev: true
 
   /signal-exit/3.0.3:
@@ -26112,7 +26202,8 @@ packages:
     dev: true
 
   /tr46/0.0.3:
-    resolution: { integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o= }
+    resolution:
+      { integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw== }
 
   /tr46/2.0.2:
     resolution:
@@ -27717,7 +27808,7 @@ packages:
       is-bigint: 1.0.2
       is-boolean-object: 1.1.1
       is-number-object: 1.0.5
-      is-string: 1.0.6
+      is-string: 1.0.7
       is-symbol: 1.0.4
     dev: true
 


### PR DESCRIPTION
Listing files for big workspaces is a heavy task because of the many DOM operations React needs to perform. Some solutions to this problem include Pagination, Filtering, infinite scroll, "Load more..." etc, but there's also windowing. `react-window` is a simple implementation of this strategy that allow us to keep showing entire lists but only rendering to the DOM what the users can see and interact with.

I also took the opportunity to improve the visuals of these lists, making them more consistent, so this PR fixes a set of Jiras:
- [KOGITO-7818: Home screen scroll improvements](https://issues.redhat.com/browse/KOGITO-7818)
- [KOGITO-7817: Performance and UX of Home screen drawer for large repositories](https://issues.redhat.com/browse/KOGITO-7817)
- [KOGITO-7811: File switcher performance enhancements](https://issues.redhat.com/browse/KOGITO-7811)
- [KOGITO-7812: Add a visual indicator that workspaces will open to the side on home screen workspaces list](https://issues.redhat.com/browse/KOGITO-7812)

Also on this PR:
- Fix a bug that would crash the File Switcher if clicking on `< All` too fast (before the focus could be set to the search input)
- Increasing the minWidth of the FileSwitcher from `400px` to `500px` .
- Improved the visuals of `WorkspaceLoadingCard`

---

Here are some screenshots of the changes: 

`BEFORE                                                                                        AFTER`
![image](https://user-images.githubusercontent.com/1584568/194143597-7d63dbe7-832c-46c7-a115-8ef108b049d8.png)
`BEFORE                                                                                 AFTER`
![Screen Shot 2022-10-03 at 13 35 56](https://user-images.githubusercontent.com/1584568/193633700-5717e13e-2f12-44fd-a8c8-6bfcb360d263.png)
`BEFORE                                                                                 AFTER`
![Screen Shot 2022-10-03 at 13 36 13](https://user-images.githubusercontent.com/1584568/193633714-790a3576-4ace-4236-8904-5eba5f08f20c.png)
