### PR TITLE
NO-ISSUE: Revert git-cors-proxy-image port to 8080

### DIFF
--- a/packages/git-cors-proxy-image/Containerfile
+++ b/packages/git-cors-proxy-image/Containerfile
@@ -24,6 +24,6 @@ RUN mkdir /kie-sandbox \
   && chmod -R g=u /kie-sandbox \
   && npm install --production --silent --prefix /kie-sandbox/git-cors-proxy
 
-EXPOSE 3000
+EXPOSE 8080
 
-CMD [ "/kie-sandbox/git-cors-proxy/bin.js", "start", "-p", "3000" ]
+CMD [ "/kie-sandbox/git-cors-proxy/bin.js", "start", "-p", "8080" ]

--- a/packages/git-cors-proxy-image/README.md
+++ b/packages/git-cors-proxy-image/README.md
@@ -42,7 +42,7 @@ $ podman images
 Start up a new container with:
 
 ```bash
-$ podman run -p 3000:3000 -i --rm quay.io/kie-tools/cors-proxy-image:latest
+$ podman run -p 8080:8080 -i --rm quay.io/kie-tools/cors-proxy-image:latest
 ```
 
-The service will be up at http://localhost:3000
+The service will be up at http://localhost:8080

--- a/packages/git-cors-proxy-image/env/index.js
+++ b/packages/git-cors-proxy-image/env/index.js
@@ -45,7 +45,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
           buildTags: getOrDefault(this.vars.GIT_CORS_PROXY__imageBuildTags),
         },
         dev: {
-          port: 3000,
+          port: 8080,
         },
       },
     };

--- a/packages/git-cors-proxy-image/package.json
+++ b/packages/git-cors-proxy-image/package.json
@@ -26,7 +26,7 @@
     "copy:git-cors-proxy-package:win32": "echo \"Copy git-cors-proxy package not supported on Windows\"",
     "postinstall": "patch-package",
     "podman:build": "run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build $(echo $(build-env gitCorsProxy.image.buildTags) | xargs printf -- \"-t $(build-env gitCorsProxy.image.registry)/$(build-env gitCorsProxy.image.account)/$(build-env gitCorsProxy.image.name):%s\n\" | xargs echo) -f Containerfile\" --else \"echo Podman not found, skipping image build.\"",
-    "start": "cd ./node_modules/@isomorphic-git/cors-proxy && pnpm start"
+    "start": "cd ./node_modules/@isomorphic-git/cors-proxy && pnpm start -p 8080"
   },
   "devDependencies": {
     "@isomorphic-git/cors-proxy": "^2.7.1",


### PR DESCRIPTION
#1418 changes the default `git-cors-proxy-image` port to 3000, matching it to the `isomorphic-git` default port, but that didn't reflect when published on our cluster.
This PR reverts this change and adds a `-p 8080` to the `start` script on the `git-cors-proxy-image` package, making it work without any hassle for the KIE Sandbox and Serverless Logic Web Tools applications.