### PR TITLE
KOGITO-8398: Fix `vscode-extension` SWF autocompletion test broken by update of VSCode

### DIFF
--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.json.result
@@ -1,7 +1,7 @@
 {
   "id": "Workflow unique identifier",
   "version": "0.1",
-  "specVersion": "0.1",
+  "specVersion": "0.8",
   "name": "Workflow name",
   "description": "Workflow description",
   "start": "StartState",

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/resources/autocompletion/emptyfile_autocompletion.sw.yaml.result
@@ -1,6 +1,6 @@
 id: 'Workflow unique identifier'
 version: '0.1'
-specVersion: '0.1'
+specVersion: '0.8'
 name: 'Workflow name'
 description: 'Workflow description'
 start: 'StartState'


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-8398

This PR fixes the issue caused by different `specVersion` introduced in new version of VSCode. The VSCode update was introduced in #1369, but this was missed.