### PR TITLE
Replace deprecated `set-output` command on GitHub Actions

### DIFF
--- a/.github/actions/checkout-pr/action.yml
+++ b/.github/actions/checkout-pr/action.yml
@@ -46,20 +46,20 @@ runs:
 
           echo "Merge changes from $user/${{ github.head_ref }}"
           git remote add $user https://github.com/$user/kie-tools.git
-          git fetch $user ${{ github.head_ref }} 
+          git fetch $user ${{ github.head_ref }}
 
           echo "Before merging..."
           git log -n 1
-          echo "::set-output name=base_sha::$(git rev-parse HEAD)"
+          echo "base_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           git merge --squash $user/${{ github.head_ref }}
           git commit --no-edit
 
           echo "After merging..."
           git log -n 1
-          echo "::set-output name=head_sha::$(git rev-parse HEAD)"
+          echo "head_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         else
           echo "Skip merge, not a pull request"
-          echo "::set-output name=base_sha::$(git rev-parse HEAD^1)"
-          echo "::set-output name=head_sha::$(git rev-parse HEAD)"
+          echo "base_sha=$(git rev-parse HEAD^1)" >> $GITHUB_OUTPUT
+          echo "head_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/deploy-openshift/action.yml
+++ b/.github/actions/deploy-openshift/action.yml
@@ -93,4 +93,4 @@ runs:
       run: |
         url=https://$(oc get route ${{ inputs.app_name }} -o jsonpath='{.spec.host}')
         echo "Route URL: $url"
-        echo ::set-output name=route_url::$url
+        echo "route_url=$url" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: "**"
+    branches: ["**"]
     types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
@@ -54,16 +54,16 @@ jobs:
 
           if [ ${#CHANGED_SOURCE_PATHS[@]} -eq 0 ]; then
             echo 'No source files changed; `CI :: Build` (none) will run.'
-            echo "::set-output name=mode::none"
+            echo "mode=none" >> $GITHUB_OUTPUT
           elif [ ! ${{ github.event.pull_request }} ]; then
             echo 'Push to the `main` branch happened; `CI :: Build` (full) will run.'
-            echo "::set-output name=mode::full"
+            echo "mode=full" >> $GITHUB_OUTPUT
           elif [ ${#CHANGED_SOURCE_PATHS_IN_ROOT[@]} -eq 0 ]; then
             echo 'No source files changed in root; `CI :: Build` (partial) will run.'
-            echo "::set-output name=mode::partial"
+            echo "mode=partial" >> $GITHUB_OUTPUT
           else
             echo 'Source files changed in root; `CI :: Build` (full) will run.'
-            echo "::set-output name=mode::full"
+            echo "mode=full" >> $GITHUB_OUTPUT
           fi
 
           echo "Done"

--- a/.github/workflows/ci_check_code_formatting.yml
+++ b/.github/workflows/ci_check_code_formatting.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: "**"
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.event.pull_request && format('check-code-formatting-pr-{0}', github.event.pull_request.number) || format('check-code-formatting-push-main-{0}', github.sha) }}

--- a/.github/workflows/ci_check_dependencies_consistency.yaml
+++ b/.github/workflows/ci_check_dependencies_consistency.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: "**"
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.event.pull_request && format('check-dependencies-consistency-pr-{0}', github.event.pull_request.number) || format('check-dependencies-consistency-push-main-{0}', github.sha) }}

--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -71,7 +71,7 @@ jobs:
         id: version
         run: |
           cd kie-tools
-          echo ::set-output name=version::$(node -e "console.log(require('./package.json').version);")
+          echo "version=$(node -e "console.log(require('./package.json').version);")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: "Cache Maven packages"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -13,10 +13,6 @@ on:
         type: string
         required: false
         default: "0.0.0"
-      download_asset_url:
-        type: string
-        required: false
-        default: ""
       upload_asset_url:
         type: string
         required: false
@@ -86,24 +82,24 @@ jobs:
         id: set_runners
         shell: bash
         run: |
