### PR TITLE
kie-issues#98: Fix create repository modal for GitHub

### DIFF
--- a/packages/online-editor/src/editor/CreateGistOrSnippetModal.tsx
+++ b/packages/online-editor/src/editor/CreateGistOrSnippetModal.tsx
@@ -42,7 +42,7 @@ import {
 import { useAuthProvider } from "../authProviders/AuthProvidersContext";
 import { switchExpression } from "../switchExpression/switchExpression";
 import { useOnlineI18n } from "../i18n";
-import { LoadOrganizationsSelect } from "./LoadOrganizationsSelect";
+import { LoadOrganizationsSelect, SelectOptionObjectType } from "./LoadOrganizationsSelect";
 
 export interface CreateGistOrSnippetResponse {
   cloneUrl: string;
@@ -65,7 +65,7 @@ export const CreateGistOrSnippetModal = (props: {
   const [isPrivate, setPrivate] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
   const { i18n } = useOnlineI18n();
-  const [selectedOrganization, setSelectedOrganization] = useState<string>();
+  const [selectedOrganization, setSelectedOrganization] = useState<SelectOptionObjectType>();
   const [isGistOrSnippetLoading, setGistOrSnippetLoading] = useState(false);
 
   const createGitHubGist: () => Promise<CreateGistOrSnippetResponse> = useCallback(async () => {
@@ -93,11 +93,11 @@ If you are, it means that creating this Gist failed and it can safely be deleted
   }, [gitHubClient.gists, isPrivate, props.workspace.name]);
 
   const createBitbucketSnippet: () => Promise<CreateGistOrSnippetResponse> = useCallback(async () => {
-    if (!selectedOrganization) {
+    if (selectedOrganization?.kind !== "organization") {
       throw new Error("No workspace was selected for Bitbucket Snippet.");
     }
     const response = await bitbucketClient.createSnippet({
-      workspace: selectedOrganization,
+      workspace: selectedOrganization.value,
       title: props.workspace.name ?? "KIE Sandbox Snippet",
       files: {
         "README.md": {


### PR DESCRIPTION
Fixes kiegroup/kie-issues#98

Fixing bug which prevented users to create GitHub repository in their userspace, due to incorrect condition in the Modal which was not accounting for the fact that the selected option is always set - it has a default.
The modal tried to use organization-specific API call even in case when it should have used the authenticated user related end point.

The solution does expose the "kind" information of the selected option from LoadOrganizationsSelect component to the parent component (using onSelect function). Parent component then decides on the selectedOption's `kind` property if the selected value is actually a user or an organization and is able to call correct API endpoint.