### PR TITLE
KOGITO-8187: Provide `quarkus.knative.name` arg during deploy

### DIFF
--- a/packages/serverless-logic-sandbox/src/openshift/FileTemplate.tsx
+++ b/packages/serverless-logic-sandbox/src/openshift/FileTemplate.tsx
@@ -54,6 +54,7 @@ export function createDockerfileContentForBaseQuarkusProjectImage(): string {
 }
 
 export function createDockerfileContentForBaseJdk11MvnImage(args: {
+  deploymentResourceName: string;
   projectName: string;
   openShiftConfig: OpenShiftSettingsConfig;
 }): string {
@@ -66,7 +67,7 @@ export function createDockerfileContentForBaseJdk11MvnImage(args: {
   RUN mkdir ${projectPaths.root}/
   COPY --chown=185:root . ${projectPaths.root}/
   RUN ${OC_PATH} login --token=${args.openShiftConfig.token} --server=${args.openShiftConfig.host} --insecure-skip-tls-verify \
-    && ${MVNW_PATH} clean package -B -ntp -f ${projectPaths.pom} \
+    && ${MVNW_PATH} clean package -B -ntp -f ${projectPaths.pom} -Dquarkus.knative.name=${args.deploymentResourceName} \
     && if [ -f ${projectPaths.kubernetes}/kogito.yml ]; then ${OC_PATH} apply -n ${args.openShiftConfig.namespace} -f ${projectPaths.kubernetes}/kogito.yml; fi \
     && cp ${projectPaths.quarkusApp}/*.jar ${DEPLOYMENTS_FOLDER} \
     && cp -R ${projectPaths.quarkusApp}/lib/ ${DEPLOYMENTS_FOLDER} \

--- a/packages/serverless-logic-sandbox/src/openshift/OpenShiftContextProvider.tsx
+++ b/packages/serverless-logic-sandbox/src/openshift/OpenShiftContextProvider.tsx
@@ -93,12 +93,15 @@ export function OpenShiftContextProvider(props: Props) {
             ? descriptor.name
             : args.workspaceFile.name;
 
+        const deploymentResourceName = settingsDispatch.openshift.service.newResourceName();
+
         const dockerfileFile = new WorkspaceFile({
           workspaceId: args.workspaceFile.workspaceId,
           relativePath: PROJECT_FILES.dockerFile,
           getFileContents: async () => {
             const dockerfileContent = args.shouldDeployAsProject
               ? createDockerfileContentForBaseJdk11MvnImage({
+                  deploymentResourceName,
                   projectName: workspaceName,
                   openShiftConfig: settings.openshift.config,
                 })
@@ -121,6 +124,7 @@ export function OpenShiftContextProvider(props: Props) {
         });
 
         return settingsDispatch.openshift.service.deploy({
+          deploymentResourceName,
           workspaceName: workspaceName,
           targetFilePath: args.workspaceFile.relativePath,
           workspaceZipBlob: zipBlob,

--- a/packages/serverless-logic-sandbox/src/openshift/OpenShiftService.tsx
+++ b/packages/serverless-logic-sandbox/src/openshift/OpenShiftService.tsx
@@ -131,13 +131,18 @@ export class OpenShiftService {
     }
   }
 
+  public newResourceName(): string {
+    return `sandbox-${this.generateRandomId()}`;
+  }
+
   public async deploy(args: {
+    deploymentResourceName?: string;
     targetFilePath: string;
     workspaceName: string;
     workspaceZipBlob: Blob;
     shouldAttachKafkaSource: boolean;
   }): Promise<string | undefined> {
-    const resourceName = `sandbox-${this.generateRandomId()}`;
+    const resourceName = args.deploymentResourceName ?? this.newResourceName();
 
     const resourceArgs = {
       ...this.prepareCommonResourceArgs(),


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8187

By providing the arg `-Dquarkus.knative.name=<service-name>` during maven build, the generated `kogito.yml` file can point to the specified service name. Thus, the `kogito.yml` can be properly applied during the deployment created by the Serverless Logic Web Tools.