### PR TITLE
kie-issues#28: DMN Editor - Three undos are required to remove a newly added node

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DRGElementTextPropertyProviderImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/DRGElementTextPropertyProviderImpl.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.canvas.controls.actions;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -70,12 +72,14 @@ public class DRGElementTextPropertyProviderImpl implements TextPropertyProvider 
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final Object definition = DefinitionUtils.getElementDefinition(element);
-        final CanvasCommand<AbstractCanvasHandler> command =
-                canvasCommandFactory.updatePropertyValue(element,
-                                                         definitionUtils.getNameIdentifier(definition),
-                                                         new Name(NameUtils.normaliseName(text)));
-        commandManager.execute(canvasHandler,
-                               command);
+        if (!Objects.equals(text, getText(element))) {
+            final Object definition = DefinitionUtils.getElementDefinition(element);
+            final CanvasCommand<AbstractCanvasHandler> command = canvasCommandFactory.updatePropertyValue(
+                    element,
+                    definitionUtils.getNameIdentifier(definition),
+                    new Name(NameUtils.normaliseName(text)));
+
+            commandManager.execute(canvasHandler, command);
+        }
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImpl.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.dmn.client.canvas.controls.actions;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -62,19 +64,19 @@ public class TextAnnotationTextPropertyProviderImpl implements TextPropertyProvi
                         final CanvasCommandManager<AbstractCanvasHandler> commandManager,
                         final Element<? extends Definition> element,
                         final String text) {
-        final Object definition = DefinitionUtils.getElementDefinition(element);
-        final CanvasCommand<AbstractCanvasHandler> command =
-                canvasCommandFactory.updatePropertyValue(element,
-                                                         definitionUtils.getNameIdentifier(definition),
-                                                         text);
-        commandManager.execute(canvasHandler,
-                               command);
+        if (!Objects.equals(text, getText(element))) {
+            final Object definition = DefinitionUtils.getElementDefinition(element);
+            final CanvasCommand<AbstractCanvasHandler> command = canvasCommandFactory.updatePropertyValue(
+                    element,
+                    definitionUtils.getNameIdentifier(definition),
+                    text);
+            commandManager.execute(canvasHandler, command);
+        }
     }
 
     @Override
     public String getText(final Element<? extends Definition> element) {
         final TextAnnotation ta = (TextAnnotation) DefinitionUtils.getElementDefinition(element);
-        final String text = ta.getText().getValue();
-        return text;
+        return ta.getText().getValue();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/canvas/controls/actions/TextAnnotationTextPropertyProviderImplTest.java
@@ -30,14 +30,20 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.util.DefinitionUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +53,8 @@ public class TextAnnotationTextPropertyProviderImplTest {
     private static final String NAME_FIELD = "name";
 
     private static final String NAME_VALUE = "text";
+
+    private static final String NAME_VALUE_WITH_WHITESPACE = "   " + NAME_VALUE + "   ";
 
     @Mock
     private DefinitionUtils definitionUtils;
@@ -75,19 +83,21 @@ public class TextAnnotationTextPropertyProviderImplTest {
     @Mock
     private CanvasCommand<AbstractCanvasHandler> command;
 
+    @Captor
+    private ArgumentCaptor<Object> nameArgumentCaptor;
+
     private TextPropertyProvider provider;
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setup() {
-        this.provider = new TextAnnotationTextPropertyProviderImpl(canvasCommandFactory, definitionUtils);
+        this.provider = spy(new TextAnnotationTextPropertyProviderImpl(canvasCommandFactory, definitionUtils));
         when(element.getContent()).thenReturn(content);
         when(content.getDefinition()).thenReturn(definition);
         when(definition.getText()).thenReturn(text);
-        when(definitionUtils.getNameIdentifier(eq(definition))).thenReturn(NAME_FIELD);
+        when(definitionUtils.getNameIdentifier(definition)).thenReturn(NAME_FIELD);
         when(canvasCommandFactory.updatePropertyValue(eq(element),
-                                                      Mockito.<String>any(),
-                                                      Mockito.<String>any())).thenReturn(command);
+                                                      Mockito.any(),
+                                                      Mockito.any())).thenReturn(command);
     }
 
     @Test
@@ -96,7 +106,6 @@ public class TextAnnotationTextPropertyProviderImplTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void checkSupportsTextAnnotationElements() {
         assertTrue(provider.supports(element));
 
@@ -121,6 +130,27 @@ public class TextAnnotationTextPropertyProviderImplTest {
         provider.setText(canvasHandler, commandManager, element, NAME_VALUE);
 
         verify(canvasCommandFactory).updatePropertyValue(element, NAME_FIELD, NAME_VALUE);
-        verify(commandManager).execute(eq(canvasHandler), eq(command));
+        verify(commandManager).execute(canvasHandler, command);
+    }
+
+    @Test
+    public void checkNodeUpdateWithSameAssignedName() {
+        when(provider.getText(element)).thenReturn(NAME_VALUE);
+
+        provider.setText(canvasHandler, commandManager, element, NAME_VALUE);
+
+        verify(canvasCommandFactory, never()).updatePropertyValue(eq(element), eq(NAME_FIELD), nameArgumentCaptor.capture());
+        verify(commandManager, never()).execute(canvasHandler, command);
+    }
+
+    @Test
+    public void checkNodeUpdateWithDifferentAssignedName() {
+        when(provider.getText(element)).thenReturn(NAME_VALUE_WITH_WHITESPACE);
+
+        provider.setText(canvasHandler, commandManager, element, NAME_VALUE);
+
+        verify(canvasCommandFactory, times(1)).updatePropertyValue(eq(element), eq(NAME_FIELD), nameArgumentCaptor.capture());
+        assertEquals(NAME_VALUE, nameArgumentCaptor.getValue().toString());
+        verify(commandManager, times(1)).execute(canvasHandler, command);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextPropertyProviderFactoryImpl.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/actions/TextPropertyProviderFactoryImpl.java
@@ -16,6 +16,7 @@
 package org.kie.workbench.common.stunner.core.client.canvas.controls.actions;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -39,17 +40,15 @@ public class TextPropertyProviderFactoryImpl implements TextPropertyProviderFact
         for (TextPropertyProvider provider : providers) {
             this.providers.add(provider);
         }
-        this.providers.sort((p1,
-                             p2) -> p1.getPriority() - p2.getPriority());
+        this.providers.sort(Comparator.comparingInt(TextPropertyProvider::getPriority));
     }
 
     @Override
     public TextPropertyProvider getProvider(final Element<? extends Definition> element) {
-        final TextPropertyProvider provider = providers
+        return providers
                 .stream()
-                .filter((p) -> p.supports(element))
+                .filter(p -> p.supports(element))
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No TextPropertyProvider found for '" + element.getClass().getName() + "'."));
-        return provider;
     }
 }


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/28

Reason for the issue: At every MouseDown event bound to the TextNode of the new node, the handler will execute a new Text edit command, that results in a new Undo/Redo action. 
When creating a new node, 3 Mouse Down events occur, explaining why 3 undo are required to remove the newly added node.
The same issue occurs if you simply double-click in any Node label - this results in a MouseDown click on the Text Element of the node, adding a new item in the Undo/Redo queue (and enabling isDirty on the editor)

To fix that, I added a simple `if` that check if the new node name value is equal or not to the previous value. If it is equal, no command is launched.
 

