### PR TITLE
Regression on kie-issues#46: Disable/Enable Constraint modal OK button properly

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalView.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalView.java
@@ -235,7 +235,7 @@ public class DataTypeConstraintModalView implements DataTypeConstraintModal.View
 
     @Override
     public void enableOkButton() {
-        okButton.setAttribute(DISABLED, false);
+        okButton.removeAttribute(DISABLED);
         getOkButtonClassList().remove(DISABLED);
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalViewTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalViewTest.java
@@ -159,7 +159,7 @@ public class DataTypeConstraintModalViewTest {
 
         view.enableOkButton();
 
-        verify(okButton).setAttribute("disabled", false);
+        verify(okButton).removeAttribute("disabled");
         verify(okButtonClassList).remove("disabled");
     }
 


### PR DESCRIPTION
Previous changes [1] caused the constraint modal ok button was always disabled. The issue the 'disabled' html attribte can not be present at all.

[1] kiegroup/kie-tools#1352