### PR TITLE
KOGITO-8128: [SWF Editor] Diagram nodes highlighting is triggered too many times

### DIFF
--- a/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditorController.ts
+++ b/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditorController.ts
@@ -18,7 +18,7 @@ import { EditorTheme } from "@kie-tools-core/editor/dist/api";
 import { OperatingSystem } from "@kie-tools-core/operating-system";
 import { FileLanguage, SwfLanguageServiceCommandIds } from "@kie-tools/serverless-workflow-language-service/dist/api";
 import { SwfJsonOffsets, SwfYamlOffsets } from "@kie-tools/serverless-workflow-language-service/dist/editor";
-import { editor, KeyCode, KeyMod } from "monaco-editor";
+import { editor, KeyCode, KeyMod, Position } from "monaco-editor";
 import { initJsonSchemaDiagnostics } from "./augmentation/language/json";
 import { initYamlSchemaDiagnostics } from "./augmentation/language/yaml";
 
@@ -77,7 +77,7 @@ export class SwfTextEditorController implements SwfTextEditorApi {
     });
 
     editor.onDidCreateEditor((codeEditor) => {
-      codeEditor.onDidChangeCursorPosition((event) => this.handleDidChangeCursorPosition(event));
+      codeEditor.onDidChangeCursorSelection((event) => this.handleDidChangeCursorSelection(event));
     });
   }
 
@@ -177,13 +177,16 @@ export class SwfTextEditorController implements SwfTextEditorApi {
     this.editor?.focus();
   }
 
-  public handleDidChangeCursorPosition(event: editor.ICursorPositionChangedEvent): void {
-    const position = event.position;
-    if (!position || event.reason !== editor.CursorChangeReason.Explicit) {
+  public handleDidChangeCursorSelection(event: editor.ICursorSelectionChangedEvent): void {
+    const selection = event.selection;
+    if (
+      event.reason !== editor.CursorChangeReason.Explicit ||
+      !Position.equals(selection.getStartPosition(), selection.getEndPosition())
+    ) {
       return;
     }
 
-    const offset = this.editor?.getModel()?.getOffsetAt(position);
+    const offset = this.editor?.getModel()?.getOffsetAt(selection.getStartPosition());
     if (!offset) {
       return;
     }

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/builtInVsCodeEditorSwfContributions.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/builtInVsCodeEditorSwfContributions.ts
@@ -258,7 +258,9 @@ export function setupBuiltInVsCodeEditorSwfContributions(args: {
   );
 
   vscode.window.onDidChangeTextEditorSelection((e) => {
-    if (!isEventFiredFromUser(e)) {
+    const selection = e.selections[0];
+
+    if (!isEventFiredFromUser(e) || !selection.start.isEqual(selection.end)) {
       return;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8128

Description:
During text highlighting (by keyboard or mouse) the event `kogitoSwfTextEditor__onSelectionChanged` is triggered too many times.

Solution:
Disabled the event during text block selection for mouse and keyboard

Before:
![Jira](https://issues.redhat.com/secure/attachment/12772931/Peek%202022-10-13%2016-39.gif)

After:
![KOGITO-8128](https://user-images.githubusercontent.com/17780574/197171758-3ef5920a-fdf1-4365-82fa-a253d7342e39.gif)

