### PR TITLE
DROOLS-4640: Reflect DataType constraint into decision table column

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -86,18 +86,18 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
         String text;
         QName typeRef;
-        Optional<String> constraintValue;
-        Optional<ConstraintType> constraintType;
+        String constraintValue;
+        ConstraintType constraintType;
 
         ClauseRequirement(final String text,
                           final QName typeRef) {
-            this(text, typeRef, Optional.empty(), Optional.empty());
+            this(text, typeRef, null, null);
         }
 
         ClauseRequirement(final String text,
                           final QName typeRef,
-                          final Optional<String> constraintValue,
-                          final Optional<ConstraintType> constraintType) {
+                          String constraintValue,
+                          ConstraintType constraintType) {
             this.text = text;
             this.typeRef = typeRef;
             this.constraintValue = constraintValue;
@@ -173,7 +173,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
         if (outputClausesRequirement.isEmpty()) {
             dTable.getOutput().add(
-                    buildOutputClause(dTable, typeRef, name, Optional.empty())
+                    buildOutputClause(dTable, typeRef, name, null)
             );
             populateOutputEntries(decisionRule);
         } else {
@@ -235,8 +235,8 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
         return new ClauseRequirement(
                 name,
                 typeRef,
-                Optional.ofNullable(itemDefinitionUtils.getConstraintText(itemDefinition)),
-                Optional.ofNullable(itemDefinitionUtils.getConstraintType(itemDefinition)));
+                itemDefinitionUtils.getConstraintText(itemDefinition),
+                itemDefinitionUtils.getConstraintType(itemDefinition));
     }
 
     private boolean typeRefDoesNotMatchAnyDefinition(final QName typeRef) {
@@ -246,13 +246,13 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                         .noneMatch(typeRefIsCustom(typeRef));
     }
 
