### PR TITLE
KOGITO-7078: SWF Viewer - Connector labels

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/ext/WiresConnectorViewExt.java
@@ -121,8 +121,6 @@ public class WiresConnectorViewExt<T>
     public T setTitle(final String title) {
         return Optional.ofNullable(title)
                 .map(t -> label.map(l -> l.configure(text -> {
-                                                         l.rectangle.setHeight(text.getBoundingBox().getHeight());
-                                                         l.rectangle.setWidth(text.getBoundingBox().getWidth());
                                                          text.setFillColor("white");
                                                          text.setStrokeColor("white");
                                                          text.setFontFamily("Verdana");

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/util/WiresConnectorLabel.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/shape/wires/util/WiresConnectorLabel.java
@@ -65,6 +65,7 @@ public class WiresConnectorLabel implements IDestroyable {
     public WiresConnectorLabel configure(Consumer<Text> consumer) {
         consumer.accept(text);
         refresh();
+        batch();
         return this;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7078 (First comment)

Since we don't have orthogonal lines with the new autolayout impl, labels must be fixed as:
- Fix the position of the label for vertical (less that 45degreesl) connectors
- Also consider the possiblty to reduce the width of the label (in case of overlapping)
- Fix the tooltip, which does not appear on mouse hover the label