### PR TITLE
kie-issues#36 Run the validation for bpmn2 file extension

### DIFF
--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -288,6 +288,7 @@ export function EditorPage(props: Props) {
     if (
       workspaceFilePromise.data?.workspaceFile.extension === "dmn" ||
       workspaceFilePromise.data?.workspaceFile.extension === "bpmn" ||
+      workspaceFilePromise.data?.workspaceFile.extension === "bpmn2" ||
       !workspaceFilePromise.data ||
       !editor?.isReady
     ) {

--- a/packages/online-editor/src/editor/EditorPageDockDrawer.tsx
+++ b/packages/online-editor/src/editor/EditorPageDockDrawer.tsx
@@ -127,7 +127,8 @@ export const EditorPageDockDrawer = React.forwardRef<
   const notificationsPanelIsDisabled = useMemo(() => {
     return (
       (props.workspaceFile.extension.toLowerCase() === "dmn" ||
-        props.workspaceFile.extension.toLowerCase() === "bpmn") &&
+        props.workspaceFile.extension.toLowerCase() === "bpmn" ||
+        props.workspaceFile.extension.toLowerCase() === "bpmn2") &&
       extendedServices.status !== KieSandboxExtendedServicesStatus.RUNNING
     );
   }, [extendedServices.status, props.workspaceFile.extension]);
@@ -135,7 +136,8 @@ export const EditorPageDockDrawer = React.forwardRef<
   const notificationsPanelDisabledReason = useMemo(() => {
     if (
       (props.workspaceFile.extension.toLowerCase() === "dmn" ||
-        props.workspaceFile.extension.toLowerCase() === "bpmn") &&
+        props.workspaceFile.extension.toLowerCase() === "bpmn" ||
+        props.workspaceFile.extension.toLowerCase() === "bpmn2") &&
       extendedServices.status !== KieSandboxExtendedServicesStatus.RUNNING
     ) {
       return "In order to have access to Problems tab you need to use the KIE Sandbox Extended Services";

--- a/packages/online-editor/src/editor/Validation.tsx
+++ b/packages/online-editor/src/editor/Validation.tsx
@@ -21,6 +21,7 @@ export function useFileValidation(
     }
     if (
       workspaceFile.extension.toLocaleLowerCase() !== "bpmn" &&
+      workspaceFile.extension.toLocaleLowerCase() !== "bpmn2" &&
       workspaceFile.extension.toLocaleLowerCase() !== "dmn"
     ) {
       return;
@@ -44,7 +45,7 @@ export function useFileValidation(
           ],
         };
 
-        if (workspaceFile.extension.toLowerCase() === "bpmn") {
+        if (workspaceFile.extension.toLowerCase() === "bpmn" || workspaceFile.extension.toLowerCase() === "bpmn2") {
           extendedServices.client.validateBpmn(payload).then((validationResults) => {
             const notifications: Notification[] = validationResults.map((validationResult: any) => ({
               type: "PROBLEM",


### PR DESCRIPTION
This is a small addition to #1409 to run validation as for **bpmn** so for **bpmn2** files.

Please notice that the **bpmn2** is used for historical reasons also a lot in kiegroup/kogito-examples