### PR TITLE
KOGITO-8166: Enable major browsers on Serverless Logic Web Tools

### DIFF
--- a/packages/serverless-logic-sandbox/package.json
+++ b/packages/serverless-logic-sandbox/package.json
@@ -80,6 +80,7 @@
     "@kie-tools/serverless-logic-sandbox-base-image-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@svgr/webpack": "6.2.1",
+    "@testing-library/jest-dom": "^5.16.1",
     "@types/history": "^4.7.3",
     "@types/jest": "^26.0.23",
     "@types/jest-when": "^2.7.4",

--- a/packages/serverless-logic-sandbox/src/__tests__/workspace/startupBrockers/SupportedBrowsers.test.ts
+++ b/packages/serverless-logic-sandbox/src/__tests__/workspace/startupBrockers/SupportedBrowsers.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BowserSatisfies,
+  mapSupportedVersionsToBowser,
+  MinVersionForFeature,
+} from "../../../workspace/startupBlockers/SupportedBrowsers";
+
+describe("SupportedBrowsers", () => {
+  test("mapSupportedVersionsToBowser should extract the supported versions properly", async () => {
+    const feature1: MinVersionForFeature = {
+      chrome: 1,
+      edge: 2,
+      firefox: 2,
+      opera: 2,
+      safari: 1,
+    };
+    const feature2: MinVersionForFeature = {
+      chrome: 2,
+      edge: 2,
+      firefox: 1,
+      opera: 2,
+      safari: 1,
+    };
+    const feature3: MinVersionForFeature = {
+      chrome: 3,
+      edge: 3,
+      firefox: 1,
+      opera: 1,
+      safari: 1,
+    };
+
+    const expected: BowserSatisfies = {
+      chrome: ">=3",
+      edge: ">=3",
+      firefox: ">=2",
+      opera: ">=2",
+      safari: ">=1",
+    };
+
+    expect(mapSupportedVersionsToBowser(feature1, feature2, feature3)).toStrictEqual(expected);
+  });
+});

--- a/packages/serverless-logic-sandbox/src/workspace/startupBlockers/IncompatibleBrowser.tsx
+++ b/packages/serverless-logic-sandbox/src/workspace/startupBlockers/IncompatibleBrowser.tsx
@@ -18,25 +18,15 @@ import { Modal } from "@patternfly/react-core/dist/js/components/Modal";
 import { ModalVariant } from "@patternfly/react-core/dist/esm/components/Modal";
 import * as React from "react";
 import { StartupBlockerTemplate } from "./StartupBlockerTemplate";
-import * as Bowser from "bowser";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
 import { KieIcon } from "./KieIcon";
 import { LATEST_VERSION_COMPATIBLE_WITH_LFS } from "./LatestCompatibleVersion";
 import { APP_NAME } from "../../AppConstants";
