### PR TITLE
KOGITO-8236: SWF Viewer - Fixing layers for Auto-layout

### DIFF
--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/LayeredGraph.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/LayeredGraph.java
@@ -164,4 +164,14 @@ public class LayeredGraph implements ReorderedGraph {
         }
         return verticesFrom.toArray(new String[0]);
     }
+
+    public String[] getVerticesTo(final String vertex) {
+        final HashSet<String> verticesTo = new HashSet<>();
+        for (final OrientedEdge edge : this.edges) {
+            if (Objects.equals(edge.getToVertexId(), vertex)) {
+                verticesTo.add(edge.getFromVertexId());
+            }
+        }
+        return verticesTo.toArray(new String[0]);
+    }
 }

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/step03/DefaultVertexOrdering.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/step03/DefaultVertexOrdering.java
@@ -106,6 +106,7 @@ public final class DefaultVertexOrdering implements VertexOrdering {
         for (int i = 0; i < virtualized.size() - 1; i++) {
             final GraphLayer currentLayer = virtualized.get(i);
             final GraphLayer nextLayer = virtualized.get(i + 1);
+            final int layerHeight = calculateLayerHeight(nextLayer);
             for (final VertexPosition vertexPosition : currentLayer.getVertices()) {
 
                 final List<OrientedEdge> outgoing = edges.stream()
@@ -120,6 +121,7 @@ public final class DefaultVertexOrdering implements VertexOrdering {
 
                 for (final OrientedEdge edge : outgoing) {
                     final VertexPosition virtualVertexPosition = new VertexPosition("V" + virtualIndex++, true);
+                    virtualVertexPosition.setHeight(layerHeight);
                     nextLayer.getVertices().add(virtualVertexPosition);
                     edges.remove(edge);
                     final OrientedEdge v1 = new OrientedEdgeImpl(edge.getFromVertexId(), virtualVertexPosition.getId());
@@ -130,6 +132,7 @@ public final class DefaultVertexOrdering implements VertexOrdering {
 
                 for (final OrientedEdge edge : incoming) {
                     final VertexPosition virtualVertexPosition = new VertexPosition("V" + virtualIndex++, true);
+                    virtualVertexPosition.setHeight(layerHeight);
                     nextLayer.getVertices().add(virtualVertexPosition);
                     edges.remove(edge);
                     final OrientedEdge v1 = new OrientedEdgeImpl(virtualVertexPosition.getId(), edge.getToVertexId());
@@ -141,6 +144,10 @@ public final class DefaultVertexOrdering implements VertexOrdering {
         }
 
         return virtualized;
+    }
+
+    int calculateLayerHeight(final GraphLayer currentLayer) {
+        return currentLayer.getVertices().stream().mapToInt(v -> v.getHeight()).max().orElse(0);
     }
 
     private int getLayerNumber(final String vertex,

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/step04/DefaultVertexPositioning.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/layout/sugiyama/step04/DefaultVertexPositioning.java
@@ -167,7 +167,6 @@ public class DefaultVertexPositioning implements VertexPositioning {
                     .findFirst();
 
             if (nextEdge.isPresent()) {
-                bendingPoints.add(createBendingPoint(virtualVertices.get(nextVertexId)));
                 addBendingPoints(nextVertexId, edges, virtualVertices, bendingPoints, nextEdge.get());
             }
         }
@@ -203,11 +202,11 @@ public class DefaultVertexPositioning implements VertexPositioning {
         final HashMap<Integer, Integer> layersStartX = getLayersStartX(layers.size(), layersWidth, largestWidth);
 
         int y = DEFAULT_LAYER_VERTICAL_PADDING;
-        if (arrangement == LayerArrangement.TopDown) {
+        if (arrangement == LayerArrangement.BottomUp) {
             for (int i = 0; i < layers.size(); i++) {
                 y = distributeVertices(layers, layersStartX, y, i, graph);
             }
-        } else if (arrangement == LayerArrangement.BottomUp) {
+        } else if (arrangement == LayerArrangement.TopDown) {
             for (int i = layers.size() - 1; i >= 0; i--) {
                 y = distributeVertices(layers, layersStartX, y, i, graph);
             }

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/test/java/com/ait/lienzo/client/core/layout/sugiyama/step02/LongestPathVertexLayererTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/test/java/com/ait/lienzo/client/core/layout/sugiyama/step02/LongestPathVertexLayererTest.java
@@ -49,10 +49,10 @@ public class LongestPathVertexLayererTest {
 
         assertEquals(2, result.size());
 
-        final GraphLayer layer01 = result.get(0);
+        final GraphLayer layer01 = result.get(1);
         match(new String[]{"A", "B", "C", "D"}, layer01);
 
-        final GraphLayer layer02 = result.get(1);
+        final GraphLayer layer02 = result.get(0);
         match(new String[]{"E", "F", "G", "H"}, layer02);
     }
 
@@ -74,13 +74,13 @@ public class LongestPathVertexLayererTest {
 
         assertEquals(3, result.size());
 
-        final GraphLayer layer01 = result.get(0);
-        match(new String[]{"A"}, layer01);
+        final GraphLayer layer01 = result.get(2);
+        match(new String[]{"A", "D"}, layer01);
 
         final GraphLayer layer02 = result.get(1);
-        match(new String[]{"D", "B", "C"}, layer02);
+        match(new String[]{"B", "C"}, layer02);
 
-        final GraphLayer layer03 = result.get(2);
+        final GraphLayer layer03 = result.get(0);
         match(new String[]{"E", "F", "G", "H"}, layer03);
     }
 
@@ -107,17 +107,17 @@ public class LongestPathVertexLayererTest {
         /* We're ensuring that the default algorithm behaviour is "good enough" and is not break by some change,
          * but If we changed it to a better one we'll have to modify this test to the new better expected result.
          */
-        final GraphLayer layer01 = result.get(0);
+        final GraphLayer layer01 = result.get(3);
         match(new String[]{"A"}, layer01);
 
-        final GraphLayer layer02 = result.get(1);
-        match(new String[]{"C"}, layer02);
+        final GraphLayer layer02 = result.get(2);
+        match(new String[]{"C", "B"}, layer02);
 
-        final GraphLayer layer03 = result.get(2);
-        match(new String[]{"B", "G", "H"}, layer03);
+        final GraphLayer layer03 = result.get(1);
+        match(new String[]{"E", "F", "G", "H"}, layer03);
 
-        final GraphLayer layer04 = result.get(3);
-        match(new String[]{"F", "I", "E"}, layer04);
+        final GraphLayer layer04 = result.get(0);
+        match(new String[]{"I"}, layer04);
     }
 
     @Test
@@ -145,13 +145,13 @@ public class LongestPathVertexLayererTest {
                 .isEqualTo(3);
 
         match(new String[]{"A1", "A2"},
-              result.get(0));
+              result.get(2));
 
-        match(new String[]{"C1", "B2", "D2"},
+        match(new String[]{"B1", "C1", "B2", "C2", "D2"},
               result.get(1));
 
-        match(new String[]{"B1", "D1", "E1", "E2", "C2", "F2"},
-              result.get(2));
+        match(new String[]{"D1", "E1", "E2", "F2"},
+              result.get(0));
     }
 
     @Test
@@ -163,11 +163,11 @@ public class LongestPathVertexLayererTest {
         Assertions.assertThat(result.size())
                 .as("TwoSeparateTreesToRoots graph vertices should be placed into three layers")
                 .isEqualTo(3);
-        match(new String[]{"A1", "A2"},
+        match(new String[]{"B1", "E1", "D1", "E2", "F2", "C2"},
               result.get(2));
-        match(new String[]{"B1", "C1", "B2", "C2", "D2"},
+        match(new String[]{"C1", "B2", "D2"},
               result.get(1));
-        match(new String[]{"D1", "E1", "E2", "F2"},
+        match(new String[]{"A1", "A2"},
               result.get(0));
     }
 

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/test/java/com/ait/lienzo/client/core/layout/sugiyama/step04/DefaultVertexPositioningTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/test/java/com/ait/lienzo/client/core/layout/sugiyama/step04/DefaultVertexPositioningTest.java
@@ -35,12 +35,14 @@ import org.mockito.InOrder;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.ait.lienzo.client.core.layout.sugiyama.step04.DefaultVertexPositioning.DEFAULT_LAYER_HORIZONTAL_PADDING;
+import static com.ait.lienzo.client.core.layout.sugiyama.step04.DefaultVertexPositioning.DEFAULT_LAYER_SPACE;
 import static com.ait.lienzo.client.core.layout.sugiyama.step04.DefaultVertexPositioning.DEFAULT_LAYER_VERTICAL_PADDING;
 import static com.ait.lienzo.client.core.layout.sugiyama.step04.DefaultVertexPositioning.DEFAULT_VERTEX_SPACE;
 import static com.ait.lienzo.tools.common.api.java.util.UUID.uuid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
@@ -68,38 +70,28 @@ public class DefaultVertexPositioningTest {
         final HashMap hash = mock(HashMap.class);
         final HashMap layersStartX = mock(HashMap.class);
         final int largestWidth = 100;
-        final int newY = 17;
+        final int newY = DEFAULT_LAYER_SPACE + DEFAULT_VERTEX_SPACE;
+        when(layersStartX.get(any())).thenReturn(0);
         doReturn(hash).when(tested).createHashForLayersWidth();
         doReturn(largestWidth).when(tested).calculateLayersWidth(layers, hash);
         doReturn(layersStartX).when(tested).getLayersStartX(layers.size(), hash, largestWidth);
 
-        doReturn(newY).when(tested).distributeVertices(layers,
-                                                       layersStartX,
-                                                       DEFAULT_LAYER_VERTICAL_PADDING,
-                                                       0,
-                                                       graph);
+        final InOrder inOrder = inOrder(tested);
 
-        doReturn(newY).when(tested).distributeVertices(layers,
-                                                       layersStartX,
-                                                       newY,
-                                                       1,
-                                                       graph);
         tested.arrangeVertices(layers,
                                LayerArrangement.TopDown,
                                graph);
 
-        final InOrder inOrder = inOrder(tested);
-
         inOrder.verify(tested).distributeVertices(layers,
                                                   layersStartX,
                                                   DEFAULT_LAYER_VERTICAL_PADDING,
-                                                  0,
+                                                  1,
                                                   graph);
 
         inOrder.verify(tested).distributeVertices(layers,
                                                   layersStartX,
                                                   newY,
-                                                  1,
+                                                  0,
                                                   graph);
     }
 
@@ -114,19 +106,20 @@ public class DefaultVertexPositioningTest {
         final HashMap layersStartX = mock(HashMap.class);
         final int largestWidth = 100;
         final int newY = 17;
+
         doReturn(hash).when(tested).createHashForLayersWidth();
         doReturn(largestWidth).when(tested).calculateLayersWidth(layers, hash);
         doReturn(layersStartX).when(tested).getLayersStartX(layers.size(), hash, largestWidth);
 
         doReturn(newY).when(tested).distributeVertices(layers,
                                                        layersStartX,
-                                                       newY,
+                                                       DEFAULT_LAYER_VERTICAL_PADDING,
                                                        0,
                                                        graph);
 
         doReturn(newY).when(tested).distributeVertices(layers,
                                                        layersStartX,
-                                                       DEFAULT_LAYER_VERTICAL_PADDING,
+                                                       newY,
                                                        1,
                                                        graph);
         tested.arrangeVertices(layers,
@@ -138,13 +131,13 @@ public class DefaultVertexPositioningTest {
         inOrder.verify(tested).distributeVertices(layers,
                                                   layersStartX,
                                                   DEFAULT_LAYER_VERTICAL_PADDING,
-                                                  1,
+                                                  0,
                                                   graph);
 
         inOrder.verify(tested).distributeVertices(layers,
                                                   layersStartX,
                                                   newY,
-                                                  0,
+                                                  1,
                                                   graph);
     }
 


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/KOGITO-8236
This PR changes the algorithm to make the resulting diagram ordered from top to bottom as suggested by @handreyrc  and more compact.

The code to isolate the ending vertex was deleted because I didn't find any case that it required after those changes.