### PR TITLE
kie-issues#39: BPMN Editor: SuperDev mode doesn't work

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationList.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/customproperties/AssociationList.java
@@ -19,11 +19,9 @@ package org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customp
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.kie.workbench.common.stunner.core.util.StringUtils;
 import org.uberfire.commons.UUID;
 
 import static java.util.stream.Collectors.toList;
@@ -60,14 +58,17 @@ public class AssociationList {
     }
 
     public static AssociationList fromString(String encoded) {
-        return Optional.ofNullable(encoded)
-                .filter(StringUtils::nonEmpty)
-                .map(s -> new AssociationList(
-                        Arrays.stream(s.replaceAll(REGEX_DELIMITER, REPLACE_DELIMITER_AVOID_CONFLICTS)
-                                              .split(REPLACED_DELIMITER))
-                                .map(AssociationDeclaration::fromString)
-                                .collect(toList())))
-                .orElse(new AssociationList());
+        // The change below is to fix SDM issue on Mac OS
+        if (encoded == null || encoded.isEmpty()) {
+            return new AssociationList();
+        } else {
+            return new AssociationList(
+                    Arrays.stream(encoded.replaceAll(REGEX_DELIMITER, REPLACE_DELIMITER_AVOID_CONFLICTS)
+                                    .split(REPLACED_DELIMITER))
+                            .map(AssociationDeclaration::fromString)
+                            .collect(toList()));
+
+        }
     }
 
     public List<AssociationDeclaration> getInputs() {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/ProcessConverterDelegate.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/ProcessConverterDelegate.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.gwt.core.client.GWT;
+import elemental2.dom.DomGlobal;
 import org.eclipse.bpmn2.BaseElement;
 import org.eclipse.bpmn2.FlowElement;
 import org.eclipse.bpmn2.Lane;
@@ -115,28 +115,28 @@ final class ProcessConverterDelegate {
     }
 
     private Result<Map<String, BpmnNode>> convertFlowElements(List<FlowElement> flowElements) {
-        final List<Result<BpmnNode>> results = new ArrayList<Result<BpmnNode>>();
-        final Map<String, BpmnNode> resultMap = new HashMap<String, BpmnNode>();
+        final List<Result<BpmnNode>> results = new ArrayList<>();
+        final Map<String, BpmnNode> resultMap = new HashMap<>();
         for (FlowElement element : flowElements) {
             try {
-                GWT.log("Converting  " + element);
+                DomGlobal.console.log("Converting  " + element);
                 Result<BpmnNode> result = converterFactory.flowElementConverter().convertNode(element);
                 results.add(result);
-                GWT.log("Mapping  " + result);
+                DomGlobal.console.log("Mapping  " + result);
                 if (result.value() != null) {
                     BpmnNode n = result.value();
                     resultMap.put(n.value().getUUID(), n);
                 }
             } catch (Throwable t) {
-                GWT.log("Failed to convert/map " + element, t);
+                DomGlobal.console.log("Failed to convert/map " + element, t);
             }
         }
         Result toReturn = null;
         try {
-            GWT.log("Composing result");
+            DomGlobal.console.log("Composing result");
             toReturn = ResultComposer.composeResults(resultMap, results);
         }  catch (Throwable t) {
-            GWT.log("Failed to compose result ", t);
+            DomGlobal.console.log("Failed to compose result ", t);
         }
         return toReturn;
     }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/ProcessConverterDelegate.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/ProcessConverterDelegate.java
@@ -119,28 +119,33 @@ final class ProcessConverterDelegate {
         final Map<String, BpmnNode> resultMap = new HashMap<>();
         for (FlowElement element : flowElements) {
             try {
-                DomGlobal.console.log("Converting  " + element);
+                logMessage("Converting  " + element);
                 Result<BpmnNode> result = converterFactory.flowElementConverter().convertNode(element);
                 results.add(result);
-                DomGlobal.console.log("Mapping  " + result);
+                logMessage("Mapping  " + result);
                 if (result.value() != null) {
                     BpmnNode n = result.value();
                     resultMap.put(n.value().getUUID(), n);
                 }
             } catch (Throwable t) {
-                DomGlobal.console.log("Failed to convert/map " + element, t);
+                logMessage("Failed to convert/map " + element + t);
             }
         }
         Result toReturn = null;
         try {
-            DomGlobal.console.log("Composing result");
+            logMessage("Composing result");
             toReturn = ResultComposer.composeResults(resultMap, results);
         }  catch (Throwable t) {
-            DomGlobal.console.log("Failed to compose result ", t);
+            logMessage("Failed to compose result " + t);
         }
         return toReturn;
     }
 
+    private void logMessage(String message) {
+        if (DomGlobal.console != null) { //Safe for Unit Test
+            DomGlobal.console.log(message);
+        }
+    }
     private Result<BpmnNode>[] convertLane(Lane lane, List<Lane> parents, Map<String, BpmnNode> freeFloatingNodes, BpmnNode firstDiagramNode) {
         if (lane.getChildLaneSet() != null) {
             parents.add(lane);


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/39

Hi @yesamer @gitgabrio @Josephblt can you review this PR? To test the changes make sure you build kie-wb-common-stunner first as I have had issues with Hot Reload before on these changes. I have tested the changes on Linux, Windows (Thanks Wagner) and Mac OS and it works, tested it with different diagrams and also tested the issue on DMN which does not seem to have any errors. The problem seems to be an internal Runtime GWT Bug, on the issue that is present on Windows and Linux is a Javascript ClassCastException when going through the SequenceFlowImpl, on the Mac issue there seems to be an issue when processing the stream code, it is only present in Super Dev Mode and it does not happen on production build. Thanks, let me know