-
-const hasNecessaryApis = window["SharedWorker"] && window["BroadcastChannel"];
-const isCompatibleBrowser = Bowser.getParser(window.navigator.userAgent).satisfies({
-  chrome: ">=4",
-  // edge: ">=79", KOGITO-8166: Assess browser compatibility
-  safari: ">=16",
-  firefox: ">=29", // KOGITO-8166: Assess browser compatibility
-  // opera: ">=12", KOGITO-8166: Assess browser compatibility
-});
-const browserInfo = Bowser.parse(window.navigator.userAgent);
+import { BROWSER_DETAILS, SUPPORTED_BROWSERS } from "./SupportedBrowsers";
 
 export async function isTrue() {
-  return !hasNecessaryApis || !isCompatibleBrowser;
+  return !BROWSER_DETAILS.isCompatible;
 }
 
 export function Component() {
@@ -53,9 +43,10 @@ export function Component() {
         <br />
         <TextContent>
           <Text component={TextVariants.h4}>
-            {`${APP_NAME} is not compatible with this browser.`}{" "}
+            {`${APP_NAME} is not compatible with this browser.`}
+            <br />
             <small style={{ display: "inline" }}>
-              ({browserInfo.browser.name} {browserInfo.browser.version})
+              {BROWSER_DETAILS.info.browser.name} {BROWSER_DETAILS.info.os.name} {BROWSER_DETAILS.info.browser.version}
             </small>
           </Text>
         </TextContent>
@@ -63,11 +54,13 @@ export function Component() {
         <hr />
         <br />
         <TextContent>
-          <Text component={TextVariants.p}>Compatible browsers are:</Text>
+          <Text component={TextVariants.p}>Compatible desktop browsers are:</Text>
           <List>
-            <ListItem>Chromium-based</ListItem>
-            <ListItem>Firefox</ListItem>
-            <ListItem>Safari 16 or newer</ListItem>
+            <ListItem>{`Chrome (${SUPPORTED_BROWSERS.chrome}) - recommended`}</ListItem>
+            <ListItem>{`Firefox (${SUPPORTED_BROWSERS.firefox})`}</ListItem>
+            <ListItem>{`Safari (${SUPPORTED_BROWSERS.safari})`}</ListItem>
+            <ListItem>{`Opera (${SUPPORTED_BROWSERS.opera})`}</ListItem>
+            <ListItem>{`Edge (${SUPPORTED_BROWSERS.edge})`}</ListItem>
           </List>
         </TextContent>
         <br />

--- a/packages/serverless-logic-sandbox/src/workspace/startupBlockers/SupportedBrowsers.ts
+++ b/packages/serverless-logic-sandbox/src/workspace/startupBlockers/SupportedBrowsers.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Bowser from "bowser";
+
+export type SupportedBrowsers = "chrome" | "edge" | "safari" | "firefox" | "opera";
+export type MinVersionForFeature = Record<SupportedBrowsers, number>;
+export type BowserSatisfies = Record<SupportedBrowsers, `>=${number}`>;
+
+// https://caniuse.com/sharedworkers
+const SharedWebWorkersFeature: MinVersionForFeature = {
+  chrome: 4,
+  edge: 79,
+  safari: 16,
+  firefox: 29,
+  opera: 11.5,
+};
+
+// https://caniuse.com/broadcastchannel
+const BroadcastChannelFeature: MinVersionForFeature = {
+  chrome: 54,
+  edge: 79,
+  safari: 15.4,
+  firefox: 38,
+  opera: 41,
+};
+
+export const mapSupportedVersionsToBowser = (...features: MinVersionForFeature[]) => {
+  const minSupportedVersions = features.reduceRight((prev, curr) =>
+    Object.keys(prev).reduce(
+      (obj, browser: keyof MinVersionForFeature) => ({ ...obj, [browser]: Math.max(prev[browser], curr[browser]) }),
+      {} as MinVersionForFeature
+    )
+  );
+
+  return Object.keys(minSupportedVersions).reduce(
+    (obj, browser: keyof MinVersionForFeature) => ({ ...obj, [browser]: `>=${minSupportedVersions[browser]}` }),
+    {} as BowserSatisfies
+  );
+};
+
+export const SUPPORTED_BROWSERS = mapSupportedVersionsToBowser(SharedWebWorkersFeature, BroadcastChannelFeature);
+
+const IS_SUPPORTED = Bowser.getParser(window.navigator.userAgent).satisfies(SUPPORTED_BROWSERS);
+const HAS_NECESSARY_APIS = window["SharedWorker"] && window["BroadcastChannel"];
+export const BROWSER_DETAILS = {
+  info: Bowser.parse(window.navigator.userAgent),
+  isCompatible: HAS_NECESSARY_APIS && IS_SUPPORTED,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3709,6 +3709,7 @@ importers:
       "@patternfly/react-tokens": ^4.33.1
       "@rhoas/registry-instance-sdk": ^0.34.1
       "@svgr/webpack": 6.2.1
+      "@testing-library/jest-dom": ^5.16.1
       "@types/history": ^4.7.3
       "@types/jest": ^26.0.23
       "@types/jest-when": ^2.7.4
@@ -3805,6 +3806,7 @@ importers:
       "@kie-tools/serverless-logic-sandbox-base-image-env": link:../serverless-logic-sandbox-base-image-env
       "@kie-tools/tsconfig": link:../tsconfig
       "@svgr/webpack": 6.2.1
+      "@testing-library/jest-dom": 5.16.1
       "@types/history": 4.7.5
       "@types/jest": 26.0.23
       "@types/jest-when": 2.7.4


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8166

Besides Chrome and Firefox, which were already enabled, this PR enables Opera and Edge to run the Serverless Logic Web Tools. I spent some time doing a sanity check on all browsers and I couldn't find any browser-specific blocker issue. The only thing that I've noticed is that scrolling the diagram up and down using the mouse wheel does not work on Firefox. Besides that, everything worked very well from editing and file management, all the way to GitHub and OpenShift integration.