-          echo "::set-output name=dmn_dev_sandbox_image::${{ fromJSON(inputs.runners).dmn_dev_sandbox_image }}"
-          echo "::set-output name=kie_sandbox_image::${{ fromJSON(inputs.runners).kie_sandbox_image }}"
-          echo "::set-output name=kie_sandbox_extended_services_image::${{ fromJSON(inputs.runners).kie_sandbox_extended_services_image }}"
-          echo "::set-output name=cors_proxy_image::${{ fromJSON(inputs.runners).cors_proxy_image }}"
-          echo "::set-output name=online_editor::${{ fromJSON(inputs.runners).online_editor }}"
-          echo "::set-output name=chrome_extensions::${{ fromJSON(inputs.runners).chrome_extensions }}"
-          echo "::set-output name=vscode_extensions_dev::${{ fromJSON(inputs.runners).vscode_extensions_dev }}"
-          echo "::set-output name=vscode_extensions_prod::${{ fromJSON(inputs.runners).vscode_extensions_prod }}"
-          echo "::set-output name=desktop::${{ fromJSON(inputs.runners).desktop }}"
-          echo "::set-output name=npm_packages::${{ fromJSON(inputs.runners).npm_packages }}"
-          echo "::set-output name=standalone_editors_cdn::${{ fromJSON(inputs.runners).standalone_editors_cdn }}"
-          echo "::set-output name=extended_services::${{ fromJSON(inputs.runners).extended_services }}"
-          echo "::set-output name=dashbuilder::${{ fromJSON(inputs.runners).dashbuilder }}"
-          echo "::set-output name=dashbuilder_images::${{ fromJSON(inputs.runners).dashbuilder_images }}"
-          echo "::set-output name=serverless_logic_sandbox::${{ fromJSON(inputs.runners).serverless_logic_sandbox }}"
-          echo "::set-output name=serverless_logic_sandbox_base_image::${{ fromJSON(inputs.runners).serverless_logic_sandbox_base_image }}"
-          echo "::set-output name=openjdk11_mvn_image::${{ fromJSON(inputs.runners).openjdk11_mvn_image }}"
-          echo "::set-output name=kn_plugin_workflow::${{ fromJSON(inputs.runners).kn_plugin_workflow }}"
+          echo "dmn_dev_sandbox_image=${{ fromJSON(inputs.runners).dmn_dev_sandbox_image }}" >> $GITHUB_OUTPUT
+          echo "kie_sandbox_image=${{ fromJSON(inputs.runners).kie_sandbox_image }}" >> $GITHUB_OUTPUT
+          echo "kie_sandbox_extended_services_image=${{ fromJSON(inputs.runners).kie_sandbox_extended_services_image }}" >> $GITHUB_OUTPUT
+          echo "cors_proxy_image=${{ fromJSON(inputs.runners).cors_proxy_image }}" >> $GITHUB_OUTPUT
+          echo "online_editor=${{ fromJSON(inputs.runners).online_editor }}" >> $GITHUB_OUTPUT
+          echo "chrome_extensions=${{ fromJSON(inputs.runners).chrome_extensions }}" >> $GITHUB_OUTPUT
+          echo "vscode_extensions_dev=${{ fromJSON(inputs.runners).vscode_extensions_dev }}" >> $GITHUB_OUTPUT
+          echo "vscode_extensions_prod=${{ fromJSON(inputs.runners).vscode_extensions_prod }}" >> $GITHUB_OUTPUT
+          echo "desktop=${{ fromJSON(inputs.runners).desktop }}" >> $GITHUB_OUTPUT
+          echo "npm_packages=${{ fromJSON(inputs.runners).npm_packages }}" >> $GITHUB_OUTPUT
+          echo "standalone_editors_cdn=${{ fromJSON(inputs.runners).standalone_editors_cdn }}" >> $GITHUB_OUTPUT
+          echo "extended_services=${{ fromJSON(inputs.runners).extended_services }}" >> $GITHUB_OUTPUT
+          echo "dashbuilder=${{ fromJSON(inputs.runners).dashbuilder }}" >> $GITHUB_OUTPUT
+          echo "dashbuilder_images=${{ fromJSON(inputs.runners).dashbuilder_images }}" >> $GITHUB_OUTPUT
+          echo "serverless_logic_sandbox=${{ fromJSON(inputs.runners).serverless_logic_sandbox }}" >> $GITHUB_OUTPUT
+          echo "serverless_logic_sandbox_base_image=${{ fromJSON(inputs.runners).serverless_logic_sandbox_base_image }}" >> $GITHUB_OUTPUT
+          echo "openjdk11_mvn_image=${{ fromJSON(inputs.runners).openjdk11_mvn_image }}" >> $GITHUB_OUTPUT
+          echo "kn_plugin_workflow=${{ fromJSON(inputs.runners).kn_plugin_workflow }}" >> $GITHUB_OUTPUT
 
       - name: "Print Runners"
         shell: bash
