### PR TITLE
Bump `tycho` to `2.7.5` version in VSCode Java Code Completion Extension Plugin 

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.5.0</tycho.version>
+    <tycho.version>2.7.5</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
@@ -40,7 +40,7 @@
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
     <!-- Code coverage -->
-    <jacoco.version>0.7.9</jacoco.version>
+    <jacoco.version>0.8.5</jacoco.version>
     <coverage.filter>org.eclipse.jdt.ls.*</coverage.filter>
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>


### PR DESCRIPTION
Updating `tycho` to `2.7.5` version, which is the last supported version for JDK 11. Newer versions (3.0.0+) require JDK 17.
The reason for that is just to keep the component more stable, relying on an updated `tycho` version. 

Updated `jacoco` as well, just to keep it aligned with `stunner-editors`

This change impacts the Java Code Completion Extension component only.