-    private OutputClause buildOutputClause(final DecisionTable dtable, final QName typeRef, final String text, final Optional<String> constraintValue) {
+    private OutputClause buildOutputClause(final DecisionTable dtable, final QName typeRef, final String text, final String constraintValue) {
         final OutputClause outputClause = new OutputClause();
         outputClause.setName(text);
         outputClause.setTypeRef(typeRef);
         final OutputClauseUnaryTests ocUnaryTests = new OutputClauseUnaryTests();
-        if (constraintValue.isPresent()) {
-            ocUnaryTests.setText(new Text(constraintValue.get()));
+        if (constraintValue != null) {
+            ocUnaryTests.setText(new Text(constraintValue));
         }
         outputClause.setOutputValues(ocUnaryTests);
         outputClause.setParent(dtable);
@@ -325,11 +325,11 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                     literalExpression.setTypeRef(inputClauseRequirement.typeRef);
                     inputClause.setInputExpression(literalExpression);
                     final InputClauseUnaryTests icUnaryTests = new InputClauseUnaryTests();
-                    if (inputClauseRequirement.constraintValue.isPresent()) {
-                        icUnaryTests.setText(new Text(inputClauseRequirement.constraintValue.get()));
+                    if (inputClauseRequirement.constraintValue != null) {
+                        icUnaryTests.setText(new Text(inputClauseRequirement.constraintValue));
                     }
-                    if (inputClauseRequirement.constraintType.isPresent()) {
-                        icUnaryTests.setConstraintTypeProperty(new ConstraintTypeProperty(inputClauseRequirement.constraintType.get().value()));
+                    if (inputClauseRequirement.constraintType != null) {
+                        icUnaryTests.setConstraintTypeProperty(new ConstraintTypeProperty(inputClauseRequirement.constraintType.value()));
                     }
                     inputClause.setInputValues(icUnaryTests);
                     dtable.getInput().add(inputClause);
@@ -372,8 +372,8 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                     new ClauseRequirement(
                             text,
                             getQName(itemDefinition),
-                            Optional.ofNullable(itemDefinitionUtils.getConstraintText(itemDefinition)),
-                            Optional.ofNullable(itemDefinitionUtils.getConstraintType(itemDefinition))
+                            itemDefinitionUtils.getConstraintText(itemDefinition),
+                            itemDefinitionUtils.getConstraintType(itemDefinition)
                     )
             );
         } else {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricher.java
@@ -173,7 +173,7 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
 
         if (outputClausesRequirement.isEmpty()) {
             dTable.getOutput().add(
-                    buildOutputClause(dTable, typeRef, name, null)
+                    buildOutputClause(dTable, typeRef, name, null, null)
             );
             populateOutputEntries(decisionRule);
         } else {
@@ -183,7 +183,8 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                     .map(outputClauseRequirement -> buildOutputClause(dTable,
                                                                       outputClauseRequirement.typeRef,
                                                                       outputClauseRequirement.text,
-                                                                      outputClauseRequirement.constraintValue))
+                                                                      outputClauseRequirement.constraintValue,
+                                                                      outputClauseRequirement.constraintType))
                     .forEach(outputClause -> {
                         dTable.getOutput().add(outputClause);
                         populateOutputEntries(decisionRule);
@@ -246,13 +247,16 @@ public class DecisionTableEditorDefinitionEnricher implements ExpressionEditorMo
                         .noneMatch(typeRefIsCustom(typeRef));
     }
 
-    private OutputClause buildOutputClause(final DecisionTable dtable, final QName typeRef, final String text, final String constraintValue) {
+    private OutputClause buildOutputClause(final DecisionTable dtable, final QName typeRef, final String text, final String constraintValue, final ConstraintType constraintType) {
         final OutputClause outputClause = new OutputClause();
         outputClause.setName(text);
         outputClause.setTypeRef(typeRef);
         final OutputClauseUnaryTests ocUnaryTests = new OutputClauseUnaryTests();
         if (constraintValue != null) {
             ocUnaryTests.setText(new Text(constraintValue));
+        }
+        if (constraintType != null) {
+            ocUnaryTests.setConstraintTypeField(constraintType);
         }
         outputClause.setOutputValues(ocUnaryTests);
         outputClause.setParent(dtable);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/ItemDefinitionUtils.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/common/ItemDefinitionUtils.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
@@ -66,6 +67,13 @@ public class ItemDefinitionUtils {
                 .map(UnaryTests::getText)
                 .orElse(new Text())
                 .getValue();
+    }
+
+    public ConstraintType getConstraintType(final ItemDefinition itemDefinition) {
+        return Optional
+                .ofNullable(itemDefinition.getAllowedValues())
+                .map(UnaryTests::getConstraintType)
+                .orElse(ConstraintType.NONE);
     }
 
     public QName normaliseTypeRef(final QName typeRef) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
+import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
 import org.kie.workbench.common.dmn.api.definition.model.Context;
 import org.kie.workbench.common.dmn.api.definition.model.ContextEntry;
 import org.kie.workbench.common.dmn.api.definition.model.DMNDiagram;
@@ -209,6 +210,8 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         simpleItemDefinition.setTypeRef(simpleItemDefinitionTypeRef);
         definitions.getItemDefinition().add(simpleItemDefinition);
 
+        mockItemDefinitionConstraint(simpleItemDefinition, "", ConstraintType.NONE);
+
         final QName inputData1TypeRef = new QName(QName.NULL_NS_URI, simpleItemDefinitionName);
         inputData1.getVariable().setTypeRef(inputData1TypeRef);
 
@@ -247,14 +250,18 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final QName complexItemDefinitionPart2TypeRef = new QName(QName.NULL_NS_URI, BuiltInType.BOOLEAN.getName());
         final ItemDefinition complexItemDefinition = new ItemDefinition();
         complexItemDefinition.setName(new Name(complexItemDefinitionName));
-        complexItemDefinition.getItemComponent().add(new ItemDefinition() {{
+        final ItemDefinition part1ItemDefinition = new ItemDefinition() {{
             setName(new Name(complexItemDefinitionPart1Name));
             setTypeRef(complexItemDefinitionPart1TypeRef);
-        }});
-        complexItemDefinition.getItemComponent().add(new ItemDefinition() {{
+        }};
+        final ItemDefinition part2ItemDefinition = new ItemDefinition() {{
             setName(new Name(complexItemDefinitionPart2Name));
             setTypeRef(complexItemDefinitionPart2TypeRef);
-        }});
+        }};
+        mockItemDefinitionConstraint(part1ItemDefinition, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(part2ItemDefinition, "", ConstraintType.NONE);
+        complexItemDefinition.getItemComponent().add(part1ItemDefinition);
+        complexItemDefinition.getItemComponent().add(part2ItemDefinition);
 
         definitions.getItemDefinition().add(complexItemDefinition);
 
@@ -301,18 +308,24 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         final QName parentCustomType = new QName(QName.NULL_NS_URI, tSmurfName);
         final ItemDefinition tSmurfCustomDataType = new ItemDefinition();
         tSmurfCustomDataType.setName(new Name(tSmurfName));
-        tSmurfCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        final ItemDefinition birthDateItemDefinition = new ItemDefinition() {{
             setName(new Name(tDateOfBirthName));
             setTypeRef(dateBuiltInType);
-        }});
-        tSmurfCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        }};
+        final ItemDefinition isBlueItemDefinition = new ItemDefinition() {{
             setName(new Name(tIsBlueName));
             setTypeRef(booleanBuiltInType);
-        }});
-        tSmurfCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        }};
+        final ItemDefinition parentItemDefinition = new ItemDefinition() {{
             setName(new Name(tParentName));
             setTypeRef(parentCustomType);
-        }});
+        }};
+        mockItemDefinitionConstraint(birthDateItemDefinition, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(isBlueItemDefinition, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(parentItemDefinition, "", ConstraintType.NONE);
+        tSmurfCustomDataType.getItemComponent().add(birthDateItemDefinition);
+        tSmurfCustomDataType.getItemComponent().add(isBlueItemDefinition);
+        tSmurfCustomDataType.getItemComponent().add(parentItemDefinition);
 
         definitions.getItemDefinition().add(tSmurfCustomDataType);
 
@@ -360,25 +373,33 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final ItemDefinition tSmurfAddressCustomDataType = new ItemDefinition();
         tSmurfAddressCustomDataType.setName(new Name(tSmurfAddress));
-        tSmurfAddressCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        final ItemDefinition line1ItemDefinition = new ItemDefinition() {{
             setName(new Name("line1"));
             setTypeRef(stringBuiltInType);
-        }});
-        tSmurfAddressCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        }};
+        final ItemDefinition line2ItemDefinition = new ItemDefinition() {{
             setName(new Name("line2"));
             setTypeRef(stringBuiltInType);
-        }});
+        }};
+        mockItemDefinitionConstraint(line1ItemDefinition, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(line2ItemDefinition, "", ConstraintType.NONE);
+        tSmurfAddressCustomDataType.getItemComponent().add(line1ItemDefinition);
+        tSmurfAddressCustomDataType.getItemComponent().add(line2ItemDefinition);
 
         final ItemDefinition tSmurfCustomDataType = new ItemDefinition();
         tSmurfCustomDataType.setName(new Name(tSmurf));
-        tSmurfCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        final ItemDefinition dobItemDefinition = new ItemDefinition() {{
             setName(new Name("dob"));
             setTypeRef(dateBuiltInType);
-        }});
-        tSmurfCustomDataType.getItemComponent().add(new ItemDefinition() {{
+        }};
+        final ItemDefinition addressItemDefinition = new ItemDefinition() {{
             setName(new Name("address"));
             getItemComponent().add(tSmurfAddressCustomDataType);
-        }});
+        }};
+        mockItemDefinitionConstraint(dobItemDefinition, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(addressItemDefinition, "", ConstraintType.NONE);
+        tSmurfCustomDataType.getItemComponent().add(dobItemDefinition);
+        tSmurfCustomDataType.getItemComponent().add(addressItemDefinition);
 
         definitions.getItemDefinition().add(tSmurfCustomDataType);
 
@@ -756,6 +777,9 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(tCompany.getName()).thenReturn(new Name(TYPE_COMPANY));
         when(tCompany.getTypeRef()).thenReturn(null);
         when(tCompany.getItemComponent()).thenReturn(asList(name, tAddress));
+
+        mockItemDefinitionConstraint(name, "", ConstraintType.NONE);
+
         return tCompany;
     }
 
