### PR TITLE
Bump `mikepenz/action-junit-report` and `pnpm/action-setup` to remove deprecated warnings

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,7 +18,7 @@ runs:
         du -sh .
 
     - name: "Setup pnpm"
-      uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
+      uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
       with:
         version: 7.0.0
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: "Check tests result (`main` only)"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request
-        uses: mikepenz/action-junit-report@1b47bb811362f3d8d753fc148cb7a13ec9e55570
+        uses: mikepenz/action-junit-report@ab07dd7abefd456d92ecbeb22f81392fafe3d528
         with:
           check_name: "-"
           annotate_only: true


### PR DESCRIPTION
There are still some deprecation warnings on our CI due to an external GitHub Action (mikepenz/action-junit-report).
However, this has been resolved in their latest release. See https://github.com/mikepenz/action-junit-report/issues/712

Note: The new SHA corresponds to the latest release (https://github.com/mikepenz/action-junit-report/releases/tag/v3.5.2).