### PR TITLE
KOGITO-8317: Show condition names, instead of expressions, when possible

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/TransitionShape.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/TransitionShape.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.sw.client.shapes;
 import org.kie.workbench.common.stunner.client.lienzo.shape.impl.ShapeStateDefaultHandler;
 import org.kie.workbench.common.stunner.core.client.shape.common.DashArray;
 import org.kie.workbench.common.stunner.core.client.shape.impl.ConnectorShape;
+import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.kie.workbench.common.stunner.sw.definition.ActionTransition;
 import org.kie.workbench.common.stunner.sw.definition.CompensationTransition;
 import org.kie.workbench.common.stunner.sw.definition.DataConditionTransition;
@@ -56,7 +57,11 @@ public class TransitionShape<W>
             getShapeView().setTitleBackgroundColor("orange");
         } else if (transitionType instanceof DataConditionTransition) {
             final DataConditionTransition definition = (DataConditionTransition) transitionType;
-            getShapeView().setTitle(definition.getCondition());
+            if (StringUtils.nonEmpty(definition.getName())) {
+                getShapeView().setTitle(definition.getName());
+            } else {
+                getShapeView().setTitle(definition.getCondition());
+            }
             getShapeView().setTitleBackgroundColor("gray");
         }
 
@@ -79,7 +84,7 @@ public class TransitionShape<W>
         } else if (clazz.equals(DataConditionTransition.class)) {
             return "#757575";
         } else if (clazz.equals(DefaultConditionTransition.class)) {
-            return "#3e8635";
+            return "#12DE70";
         } else if (clazz.equals(ActionTransition.class)) {
             return "#757575";
         } else if (clazz.equals(CompensationTransition.class)) {

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/TransitionView.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/TransitionView.java
@@ -26,10 +26,10 @@ import org.kie.workbench.common.stunner.core.client.shape.view.event.ShapeViewSu
 public class TransitionView extends WiresConnectorViewExt<TransitionView> {
 
     private static final double SELECTION_OFFSET = 30;
-    private static final double DECORATOR_WIDTH = 10;
-    private static final double DECORATOR_HEIGHT = 15;
+    private static final double DECORATOR_WIDTH = 8;
+    private static final double DECORATOR_HEIGHT = 12;
 
-    private static final double STROKE_WIDTH = 1.5;
+    private static final double STROKE_WIDTH = 2;
 
     private static final double[] DEFAULT_POLYLINE_POINTS = {0, 0, 100, 100};
 


### PR DESCRIPTION
[KOGITO-8317](https://issues.redhat.com/browse/KOGITO-8317)

Hello @romartin, @LuboTerifaj,

There is a PR for KOGITO-8317 it gives priority to show condition name for data switch over condition value itself, since values mostly too long to see it property, but names are easily configurable to have better reading options.

Also default branch color made more contrast to distinguish it easier at first glance at the diagram.

To improve visibility differences for connections, I also did them a bit thicker and decreased the tip size.

See screenshots: 

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/1477262/206706370-7caf7741-5b53-4adc-a463-c02e0a08e865.png">

<img width="948" alt="image" src="https://user-images.githubusercontent.com/1477262/206707113-b329a8f0-2fa1-4b7a-a846-adad05754f89.png">

