### PR TITLE
KOGITO-7533: Keyboard navigation though workflow states

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/DefaultViewerSession.java
@@ -27,8 +27,10 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AlertsControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.MediatorsControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.SelectionControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.SingleSelection;
 import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.diagram.Metadata;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.uberfire.mvp.Command;
@@ -60,6 +62,7 @@ public class DefaultViewerSession
                      final Command callback) {
         init(s -> s.registerCanvasControl(MediatorsControl.class)
                      .registerCanvasControl(AlertsControl.class)
+                     .registerCanvasControl(KeyboardControl.class)
                      .registerCanvasHandlerControl(SelectionControl.class,
                                                    SingleSelection.class),
              metadata,
@@ -126,5 +129,10 @@ public class DefaultViewerSession
     @Override
     public SelectionControl<AbstractCanvasHandler, Element> getSelectionControl() {
         return (SelectionControl<AbstractCanvasHandler, Element>) session.getCanvasHandlerControl(SelectionControl.class);
+    }
+
+    @Override
+    public KeyboardControl<AbstractCanvas, ClientSession> getKeyboardControl() {
+        return (KeyboardControl<AbstractCanvas, ClientSession>) session.getCanvasControl(KeyboardControl.class);
     }
 }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ViewerSession.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/impl/ViewerSession.java
@@ -20,6 +20,8 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.AlertsControl;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.MediatorsControl;
+import org.kie.workbench.common.stunner.core.client.canvas.controls.keyboard.KeyboardControl;
+import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 
 public abstract class ViewerSession
         extends AbstractSession<AbstractCanvas, AbstractCanvasHandler> {
@@ -31,4 +33,6 @@ public abstract class ViewerSession
     public abstract MediatorsControl<AbstractCanvas> getMediatorsControl();
 
     public abstract AlertsControl<AbstractCanvas> getAlertsControl();
+
+    public abstract KeyboardControl<AbstractCanvas, ClientSession> getKeyboardControl();
 }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtils.java
@@ -327,6 +327,37 @@ public class GraphUtils {
                 .collect(Collectors.toList());
     }
 
+    private static List<Node> getNodesFromInEdges(final Node<?, ? extends Edge> element, Predicate<Edge> filter) {
+        Objects.requireNonNull(element.getInEdges());
+        return element.getInEdges()
+                .stream()
+                .filter(filter::test)
+                .map(Edge::getSourceNode)
+                .collect(Collectors.toList());
+    }
+
+    public static List<Node> getSourceNodes(final Node<?, ? extends Edge> element) {
+        Objects.requireNonNull(element);
+        return getTargetConnections(element).stream()
+                .map(nodeEdge -> nodeEdge.getSourceNode())
+                .collect(Collectors.toList());
+    }
+
+    public static List<Node> getTargetNodes(final Node<?, ? extends Edge> element) {
+        Objects.requireNonNull(element);
+        return getSourceConnections(element).stream()
+                .map(nodeEdge -> nodeEdge.getTargetNode())
+                .collect(Collectors.toList());
+    }
+
+    public static List<Node> getSiblingNodes(final Node<?, ? extends Edge> element) {
+        Objects.requireNonNull(element);
+        return getSourceNodes(element).stream()
+                .findFirst()
+                .map(parent -> getTargetNodes(parent))
+                .orElse(Collections.emptyList());
+    }
+
     public static List<Edge<? extends ViewConnector<?>, Node>> getSourceConnections(
             final Node<?, ? extends Edge> element) {
         Objects.requireNonNull(element.getOutEdges());

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/ServerlessWorkflowDiagramEditorChannelApiImpl.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/ServerlessWorkflowDiagramEditorChannelApiImpl.ts
@@ -203,7 +203,7 @@ export class ServerlessWorkflowDiagramEditorChannelApiImpl implements Serverless
 
     await vscode.commands.executeCommand("vscode.open", resourceUri, {
       viewColumn: textEditor.viewColumn,
-      preserveFocus: false,
+      preserveFocus: true,
     } as vscode.TextDocumentShowOptions);
 
     const targetRange = new vscode.Range(targetPosition, targetPosition);


### PR DESCRIPTION
**JIRA:** [KOGITO-7533 - Keyboard navigation though workflow states](https://issues.redhat.com/browse/KOGITO-7533)

Node Navigation using arrows is now possible. Use the up, down, left, and right keys to navigate. Left and Right keys navigate through sibling nodes. Up navigates to source nodes and down navigates to target nodes. When using up or down it tries to go through the path it came from in cases where there are multiple targets or sources. In VSCode the text editor still selects the line corresponding to the selected node, but it does not steal the focus from the canvas.

**VS Code Extension:** [Serverless Workflow](https://drive.google.com/file/d/1G2jAAgrmIzfaopnbEvz6YHpU-up3afYW/view?usp=share_link)