### PR TITLE
kie-issues#45: DMN Editor: Expression Editor context menu not visible in corner cases

### DIFF
--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistry.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistry.java
@@ -42,6 +42,8 @@ import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 @Dependent
 public class ScenarioContextMenuRegistry {
 
+    private static final int BIGGEST_MENU_HEIGHT_PX = 130;
+
     protected OtherContextMenu otherContextMenu;
     protected HeaderGivenContextMenu headerGivenContextMenu;
     protected HeaderExpectedContextMenu headerExpectedContextMenu;
@@ -126,16 +128,20 @@ public class ScenarioContextMenuRegistry {
         if (scenarioGridColumn == null) {
             return false;
         }
+        final int gridHeight =
+                (int) scenarioGrid.getRendererHelper().getRenderingInformation().getBounds().getHeight();
+        final int adjustedYPosition =
+                clientYPosition + BIGGEST_MENU_HEIGHT_PX < gridHeight ? clientYPosition : clientYPosition - BIGGEST_MENU_HEIGHT_PX;
         if (isHeader) {
             return manageHeaderRightClick(scenarioGrid,
                                           clientXPosition,
-                                          clientYPosition,
+                                          adjustedYPosition,
                                           uiRowIndex,
                                           uiColumnIndex);
         } else {
             return manageBodyRightClickLocal(scenarioGrid,
                                              clientXPosition,
-                                             clientYPosition,
+                                             adjustedYPosition,
                                              uiRowIndex,
                                              uiColumnIndex);
         }

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
@@ -142,6 +142,7 @@ public class TestProperties {
     public static final Map<String, String> EXPECTED_MAP_FOR_EXPANDABLE_TYPE_2 = new HashMap<>();
 
     public static final Double GRID_WIDTH = 100.0;
+    public static final Double GRID_HEIGHT = 400.0;
     public static final Double HEADER_HEIGHT = 10.0;
     public static final Double HEADER_ROW_HEIGHT = 10.0;
     public static final int UI_COLUMN_INDEX = 0;

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridHandlerTest.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridHandlerTest.java
@@ -28,10 +28,12 @@ import org.junit.Before;
 import org.mockito.AdditionalMatchers;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLICK_POINT_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_HEIGHT;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_WIDTH;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_ROW_HEIGHT;
@@ -97,5 +99,7 @@ public abstract class AbstractScenarioSimulationGridHandlerTest extends Abstract
         when(scenarioGridRendererHelperMock.getColumnInformation(AdditionalMatchers.or(eq(0.0), eq(CLICK_POINT_X))))
                 .thenReturn(columnInformation);
         when(scenarioRenderingInformationMock.getFloatingBlockInformation()).thenReturn(floatingBlockInformationMock);
+
+        when(scenarioRenderingInformationMock.getBounds()).thenReturn(new BaseBounds(0, 0, GRID_WIDTH, GRID_HEIGHT));
     }
 }

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
@@ -183,10 +183,11 @@ public class ScenarioContextMenuRegistryTest extends AbstractScenarioSimulationG
         verify(scenarioGridMock, times(1)).clearSelections();
 
         final int expectedClickPointY = 260; // clickPointY - Scenario.ContextMenuRegistry.BIGGEST_MENU_HEIGHT_PX
-        verify(gridContextMenuMock).show(GridWidget.SIMULATION,
-                clickPointX,
-                expectedClickPointY,
-                0);
+        verify(gridContextMenuMock)
+                .show(GridWidget.SIMULATION,
+                        clickPointX,
+                        expectedClickPointY,
+                        0);
         verify(scenarioGridMock, times(1)).setSelectedCell(eq(0), eq(0));
     }
 }

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
@@ -37,7 +37,9 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLICK_POINT_X;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_HEIGHT;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -159,6 +161,32 @@ public class ScenarioContextMenuRegistryTest extends AbstractScenarioSimulationG
                                          clickPointX,
                                          clickPointY,
                                          0);