@@ -839,7 +863,16 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
         when(tPerson.getName()).thenReturn(new Name(TYPE_PERSON));
         when(tPerson.getTypeRef()).thenReturn(null);
         when(tPerson.getItemComponent()).thenReturn(asList(name, age));
+
+        mockItemDefinitionConstraint(name, "", ConstraintType.NONE);
+        mockItemDefinitionConstraint(age, "", ConstraintType.NONE);
+
         return tPerson;
+    }
+
+    private void mockItemDefinitionConstraint(final ItemDefinition itemDefinition, final String constraint, final ConstraintType constraintType) {
+        when(itemDefinitionUtils.getConstraintText(itemDefinition)).thenReturn(constraint);
+        when(itemDefinitionUtils.getConstraintType(itemDefinition)).thenReturn(constraintType);
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/types/dtable/DecisionTableEditorDefinitionEnricherTest.java
@@ -814,7 +814,7 @@ public class DecisionTableEditorDefinitionEnricherTest extends BaseDecisionTable
 
         final OutputClause outputClause = outputClauses.get(0);
 
-        assertEquals(DEFAULT_OUTPUT_NAME, outputClause.getName());
+        assertEquals(TYPE_PERSON, outputClause.getName());
         assertEquals(tPersonTypeRef, outputClause.getTypeRef());
     }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/ItemDefinitionUtilsTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/common/ItemDefinitionUtilsTest.java
@@ -24,6 +24,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
 import org.kie.workbench.common.dmn.api.definition.model.Definitions;
 import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
@@ -193,6 +194,20 @@ public class ItemDefinitionUtilsTest {
         final String actualText = utils.getConstraintText(itemDefinition);
 
         assertEquals(expectedText, actualText);
+    }
+
+    @Test
+    public void testGetConstraintType() {
+        final ItemDefinition itemDefinition = mock(ItemDefinition.class);
+        final UnaryTests allowedValues = mock(UnaryTests.class);
+        final ConstraintType expectedConstraintType = ConstraintType.RANGE;
+
+        when(itemDefinition.getAllowedValues()).thenReturn(allowedValues);
+        when(allowedValues.getConstraintType()).thenReturn(expectedConstraintType);
+
+        final ConstraintType actualConstraintType = utils.getConstraintType(itemDefinition);
+
+        assertEquals(expectedConstraintType, actualConstraintType);
     }
 
     private ItemDefinition makeItem(final String itemName) {


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/75

Decision table columns are bound to DMN data types. As some DMN Data types may include a constraint as part of its definition, these constraint should be reflected also in Decsion Table column definition. This PR introduces a feature for first generation of a decision table as an expression of a Decision node. If the Decion Table columns uses DMN data types with constraints, these will be auto defined in column definition.

For more details see: https://issues.redhat.com/browse/DROOLS-4640