### PR TITLE
Fix link to github-ci on VS Code extension README

### DIFF
--- a/packages/vscode-extension-bpmn-editor/README.md
+++ b/packages/vscode-extension-bpmn-editor/README.md
@@ -1,7 +1,7 @@
 ## BPMN Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit BPMN and BPMN2 files.
 

--- a/packages/vscode-extension-dashbuilder-editor/README.md
+++ b/packages/vscode-extension-dashbuilder-editor/README.md
@@ -1,7 +1,7 @@
 ## Kogito Dashbuilder Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit Dashbuilder dashboards files (\*.dash.json, \*.dash.yaml, \*.dash.yml).
 

--- a/packages/vscode-extension-dmn-editor/README.md
+++ b/packages/vscode-extension-dmn-editor/README.md
@@ -1,7 +1,7 @@
 ## DMN Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit DMN and SceSim files.
 

--- a/packages/vscode-extension-kie-ba-bundle/README.md
+++ b/packages/vscode-extension-kie-ba-bundle/README.md
@@ -1,7 +1,7 @@
 ## KIE Business Automation Bundle
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit BPMN, DMN and SceSim files.
 

--- a/packages/vscode-extension-kogito-bundle/README.md
+++ b/packages/vscode-extension-kogito-bundle/README.md
@@ -1,7 +1,7 @@
 ## Kogito Bundle
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit Dashbuilder, Serverless Workflow, BPMN, DMN and SceSim files.
 

--- a/packages/vscode-extension-pmml-editor/README.md
+++ b/packages/vscode-extension-pmml-editor/README.md
@@ -1,7 +1,7 @@
 ## PMML Scorecard Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 ### **This is a pre-release version to seek feedback from the community**
 

--- a/packages/vscode-extension-red-hat-business-automation-bundle/README.md
+++ b/packages/vscode-extension-red-hat-business-automation-bundle/README.md
@@ -1,7 +1,7 @@
 ## Red Hat Business Automation Bundle
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit BPMN, DMN and SceSim files.
 

--- a/packages/vscode-extension-serverless-workflow-editor/README.md
+++ b/packages/vscode-extension-serverless-workflow-editor/README.md
@@ -1,7 +1,7 @@
 ## Kogito Serverless Workflow Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit Serverless Workflow definition files (\*.sw.json, \*.sw.yaml, \*.sw.yml).
 

--- a/packages/vscode-extension-yard-editor/README.md
+++ b/packages/vscode-extension-yard-editor/README.md
@@ -1,7 +1,7 @@
 ## Kogito yard Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.66.0+-blue.svg)
-![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/monorepo_pr_ci_full.yml/badge.svg)
+![github-ci](https://github.com/kiegroup/kie-tools/actions/workflows/ci_build.yml/badge.svg)
 
 Create and edit yard (Yet Another Rule Definition) files (\*.yard.yaml, \*.yard.yml, \*.yard.json).
 


### PR DESCRIPTION
I've noticed that the links are broken after renaming the workflow so this PRs fixes them.