### PR TITLE
KOGITO-8119: [DMN Editor] Import Java classes thrown an exception in Windows 

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -49,6 +49,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
 
+    <version.flatten.plugin>1.3.0</version.flatten.plugin>
   </properties>
   <repositories>
     <repository>
@@ -97,7 +98,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.3.0</version>
+        <version>${version.flatten.plugin}</version>
         <configuration>
           <updatePomFile>true</updatePomFile>
           <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <version.org.freemarker>2.3.31</version.org.freemarker>
     <version.org.assertj>3.23.1</version.org.assertj>
-    <version.org.junit.jupiter>5.8.2</version.org.junit.jupiter>
-    <version.org.mockito>4.6.1</version.org.mockito>
+    <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
+    <version.org.mockito>4.8.0</version.org.mockito>
   </properties>
 
   <dependencyManagement>
@@ -37,7 +37,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
+        <artifactId>mockito-inline</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
     </dependencies>
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/DelegateHandler.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/DelegateHandler.java
@@ -29,12 +29,11 @@ import org.kogito.core.internal.handlers.GetClassesHandler;
 import org.kogito.core.internal.handlers.Handler;
 import org.kogito.core.internal.handlers.HandlerConstants;
 import org.kogito.core.internal.handlers.IsLanguageServerAvailableHandler;
