### PR TITLE
bump `xstream` to version `1.4.20`

### DIFF
--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -269,7 +269,7 @@
     <version.com.google.guava>30.1-jre</version.com.google.guava>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
-    <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
     <version.enforce-managed-deps-rule>1.3</version.enforce-managed-deps-rule>
     <version.enfore-victims-rule>1.3.4</version.enfore-victims-rule>
     <version.illegal-transitive-dependency-check>1.7.4</version.illegal-transitive-dependency-check>


### PR DESCRIPTION
This maintenance release addresses the security vulnerabilities [CVE-2022-40151](https://x-stream.github.io/CVE-2022-40151.html) and [CVE-2022-41966](https://x-stream.github.io/CVE-2022-41966.html)