### PR TITLE
KOGITO-8077: KIE Tools Security updates (3rd round)

### DIFF
--- a/packages/backend-extended-services/pom.xml
+++ b/packages/backend-extended-services/pom.xml
@@ -62,10 +62,10 @@
 
     <jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
     <org.jboss.spec.javax.ws.rs.version>2.0.1.Final</org.jboss.spec.javax.ws.rs.version>
-    <quarkus-plugin.version>2.13.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.13.1.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.1.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <jandex-maven-plugin.version>1.0.7</jandex-maven-plugin.version>
   </properties>

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/greeting-flow/pom.xml
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/greeting-flow/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.10.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.1.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>


### PR DESCRIPTION
The scope of this PR is to update insecure dependencies reported by code scanning programs.
Updated dependencies are:

`quarkus` in `backend-extended-services` (`2.13.0` -> `2.13.1`); 
`quarkus` in `vscode-extension-serverless-workflow-editor` (`2.10.0` -> `2.13.1`);