### PR TITLE
kie-issues#41: DMN\BMPN Editors: The file is kept "dirty" after undoing one copy/paste operation

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
@@ -36,7 +36,6 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
-import org.appformer.client.stateControl.registry.Registry;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.kie.workbench.common.stunner.core.client.api.SessionManager;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
@@ -53,7 +52,6 @@ import org.kie.workbench.common.stunner.core.client.event.keyboard.KeyboardEvent
 import org.kie.workbench.common.stunner.core.client.session.ClientSession;
 import org.kie.workbench.common.stunner.core.client.session.command.AbstractClientSessionCommand;
 import org.kie.workbench.common.stunner.core.client.session.impl.EditorSession;
-import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.command.impl.CompositeCommand;
 import org.kie.workbench.common.stunner.core.command.impl.ReverseCommand;
@@ -207,6 +205,7 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<E
     }
 
     private CommandResult<CanvasViolation> executeCommands(CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation> commandBuilder, Counter processedNodesCountdown) {
+        sessionCommandManager.start();
         CommandResult<CanvasViolation> nodesResult = sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
 
         if (CommandUtils.isError(nodesResult)) {
@@ -215,11 +214,8 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<E
 
         // Processing connectors: after all nodes has been cloned (this is necessary because we need the cloned nodes UUIDs to than clone the Connectors
         CommandResult<CanvasViolation> connectorsResult = processConnectors(processedNodesCountdown);
+        sessionCommandManager.complete();
 
-        //After nodes and connectors command execution than it is necessary to update the command registry (to allow a single undo/redo)
-        if (!CommandUtils.isError(connectorsResult)) {
-            updateCommandsRegistry();
-        }
         return new CanvasCommandResultBuilder()
                 .setType(nodesResult.getType())
                 .addViolations((Objects.nonNull(nodesResult.getViolations()) ?
@@ -229,17 +225,6 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<E
                         StreamSupport.stream(connectorsResult.getViolations().spliterator(), false).collect(Collectors.toList()) :
                         Collections.emptyList()))
                 .build();
-    }
-
-    private void updateCommandsRegistry() {
-        final Registry<Command<AbstractCanvasHandler, CanvasViolation>> commandRegistry = getSession().getCommandRegistry();
-        Command<AbstractCanvasHandler, CanvasViolation> connectorsExecutedCommand = commandRegistry.pop();
-        Command<AbstractCanvasHandler, CanvasViolation> nodesExecutedCommand = commandRegistry.pop();
-        commandRegistry.register(new CompositeCommand.Builder<AbstractCanvasHandler, CanvasViolation>()
-                                         .addCommand(nodesExecutedCommand)
-                                         .addCommand(connectorsExecutedCommand)
-                                         .reverse()
-                                         .build());
     }
 
     private CommandResult<CanvasViolation> processConnectors(Counter processedNodesCountdown) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/PasteSelectionSessionCommand.java
@@ -209,11 +209,17 @@ public class PasteSelectionSessionCommand extends AbstractClientSessionCommand<E
         CommandResult<CanvasViolation> nodesResult = sessionCommandManager.execute(getCanvasHandler(), commandBuilder.build());
 
         if (CommandUtils.isError(nodesResult)) {
+            sessionCommandManager.rollback();
+            sessionCommandManager.complete();
             return nodesResult;
         }
 
         // Processing connectors: after all nodes has been cloned (this is necessary because we need the cloned nodes UUIDs to than clone the Connectors
         CommandResult<CanvasViolation> connectorsResult = processConnectors(processedNodesCountdown);
+        if (CommandUtils.isError(connectorsResult)) {
+            sessionCommandManager.rollback();
+        }
+
         sessionCommandManager.complete();
 
         return new CanvasCommandResultBuilder()


### PR DESCRIPTION
This PR closes: https://github.com/kiegroup/kie-issues/issues/41

Editor operations are implemented as commands, that are stored in a registry to have an option of undo an redo. The situation is quite complicated for complex operations, that are internally implemented as multiple commands, but for the end user is visible as single operation. For such, we must compose multiple commands into single one. In copy and paste scenario, we must go one level further and compose two already composed commands into single command.