@@ -575,7 +571,7 @@ jobs:
           access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.google_developer_console_client_id }}&client_secret=${{ secrets.google_developer_console_client_secret }}&refresh_token=${{ secrets.google_developer_console_refresh_token }}&grant_type=refresh_token" | jq -r '.access_token')
           uploadResponse=$(curl -X PUT -sS "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${{ secrets.chrome_extension_id }}" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -T ${{ github.workspace }}/kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${{ inputs.tag }}.zip)
           echo "$uploadResponse"
-          echo ::set-output name=upload_status::$(echo "$uploadResponse" | jq -r '.uploadState')
+          echo "upload_status=$(echo "$uploadResponse" | jq -r '.uploadState')" >> $GITHUB_OUTPUT
 
       - name: "Check Upload - Chrome Extension for KIE Editors"
         if: ${{ !inputs.dry_run }}
@@ -589,7 +585,7 @@ jobs:
           access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.google_developer_console_client_id }}&client_secret=${{ secrets.google_developer_console_client_secret }}&refresh_token=${{ secrets.google_developer_console_refresh_token }}&grant_type=refresh_token" | jq -r '.access_token')
           publishResponse=$(curl -X POST -sS "https://www.googleapis.com/chromewebstore/v1.1/items/${{ secrets.chrome_extension_id }}/publish" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -H "Content-Length:0")
           echo "$publishResponse"
-          echo ::set-output name=publish_status::$(echo "$publishResponse" | jq -r '.status | .[0]')
+          echo "publish_status=$(echo "$publishResponse" | jq -r '.status | .[0]')" >> $GITHUB_OUTPUT
 
       - name: "Check Publish - Chrome Extension for KIE Editors"
         if: ${{ !inputs.dry_run }}
@@ -631,7 +627,7 @@ jobs:
           access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.google_developer_console_client_id }}&client_secret=${{ secrets.google_developer_console_client_secret }}&refresh_token=${{ secrets.google_developer_console_refresh_token }}&grant_type=refresh_token" | jq -r '.access_token')
           uploadResponse=$(curl -X PUT -sS "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${{ secrets.swf_chrome_extension_id }}" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -T ${{ github.workspace }}/kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${{ inputs.tag }}.zip)
           echo "$uploadResponse"
-          echo ::set-output name=upload_status::$(echo "$uploadResponse" | jq -r '.uploadState')
+          echo "upload_status=$(echo "$uploadResponse" | jq -r '.uploadState')" >> $GITHUB_OUTPUT
 
       - name: "Check Upload - Chrome Extension for Serverless Workflow Editor"
         if: ${{ !inputs.dry_run }}
@@ -645,7 +641,7 @@ jobs:
           access_token=$(curl -X POST -fsS "https://oauth2.googleapis.com/token" -d "client_id=${{ secrets.google_developer_console_client_id }}&client_secret=${{ secrets.google_developer_console_client_secret }}&refresh_token=${{ secrets.google_developer_console_refresh_token }}&grant_type=refresh_token" | jq -r '.access_token')
           publishResponse=$(curl -X POST -sS "https://www.googleapis.com/chromewebstore/v1.1/items/${{ secrets.swf_chrome_extension_id }}/publish" -H "Authorization:Bearer ${access_token}" -H "x-goog-api-version:2" -H "Content-Length:0")
           echo "$publishResponse"
-          echo ::set-output name=publish_status::$(echo "$publishResponse" | jq -r '.status | .[0]')
+          echo "publish_status=$(echo "$publishResponse" | jq -r '.status | .[0]')" >> $GITHUB_OUTPUT
 
       - name: "Check Publish - Chrome Extension for Serverless Workflow Editor"
         if: ${{ !inputs.dry_run }}
@@ -918,7 +914,9 @@ jobs:
         run: |
           export PNPM_FILTER_STRING_FOR_BUILDING=$(pnpm -r exec 'bash' '-c' 'PKG_NAME=$(jq -r ".name" package.json) PKG_IS_PVT=$(jq -r ".private" package.json); if [ "$PKG_IS_PVT" != "true" ]; then echo "-F $PKG_NAME..."; fi')
           echo $PNPM_FILTER_STRING_FOR_BUILDING
