### PR TITLE
kie-tools#1273: Remove hardcoded children count for data tyle list view

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemView.java
@@ -184,10 +184,11 @@ public class DataTypeListItemView implements DataTypeListItem.View,
         final AtomicInteger i = new AtomicInteger(1);
 
         asDownArrow(getArrow());
+        final int childrenCount = getChildren(parent).length;
         forEachChildElement(parent, child -> {
 
             show(child);
-            double positionY = parentPositionY + (i.getAndIncrement() / 10.0);
+            double positionY = parentPositionY + (i.getAndIncrement() / (childrenCount + 1.0));
             presenter.setPositionY(child, positionY);
 
             return !isCollapsed(child.querySelector(ARROW_BUTTON_SELECTOR));

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
@@ -58,6 +58,7 @@ import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConsta
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DataTypeListItemView_Remove;
 import static org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants.DataTypeListItemView_Save;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.doubleThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -681,6 +682,11 @@ public class DataTypeListItemViewTest {
         verify(arrowClassList).remove(RIGHT_ARROW_CSS_CLASS);
         verify(child1.classList).remove(HIDDEN_CSS_CLASS);
         verify(child2.classList).remove(HIDDEN_CSS_CLASS);
+        // item 0 - yPosition: 0
+        // item 1 - yPosition: 1
+        // child1 and child2 yPosition need to be greater than 0 and less than 1
+        verify(presenter).setPositionY(eq(child1), doubleThat(d -> d > 0.3));
+        verify(presenter).setPositionY(eq(child2), doubleThat(d -> d > 0.6));
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/DataTypeListItemViewTest.java
@@ -685,8 +685,8 @@ public class DataTypeListItemViewTest {
         // item 0 - yPosition: 0
         // item 1 - yPosition: 1
         // child1 and child2 yPosition need to be greater than 0 and less than 1
-        verify(presenter).setPositionY(eq(child1), doubleThat(d -> d > 0.3));
-        verify(presenter).setPositionY(eq(child2), doubleThat(d -> d > 0.6));
+        verify(presenter).setPositionY(eq(child1), doubleThat(d -> d > 0.3 && d < 0.6));
+        verify(presenter).setPositionY(eq(child2), doubleThat(d -> d > 0.6 && d < 1.0));
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-tools/issues/1273

The mechanism for expanding a DMN data type didn't take into account scenarios with more than 10 Fields of a Structure