### PR TITLE
kie-issues#95-2: Removing all DMN  `testing` module references

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                     if (isNormalPRCheck() && isSonarCloudEnabled()) {
                         mvnCmd.withProfiles(['run-code-coverage'])
                     }
-                    mvnCmd.withOptions(["-pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing,!lienzo-webapp'"])
+                    mvnCmd.withOptions(["-pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!lienzo-webapp'"])
                     mvnCmd.withProperty('revision', '0.0.0')
                     mvnCmd.run('clean install')
                 }
@@ -59,7 +59,7 @@ pipeline {
                 script {
                     if (isSonarCloudEnabled()) {
                         getMavenCommand('kie-tools/packages/stunner-editors')
-                                .withOptions(['-Drevision=0.0.0', '-e', '-nsu', "-pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing,!lienzo-webapp'"])
+                                .withOptions(['-Drevision=0.0.0', '-e', '-nsu', "-pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!lienzo-webapp'"])
                                 .withProperty('sonar.projectKey', 'org.kie.kogito:kogito-tooling')
                                 .withProperty('sonar.organization', 'kiegroup')
                                 .withProperty('sonar.host.url', 'https://sonarcloud.io')

--- a/.github/workflows/ci_sonar_analysis_stunner_editors.yml
+++ b/.github/workflows/ci_sonar_analysis_stunner_editors.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pnpm -F @kie-tools/stunner-editors^... build:dev
           cd packages/stunner-editors
-          mvn clean install --fail-at-end -Prun-code-coverage -pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing,!lienzo-webapp'
+          mvn clean install --fail-at-end -Prun-code-coverage -pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!lienzo-webapp'
 
       - name: "Analyze with Sonar"
         env:
@@ -47,4 +47,4 @@ jobs:
           SONARCLOUD_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd packages/stunner-editors
-          mvn -B validate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=org.kie.kogito:kogito-tooling -Dsonar.organization=kiegroup -Dsonar.host.url=https://sonarcloud.io -DskipTests -Dgwt.compiler.skip -Dsonar.login=${{ env.SONARCLOUD_TOKEN }} -pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing,!lienzo-webapp'
+          mvn -B validate org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=org.kie.kogito:kogito-tooling -Dsonar.organization=kiegroup -Dsonar.host.url=https://sonarcloud.io -DskipTests -Dgwt.compiler.skip -Dsonar.login=${{ env.SONARCLOUD_TOKEN }} -pl '!kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime,!lienzo-webapp'

--- a/.gitignore
+++ b/.gitignore
@@ -106,16 +106,6 @@ packages/stunner-editors/**/.netlify
 packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-marshaller/src/main/java/org/
 packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-marshaller/src/main/resources/org/drools/workbench/scenariosimulation/kogito/marshaller/js/SCESIM.js
 packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-marshaller/src/main/resources/org/drools/workbench/scenariosimulation/kogito/marshaller/js/Jsonix-all.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/org.kie.workbench.common.dmn.showcase.DMNKogitoTestingWebapp/
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/DC.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/DI.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/DMN12.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/DMNDI12.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/KIE.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/Jsonix-all.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/MainJs.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/model/FormatterJs.js
-packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing/src/main/webapp/kogito-editors-js
 packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/webapp/kogito-editors-js
 packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/webapp/org.kie.workbench.common.dmn.showcase.DMNKogitoRuntimeWebapp/
 packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/webapp/model/DC.js

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ After that, you're ready to start developing the Editors individually.
 
 - DMN
 
-  - Located at `packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-testing`.
+  - Located at `packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime`.
   - Run `mvn clean gwt:run` to start.
   - If you want to enable live-reloading capabilities of the React components that are part of the DMN Editor, follow [these steps](./packages/stunner-editors/docs/live-reload-dmn-loader.md).
 


### PR DESCRIPTION
After merging https://github.com/kiegroup/kie-tools/pull/1425, Sonar is failing because still has references to the removed `testing` module. 
This PR aim is to remove all references to `testing` module from the project (CD/CI, Readme, git ignore)