### PR TITLE
Bump `actions/setup-java` and `actions/cache` to remove deprecated warnings

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -28,9 +28,10 @@ runs:
         node-version: 16.13.2
 
     - name: "Setup JDK 11"
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc
       with:
         java-version: 11
+        distribution: "zulu"
 
     - name: "Set up GOLANG 1.19"
       uses: actions/setup-go@v3

--- a/.github/workflows/ci_sonar_analysis_stunner_editors.yml
+++ b/.github/workflows/ci_sonar_analysis_stunner_editors.yml
@@ -29,7 +29,7 @@ jobs:
           pnpm_filter_string: -F @kie-tools/stunner-editors...
 
       - name: "Cache SonarCloud packages"
-        uses: actions/cache@v1
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-stunner-editors

--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
 
       - name: "Cache Maven packages"
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-daily-dev-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -36,9 +36,10 @@ jobs:
 
       - name: "Set up JDK 11"
         if: runner.os != 'Windows'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc
         with:
           java-version: "11"
+          distribution: "zulu"
 
       - name: "Set long paths for Windows"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -49,11 +49,11 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install make && \
-          wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-darwin-amd64-21.3.0.tar.gz && \
-          tar -xzf graalvm-ce-java11-darwin-amd64-21.3.0.tar.gz && \
-          sudo mv graalvm-ce-java11-21.3.0 /Library/Java/JavaVirtualMachines
-          export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-java11-21.3.0/Contents/Home/bin:$PATH && \
-          export GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-ce-java11-21.3.0/Contents/Home && \
+          wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-darwin-amd64-22.3.0.tar.gz && \
+          tar -xzf graalvm-ce-java11-darwin-amd64-22.3.0.tar.gz && \
+          sudo mv graalvm-ce-java11-22.3.0 /Library/Java/JavaVirtualMachines/graalvm-ce-java11-darwin-amd64-22.3.0
+          export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-java11-darwin-amd64-22.3.0/Contents/Home/bin:$PATH && \
+          export GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-ce-java11-darwin-amd64-22.3.0/Contents/Home && \
           gu install native-image && \
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
@@ -89,7 +89,7 @@ jobs:
         uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
         with:
           java-version: 11
-          graalvm-version: 21.3.0
+          graalvm-version: 22.3.0
           native-image: true
 
       - name: "Build Windows"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -146,7 +146,7 @@ jobs:
           ref: ${{ inputs.base_ref }}
 
       - name: "Cache Maven packages"
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-dmn-dev-sandbox-deployment-base-image-m2-${{ hashFiles('**/pom.xml') }}
@@ -425,7 +425,7 @@ jobs:
           ref: gh-pages
 
       - name: "Cache Maven packages"
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-release-m2-${{ hashFiles('**/pom.xml') }}
@@ -1264,7 +1264,7 @@ jobs:
           ref: ${{ inputs.base_ref }}
 
       - name: "Cache Maven packages"
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-serverless-logic-sandbox-base-image-m2-${{ hashFiles('**/pom.xml') }}
@@ -1382,7 +1382,7 @@ jobs:
           ref: gh-pages
 
       - name: "Cache Maven packages"
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-serverless-logic-sandbox-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -129,7 +129,7 @@ jobs:
       # https://github.com/actions/runner/pull/1844
       - name: "Cache Maven packages (Ubuntu only - see comments in source)"
         if: ${{ runner.os == 'Linux' }}
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.m2
           key: ${{ runner.os }}-staging-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
`actions/setup-java`
Fixed on https://github.com/actions/setup-java/issues/393
`de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc` corresponds to [v3.6.0](https://github.com/actions/setup-java/releases/tag/v3.6.0) (latest atm)

`actions/cache`
Fixed on https://github.com/actions/cache/issues/953
`9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7` corresponds to [ v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11) (latest atm)

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands

Also, GraalVM upgraded to `22.3.0` following Quarkus compatibility.