### PR TITLE
KOGITO-7962: Configure integration tests of vscode-extensions to run tests twice in case of fails

### DIFF
--- a/packages/vscode-extension-serverless-workflow-editor/.mocharc.json
+++ b/packages/vscode-extension-serverless-workflow-editor/.mocharc.json
@@ -2,5 +2,6 @@
   "reporter": "mocha-multi-reporters",
   "reporterOptions": {
     "configFile": "./mocha-reporter-config.json"
-  }
+  },
+  "retries": 1
 }

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/helpers/VSCodeTestHelper.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/helpers/VSCodeTestHelper.ts
@@ -170,7 +170,7 @@ export default class VSCodeTestHelper {
     }
 
     const menu = await fileItem?.openContextMenu();
-    await menu?.select("Rename");
+    await menu?.select("Rename...");
 
     const inputElement = await this.workspaceSectionView.findElement(By.xpath('.//input[@type="text"]'));
     await inputElement.sendKeys(Key.chord(Key.CONTROL, "a"));

--- a/packages/vscode-extension-yard-editor/.mocharc.json
+++ b/packages/vscode-extension-yard-editor/.mocharc.json
@@ -2,5 +2,6 @@
   "reporter": "mocha-multi-reporters",
   "reporterOptions": {
     "configFile": "./mocha-reporter-config.json"
-  }
+  },
+  "retries": 1
 }


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-7962

Apart from the main purpose described in Jira, this PR incorporates a fix of a currently skipped test - this test is still affected by a [bug](https://issues.redhat.com/browse/KOGITO-8384) that prevents the test from unskipping, but once the bug is solved, the test would be failing without this fix.