### PR TITLE
kie-issues#77: DMN Editor: It is not possible to add constraints to nested data types

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelector.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelector.java
@@ -33,7 +33,7 @@ public class StringSelector extends BaseSelector {
 
     @Override
     public void setValue(final String value) {
-        super.setValue(convertFromString(value));
+        super.setValue(removingDoubleQuote(value));
     }
 
     @Override
@@ -55,7 +55,10 @@ public class StringSelector extends BaseSelector {
         return prefix + value + suffix;
     }
 
-    private String convertFromString(final String value) {
-        return value.substring(1, value.length() - 1);
+    private String removingDoubleQuote(final String value) {
+        if (isEmpty(value)) {
+            return "";
+        }
+        return value.replaceAll("(^\\\")|(\\\"$)", "");
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelector.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelector.java
@@ -33,7 +33,7 @@ public class StringSelector extends BaseSelector {
 
     @Override
     public void setValue(final String value) {
-        super.setValue(removingDoubleQuote(value));
+        super.setValue(removeDoubleQuotesWrapper(value));
     }
 
     @Override
@@ -55,7 +55,7 @@ public class StringSelector extends BaseSelector {
         return prefix + value + suffix;
     }
 
-    private String removingDoubleQuote(final String value) {
+    private String removeDoubleQuotesWrapper(final String value) {
         if (isEmpty(value)) {
             return "";
         }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelectorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelectorTest.java
@@ -65,6 +65,12 @@ public class StringSelectorTest {
     }
 
     @Test
+    public void testSetValueWithMultipleDoubleQuote() {
+        stringSelector.setValue("\"\"value\"\"");
+        verify(view).setValue("\"value\"");
+    }
+
+    @Test
     public void testGetValueWithRawValue() {
 
         when(view.getValue()).thenReturn("value");

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelectorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/string/StringSelectorTest.java
@@ -47,6 +47,24 @@ public class StringSelectorTest {
     }
 
     @Test
+    public void testSetEmptyValue() {
+        stringSelector.setValue("");
+        verify(view).setValue("");
+    }
+
+    @Test
+    public void testSetNullValue() {
+        stringSelector.setValue(null);
+        verify(view).setValue("");
+    }
+
+    @Test
+    public void testSetValueWithIntermediateDoubleQuote() {
+        stringSelector.setValue("\"va\"lue\"");
+        verify(view).setValue("va\"lue");
+    }
+
+    @Test
     public void testGetValueWithRawValue() {
 
         when(view.getValue()).thenReturn("value");


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/77

This regression is a consequence of GWT 2.10 update: https://github.com/kiegroup/kie-tools/pull/1330.
As I mentioned:
This commit https://github.com/gwtproject/gwt/commit/657ae98c5d8bb20b67639d3175cf843e86ce3cda in GWT repo, fixed the String#substring emulation behavior.
Therefore, `substring` usage can potentially throw an exception in case of bad conditions.
In this case, the `substring` method throws an exception when the given string is empty. 

All `substring` usage can lead to this behavior, thus we need to pay great attention to that.