+        verify(scenarioGridMock, times(1)).setSelectedCell(eq(0), eq(0));
+    }
+
+    @Test
+    public void testManageBodyRightClickNotEnoughSpaceForMenu() {
+        final int clickPointX = (int) CLICK_POINT_X;
+        final int clickPointY = (int) (GRID_HEIGHT - 10);
+        final double widgetHeight = GRID_HEIGHT;
+        final double rowHeight = widgetHeight - HEADER_HEIGHT;
+        doReturn(clickPointX).when(contextNativeEventMock).getClientX();
+        doReturn(clickPointY).when(contextNativeEventMock).getClientY();
+        doReturn(widgetHeight).when(scenarioGridMock).getHeight();
+        doReturn(1).when(scenarioGridModelMock).getRowCount();
+        final GridRow gridRowMock = mock(GridRow.class);
+        doReturn(gridRowMock).when(scenarioGridModelMock).getRow(0);
+        doReturn(rowHeight).when(gridRowMock).getHeight();
+        assertThat(scenarioContextMenuRegistry.manageRightClick(scenarioGridMock, contextMenuEventMock))
+                .as("Click to expect/given body cell")
+                .isTrue();
+        verify(scenarioGridMock, times(1)).clearSelections();
+
+        final int expectedClickPointY = 260; // clickPointY - Scenario.ContextMenuRegistry.BIGGEST_MENU_HEIGHT_PX
+        verify(gridContextMenuMock).show(GridWidget.SIMULATION,
+                clickPointX,
+                expectedClickPointY,
+                0);
         verify(scenarioGridMock, times(1)).setSelectedCell(eq(0), eq(0));
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControls.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControls.java
@@ -81,7 +81,7 @@ public class CellEditorControls implements CellEditorControlsView.Presenter {
         int yCoordinate = (int) ((y * transform.getScaleY()) + transform.getTranslateY()) + gridPanel.getAbsoluteTop();
         final int absoluteGridBottom = gridPanel.getElement().getAbsoluteBottom();
 
-        if(yCoordinate +  BIGGEST_MENU_HEIGHT_PX > absoluteGridBottom) {
+        if (yCoordinate + BIGGEST_MENU_HEIGHT_PX > absoluteGridBottom) {
             yCoordinate -= BIGGEST_MENU_HEIGHT_PX;
         }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControls.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/container/CellEditorControls.java
@@ -29,6 +29,8 @@ import org.kie.workbench.common.dmn.client.widgets.panel.DMNGridPanel;
 @Dependent
 public class CellEditorControls implements CellEditorControlsView.Presenter {
 
+    private static final int BIGGEST_MENU_HEIGHT_PX = 250;
+
     private Optional<Supplier<DMNGridPanel>> gridPanelSupplier;
     private CellEditorControlsView view;
 
@@ -76,6 +78,13 @@ public class CellEditorControls implements CellEditorControlsView.Presenter {
     private int getTransformedY(final int y) {
         final DMNGridPanel gridPanel = gridPanelSupplier.get().get();
         final Transform transform = gridPanel.getViewport().getTransform();
-        return (int) ((y * transform.getScaleY()) + transform.getTranslateY()) + gridPanel.getAbsoluteTop();
+        int yCoordinate = (int) ((y * transform.getScaleY()) + transform.getTranslateY()) + gridPanel.getAbsoluteTop();
+        final int absoluteGridBottom = gridPanel.getElement().getAbsoluteBottom();
+
+        if(yCoordinate +  BIGGEST_MENU_HEIGHT_PX > absoluteGridBottom) {
+            yCoordinate -= BIGGEST_MENU_HEIGHT_PX;
+        }
+
+        return yCoordinate;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.user.client.Element;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,9 @@ public class CellEditorControlsTest {
     @Mock
     private HasCellEditorControls.Editor editor;
 
+    @Mock
+    private Element gridElement;
+
     private CellEditorControlsView.Presenter controls;
 
     @Before
@@ -60,6 +64,7 @@ public class CellEditorControlsTest {
         this.controls.setGridPanelSupplier(Optional.of(() -> gridPanel));
 
         doReturn(viewport).when(gridPanel).getViewport();
+        doReturn(gridElement).when(gridPanel).getElement();
         doReturn(transform).when(viewport).getTransform();
     }
 
@@ -78,6 +83,25 @@ public class CellEditorControlsTest {
         verify(view).show(eq(editor),
                           eq(-145),
                           eq(-270));
+    }
+
+    @Test
+    public void testShowWhenNotEnoughPlace() {
+        doReturn(1.0).when(transform).getScaleX();
+        doReturn(0.0).when(transform).getTranslateX();
+        doReturn(50).when(gridPanel).getAbsoluteLeft();
+
+        doReturn(1.0).when(transform).getScaleY();
+        doReturn(0.0).when(transform).getTranslateY();
+        doReturn(10).when(gridPanel).getAbsoluteTop();
+
+        doReturn(500).when(gridElement).getAbsoluteBottom();
+
+        controls.show(editor, 10, 450);
+
+        verify(view).show(eq(editor),
+                eq(60),
+                eq(210)); // 450 + 10 - CellEditorControls.BIGGEST_MENU_HEIGHT_PX
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/grid/controls/CellEditorControlsTest.java
@@ -99,9 +99,10 @@ public class CellEditorControlsTest {
 
         controls.show(editor, 10, 450);
 
-        verify(view).show(eq(editor),
-                eq(60),
-                eq(210)); // 450 + 10 - CellEditorControls.BIGGEST_MENU_HEIGHT_PX
+        verify(view)
+                .show(eq(editor),
+                        eq(60),
+                        eq(210)); // 450 + 10 - CellEditorControls.BIGGEST_MENU_HEIGHT_PX
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/45

### DMN enough space
![Screenshot from 2022-12-09 06-56-12](https://user-images.githubusercontent.com/8044780/206634920-f8519534-7ce4-4741-852c-c8cbc3d470d1.png)



### DMN NOT enough space
![Screenshot from 2022-12-09 06-56-03](https://user-images.githubusercontent.com/8044780/206634802-b02f0ecd-65b0-4434-954e-3e1a9f63ab65.png)

### SceSim enough space
![Screenshot from 2022-12-09 08-27-14](https://user-images.githubusercontent.com/8044780/206648217-1e49ca26-adfd-45bd-b4ce-e630b0f7d427.png)

### SceSim NOT enough space
![Screenshot from 2022-12-09 08-27-02](https://user-images.githubusercontent.com/8044780/206648277-2411de0b-ad3f-4f86-a005-f9f813e77138.png)
