### PR TITLE
KOGITO-7963: Configure integration tests of cypress packages to run tests twice in case of fails

### DIFF
--- a/packages/boxed-expression-component/it-tests/cypress.config.ts
+++ b/packages/boxed-expression-component/it-tests/cypress.config.ts
@@ -21,4 +21,8 @@ export default defineConfig({
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "support/e2e.ts",
   },
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 });

--- a/packages/kie-editors-standalone/it-tests/cypress.config.ts
+++ b/packages/kie-editors-standalone/it-tests/cypress.config.ts
@@ -17,4 +17,8 @@ export default defineConfig({
   e2e: {
     specPattern: "./cypress/e2e/**/*.cy.{js,jsx,ts,tsx}",
   },
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 });

--- a/packages/online-editor/it-tests/cypress.config.ts
+++ b/packages/online-editor/it-tests/cypress.config.ts
@@ -20,4 +20,8 @@ export default defineConfig({
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "support/e2e.ts",
   },
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 });

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -41,6 +41,7 @@
     "@kie-tools-core/workspace": "workspace:*",
     "@kie-tools-core/workspaces-git-fs": "workspace:*",
     "@kie-tools/boxed-expression-component": "workspace:*",
+    "@kie-tools/cors-proxy-image": "workspace:*",
     "@kie-tools/emscripten-fs": "^0.0.2",
     "@kie-tools/form": "workspace:*",
     "@kie-tools/form-dmn": "workspace:*",

--- a/packages/pmml-editor/it-tests/cypress.config.ts
+++ b/packages/pmml-editor/it-tests/cypress.config.ts
@@ -19,4 +19,8 @@ export default defineConfig({
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "support/e2e.ts",
   },
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 });