-          echo ::set-output name=filter::$PNPM_FILTER_STRING_FOR_BUILDING
+          echo 'filter<<EOF' >> $GITHUB_OUTPUT
+          echo $PNPM_FILTER_STRING_FOR_BUILDING >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: "Bootstrap"
         id: bootstrap

--- a/.github/workflows/release_dry_run.yml
+++ b/.github/workflows/release_dry_run.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 4 * * *" # 4am UTC everyday
   pull_request:
-    branches: "**"
+    branches: ["**"]
     paths:
       - ".github/workflows/release*"
       - ".github/actions/**"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -6,17 +6,18 @@ on:
       tag:
         type: string
         required: true
+        description: "Tag associated with the release"
       runners:
         type: string
         required: true
         default: '{"dmn_dev_sandbox_image":"true","kie_sandbox_image":"true","kie_sandbox_extended_services_image":"true","cors_proxy_image":"true","online_editor":"true","chrome_extensions":"true","vscode_extensions_dev":"true","vscode_extensions_prod":"true","desktop":"true","npm_packages":"true","standalone_editors_cdn":"true","extended_services":"true","dashbuilder":"true","dashbuilder_images":"true","serverless_logic_sandbox":"true","serverless_logic_sandbox_base_image":"true","openjdk11_mvn_image":"true","kn_plugin_workflow":"true"}'
+        description: "Jobs to run (JSON)"
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
       upload_asset_url: ${{ fromJSON(steps.fetch_release_for_tag.outputs.data).upload_url }}
-      download_asset_url: ${{ steps.download_asset_url.outputs.download_url }}
       release_ref: ${{ fromJSON(steps.fetch_release_for_tag.outputs.data).target_commitish }}
     steps:
       - name: "Fetch release for ${{ github.event.inputs.tag }}"
@@ -39,12 +40,6 @@ jobs:
         run: |
           [ "${{ github.event.inputs.tag }}" == "$(node -p "require('./package.json').version")" ]
 
-      - name: "Generate download URL for Release assets"
-        id: download_asset_url
-        shell: python
-        run: |
-          print('::set-output name=download_url::' + '${{ fromJSON(steps.fetch_release_for_tag.outputs.data).html_url }}'.replace('/tag/', '/download/'));
-
   build_and_publish:
     needs: [prepare]
     uses: ./.github/workflows/release_build.yml
@@ -52,7 +47,6 @@ jobs:
       dry_run: false
       base_ref: ${{ needs.prepare.outputs.release_ref }}
       tag: ${{ github.event.inputs.tag }}
-      download_asset_url: ${{ needs.prepare.outputs.download_asset_url }}
       upload_asset_url: ${{ needs.prepare.outputs.upload_asset_url }}
       runners: ${{ github.event.inputs.runners }}
     secrets:

--- a/.github/workflows/staging_dry_run.yml
+++ b/.github/workflows/staging_dry_run.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 3 * * *" # 3am UTC everyday
   pull_request:
-    branches: "**"
+    branches: ["**"]
     paths:
       - ".github/workflows/staging*"
       - ".github/actions/**"

--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -28,8 +28,8 @@ jobs:
         # This bash script returns the `tag` name for the release.
         # Will match "/refs/{tags,heads}/{tag}-prerelease"
         run: |
-          echo ::set-output name=tag::$(node -p "'${{ github.ref }}'.match(/^.*\/(.+)-prerelease$/)[1]")
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+          echo "tag=$(node -p "'${{ github.ref }}'.match(/^.*\/(.+)-prerelease$/)[1]")" >> $GITHUB_OUTPUT
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: "Check `tag` against `package.json.version`"
         shell: bash
@@ -50,9 +50,10 @@ jobs:
 
       - name: "Generate download URL for Release assets"
         id: release_json_ext
-        shell: python
+        shell: bash
         run: |
-          print('::set-output name=download_url::' + '${{ steps.create_release_draft.outputs.html_url }}'.replace('/tag/', '/download/'));
+          url=$(echo ${{ steps.create_release_draft.outputs.html_url }} | sed "s#/tag/#/download/#")
+          echo "download_url=$url" >> $GITHUB_OUTPUT
 
   build_and_publish:
     needs: [create_release]


### PR DESCRIPTION
Fixing them after noticing many warnings like the following:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/638737/199734744-ae08ca57-45fc-4da3-85e1-39f180057a68.png">

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands