### PR TITLE
KOGITO-7898: Upgrade KIE Sandbox Runtime

### DIFF
--- a/packages/dmn-dev-sandbox-quarkus/pom.xml
+++ b/packages/dmn-dev-sandbox-quarkus/pom.xml
@@ -65,6 +65,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-multipart</artifactId>
     </dependency>
     <dependency>

--- a/packages/dmn-dev-sandbox-quarkus/pom.xml
+++ b/packages/dmn-dev-sandbox-quarkus/pom.xml
@@ -50,7 +50,7 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-kie7-bom</artifactId>
+        <artifactId>kogito-kie-bom</artifactId>
         <version>${version.org.kie.kogito}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/packages/dmn-dev-sandbox-quarkus/src/test/resources/schema/loan.json
+++ b/packages/dmn-dev-sandbox-quarkus/src/test/resources/schema/loan.json
@@ -1,5 +1,59 @@
 {
   "definitions": {
+    "InputSetloan__pre__qualification": {
+      "required": ["Credit Score", "Applicant Data", "Requested Product"],
+      "type": "object",
+      "properties": {
+        "Credit Score": {
+          "$ref": "#/definitions/Credit__Score"
+        },
+        "Applicant Data": {
+          "$ref": "#/definitions/Applicant__Data"
+        },
+        "Requested Product": {
+          "$ref": "#/definitions/Requested__Product"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : InputSetloan_pre_qualification }",
+      "x-dmn-descriptions": {}
+    },
+    "InputSetTraffic_32Violation": {
+      "required": ["Violation", "Driver"],
+      "type": "object",
+      "properties": {
+        "Violation": {
+          "$ref": "#/definitions/tViolation"
+        },
+        "Driver": {
+          "$ref": "#/definitions/tDriver"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : InputSetTraffic Violation }",
+      "x-dmn-descriptions": {}
+    },
+    "Applicant__Data": {
+      "type": "object",
+      "properties": {
+        "Age": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Marital Status": {
+          "$ref": "#/definitions/Marital__Status"
+        },
+        "Employment Status": {
+          "$ref": "#/definitions/Applicant__Data__Employment_32Status"
+        },
+        "Existing Customer": {
+          "type": "boolean",
+          "x-dmn-type": "FEEL:boolean"
+        },
+        "Monthly": {
+          "$ref": "#/definitions/Applicant__Data__Monthly"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Applicant_Data }"
+    },
     "Applicant__Data__Monthly": {
       "type": "object",
       "properties": {
@@ -25,23 +79,6 @@
         }
       }
     },
-    "InputSet2": {
-      "required": ["Credit Score", "Applicant Data", "Requested Product"],
-      "type": "object",
-      "properties": {
-        "Credit Score": {
-          "$ref": "#/definitions/Credit__Score"
-        },
-        "Applicant Data": {
-          "$ref": "#/definitions/Applicant__Data"
-        },
-        "Requested Product": {
-          "$ref": "#/definitions/Requested__Product"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : InputSet2 }",
-      "x-dmn-descriptions": {}
-    },
     "Credit__Score__FICO": {
       "maximum": 850,
       "exclusiveMaximum": false,
@@ -50,21 +87,6 @@
       "type": "number",
       "x-dmn-type": "FEEL:number",
       "x-dmn-allowed-values": "[300..850]"
-    },
-    "tDriver__Age": {
-      "maximum": 90,
-      "exclusiveMaximum": false,
-      "minimum": 18,
-      "exclusiveMinimum": false,
-      "type": "number",
-      "x-dmn-type": "FEEL:number",
-      "x-dmn-allowed-values": "[18..90]"
-    },
-    "Credit__Score__Rating": {
-      "enum": ["Poor", "Bad", "Fair", "Good", "Excellent"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score_Rating }",
-      "x-dmn-allowed-values": "\"Poor\", \"Bad\", \"Fair\", \"Good\", \"Excellent\""
     },
     "tViolation": {
       "type": "object",
@@ -92,11 +114,95 @@
       },
       "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tViolation }"
     },
-    "Front__End__Ratio": {
-      "enum": ["Sufficient", "Insufficient"],
+    "OutputSetloan__pre__qualification": {
+      "type": "object",
+      "properties": {
+        "Front End Ratio": {
+          "$ref": "#/definitions/Front__End__Ratio"
+        },
+        "Back End Ratio": {
+          "$ref": "#/definitions/Back__End__Ratio"
+        },
+        "Credit Score Rating": {
+          "$ref": "#/definitions/Credit__Score__Rating"
+        },
+        "Loan Pre-Qualification": {
+          "$ref": "#/definitions/Loan__Qualification"
+        },
+        "Credit Score": {
+          "$ref": "#/definitions/Credit__Score"
+        },
+        "Applicant Data": {
+          "$ref": "#/definitions/Applicant__Data"
+        },
+        "Requested Product": {
+          "$ref": "#/definitions/Requested__Product"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : OutputSetloan_pre_qualification }",
+      "x-dmn-descriptions": {}
+    },
+    "tFine": {
+      "type": "object",
+      "properties": {
+        "Amount": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Points": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tFine }"
+    },
+    "Marital__Status": {
+      "enum": ["M", "D", "S"],
       "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Front_End_Ratio }",
-      "x-dmn-allowed-values": "\"Sufficient\", \"Insufficient\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Marital_Status }",
+      "x-dmn-allowed-values": "\"M\", \"D\", \"S\""
+    },
+    "tDriver__Age": {
+      "maximum": 90,
+      "exclusiveMaximum": false,
+      "minimum": 18,
+      "exclusiveMinimum": false,
+      "type": "number",
+      "x-dmn-type": "FEEL:number",
+      "x-dmn-allowed-values": "[18..90]"
+    },
+    "Requested__Product": {
+      "type": "object",
+      "properties": {
+        "Type": {
+          "$ref": "#/definitions/Product__Type"
+        },
+        "Rate": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Term": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Amount": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Requested_Product }"
+    },
+    "tViolation__Type": {
+      "enum": ["speed", "parking", "driving under the influence"],
+      "type": "string",
+      "x-dmn-type": "FEEL:string",
+      "x-dmn-allowed-values": "\"speed\", \"parking\", \"driving under the influence\""
+    },
+    "Applicant__Data__Employment_32Status": {
+      "enum": ["Unemployed", "Employed", "Self-employed", "Student"],
+      "type": "string",
+      "x-dmn-type": "FEEL:string",
+      "x-dmn-allowed-values": "\"Unemployed\", \"Employed\", \"Self-employed\", \"Student\""
     },
     "Credit__Score": {
       "type": "object",
@@ -106,48 +212,6 @@
         }
       },
       "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score }"
-    },
-    "Product__Type": {
-      "enum": ["Standard Loan", "Special Loan"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Product_Type }",
-      "x-dmn-allowed-values": "\"Standard Loan\", \"Special Loan\""
-    },
-    "Applicant__Data": {
-      "type": "object",
-      "properties": {
-        "Age": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Marital Status": {
-          "$ref": "#/definitions/Marital__Status"
-        },
-        "Employment Status": {
-          "$ref": "#/definitions/Applicant__Data__Employment_32Status"
-        },
-        "Existing Customer": {
-          "type": "boolean",
-          "x-dmn-type": "FEEL:boolean"
-        },
-        "Monthly": {
-          "$ref": "#/definitions/Applicant__Data__Monthly"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Applicant_Data }"
-    },
-    "Loan__Qualification": {
-      "type": "object",
-      "properties": {
-        "Qualification": {
-          "$ref": "#/definitions/Loan__Qualification__Qualification"
-        },
-        "Reason": {
-          "type": "string",
-          "x-dmn-type": "FEEL:string"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Loan_Qualification }"
     },
     "tDriver": {
       "type": "object",
@@ -174,88 +238,19 @@
       },
       "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tDriver }"
     },
-    "tViolation__Type": {
-      "enum": ["speed", "parking", "driving under the influence"],
+    "Front__End__Ratio": {
+      "enum": ["Sufficient", "Insufficient"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Front_End_Ratio }",
+      "x-dmn-allowed-values": "\"Sufficient\", \"Insufficient\""
+    },
+    "Loan__Qualification__Qualification": {
+      "enum": ["Qualified", "Not Qualified"],
       "type": "string",
       "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"speed\", \"parking\", \"driving under the influence\""
+      "x-dmn-allowed-values": "\"Qualified\", \"Not Qualified\""
     },
-    "OutputSet2": {
-      "type": "object",
-      "properties": {
-        "Front End Ratio": {
-          "$ref": "#/definitions/Front__End__Ratio"
-        },
-        "Back End Ratio": {
-          "$ref": "#/definitions/Back__End__Ratio"
-        },
-        "Credit Score Rating": {
-          "$ref": "#/definitions/Credit__Score__Rating"
-        },
-        "Loan Pre-Qualification": {
-          "$ref": "#/definitions/Loan__Qualification"
-        },
-        "Credit Score": {
-          "$ref": "#/definitions/Credit__Score"
-        },
-        "Applicant Data": {
-          "$ref": "#/definitions/Applicant__Data"
-        },
-        "Requested Product": {
-          "$ref": "#/definitions/Requested__Product"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : OutputSet2 }",
-      "x-dmn-descriptions": {}
-    },
-    "tFine": {
-      "type": "object",
-      "properties": {
-        "Amount": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Points": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tFine }"
-    },
-    "Back__End__Ratio": {
-      "enum": ["Insufficient", "Sufficient"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Back_End_Ratio }",
-      "x-dmn-allowed-values": "\"Insufficient\", \"Sufficient\""
-    },
-    "Requested__Product": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "$ref": "#/definitions/Product__Type"
-        },
-        "Rate": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Term": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Amount": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Requested_Product }"
-    },
-    "Applicant__Data__Employment_32Status": {
-      "enum": ["Unemployed", "Employed", "Self-employed", "Student"],
-      "type": "string",
-      "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"Unemployed\", \"Employed\", \"Self-employed\", \"Student\""
-    },
-    "OutputSet1": {
+    "OutputSetTraffic_32Violation": {
       "type": "object",
       "properties": {
         "Fine": {
@@ -272,35 +267,40 @@
           "$ref": "#/definitions/tDriver"
         }
       },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : OutputSet1 }",
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : OutputSetTraffic Violation }",
       "x-dmn-descriptions": {}
     },
-    "Loan__Qualification__Qualification": {
-      "enum": ["Qualified", "Not Qualified"],
+    "Credit__Score__Rating": {
+      "enum": ["Poor", "Bad", "Fair", "Good", "Excellent"],
       "type": "string",
-      "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"Qualified\", \"Not Qualified\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score_Rating }",
+      "x-dmn-allowed-values": "\"Poor\", \"Bad\", \"Fair\", \"Good\", \"Excellent\""
     },
-    "InputSet1": {
-      "required": ["Violation", "Driver"],
+    "Product__Type": {
+      "enum": ["Standard Loan", "Special Loan"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Product_Type }",
+      "x-dmn-allowed-values": "\"Standard Loan\", \"Special Loan\""
+    },
+    "Back__End__Ratio": {
+      "enum": ["Insufficient", "Sufficient"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Back_End_Ratio }",
+      "x-dmn-allowed-values": "\"Insufficient\", \"Sufficient\""
+    },
+    "Loan__Qualification": {
       "type": "object",
       "properties": {
-        "Violation": {
-          "$ref": "#/definitions/tViolation"
+        "Qualification": {
+          "$ref": "#/definitions/Loan__Qualification__Qualification"
         },
-        "Driver": {
-          "$ref": "#/definitions/tDriver"
+        "Reason": {
+          "type": "string",
+          "x-dmn-type": "FEEL:string"
         }
       },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : InputSet1 }",
-      "x-dmn-descriptions": {}
-    },
-    "Marital__Status": {
-      "enum": ["M", "D", "S"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Marital_Status }",
-      "x-dmn-allowed-values": "\"M\", \"D\", \"S\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Loan_Qualification }"
     }
   },
-  "$ref": "#/definitions/InputSet2"
+  "$ref": "#/definitions/InputSetloan__pre__qualification"
 }

--- a/packages/dmn-dev-sandbox-quarkus/src/test/resources/schema/traffic.json
+++ b/packages/dmn-dev-sandbox-quarkus/src/test/resources/schema/traffic.json
@@ -1,5 +1,59 @@
 {
   "definitions": {
+    "InputSetloan__pre__qualification": {
+      "required": ["Credit Score", "Applicant Data", "Requested Product"],
+      "type": "object",
+      "properties": {
+        "Credit Score": {
+          "$ref": "#/definitions/Credit__Score"
+        },
+        "Applicant Data": {
+          "$ref": "#/definitions/Applicant__Data"
+        },
+        "Requested Product": {
+          "$ref": "#/definitions/Requested__Product"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : InputSetloan_pre_qualification }",
+      "x-dmn-descriptions": {}
+    },
+    "InputSetTraffic_32Violation": {
+      "required": ["Violation", "Driver"],
+      "type": "object",
+      "properties": {
+        "Violation": {
+          "$ref": "#/definitions/tViolation"
+        },
+        "Driver": {
+          "$ref": "#/definitions/tDriver"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : InputSetTraffic Violation }",
+      "x-dmn-descriptions": {}
+    },
+    "Applicant__Data": {
+      "type": "object",
+      "properties": {
+        "Age": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Marital Status": {
+          "$ref": "#/definitions/Marital__Status"
+        },
+        "Employment Status": {
+          "$ref": "#/definitions/Applicant__Data__Employment_32Status"
+        },
+        "Existing Customer": {
+          "type": "boolean",
+          "x-dmn-type": "FEEL:boolean"
+        },
+        "Monthly": {
+          "$ref": "#/definitions/Applicant__Data__Monthly"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Applicant_Data }"
+    },
     "Applicant__Data__Monthly": {
       "type": "object",
       "properties": {
@@ -25,23 +79,6 @@
         }
       }
     },
-    "InputSet2": {
-      "required": ["Credit Score", "Applicant Data", "Requested Product"],
-      "type": "object",
-      "properties": {
-        "Credit Score": {
-          "$ref": "#/definitions/Credit__Score"
-        },
-        "Applicant Data": {
-          "$ref": "#/definitions/Applicant__Data"
-        },
-        "Requested Product": {
-          "$ref": "#/definitions/Requested__Product"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : InputSet2 }",
-      "x-dmn-descriptions": {}
-    },
     "Credit__Score__FICO": {
       "maximum": 850,
       "exclusiveMaximum": false,
@@ -50,21 +87,6 @@
       "type": "number",
       "x-dmn-type": "FEEL:number",
       "x-dmn-allowed-values": "[300..850]"
-    },
-    "tDriver__Age": {
-      "maximum": 90,
-      "exclusiveMaximum": false,
-      "minimum": 18,
-      "exclusiveMinimum": false,
-      "type": "number",
-      "x-dmn-type": "FEEL:number",
-      "x-dmn-allowed-values": "[18..90]"
-    },
-    "Credit__Score__Rating": {
-      "enum": ["Poor", "Bad", "Fair", "Good", "Excellent"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score_Rating }",
-      "x-dmn-allowed-values": "\"Poor\", \"Bad\", \"Fair\", \"Good\", \"Excellent\""
     },
     "tViolation": {
       "type": "object",
@@ -92,11 +114,95 @@
       },
       "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tViolation }"
     },
-    "Front__End__Ratio": {
-      "enum": ["Sufficient", "Insufficient"],
+    "OutputSetloan__pre__qualification": {
+      "type": "object",
+      "properties": {
+        "Front End Ratio": {
+          "$ref": "#/definitions/Front__End__Ratio"
+        },
+        "Back End Ratio": {
+          "$ref": "#/definitions/Back__End__Ratio"
+        },
+        "Credit Score Rating": {
+          "$ref": "#/definitions/Credit__Score__Rating"
+        },
+        "Loan Pre-Qualification": {
+          "$ref": "#/definitions/Loan__Qualification"
+        },
+        "Credit Score": {
+          "$ref": "#/definitions/Credit__Score"
+        },
+        "Applicant Data": {
+          "$ref": "#/definitions/Applicant__Data"
+        },
+        "Requested Product": {
+          "$ref": "#/definitions/Requested__Product"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : OutputSetloan_pre_qualification }",
+      "x-dmn-descriptions": {}
+    },
+    "tFine": {
+      "type": "object",
+      "properties": {
+        "Amount": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Points": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tFine }"
+    },
+    "Marital__Status": {
+      "enum": ["M", "D", "S"],
       "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Front_End_Ratio }",
-      "x-dmn-allowed-values": "\"Sufficient\", \"Insufficient\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Marital_Status }",
+      "x-dmn-allowed-values": "\"M\", \"D\", \"S\""
+    },
+    "tDriver__Age": {
+      "maximum": 90,
+      "exclusiveMaximum": false,
+      "minimum": 18,
+      "exclusiveMinimum": false,
+      "type": "number",
+      "x-dmn-type": "FEEL:number",
+      "x-dmn-allowed-values": "[18..90]"
+    },
+    "Requested__Product": {
+      "type": "object",
+      "properties": {
+        "Type": {
+          "$ref": "#/definitions/Product__Type"
+        },
+        "Rate": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Term": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        },
+        "Amount": {
+          "type": "number",
+          "x-dmn-type": "FEEL:number"
+        }
+      },
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Requested_Product }"
+    },
+    "tViolation__Type": {
+      "enum": ["speed", "parking", "driving under the influence"],
+      "type": "string",
+      "x-dmn-type": "FEEL:string",
+      "x-dmn-allowed-values": "\"speed\", \"parking\", \"driving under the influence\""
+    },
+    "Applicant__Data__Employment_32Status": {
+      "enum": ["Unemployed", "Employed", "Self-employed", "Student"],
+      "type": "string",
+      "x-dmn-type": "FEEL:string",
+      "x-dmn-allowed-values": "\"Unemployed\", \"Employed\", \"Self-employed\", \"Student\""
     },
     "Credit__Score": {
       "type": "object",
@@ -106,48 +212,6 @@
         }
       },
       "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score }"
-    },
-    "Product__Type": {
-      "enum": ["Standard Loan", "Special Loan"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Product_Type }",
-      "x-dmn-allowed-values": "\"Standard Loan\", \"Special Loan\""
-    },
-    "Applicant__Data": {
-      "type": "object",
-      "properties": {
-        "Age": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Marital Status": {
-          "$ref": "#/definitions/Marital__Status"
-        },
-        "Employment Status": {
-          "$ref": "#/definitions/Applicant__Data__Employment_32Status"
-        },
-        "Existing Customer": {
-          "type": "boolean",
-          "x-dmn-type": "FEEL:boolean"
-        },
-        "Monthly": {
-          "$ref": "#/definitions/Applicant__Data__Monthly"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Applicant_Data }"
-    },
-    "Loan__Qualification": {
-      "type": "object",
-      "properties": {
-        "Qualification": {
-          "$ref": "#/definitions/Loan__Qualification__Qualification"
-        },
-        "Reason": {
-          "type": "string",
-          "x-dmn-type": "FEEL:string"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Loan_Qualification }"
     },
     "tDriver": {
       "type": "object",
@@ -174,88 +238,19 @@
       },
       "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tDriver }"
     },
-    "tViolation__Type": {
-      "enum": ["speed", "parking", "driving under the influence"],
+    "Front__End__Ratio": {
+      "enum": ["Sufficient", "Insufficient"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Front_End_Ratio }",
+      "x-dmn-allowed-values": "\"Sufficient\", \"Insufficient\""
+    },
+    "Loan__Qualification__Qualification": {
+      "enum": ["Qualified", "Not Qualified"],
       "type": "string",
       "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"speed\", \"parking\", \"driving under the influence\""
+      "x-dmn-allowed-values": "\"Qualified\", \"Not Qualified\""
     },
-    "OutputSet2": {
-      "type": "object",
-      "properties": {
-        "Front End Ratio": {
-          "$ref": "#/definitions/Front__End__Ratio"
-        },
-        "Back End Ratio": {
-          "$ref": "#/definitions/Back__End__Ratio"
-        },
-        "Credit Score Rating": {
-          "$ref": "#/definitions/Credit__Score__Rating"
-        },
-        "Loan Pre-Qualification": {
-          "$ref": "#/definitions/Loan__Qualification"
-        },
-        "Credit Score": {
-          "$ref": "#/definitions/Credit__Score"
-        },
-        "Applicant Data": {
-          "$ref": "#/definitions/Applicant__Data"
-        },
-        "Requested Product": {
-          "$ref": "#/definitions/Requested__Product"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : OutputSet2 }",
-      "x-dmn-descriptions": {}
-    },
-    "tFine": {
-      "type": "object",
-      "properties": {
-        "Amount": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Points": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : tFine }"
-    },
-    "Back__End__Ratio": {
-      "enum": ["Insufficient", "Sufficient"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Back_End_Ratio }",
-      "x-dmn-allowed-values": "\"Insufficient\", \"Sufficient\""
-    },
-    "Requested__Product": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "$ref": "#/definitions/Product__Type"
-        },
-        "Rate": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Term": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        },
-        "Amount": {
-          "type": "number",
-          "x-dmn-type": "FEEL:number"
-        }
-      },
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Requested_Product }"
-    },
-    "Applicant__Data__Employment_32Status": {
-      "enum": ["Unemployed", "Employed", "Self-employed", "Student"],
-      "type": "string",
-      "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"Unemployed\", \"Employed\", \"Self-employed\", \"Student\""
-    },
-    "OutputSet1": {
+    "OutputSetTraffic_32Violation": {
       "type": "object",
       "properties": {
         "Fine": {
@@ -272,35 +267,40 @@
           "$ref": "#/definitions/tDriver"
         }
       },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : OutputSet1 }",
+      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : OutputSetTraffic Violation }",
       "x-dmn-descriptions": {}
     },
-    "Loan__Qualification__Qualification": {
-      "enum": ["Qualified", "Not Qualified"],
+    "Credit__Score__Rating": {
+      "enum": ["Poor", "Bad", "Fair", "Good", "Excellent"],
       "type": "string",
-      "x-dmn-type": "FEEL:string",
-      "x-dmn-allowed-values": "\"Qualified\", \"Not Qualified\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Credit_Score_Rating }",
+      "x-dmn-allowed-values": "\"Poor\", \"Bad\", \"Fair\", \"Good\", \"Excellent\""
     },
-    "InputSet1": {
-      "required": ["Violation", "Driver"],
+    "Product__Type": {
+      "enum": ["Standard Loan", "Special Loan"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Product_Type }",
+      "x-dmn-allowed-values": "\"Standard Loan\", \"Special Loan\""
+    },
+    "Back__End__Ratio": {
+      "enum": ["Insufficient", "Sufficient"],
+      "type": "string",
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Back_End_Ratio }",
+      "x-dmn-allowed-values": "\"Insufficient\", \"Sufficient\""
+    },
+    "Loan__Qualification": {
       "type": "object",
       "properties": {
-        "Violation": {
-          "$ref": "#/definitions/tViolation"
+        "Qualification": {
+          "$ref": "#/definitions/Loan__Qualification__Qualification"
         },
-        "Driver": {
-          "$ref": "#/definitions/tDriver"
+        "Reason": {
+          "type": "string",
+          "x-dmn-type": "FEEL:string"
         }
       },
-      "x-dmn-type": "DMNType{ https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF : InputSet1 }",
-      "x-dmn-descriptions": {}
-    },
-    "Marital__Status": {
-      "enum": ["M", "D", "S"],
-      "type": "string",
-      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Marital_Status }",
-      "x-dmn-allowed-values": "\"M\", \"D\", \"S\""
+      "x-dmn-type": "DMNType{ https://kiegroup.org/dmn/_857FE424-BEDA-4772-AB8E-2F4CDDB864AB : Loan_Qualification }"
     }
   },
-  "$ref": "#/definitions/InputSet1"
+  "$ref": "#/definitions/InputSetTraffic_32Violation"
 }

--- a/packages/extended-services/package.json
+++ b/packages/extended-services/package.json
@@ -37,7 +37,7 @@
     "start": "cross-env ENV=dev go run main.go"
   },
   "dependencies": {
-    "@kie-tools/jitexecutor-native": "1.28.0-Final"
+    "@kie-tools/jitexecutor-native": "1.29.0-Final"
   },
   "devDependencies": {
     "@kie-tools/root-env": "workspace:*",

--- a/packages/extended-services/package.json
+++ b/packages/extended-services/package.json
@@ -37,7 +37,7 @@
     "start": "cross-env ENV=dev go run main.go"
   },
   "dependencies": {
-    "@kie-tools/jitexecutor-native": "1.12.0-Final"
+    "@kie-tools/jitexecutor-native": "1.28.0-Final"
   },
   "devDependencies": {
     "@kie-tools/root-env": "workspace:*",

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -48,11 +48,11 @@ module.exports = composeEnv([], {
       description: "Enables/disables building example packages during the build.",
     },
     QUARKUS_PLATFORM_version: {
-      default: "2.13.2.Final",
+      default: "2.13.3.Final",
       description: "Quarkus version to be used on dependency declaration.",
     },
     KOGITO_RUNTIME_version: {
-      default: "1.28.0.Final",
+      default: "1.29.0.Final",
       description: "Kogito version to be used on dependency declaration.",
     },
   }),

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -48,11 +48,11 @@ module.exports = composeEnv([], {
       description: "Enables/disables building example packages during the build.",
     },
     QUARKUS_PLATFORM_version: {
-      default: "2.4.0.Final",
+      default: "2.13.2.Final",
       description: "Quarkus version to be used on dependency declaration.",
     },
     KOGITO_RUNTIME_version: {
-      default: "1.12.0.Final",
+      default: "1.28.0.Final",
       description: "Kogito version to be used on dependency declaration.",
     },
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2223,14 +2223,14 @@ importers:
 
   packages/extended-services:
     specifiers:
-      "@kie-tools/jitexecutor-native": 1.12.0-Final
+      "@kie-tools/jitexecutor-native": 1.28.0-Final
       "@kie-tools/root-env": workspace:*
       cross-env: ^7.0.3
       js-yaml: ^4.1.0
       rimraf: ^3.0.2
       run-script-os: ^1.1.6
     dependencies:
-      "@kie-tools/jitexecutor-native": 1.12.0-Final
+      "@kie-tools/jitexecutor-native": 1.28.0-Final
     devDependencies:
       "@kie-tools/root-env": link:../root-env
       cross-env: 7.0.3
@@ -8193,9 +8193,9 @@ packages:
       { integrity: sha512-dxmfwq2F+yxawuGrVVRGmTeZHTqRHa79Vp4FX2KEXHAA9AgK1aaVz8mxZxXYFs2ycfp30NjWvhZCOIRbIKTjAQ== }
     dev: false
 
-  /@kie-tools/jitexecutor-native/1.12.0-Final:
+  /@kie-tools/jitexecutor-native/1.28.0-Final:
     resolution:
-      { integrity: sha512-8mglRmsYN9cYlexjY7P/S4d/5zBTXyKIMJwGc19PNQoNKgphAQQ3V8htrSJaBAyOevnyHFDRi1qQ5Zu0rXA5VQ== }
+      { integrity: sha512-RmPuVWEZK/g3458QnpXsU8xVsZ000YFQoYXmwMvJOQAK9wggrN8sUste3CDxrbaJCXH8UcwU/igSQoMc2KlYSA== }
     dev: false
 
   /@koa/cors/3.4.1:
@@ -23966,7 +23966,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0
+      webpack: 5.70.0_webpack-cli@4.7.0
     dev: true
 
   /rc/1.2.8:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2223,14 +2223,14 @@ importers:
 
   packages/extended-services:
     specifiers:
-      "@kie-tools/jitexecutor-native": 1.28.0-Final
+      "@kie-tools/jitexecutor-native": 1.29.0-Final
       "@kie-tools/root-env": workspace:*
       cross-env: ^7.0.3
       js-yaml: ^4.1.0
       rimraf: ^3.0.2
       run-script-os: ^1.1.6
     dependencies:
-      "@kie-tools/jitexecutor-native": 1.28.0-Final
+      "@kie-tools/jitexecutor-native": 1.29.0-Final
     devDependencies:
       "@kie-tools/root-env": link:../root-env
       cross-env: 7.0.3
@@ -8193,9 +8193,9 @@ packages:
       { integrity: sha512-dxmfwq2F+yxawuGrVVRGmTeZHTqRHa79Vp4FX2KEXHAA9AgK1aaVz8mxZxXYFs2ycfp30NjWvhZCOIRbIKTjAQ== }
     dev: false
 
-  /@kie-tools/jitexecutor-native/1.28.0-Final:
+  /@kie-tools/jitexecutor-native/1.29.0-Final:
     resolution:
-      { integrity: sha512-RmPuVWEZK/g3458QnpXsU8xVsZ000YFQoYXmwMvJOQAK9wggrN8sUste3CDxrbaJCXH8UcwU/igSQoMc2KlYSA== }
+      { integrity: sha512-oZ5LxMCILgDGYxEqAPOYos7zJqgetS2JnRhf6hpzY4626k9O/2GhSOxNw8hL9fySJMwguzGZtPFFWBOMtDtAbg== }
     dev: false
 
   /@koa/cors/3.4.1:
@@ -23966,7 +23966,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0_webpack-cli@4.7.0
+      webpack: 5.70.0
     dev: true
 
   /rc/1.2.8:


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7898

This PR scope is to update the KIE Sandbox `kogito` (from `1.12.0` to `1.29.0`) and `quarkus` (from `2.4.0` to `2.13.3`) versions, mainly for 2 reasons.

- Introducing the new features (DMN 1.4) introduced in the DMN Engine in the last few months;
- Resolving bugs and securities issues;

**CHANGES**
- Test updated accordingly to `dmn-open-api` changes applied here -> https://github.com/kiegroup/drools/pull/4450
- Using new kie artifact (it was: `kogito-kie7-bom`, now is `kogito-kie-bom`)
- Added `quarkus-resteasy-jackson`, which was set as optional in the newest `quarkus` versions.

`quarkus` `2.13.3` is paired with `kogito` `1.29.0` --> https://search.maven.org/artifact/io.quarkus.platform/quarkus-kogito-bom/2.13.3.Final/pom