-import org.kogito.core.internal.util.WorkspaceUtil;
 
 public class DelegateHandler implements IDelegateCommandHandler {
 
     private static final JavaEngine JAVA_ENGINE = new JavaEngine();
-    private static final ActivationChecker ACTIVATION_CHECKER = new ActivationChecker(new WorkspaceUtil());
+    private static final ActivationChecker ACTIVATION_CHECKER = new ActivationChecker();
     private static final AutocompleteHandler AUTOCOMPLETE_HANDLER = new AutocompleteHandler(ACTIVATION_CHECKER);
     private final IsLanguageServerAvailableHandler isAvailableHandler;
 

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationChecker.java
@@ -16,32 +16,17 @@
 
 package org.kogito.core.internal.engine;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.kogito.core.internal.util.WorkspaceUtil;
 
 public class ActivationChecker {
 
-    private final WorkspaceUtil workspaceUtil;
     private Path activatorPath = null;
 
-    public ActivationChecker(WorkspaceUtil workspaceUtil) {
-        this.workspaceUtil = workspaceUtil;
-    }
-
     public void check() {
-        ActivationFileVisitor visitor = new ActivationFileVisitor();
-        try {
-            Files.walkFileTree(Paths.get(workspaceUtil.getProjectLocation()), visitor);
-        } catch (IOException e) {
-            JavaLanguageServerPlugin.logException("Error trying to read workspace tree", e);
-        }
-        if (visitor.isPresent()) {
-            this.activatorPath = visitor.getActivatorFile().toAbsolutePath();
+        var fileVisitor = new ActivationFileVisitor();
+        var activatorPathOpt = fileVisitor.searchActivatorPath();
+        if (activatorPathOpt.isPresent()) {
+            activatorPath = fileVisitor.searchActivatorPath().get().toAbsolutePath();
         }
     }
 
@@ -49,9 +34,9 @@ public class ActivationChecker {
         return activatorPath != null && activatorPath.toFile().exists();
     }
 
-    public String getActivatorUri() {
+    public Path getActivatorPath() {
         if (existActivator()) {
-            return activatorPath.toUri().toASCIIString();
+            return activatorPath;
         } else {
             throw new ActivationCheckerException("Activator URI is not present");
         }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationFileVisitor.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationFileVisitor.java
@@ -17,13 +17,16 @@
 package org.kogito.core.internal.engine;
 
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Optional;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.kogito.core.internal.util.WorkspaceUtil;
 
 public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
 
@@ -31,11 +34,16 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
     protected static final String ANNOTATION_ACTIVATOR = "@KieActivator";
     protected static final String JAVA_EXTENSION = ".java";
 
-    private boolean present;
     private Path activatorPath;
 
-    public ActivationFileVisitor() {
-        this.present = false;
+    public Optional<Path> searchActivatorPath() {
+        try {
+            Files.walkFileTree(Paths.get(WorkspaceUtil.getProjectLocation()), this);
+        } catch (IOException e) {
+            JavaLanguageServerPlugin.logException("Error trying to read workspace tree", e);
+        }
+
+        return Optional.of(activatorPath);
     }
 
     @Override
@@ -50,7 +58,6 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
         long linesThatMatch = Files.lines(file).filter(this::containsActivator).count();
 
         if (linesThatMatch >= 2) {
-            this.present = true;
             JavaLanguageServerPlugin.logInfo("Activator found: " + filePath);
             this.activatorPath = file;
             return FileVisitResult.TERMINATE;
@@ -63,11 +70,4 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
         return line.contains(IMPORT_ACTIVATOR) || line.contains(ANNOTATION_ACTIVATOR);
     }
 
-    public boolean isPresent() {
-        return present;
-    }
-
-    public Path getActivatorFile() {
-        return activatorPath;
-    }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationFileVisitor.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/ActivationFileVisitor.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.kogito.core.internal.util.WorkspaceUtil;
@@ -43,7 +44,7 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
             JavaLanguageServerPlugin.logException("Error trying to read workspace tree", e);
         }
 
-        return Optional.of(activatorPath);
+        return Optional.ofNullable(activatorPath);
     }
 
     @Override
@@ -54,8 +55,11 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
         }
 
         JavaLanguageServerPlugin.logInfo("Java file found: " + filePath);
+        long linesThatMatch;
 
-        long linesThatMatch = Files.lines(file).filter(this::containsActivator).count();
+        try (Stream<String> linesStream = Files.lines(file)) {
+            linesThatMatch = linesStream.filter(this::containsActivator).count();
+        }
 
         if (linesThatMatch >= 2) {
             JavaLanguageServerPlugin.logInfo("Activator found: " + filePath);
@@ -66,7 +70,7 @@ public class ActivationFileVisitor extends SimpleFileVisitor<Path> {
         }
     }
 
-    protected boolean containsActivator(String line) {
+    private boolean containsActivator(String line) {
         return line.contains(IMPORT_ACTIVATOR) || line.contains(ANNOTATION_ACTIVATOR);
     }
 

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/BuildInformation.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/BuildInformation.java
@@ -16,16 +16,18 @@
 
 package org.kogito.core.internal.engine;
 
+import java.nio.file.Path;
+
 public class BuildInformation {
 
-    private final String uri;
+    private final Path path;
     private final String originalText;
     private final String text;
     private final int line;
     private final int position;
 
-    public BuildInformation(String uri, String originalText, String text, int line, int position) {
-        this.uri = uri;
+    public BuildInformation(Path path, String originalText, String text, int line, int position) {
+        this.path = path;
         this.originalText = originalText;
         this.text = text;
         this.line = line;
@@ -44,8 +46,8 @@ public class BuildInformation {
         return position;
     }
 
-    public String getUri() {
-        return uri;
+    public Path getPath() {
+        return path;
     }
 
     public String getOriginalText() {

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/JavaEngine.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/engine/JavaEngine.java
@@ -51,27 +51,27 @@ public class JavaEngine {
         }
     }
 
-    public BuildInformation buildImportClass(String uri, String importText) {
+    public BuildInformation buildImportClass(Path filePath, String importText) {
 
         TemplateParameters item = new TemplateParameters();
-        item.setClassName(getClassName(uri));
+        item.setClassName(getClassName(filePath));
         item.setQuery(importText);
 
         String content = this.evaluate(Templates.TEMPLATE_CLASS, item);
 
-        return new BuildInformation(uri, getContent(uri), content, 2, getEndOfLinePosition(content, 2));
+        return new BuildInformation(filePath, getContent(filePath), content, 2, getEndOfLinePosition(content, 2));
     }
 
-    public BuildInformation buildPublicContent(String uri, String fqcn, String completeText) {
+    public BuildInformation buildPublicContent(Path filePath, String fqcn, String completeText) {
 
         TemplateParameters item = new TemplateParameters();
-        item.setClassName(getClassName(uri));
+        item.setClassName(getClassName(filePath));
         item.setQuery(completeText);
         item.setFqcn(fqcn);
 
         String content = this.evaluate(Templates.TEMPLATE_ACCESSORS, item);
 
-        return new BuildInformation(uri, getContent(uri), content, 5, getEndOfLinePosition(content, 5));
+        return new BuildInformation(filePath, getContent(filePath), content, 5, getEndOfLinePosition(content, 5));
     }
 
     protected int getEndOfLinePosition(String content, int lineNumber) {
@@ -80,8 +80,8 @@ public class JavaEngine {
         return split[lineNumber].length();
     }
 
-    protected String getClassName(String url) {
-        String fileName = Paths.get(url).getFileName().toString();
+    protected String getClassName(Path path) {
+        String fileName = path.getFileName().toString();
         if (fileName.contains(".")) {
             return fileName.substring(0, fileName.lastIndexOf("."));
         } else {
@@ -89,11 +89,11 @@ public class JavaEngine {
         }
     }
 
-    protected String getContent(String uri) {
+    protected String getContent(Path path) {
         try {
-            return Files.readString(Path.of(URI.create(uri)));
+            return Files.readString(path);
         } catch (IOException e) {
-            JavaLanguageServerPlugin.logException("Can't read content from: " + uri, e);
+            JavaLanguageServerPlugin.logException("Can't read content from: " + path, e);
             return "";
         }
     }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/AutocompleteHandler.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/AutocompleteHandler.java
@@ -16,6 +16,7 @@
 
 package org.kogito.core.internal.handlers;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +52,7 @@ public class AutocompleteHandler {
 
         JDTLanguageServer languageServer = (JDTLanguageServer) JavaLanguageServerPlugin.getInstance().getProtocol();
 
-        String uri = this.getUri();
+        String uri = buildInformation.getPath().toUri().toASCIIString();
         JavaLanguageServerPlugin.logInfo(uri);
 
         System.setProperty("java.lsp.joinOnCompletion", "true");
@@ -62,7 +63,7 @@ public class AutocompleteHandler {
             TextDocumentItem textDocumentItem = new TextDocumentItem();
             textDocumentItem.setLanguageId("java");
             textDocumentItem.setText(buildInformation.getOriginalText());
-            textDocumentItem.setUri(buildInformation.getUri());
+            textDocumentItem.setUri(uri);
             textDocumentItem.setVersion(1);
             didOpenTextDocumentParams.setTextDocument(textDocumentItem);
             languageServer.didOpen(didOpenTextDocumentParams);
@@ -73,7 +74,7 @@ public class AutocompleteHandler {
             TextDocumentContentChangeEvent textDocumentContentChangeEvent = new TextDocumentContentChangeEvent();
             textDocumentContentChangeEvent.setText(buildInformation.getText());
             VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
-            versionedTextDocumentIdentifier.setUri(buildInformation.getUri());
+            versionedTextDocumentIdentifier.setUri(uri);
             versionedTextDocumentIdentifier.setVersion(2);
             didChangeTextDocumentParams.setTextDocument(versionedTextDocumentIdentifier);
             didChangeTextDocumentParams.setContentChanges(Collections.singletonList(textDocumentContentChangeEvent));
@@ -116,7 +117,7 @@ public class AutocompleteHandler {
         }
     }
 
-    public String getUri() {
-        return this.activationChecker.getActivatorUri();
+    public Path getActivatorPath() {
+        return this.activationChecker.getActivatorPath();
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/GetAccessorsHandler.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/GetAccessorsHandler.java
@@ -45,7 +45,7 @@ public class GetAccessorsHandler extends Handler<List<GetPublicResult>> {
     public List<GetPublicResult> handle(List<Object> arguments, IProgressMonitor progress) {
         JavaLanguageServerPlugin.logInfo("Handle Accessors");
         GetPublicParameters parameters = checkParameters(arguments);
-        BuildInformation buildInformation = javaEngine.buildPublicContent(this.autocompleteHandler.getUri(),
+        BuildInformation buildInformation = javaEngine.buildPublicContent(this.autocompleteHandler.getActivatorPath(),
                                                                           parameters.getFqcn(),
                                                                           parameters.getQuery());
         JavaLanguageServerPlugin.logInfo(buildInformation.getText());

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/GetClassesHandler.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/handlers/GetClassesHandler.java
@@ -40,7 +40,7 @@ public class GetClassesHandler extends Handler<List<GetClassesResult>> {
     public List<GetClassesResult> handle(List<Object> arguments, IProgressMonitor progress) {
         checkParameters(arguments);
         String completeText = (String) arguments.get(0);
-        BuildInformation buildInformation = javaEngine.buildImportClass(this.autocompleteHandler.getUri(), completeText);
+        BuildInformation buildInformation = javaEngine.buildImportClass(this.autocompleteHandler.getActivatorPath(), completeText);
         List<CompletionItem> items = this.autocompleteHandler.handle("GetClassesHandler", buildInformation);
         return this.transformCompletionItemsToResult(items);
     }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/util/WorkspaceUtil.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/main/java/org/kogito/core/internal/util/WorkspaceUtil.java
@@ -24,7 +24,9 @@ import org.eclipse.core.resources.ResourcesPlugin;
 
 public class WorkspaceUtil {
 
-    public String getProjectLocation() {
+    private WorkspaceUtil() {};
+
+    public static String getProjectLocation() {
         String workspaceStorage = ResourcesPlugin.getWorkspace().getRoot().getLocation().toOSString();
         Optional<IProject> project = Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects())
                 .filter(iProject -> !iProject.getLocation().makeAbsolute().toOSString().contains(workspaceStorage))

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
@@ -16,45 +16,46 @@
 
 package org.kogito.core.internal.engine;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kogito.core.internal.util.TestUtil;
-import org.mockito.Mockito;
 
-import java.nio.file.Path;
-import java.util.Optional;
+import java.io.File;
 
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.kogito.core.internal.util.TestUtil.COMMON_RESOURCE_PATH;
 
 class ActivationCheckerTest {
-
-    private ActivationFileVisitor activationFileVisitorMock;
 
     private ActivationChecker activationChecker;
 
     @BeforeEach
     public void setup() {
-        activationFileVisitorMock = Mockito.mock(ActivationFileVisitor.class);
-        this.activationChecker = new ActivationChecker();
+        activationChecker = new ActivationChecker();
     }
 
     @Test
     void getActivatorPathWithoutSpecialChars() {
-        TestUtil.mockWorkspace("src/test/resources/testProject/", () -> activationChecker.check());
-        var activatorUri = activationChecker.getActivatorPath();
-        Assertions.assertNotNull(activatorUri);
-        Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "testProject" + File.separator, () -> activationChecker.check());
+
+        assertThat(activationChecker.existActivator()).isTrue();
+        assertThat(activationChecker.getActivatorPath().endsWith("Activator.java")).isTrue();
     }
 
     @Test
     void getActivatorPathWithSpecialChars() {
-        TestUtil.mockWorkspace("src/test/resources/test projéct", () -> activationChecker.check());
-        var activatorUri = activationChecker.getActivatorPath();
-        System.out.println(activatorUri);
-        var path = activatorUri.toUri().toASCIIString();
-        //Assertions.assertTrue(activatorUri.toUri().toASCIIString().contains("test%20proj%C3%A9ct"));
-        Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "test projéct" + File.separator, () -> activationChecker.check());
+
+        assertThat(activationChecker.existActivator()).isTrue();
+        assertThat(activationChecker.getActivatorPath().endsWith("MyActivator.java")).isTrue();
     }
 
+    @Test
+    void getActivatorPathWithNoActivator() {
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "noActivatorProject" + File.separator, () -> activationChecker.check());
+
+        assertThat(activationChecker.existActivator()).isFalse();
+        assertThrowsExactly(ActivationCheckerException.class, () -> activationChecker.getActivatorPath());
+    }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationCheckerTest.java
@@ -19,38 +19,41 @@ package org.kogito.core.internal.engine;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.kogito.core.internal.util.WorkspaceUtil;
+import org.kogito.core.internal.util.TestUtil;
 import org.mockito.Mockito;
+
+import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 
 class ActivationCheckerTest {
 
-    private WorkspaceUtil workspaceUtilMock;
+    private ActivationFileVisitor activationFileVisitorMock;
 
     private ActivationChecker activationChecker;
 
     @BeforeEach
     public void setup() {
-        workspaceUtilMock = Mockito.mock(WorkspaceUtil.class);
-        this.activationChecker = new ActivationChecker(workspaceUtilMock);
+        activationFileVisitorMock = Mockito.mock(ActivationFileVisitor.class);
+        this.activationChecker = new ActivationChecker();
     }
 
     @Test
     void getActivatorPathWithoutSpecialChars() {
-        when(workspaceUtilMock.getProjectLocation()).thenReturn("src/test/resources/testProject/");
-        activationChecker.check();
-        var activatorUri = activationChecker.getActivatorUri();
+        TestUtil.mockWorkspace("src/test/resources/testProject/", () -> activationChecker.check());
+        var activatorUri = activationChecker.getActivatorPath();
         Assertions.assertNotNull(activatorUri);
         Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
     }
 
     @Test
     void getActivatorPathWithSpecialChars() {
-        when(workspaceUtilMock.getProjectLocation()).thenReturn("src/test/resources/test projéct");
-        activationChecker.check();
-        var activatorUri = activationChecker.getActivatorUri();
-        Assertions.assertTrue(activatorUri.contains("test%20proj%C3%A9ct"));
+        TestUtil.mockWorkspace("src/test/resources/test projéct", () -> activationChecker.check());
+        var activatorUri = activationChecker.getActivatorPath();
+        System.out.println(activatorUri);
+        var path = activatorUri.toUri().toASCIIString();
+        //Assertions.assertTrue(activatorUri.toUri().toASCIIString().contains("test%20proj%C3%A9ct"));
         Assertions.assertTrue(activatorUri.endsWith("Activator.java"));
     }
 

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationFileVisitorTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationFileVisitorTest.java
@@ -32,7 +32,6 @@ class ActivationFileVisitorTest {
 
     @BeforeEach
     public void setUp() {
-
         activationFileVisitor = new ActivationFileVisitor();
     }
 
@@ -40,7 +39,7 @@ class ActivationFileVisitorTest {
     void testContainsActivator() throws IOException {
         Path workspace = Paths.get("src/test/resources/testProject");
         Files.walkFileTree(workspace.toAbsolutePath(), this.activationFileVisitor);
-        assertThat(this.activationFileVisitor.isPresent()).isTrue();
+        //assertThat(this.activationFileVisitor.isPresent()).isTrue();
     }
 
     @Test

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationFileVisitorTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/ActivationFileVisitorTest.java
@@ -16,15 +16,14 @@
 
 package org.kogito.core.internal.engine;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kogito.core.internal.util.TestUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kogito.core.internal.util.TestUtil.COMMON_RESOURCE_PATH;
 
 class ActivationFileVisitorTest {
 
@@ -36,21 +35,20 @@ class ActivationFileVisitorTest {
     }
 
     @Test
-    void testContainsActivator() throws IOException {
-        Path workspace = Paths.get("src/test/resources/testProject");
-        Files.walkFileTree(workspace.toAbsolutePath(), this.activationFileVisitor);
-        //assertThat(this.activationFileVisitor.isPresent()).isTrue();
+    void testContainsActivator() {
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "testProject" + File.separator,
+                () -> assertThat(activationFileVisitor.searchActivatorPath().isPresent()).isTrue());
     }
 
     @Test
-    void testContainsActivatorImport() {
-        boolean present = this.activationFileVisitor.containsActivator(ActivationFileVisitor.IMPORT_ACTIVATOR);
-        assertThat(present).isTrue();
+    void testContainsActivatorSpecialPath() {
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "test projéct" + File.separator,
+                () -> assertThat(activationFileVisitor.searchActivatorPath().isPresent()).isTrue());
     }
 
     @Test
-    void testContainsActivatorAnnotation() {
-        boolean present = this.activationFileVisitor.containsActivator(ActivationFileVisitor.ANNOTATION_ACTIVATOR);
-        assertThat(present).isTrue();
+    void testContainsNotActivator() {
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "noActivatorProject" + File.separator,
+                () -> assertThat(activationFileVisitor.searchActivatorPath().isPresent()).isFalse());
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JavaEngineTest {
 
     private JavaEngine javaEngine;
-    private final Path path = Path.of("file:///aaa/src/main/java/pkg/MainClass.java)");
+    private final Path path = Path.of("aaa/src/main/java/pkg/MainClass.java)");
 
     @BeforeEach
     public void setUp() {

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
@@ -35,35 +35,35 @@ class JavaEngineTest {
 
     @Test
     void testGetClassName() {
-        String result = this.javaEngine.getClassName(uri);
-        assertThat(result).isEqualTo("MainClass");
+        //String result = this.javaEngine.getClassName(uri);
+        //assertThat(result).isEqualTo("MainClass");
     }
 
     @Test
     void testImportPosition() {
-        BuildInformation info = this.javaEngine.buildImportClass(uri, "java.util.");
+        /*BuildInformation info = this.javaEngine.buildImportClass(uri, "java.util.");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(17);
+        assertThat(position).isEqualTo(17);*/
     }
 
     @Test
     void testEmptyImportPosition() {
-        BuildInformation info = this.javaEngine.buildImportClass(uri, "");
+       /* BuildInformation info = this.javaEngine.buildImportClass(uri, "");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(7);
+        assertThat(position).isEqualTo(7); */
     }
 
     @Test
     void testPublicMethodPosition() {
-        BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "get");
+       /* BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "get");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(33);
-    }
+        assertThat(position).isEqualTo(33); */
+     }
 
     @Test
     void testEmptyPublicMethodPosition() {
-        BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "");
+        /*BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(30);
+        assertThat(position).isEqualTo(30);*/
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JavaEngineTest {
 
     private JavaEngine javaEngine;
-    private final Path path = Path.of("aaa/src/main/java/pkg/MainClass.java)");
+    private final Path path = Path.of("aaa/src/main/java/pkg/MainClass.java");
 
     @BeforeEach
     public void setUp() {

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/engine/JavaEngineTest.java
@@ -19,14 +19,14 @@ package org.kogito.core.internal.engine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JavaEngineTest {
 
-    private Templates templates;
-
     private JavaEngine javaEngine;
-    private String uri = "file:///aaa/src/main/java/pkg/MainClass.java";
+    private final Path path = Path.of("file:///aaa/src/main/java/pkg/MainClass.java)");
 
     @BeforeEach
     public void setUp() {
@@ -35,35 +35,35 @@ class JavaEngineTest {
 
     @Test
     void testGetClassName() {
-        //String result = this.javaEngine.getClassName(uri);
-        //assertThat(result).isEqualTo("MainClass");
+        String result = this.javaEngine.getClassName(path);
+        assertThat(result).isEqualTo("MainClass");
     }
 
     @Test
     void testImportPosition() {
-        /*BuildInformation info = this.javaEngine.buildImportClass(uri, "java.util.");
+        BuildInformation info = this.javaEngine.buildImportClass(path, "java.util.");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(17);*/
+        assertThat(position).isEqualTo(17);
     }
 
     @Test
     void testEmptyImportPosition() {
-       /* BuildInformation info = this.javaEngine.buildImportClass(uri, "");
+       BuildInformation info = this.javaEngine.buildImportClass(path, "");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(7); */
+        assertThat(position).isEqualTo(7);
     }
 
     @Test
     void testPublicMethodPosition() {
-       /* BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "get");
+       BuildInformation info = this.javaEngine.buildPublicContent(path, "org.kie.MyClass", "get");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(33); */
+        assertThat(position).isEqualTo(33);
      }
 
     @Test
     void testEmptyPublicMethodPosition() {
-        /*BuildInformation info = this.javaEngine.buildPublicContent(uri, "org.kie.MyClass", "");
+        BuildInformation info = this.javaEngine.buildPublicContent(path, "org.kie.MyClass", "");
         int position = info.getPosition();
-        assertThat(position).isEqualTo(30);*/
+        assertThat(position).isEqualTo(30);
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/handlers/IsLanguageServerAvailableHandlerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/handlers/IsLanguageServerAvailableHandlerTest.java
@@ -35,12 +35,11 @@ class IsLanguageServerAvailableHandlerTest {
     @BeforeEach
     public void setup() {
         workspaceUtilMock = Mockito.mock(WorkspaceUtil.class);
-        activationChecker = new ActivationChecker(workspaceUtilMock);
     }
 
     @Test
     void isLanguageServerNotAvailable() {
-        when(workspaceUtilMock.getProjectLocation()).thenReturn("src/test/resources/noActivatorProject/");
+        when(WorkspaceUtil.getProjectLocation()).thenReturn("src/test/resources/noActivatorProject/");
         IsLanguageServerAvailableHandler handler = new IsLanguageServerAvailableHandler(HandlerConstants.IS_AVAILABLE, activationChecker);
         activationChecker.check();
         assertFalse(handler.handle(null, null));
@@ -48,7 +47,7 @@ class IsLanguageServerAvailableHandlerTest {
 
     @Test
     void isLanguageServerAvailable() {
-        when(workspaceUtilMock.getProjectLocation()).thenReturn("src/test/resources/testProject/");
+        when(WorkspaceUtil.getProjectLocation()).thenReturn("src/test/resources/testProject/");
         IsLanguageServerAvailableHandler handler = new IsLanguageServerAvailableHandler(HandlerConstants.IS_AVAILABLE, activationChecker);
         activationChecker.check();
         assertTrue(handler.handle(null, null));

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/handlers/IsLanguageServerAvailableHandlerTest.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/handlers/IsLanguageServerAvailableHandlerTest.java
@@ -19,38 +19,37 @@ package org.kogito.core.internal.handlers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kogito.core.internal.engine.ActivationChecker;
-import org.kogito.core.internal.util.WorkspaceUtil;
-import org.mockito.Mockito;
+import org.kogito.core.internal.util.TestUtil;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kogito.core.internal.util.TestUtil.COMMON_RESOURCE_PATH;
 
 class IsLanguageServerAvailableHandlerTest {
 
-    private WorkspaceUtil workspaceUtilMock;
-
     private ActivationChecker activationChecker;
+    private IsLanguageServerAvailableHandler isLanguageServerAvailableHandler;
 
     @BeforeEach
     public void setup() {
-        workspaceUtilMock = Mockito.mock(WorkspaceUtil.class);
+        activationChecker = new ActivationChecker();
+        isLanguageServerAvailableHandler = new IsLanguageServerAvailableHandler(HandlerConstants.IS_AVAILABLE, activationChecker);
     }
 
     @Test
     void isLanguageServerNotAvailable() {
-        when(WorkspaceUtil.getProjectLocation()).thenReturn("src/test/resources/noActivatorProject/");
-        IsLanguageServerAvailableHandler handler = new IsLanguageServerAvailableHandler(HandlerConstants.IS_AVAILABLE, activationChecker);
-        activationChecker.check();
-        assertFalse(handler.handle(null, null));
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "noActivatorProject" + File.separator, () -> {
+            activationChecker.check();
+            assertThat(isLanguageServerAvailableHandler.handle(null, null)).isFalse();
+        });
     }
 
     @Test
     void isLanguageServerAvailable() {
-        when(WorkspaceUtil.getProjectLocation()).thenReturn("src/test/resources/testProject/");
-        IsLanguageServerAvailableHandler handler = new IsLanguageServerAvailableHandler(HandlerConstants.IS_AVAILABLE, activationChecker);
-        activationChecker.check();
-        assertTrue(handler.handle(null, null));
+        TestUtil.mockWorkspace(COMMON_RESOURCE_PATH +  "testProject" + File.separator, () -> {
+            activationChecker.check();
+            assertThat(isLanguageServerAvailableHandler.handle(null, null)).isTrue();
+        });
     }
-
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
@@ -18,10 +18,14 @@ package org.kogito.core.internal.util;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.File;
+
 /**
- * Shared Util classs for Testing purpuses
+ * Shared Util class for Testing purposes
  */
 public class TestUtil {
+
+    public static String COMMON_RESOURCE_PATH = "src" + File.separator + "test" + File.separator + "resources" + File.separator;
 
     public static void mockWorkspace(String workspacePath, Runnable functionToTest) {
         try (MockedStatic<WorkspaceUtil> utilities = Mockito.mockStatic(WorkspaceUtil.class)) {

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
@@ -33,6 +33,4 @@ public class TestUtil {
             functionToTest.run();
         }
     }
-
-
 }

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/java/org/kogito/core/internal/util/TestUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.kogito.core.internal.util;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Shared Util classs for Testing purpuses
+ */
+public class TestUtil {
+
+    public static void mockWorkspace(String workspacePath, Runnable functionToTest) {
+        try (MockedStatic<WorkspaceUtil> utilities = Mockito.mockStatic(WorkspaceUtil.class)) {
+            utilities.when(WorkspaceUtil::getProjectLocation).thenReturn(workspacePath);
+            functionToTest.run();
+        }
+    }
+
+
+}

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/MyActivator.java
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/src/test/resources/test projéct/MyActivator.java
@@ -3,6 +3,6 @@ package org.kogito.test.project;
 import org.kie.api.project.KieActivator;
 
 @KieActivator
-public class Activator {
+public class MyActivator {
 
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-8119
ISSUE: https://github.com/kiegroup/kie-tools/issues/1272

The bug occurs in `JavaEngine.java:84` in this line:
`String fileName = Paths.get(url).getFileName().toString();`
The conversion from the `string` url to the `Path` fails in Windows, with the reported exception.

To fix it, I refactored that `url` `string` parameter management. 
Considering that `url` parameter is originally retrieved by a `Path`,  I simply keep the original `Path` passing it everywhere needed. This means, in `JavaEngine.java:84` is no longer necessary to convert a `string` to a `Path`.
The conversion to `string`, is applied where is actually needed.

Together with this, I refactored the Activator Search improving decoupling and I updated test dependencies.