--- a/packages/serverless-logic-sandbox/it-tests/cypress.config.ts
+++ b/packages/serverless-logic-sandbox/it-tests/cypress.config.ts
@@ -20,4 +20,8 @@ export default defineConfig({
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "support/e2e.ts",
   },
+  retries: {
+    runMode: 1,
+    openMode: 0,
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3213,6 +3213,7 @@ importers:
       "@kie-tools-core/workspace": workspace:*
       "@kie-tools-core/workspaces-git-fs": workspace:*
       "@kie-tools/boxed-expression-component": workspace:*
+      "@kie-tools/cors-proxy-image": workspace:*
       "@kie-tools/dmn-dev-sandbox-deployment-base-image-env": workspace:*
       "@kie-tools/emscripten-fs": ^0.0.2
       "@kie-tools/eslint": workspace:*
@@ -3290,6 +3291,7 @@ importers:
       "@kie-tools-core/workspace": link:../workspace
       "@kie-tools-core/workspaces-git-fs": link:../workspaces-git-fs
       "@kie-tools/boxed-expression-component": link:../boxed-expression-component
+      "@kie-tools/cors-proxy-image": link:../cors-proxy-image
       "@kie-tools/emscripten-fs": 0.0.2
       "@kie-tools/form": link:../form
       "@kie-tools/form-dmn": link:../form-dmn
@@ -14153,7 +14155,7 @@ packages:
       p-limit: 3.1.0
       schema-utils: 3.1.1
       serialize-javascript: 5.0.1
-      webpack: 5.70.0
+      webpack: 5.70.0_webpack-cli@4.7.0
     dev: true
 
   /copyfiles/2.4.1:
@@ -15653,7 +15655,8 @@ packages:
     dev: true
 
   /depd/1.1.1:
-    resolution: { integrity: sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k= }
+    resolution:
+      { integrity: sha512-Jlk9xvkTDGXwZiIDyoM7+3AsuvJVoyOpRupvEVy9nX3YO3/ieZxhlgh8GpLNZ8AY7HjO6y2YwpMSh1ejhu3uIw== }
     engines: { node: ">= 0.6" }
     dev: true
 
@@ -18325,7 +18328,8 @@ packages:
     dev: true
 
   /http-errors/1.6.2:
-    resolution: { integrity: sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY= }
+    resolution:
+      { integrity: sha512-STnYGcKMXL9CGdtpeTFnLmgMSHTTNQJSHxiC4DETHKf934Q160Ht5pljrNeH24S0O9xUN+9vsDJZdZtk5js6Ww== }
     engines: { node: ">= 0.6" }
     dependencies:
       depd: 1.1.1
@@ -23932,7 +23936,8 @@ packages:
     dev: true
 
   /raw-body/2.3.2:
-    resolution: { integrity: sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k= }
+    resolution:
+      { integrity: sha512-Ss0DsBxqLxCmQkfG5yazYhtbVVTJqS9jTsZG2lhrNwqzOk2SUC7O/NB/M//CkEBqsrtmlNgJCPccJGuYSFr6Vg== }
     engines: { node: ">= 0.8" }
     dependencies:
       bytes: 3.0.0
@@ -23983,7 +23988,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0
+      webpack: 5.70.0_webpack-cli@4.7.0
     dev: true
 
   /rc/1.2.8:
@@ -25350,7 +25355,8 @@ packages:
     dev: true
 
   /setprototypeof/1.0.3:
-    resolution: { integrity: sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ= }
+    resolution:
+      { integrity: sha512-9jphSf3UbIgpOX/RKvX02iw/rN2TKdusnsPpGfO/rkcsrd+IRqgHZb4VGnmL0Cynps8Nj2hN45wsi30BzrHDIw== }
     dev: true
 
   /setprototypeof/1.1.0:
@@ -27949,7 +27955,8 @@ packages:
     dev: true
 
   /webidl-conversions/3.0.1:
-    resolution: { integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE= }
+    resolution:
+      { integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ== }
 
   /webidl-conversions/5.0.0:
     resolution:
@@ -28106,7 +28113,7 @@ packages:
       sockjs: 0.3.21
       spdy: 4.0.2
       strip-ansi: 7.0.1
-      webpack: 5.70.0
+      webpack: 5.70.0_esbuild@0.14.22
       webpack-dev-middleware: 5.3.0_webpack@5.70.0
       ws: 8.4.2
     transitivePeerDependencies:
@@ -28313,7 +28320,8 @@ packages:
     dev: true
 
   /whatwg-url/5.0.0:
-    resolution: { integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0= }
+    resolution:
+      { integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw== }
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3213,7 +3213,6 @@ importers:
       "@kie-tools-core/workspace": workspace:*
       "@kie-tools-core/workspaces-git-fs": workspace:*
       "@kie-tools/boxed-expression-component": workspace:*
-      "@kie-tools/cors-proxy-image": workspace:*
       "@kie-tools/dmn-dev-sandbox-deployment-base-image-env": workspace:*
       "@kie-tools/emscripten-fs": ^0.0.2
       "@kie-tools/eslint": workspace:*
@@ -3291,7 +3290,6 @@ importers:
       "@kie-tools-core/workspace": link:../workspace
       "@kie-tools-core/workspaces-git-fs": link:../workspaces-git-fs
       "@kie-tools/boxed-expression-component": link:../boxed-expression-component
-      "@kie-tools/cors-proxy-image": link:../cors-proxy-image
       "@kie-tools/emscripten-fs": 0.0.2
       "@kie-tools/form": link:../form
       "@kie-tools/form-dmn": link:../form-dmn
@@ -14155,7 +14153,7 @@ packages:
       p-limit: 3.1.0
       schema-utils: 3.1.1
       serialize-javascript: 5.0.1
-      webpack: 5.70.0_webpack-cli@4.7.0
+      webpack: 5.70.0
     dev: true
 
   /copyfiles/2.4.1:
@@ -15655,8 +15653,7 @@ packages:
     dev: true
 
   /depd/1.1.1:
-    resolution:
-      { integrity: sha512-Jlk9xvkTDGXwZiIDyoM7+3AsuvJVoyOpRupvEVy9nX3YO3/ieZxhlgh8GpLNZ8AY7HjO6y2YwpMSh1ejhu3uIw== }
+    resolution: { integrity: sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k= }
     engines: { node: ">= 0.6" }
     dev: true
 
@@ -18328,8 +18325,7 @@ packages:
     dev: true
 
   /http-errors/1.6.2:
-    resolution:
-      { integrity: sha512-STnYGcKMXL9CGdtpeTFnLmgMSHTTNQJSHxiC4DETHKf934Q160Ht5pljrNeH24S0O9xUN+9vsDJZdZtk5js6Ww== }
+    resolution: { integrity: sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY= }
     engines: { node: ">= 0.6" }
     dependencies:
       depd: 1.1.1
@@ -23936,8 +23932,7 @@ packages:
     dev: true
 
   /raw-body/2.3.2:
-    resolution:
-      { integrity: sha512-Ss0DsBxqLxCmQkfG5yazYhtbVVTJqS9jTsZG2lhrNwqzOk2SUC7O/NB/M//CkEBqsrtmlNgJCPccJGuYSFr6Vg== }
+    resolution: { integrity: sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k= }
     engines: { node: ">= 0.8" }
     dependencies:
       bytes: 3.0.0
@@ -23988,7 +23983,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0_webpack-cli@4.7.0
+      webpack: 5.70.0
     dev: true
 
   /rc/1.2.8:
@@ -25355,8 +25350,7 @@ packages:
     dev: true
 
   /setprototypeof/1.0.3:
-    resolution:
-      { integrity: sha512-9jphSf3UbIgpOX/RKvX02iw/rN2TKdusnsPpGfO/rkcsrd+IRqgHZb4VGnmL0Cynps8Nj2hN45wsi30BzrHDIw== }
+    resolution: { integrity: sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ= }
     dev: true
 
   /setprototypeof/1.1.0:
@@ -27955,8 +27949,7 @@ packages:
     dev: true
 
   /webidl-conversions/3.0.1:
-    resolution:
-      { integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ== }
+    resolution: { integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE= }
 
   /webidl-conversions/5.0.0:
     resolution:
@@ -28113,7 +28106,7 @@ packages:
       sockjs: 0.3.21
       spdy: 4.0.2
       strip-ansi: 7.0.1
-      webpack: 5.70.0_esbuild@0.14.22
+      webpack: 5.70.0
       webpack-dev-middleware: 5.3.0_webpack@5.70.0
       ws: 8.4.2
     transitivePeerDependencies:
@@ -28320,8 +28313,7 @@ packages:
     dev: true
 
   /whatwg-url/5.0.0:
-    resolution:
-      { integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw== }
+    resolution: { integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0= }
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -258,7 +258,6 @@ digraph G {
   "@kie-tools-core/notifications" -> "@kie-tools-core/i18n" [ style = "solid", color = "purple" ];
   "@kie-tools-core/notifications" -> "@kie-tools-core/workspace" [ style = "solid", color = "purple" ];
   "@kie-tools/online-editor" -> "@kie-tools-core/workspaces-git-fs" [ style = "solid", color = "black" ];
-  "@kie-tools/online-editor" -> "@kie-tools/cors-proxy-image" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/kie-bc-editors" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/pmml-editor" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/unitables-dmn" [ style = "solid", color = "black" ];

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -258,6 +258,7 @@ digraph G {
   "@kie-tools-core/notifications" -> "@kie-tools-core/i18n" [ style = "solid", color = "purple" ];
   "@kie-tools-core/notifications" -> "@kie-tools-core/workspace" [ style = "solid", color = "purple" ];
   "@kie-tools/online-editor" -> "@kie-tools-core/workspaces-git-fs" [ style = "solid", color = "black" ];
+  "@kie-tools/online-editor" -> "@kie-tools/cors-proxy-image" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/kie-bc-editors" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/pmml-editor" [ style = "solid", color = "black" ];
   "@kie-tools/online-editor" -> "@kie-tools/unitables-dmn" [ style = "solid", color = "black" ];

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -535,6 +535,7 @@
       { "source": "@kie-tools/kie-sandbox-image", "target": "@kie-tools/image-env-to-json", "weight": 1 },
       { "source": "@kie-tools/kie-sandbox-image", "target": "@kie-tools/online-editor", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools-core/workspaces-git-fs", "weight": 1 },
+      { "source": "@kie-tools/online-editor", "target": "@kie-tools/cors-proxy-image", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/kie-bc-editors", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/pmml-editor", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/unitables-dmn", "weight": 1 },

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -535,7 +535,6 @@
       { "source": "@kie-tools/kie-sandbox-image", "target": "@kie-tools/image-env-to-json", "weight": 1 },
       { "source": "@kie-tools/kie-sandbox-image", "target": "@kie-tools/online-editor", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools-core/workspaces-git-fs", "weight": 1 },
-      { "source": "@kie-tools/online-editor", "target": "@kie-tools/cors-proxy-image", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/kie-bc-editors", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/pmml-editor", "weight": 1 },
       { "source": "@kie-tools/online-editor", "target": "@kie-tools/unitables-dmn", "weight": 1 },


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-7963

Retries in case of failure are set only for `run mode` in packages using Cypress (open mode is not used in automated tests, as far as I know).

Note that there are also packages, that have the commands for running Cypress set in `package.json`, but they don't contain any tests.