### PR TITLE
KOGITO-8071: Flaky test - serverless-workflow-editor-extension-autocompletion.test.ts

### DIFF
--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/helpers/VSCodeTestHelper.ts
@@ -120,7 +120,7 @@ export default class VSCodeTestHelper {
         await fileItem.click();
       }
     }
-    await sleep(3000);
+    await sleep(5000);
 
     const editorGroups = await this.workbench.getEditorView().getEditorGroups();
     // should be always two groups, one text editor and one swf editor

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
@@ -1,7 +1,7 @@
 {
   "id": "Workflow unique identifier",
   "version": "0.1",
-  "specVersion": "0.1",
+  "specVersion": "0.8",
   "name": "Workflow name",
   "description": "Workflow description",
   "start": "StartState",

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
@@ -1,7 +1,7 @@
 {
   "id": "Workflow unique identifier",
   "version": "0.1",
-  "specVersion": "0.8",
+  "specVersion": "0.1",
   "name": "Workflow name",
   "description": "Workflow description",
   "start": "StartState",

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
@@ -1,24 +1,24 @@
 id: 'Workflow unique identifier'
 version: '0.1'
-specVersion: '0.1'
-name: Workflow name
-description: Workflow description
-start: StartState
+specVersion: '0.8'
+name: 'Workflow name'
+description: 'Workflow description'
+start: 'StartState'
 functions:
-  - name: uniqueFunctionName
+  - name: 'uniqueFunctionName'
     operation: 'localhost#operation'
-    type: rest
+    type: 'rest'
 events:
-  - name: Unique event name
-    source: CloudEvent source
-    type: CloudEvent type
+  - name: 'Unique event name'
+    source: 'CloudEvent source'
+    type: 'CloudEvent type'
 states:
-  - name: StartState
-    type: operation
+  - name: 'StartState'
+    type: 'operation'
     actions:
-      - name: uniqueActionName
+      - name: 'uniqueActionName'
         functionRef:
-          refName: uniqueFunctionName
+          refName: 'uniqueFunctionName'
           arguments:
             firstArgument: ''
             secondArgument: ''

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
@@ -1,6 +1,6 @@
 id: 'Workflow unique identifier'
 version: '0.1'
-specVersion: '0.8'
+specVersion: '0.1'
 name: 'Workflow name'
 description: 'Workflow description'
 start: 'StartState'

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
@@ -24,7 +24,6 @@ import VSCodeTestHelper, { sleep } from "./helpers/VSCodeTestHelper";
 import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
-// KOGITO-8071 - Flaky test - serverless-workflow-editor-extension-autocompletion.test.ts
 describe("Serverless workflow editor - autocompletion tests", () => {
   const TEST_PROJECT_FOLDER: string = path.resolve("it-tests-tmp", "resources", "autocompletion");
 

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+require("./serverless-workflow-editor-extension-smoke.test");
+
 import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
@@ -23,7 +23,7 @@ import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
 // KOGITO-8071 - Flaky test - serverless-workflow-editor-extension-autocompletion.test.ts
-describe.skip("Serverless workflow editor - autocompletion tests", () => {
+describe("Serverless workflow editor - autocompletion tests", () => {
   const TEST_PROJECT_FOLDER: string = path.resolve("it-tests-tmp", "resources", "autocompletion");
 
   let testHelper: VSCodeTestHelper;

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { Key, TextEditor } from "vscode-extension-tester";
-import VSCodeTestHelper from "./helpers/VSCodeTestHelper";
+import VSCodeTestHelper, { sleep } from "./helpers/VSCodeTestHelper";
 import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
@@ -217,7 +217,9 @@ end: true`);
 
   async function selectFromContentAssist(textEditor: TextEditor, value: string): Promise<void> {
     const contentAssist = await textEditor.toggleContentAssist(true);
-    let item = await contentAssist?.getItem(value);
+    const item = await contentAssist?.getItem(value);
+    await sleep(500);
+    expect(await item?.getLabel()).contain(value);
     await item?.click();
   }
 });

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-syntax-highlight.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-syntax-highlight.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+require("./serverless-workflow-editor-extension-smoke.test");
+
 import * as path from "path";
 import { expect } from "chai";
 import { By, WebDriver, WebElement } from "vscode-extension-tester";


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-8071

The test is now stable when running locally (30+ runs, no fail) and [on the CI](https://github.com/zdrapela/kie-tools/actions/runs/3637751535) (7+ runs, no fail).

The requirement to run smoke tests before other tests was added.