### PR TITLE
kie-issues#70: Loading Unsaved asset in VS Code leads to an empty file

### DIFF
--- a/packages/vscode-extension/src/VsCodeKieEditorsCustomEditorProvider.ts
+++ b/packages/vscode-extension/src/VsCodeKieEditorsCustomEditorProvider.ts
@@ -113,6 +113,6 @@ export class VsCodeKieEditorsCustomEditorProvider implements CustomEditorProvide
   }
 
   private resolveBackupUri(backupId: string | undefined): Uri | undefined {
-    return backupId ? Uri.parse(backupId) : undefined;
+    return backupId ? Uri.file(backupId) : undefined;
   }
 }


### PR DESCRIPTION
**Issue 70 - Loading Unsaved asset in VSCode leads to an empty file**

In Windows, an invalid URI is created if the backup string is solved using Uri.parse(). This method should only be used to solve stringified URIs, which is not the case here. The backupId is a file path, so Uri.file() is the correct method. This error only happens in windows because of its file system. Unix file system-based OSs are not affected by this.

**VSCode Extension:** [vscode_extension_kogito_kie_editors_0.0.0.vsix](https://drive.google.com/file/d/1lCmgOiYzgqSyxlcmaG4Th8wuPmdtytIh/view?usp=sharing)

Closes https://github.com/kiegroup/kie-issues/issues/70