### PR TITLE
DROOLS-7330: Moving DMN FEEL autocomplete modules in `kie-tools`

### DIFF
--- a/packages/stunner-editors/kie-wb-common-bom/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-bom/pom.xml
@@ -85,6 +85,32 @@
 
       <dependency>
         <groupId>org.kie.kogito.stunner.editors</groupId>
+        <artifactId>kie-dmn-feel-gwt</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito.stunner.editors</groupId>
+        <artifactId>kie-dmn-feel-gwt</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito.stunner.editors</groupId>
+        <artifactId>kie-dmn-feel-gwt-functions</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito.stunner.editors</groupId>
+        <artifactId>kie-dmn-feel-gwt-functions</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito.stunner.editors</groupId>
         <artifactId>kie-wb-common-dmn-api</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.kie.kogito.stunner.editors</groupId>
+    <artifactId>kie-wb-common-dmn</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>kie-dmn-feel-gwt-functions</artifactId>
+
+  <name>Kie Workbench - Common - DMN - FEEL DMN GWT FUNCTIONS</name>
+
+  <properties>
+    <surefire.forkCount>2</surefire.forkCount>
+    <enforcer.skip>true</enforcer.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-feel</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-user</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${basedir}/target/classes/</additionalClasspathElement>
+            <additionalClasspathElement>${basedir}/src/main/java/</additionalClasspathElement>
+            <additionalClasspathElement>${basedir}/src/test/java/</additionalClasspathElement>
+          </additionalClasspathElements>
+
+          <useManifestOnlyJar>false</useManifestOnlyJar>
+          <forkMode>pertest</forkMode>
+
+          <argLine>-Xmx1500m -Derrai.devel.nocache=true -Derrai.codegen.permissive=false -Derrai.dynamic_validation.enabled=true</argLine>
+
+          <systemProperties>
+            <property>
+              <name>errai.hosted_mode_testing</name>
+              <value>true</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionDefinition.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionDefinition.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class FunctionDefinition {
+
+    private final String name;
+    private final Set<FunctionOverrideVariation> variations;
+
+    public FunctionDefinition(final String name,
+                              final FunctionOverrideVariation... variations) {
+        this.name = name;
+        this.variations = new HashSet<>(Arrays.asList(variations));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<FunctionOverrideVariation> getVariations() {
+        return Collections.unmodifiableSet(variations);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionDefinitionStrings.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionDefinitionStrings.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+public class FunctionDefinitionStrings {
+
+    private final String humanReadable;
+    private final String template;
+
+    public FunctionDefinitionStrings(final String humanReadable,
+                                     final String template) {
+        this.humanReadable = humanReadable;
+        this.template = template;
+    }
+
+    public String getHumanReadable() {
+        return humanReadable;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariation.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.kie.dmn.feel.lang.Type;
+
+public class FunctionOverrideVariation implements HumanReadable {
+
+    private final Type returnType;
+    private String functionName;
+    private final Set<Parameter> parameters;
+
+    public FunctionOverrideVariation(final Type returnType,
+                                     final String functionName,
+                                     final Parameter... parameters) {
+        this.returnType = returnType;
+        this.functionName = functionName;
+        this.parameters = new HashSet<>(Arrays.asList(parameters));
+    }
+
+    public Type getReturnType() {
+        return returnType;
+    }
+
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    public Set<Parameter> getParameters() {
+        return Collections.unmodifiableSet(parameters);
+    }
+
+    @Override
+    public String toHumanReadableString() {
+        return parameters.stream().map(Parameter::toHumanReadableString).collect(Collectors.joining(", "));
+    }
+
+    public FunctionDefinitionStrings toHumanReadableStrings() {
+
+        final StringBuilder humanReadableBuilder = new StringBuilder();
+        final StringBuilder templateBuilder = new StringBuilder();
+
+        humanReadableBuilder.append(functionName);
+        templateBuilder.append(functionName);
+        humanReadableBuilder.append("(");
+        templateBuilder.append("(");
+        humanReadableBuilder.append(toHumanReadableString());
+
+        templateBuilder.append(IntStream.rangeClosed(1, getParameters().size())
+                                       .mapToObj(i -> "$" + i)
+                                       .collect(Collectors.joining(", ")));
+
+        humanReadableBuilder.append(")");
+        templateBuilder.append(")");
+
+        return new FunctionDefinitionStrings(humanReadableBuilder.toString(),
+                                             templateBuilder.toString());
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/HumanReadable.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/HumanReadable.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+public interface HumanReadable {
+
+    String toHumanReadableString();
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/Parameter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/Parameter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+import org.kie.dmn.feel.lang.types.BuiltInType;
+
+public class Parameter implements HumanReadable {
+
+    private final String name;
+    private final BuiltInType type;
+
+    public Parameter(final String name,
+                     final BuiltInType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public BuiltInType getType() {
+        return type;
+    }
+
+    @Override
+    public String toHumanReadableString() {
+        return type.getName();
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/Type.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/api/Type.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+/**
+ * FEEL DMN GWT functions type enum
+ *
+ * These types are used by the GWT-friendly/generated function instances.
+ */
+public enum Type {
+    NUMBER("number"),
+    PERIOD("Period"),
+    DURATION("Duration"),
+    COMPARABLE("Comparable"),
+    BOOLEAN("boolean"),
+    RANGE("Range");
+
+    private String name;
+
+    Type(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/client/FEELFunctionProvider.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/client/FEELFunctionProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.client;
+
+import java.util.List;
+
+import org.kie.dmn.feel.gwt.functions.api.FunctionOverrideVariation;
+
+public interface FEELFunctionProvider {
+
+    public List<FunctionOverrideVariation> getDefinitions();
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreator.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
+import com.google.gwt.user.rebind.SourceWriter;
+import org.kie.dmn.feel.gwt.functions.api.FunctionDefinition;
+import org.kie.dmn.feel.gwt.functions.api.FunctionOverrideVariation;
+import org.kie.dmn.feel.gwt.functions.api.Parameter;
+import org.kie.dmn.feel.gwt.functions.api.Type;
+import org.kie.dmn.feel.gwt.functions.client.FEELFunctionProvider;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+
+class FileCreator {
+
+    public static final String GENERATED_CLASS_FQCN = FEELFunctionProvider.class.getSimpleName() + "Impl";
+
+    public static final String PACKAGE_NAME = FEELFunctionProvider.class.getPackage().getName();
+
+    private final TreeLogger logger;
+
+    private final GeneratorContext context;
+
+    public FileCreator(final GeneratorContext context,
+                       final TreeLogger logger) {
+        this.logger = logger;
+        this.context = context;
+    }
+
+    private Optional<SourceWriter> getSourceWriter(final GeneratorContext context,
+                                                   final TreeLogger logger) {
+
+        final ClassSourceFileComposerFactory composerFactory = getClassSourceFileComposerFactory();
+        final Optional<PrintWriter> printWriter = Optional.ofNullable(context.tryCreate(logger, PACKAGE_NAME, GENERATED_CLASS_FQCN));
+
+        return printWriter.map(pw -> composerFactory.createSourceWriter(context, pw));
+    }
+
+    ClassSourceFileComposerFactory getClassSourceFileComposerFactory() {
+
+        final ClassSourceFileComposerFactory composerFactory = makeComposerFactory();
+
+        composerFactory.addImport(FEELFunctionProvider.class.getCanonicalName());
+        composerFactory.addImport(FunctionDefinition.class.getCanonicalName());
+        composerFactory.addImport(FunctionOverrideVariation.class.getCanonicalName());
+        composerFactory.addImport(BuiltInType.class.getCanonicalName());
+        composerFactory.addImport(Parameter.class.getCanonicalName());
+        composerFactory.addImport(List.class.getCanonicalName());
+        composerFactory.addImport(ArrayList.class.getCanonicalName());
+        composerFactory.addImport(Type.class.getCanonicalName());
+        composerFactory.addImplementedInterface(FEELFunctionProvider.class.getName());
+
+        return composerFactory;
+    }
+
+    public void write() {
+        getSourceWriter(context, logger).ifPresent(sourceWriter -> {
+            final String template = MethodTemplates.getTemplate();
+            sourceWriter.print(template);
+            sourceWriter.commit(logger);
+        });
+    }
+
+    ClassSourceFileComposerFactory makeComposerFactory() {
+        return new ClassSourceFileComposerFactory(PACKAGE_NAME, GENERATED_CLASS_FQCN);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGenerator.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import com.google.gwt.core.ext.Generator;
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.typeinfo.JClassType;
+import com.google.gwt.core.ext.typeinfo.TypeOracle;
+import org.kie.dmn.feel.gwt.functions.client.FEELFunctionProvider;
+
+public class FunctionProviderGenerator extends Generator {
+
+    @Override
+    public String generate(final TreeLogger logger,
+                           final GeneratorContext context,
+                           final String requestedClass) {
+        try {
+            final TypeOracle typeOracle = context.getTypeOracle();
+            final JClassType functionType = typeOracle.findType(requestedClass);
+
+            assertFEELFunctionProviderClass(functionType);
+            getFileCreator(logger, context).write();
+
+            return FileCreator.PACKAGE_NAME + "." + FileCreator.GENERATED_CLASS_FQCN;
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    FileCreator getFileCreator(final TreeLogger logger,
+                               final GeneratorContext context) {
+        return new FileCreator(context, logger);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    void assertFEELFunctionProviderClass(final JClassType functionType) {
+        // JClassType#getClass cannot be mocked (GWT API)
+        assert FEELFunctionProvider.class.equals(functionType.getClass());
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplates.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplates.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.functions.BuiltInFunctions;
+import org.kie.dmn.feel.runtime.functions.DateAndTimeFunction;
+import org.kie.dmn.feel.runtime.functions.DateFunction;
+import org.kie.dmn.feel.runtime.functions.GetValueFunction;
+import org.kie.dmn.feel.runtime.functions.ModeFunction;
+import org.kie.dmn.feel.runtime.functions.ParameterName;
+import org.kie.dmn.feel.runtime.functions.ReplaceFunction;
+import org.kie.dmn.feel.runtime.functions.TimeFunction;
+import org.kie.dmn.feel.runtime.functions.extended.KieExtendedDMNFunctions;
+
+public class MethodTemplates {
+
+    public static String getTemplate() {
+
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("public List<FunctionOverrideVariation> getDefinitions() {\n");
+        builder.append("    ArrayList definitions = new ArrayList();\n");
+
+        for (final String signature : getFunctionSignatures()) {
+            builder.append(String.format("definitions.add( %s );\n", signature));
+        }
+
+        builder.append("    return definitions;\n");
+        builder.append("}");
+
+        return builder.toString();
+    }
+
+    private static List<String> getFunctionSignatures() {
+        return getFeelFunctions()
+                .stream()
+                .flatMap(function -> getFunctionSignatures(function).stream())
+                .collect(Collectors.toList());
+    }
+
+    static List<FEELFunction> getFeelFunctions() {
+        final List<FEELFunction> feelFunctions = new ArrayList<>();
+        feelFunctions.addAll(Arrays.asList(BuiltInFunctions.getFunctions()));
+        feelFunctions.addAll(Arrays.asList(KieExtendedDMNFunctions.getFunctions()));
+        return feelFunctions;
+    }
+
+    private static List<String> getFunctionSignatures(final FEELFunction function) {
+
+        final List<String> result = new ArrayList<>();
+
+        for (Method declaredMethod : function.getClass().getDeclaredMethods()) {
+            if (!Modifier.isPublic(declaredMethod.getModifiers()) || !declaredMethod.getName().equals("invoke")) {
+                continue;
+            }
+
+            StringBuilder paramBuilder = new StringBuilder();
+            final Annotation[][] parameterAnnotations = declaredMethod.getParameterAnnotations();
+
+            int i = 0;
+            for (Annotation[] parameterAnnotation : parameterAnnotations) {
+                if (i != 0) {
+                    paramBuilder.append(", ");
+                }
+
+                final Class<?>[] parameterTypes = declaredMethod.getParameterTypes();
+                paramBuilder.append(String.format("new Parameter( \"%s\", %s )",
+                                                  getParameterNameAnnotation(parameterAnnotation),
+                                                  getType(parameterTypes[i].getTypeName())));
+                i++;
+            }
+
+            if (paramBuilder.length() == 0) {
+                result.add(String.format("new FunctionOverrideVariation( %s, \"%s\" )",
+                                         getReturnType(function,
+                                                       declaredMethod.getGenericReturnType()),
+                                         function.getName()));
+            } else {
+
+                result.add(String.format("new FunctionOverrideVariation( %s, \"%s\", %s )",
+                                         getReturnType(function,
+                                                       declaredMethod.getGenericReturnType()),
+                                         function.getName(),
+                                         paramBuilder.toString()));
+            }
+        }
+
+        return result;
+    }
+
+    private static String getParameterNameAnnotation(final Annotation[] parameterAnnotation) {
+        for (Annotation annotation : parameterAnnotation) {
+            if (annotation instanceof ParameterName) {
+                return ((ParameterName) annotation).value();
+            }
+        }
+        return "";
+    }
+
+    private static String getReturnType(final FEELFunction function,
+                                        final Type genericReturnType) {
+
+        if (genericReturnType instanceof ParameterizedType) {
+            final Type[] actualTypeArguments = ((ParameterizedType) genericReturnType).getActualTypeArguments();
+            if (actualTypeArguments.length == 1) {
+
+                /*
+                 * Getting dates by function since the argument type is the same for them all.
+                 * Other than that, better to use the type name so there is better support
+                 * for new functions we do not need to write an if for each function.
+                 */
+                if (function instanceof DateFunction) {
+                    return "BuiltInType.DATE";
+                } else if (function instanceof TimeFunction) {
+                    return "BuiltInType.TIME";
+                } else if (function instanceof DateAndTimeFunction) {
+                    return "BuiltInType.DATE_TIME";
+                } else if (function instanceof GetValueFunction) {
+                    return "BuiltInType.UNKNOWN";
+                } else if (function instanceof ModeFunction) {
+                    return "BuiltInType.LIST";
+                } else if (function instanceof ReplaceFunction) {
+                    return "BuiltInType.STRING";
+                }
+                return getType(actualTypeArguments[0].getTypeName());
+            }
+        }
+
+        return "BuiltInType.UNKNOWN";
+    }
+
+    private static String getType(final String typeName) {
+        if (typeName.equals("java.time.temporal.TemporalAmount")) {
+            return "BuiltInType.DURATION";
+        } else if (typeName.equals("java.time.temporal.TemporalAccessor")) {
+            return "BuiltInType.DATE_TIME";
+        } else if (typeName.equals("java.time.temporal.Temporal")) {
+            return "BuiltInType.DATE_TIME";
+        } else if (typeName.equals("java.lang.String")) {
+            return "BuiltInType.STRING";
+        } else if (typeName.equals("java.lang.Boolean")) {
+            return "BuiltInType.BOOLEAN";
+        } else if (typeName.startsWith("java.util.List")) {
+            return "BuiltInType.LIST";
+        } else if (typeName.startsWith("java.time.Duration")) {
+            return "BuiltInType.DURATION";
+        } else if (typeName.equals("java.math.BigDecimal")) {
+            return "BuiltInType.NUMBER";
+        } else if (typeName.equals("java.lang.Number")) {
+            return "BuiltInType.NUMBER";
+        } else if (typeName.endsWith("Range")) {
+            return "BuiltInType.RANGE";
+        } else if (typeName.endsWith("ComparablePeriod")) {
+            return "BuiltInType.DURATION";
+        } else if (typeName.endsWith("FEELFunction")) {
+            return "BuiltInType.FUNCTION";
+        }
+        return "BuiltInType.UNKNOWN";
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/resources/org/kie/dmn/feel/gwt/functions/DMNFeelGWTFunctions.gwt.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/main/resources/org/kie/dmn/feel/gwt/functions/DMNFeelGWTFunctions.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+  <source path="api"/>
+  <source path="client"/>
+
+  <generate-with class="org.kie.dmn.feel.gwt.functions.rebind.FunctionProviderGenerator">
+    <when-type-assignable class="org.kie.dmn.feel.gwt.functions.client.FEELFunctionProvider"/>
+  </generate-with>
+</module>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariationTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/api/FunctionOverrideVariationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.feel.lang.types.BuiltInType.STRING;
+
+public class FunctionOverrideVariationTest {
+
+    private FunctionOverrideVariation functionOverrideVariation;
+
+    @Before
+    public void setup() {
+
+        final Parameter input = new Parameter("input", STRING);
+        final Parameter pattern = new Parameter("pattern", STRING);
+        final Parameter replacement = new Parameter("replacement", STRING);
+        final Parameter flags = new Parameter("flags", STRING);
+
+        functionOverrideVariation = new FunctionOverrideVariation(STRING, "replace", input, pattern, replacement, flags);
+    }
+
+    @Test
+    public void testToHumanReadableString() {
+        assertThat(functionOverrideVariation.toHumanReadableString()).isEqualTo("string, string, string, string");
+    }
+
+    @Test
+    public void testToHumanReadableStrings() {
+        final FunctionDefinitionStrings functionDefinitionStrings = functionOverrideVariation.toHumanReadableStrings();
+        assertThat(functionDefinitionStrings.getHumanReadable()).isEqualTo("replace(string, string, string, string)");
+        assertThat(functionDefinitionStrings.getTemplate()).isEqualTo("replace($1, $2, $3, $4)");
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreatorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FileCreatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
+import com.google.gwt.user.rebind.SourceWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.dmn.feel.gwt.functions.api.FunctionDefinition;
+import org.kie.dmn.feel.gwt.functions.api.FunctionOverrideVariation;
+import org.kie.dmn.feel.gwt.functions.api.Parameter;
+import org.kie.dmn.feel.gwt.functions.api.Type;
+import org.kie.dmn.feel.gwt.functions.client.FEELFunctionProvider;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.dmn.feel.gwt.functions.rebind.FileCreator.GENERATED_CLASS_FQCN;
+import static org.kie.dmn.feel.gwt.functions.rebind.FileCreator.PACKAGE_NAME;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileCreatorTest {
+
+    @Mock
+    private GeneratorContext context;
+
+    @Mock
+    private TreeLogger logger;
+
+    @Mock
+    private ClassSourceFileComposerFactory composerFactory;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    @Mock
+    private SourceWriter sourceWriter;
+
+    private FileCreator fileCreator;
+
+    @Before
+    public void setup() {
+        fileCreator = spy(new FileCreator(context, logger));
+    }
+
+    @Test
+    public void testWrite() {
+
+        doReturn(composerFactory).when(fileCreator).getClassSourceFileComposerFactory();
+        when(context.tryCreate(logger, PACKAGE_NAME, GENERATED_CLASS_FQCN)).thenReturn(printWriter);
+        when(composerFactory.createSourceWriter(context, printWriter)).thenReturn(sourceWriter);
+
+        fileCreator.write();
+
+        verify(sourceWriter).print(MethodTemplates.getTemplate());
+        verify(sourceWriter).commit(logger);
+    }
+
+    @Test
+    public void testGetClassSourceFileComposerFactory() {
+
+        doReturn(composerFactory).when(fileCreator).makeComposerFactory();
+
+        final ClassSourceFileComposerFactory actualFactory = fileCreator.getClassSourceFileComposerFactory();
+
+        verify(composerFactory).addImport(FEELFunctionProvider.class.getCanonicalName());
+        verify(composerFactory).addImport(FunctionDefinition.class.getCanonicalName());
+        verify(composerFactory).addImport(FunctionOverrideVariation.class.getCanonicalName());
+        verify(composerFactory).addImport(BuiltInType.class.getCanonicalName());
+        verify(composerFactory).addImport(Parameter.class.getCanonicalName());
+        verify(composerFactory).addImport(List.class.getCanonicalName());
+        verify(composerFactory).addImport(ArrayList.class.getCanonicalName());
+        verify(composerFactory).addImport(Type.class.getCanonicalName());
+        verify(composerFactory).addImplementedInterface(FEELFunctionProvider.class.getName());
+
+        assertThat(actualFactory).isSameAs(composerFactory);
+    }
+
+    @Test
+    public void testMakeComposerFactory() {
+        final ClassSourceFileComposerFactory factory = fileCreator.makeComposerFactory();
+        assertThat(factory.getCreatedPackage()).isEqualTo(PACKAGE_NAME);
+        assertThat(factory.getCreatedClassShortName()).isEqualTo(GENERATED_CLASS_FQCN);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGeneratorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/FunctionProviderGeneratorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.typeinfo.TypeOracle;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FunctionProviderGeneratorTest {
+
+    @Mock
+    private TreeLogger logger;
+
+    @Mock
+    private GeneratorContext context;
+
+    @Mock
+    private TypeOracle typeOracle;
+
+    @Mock
+    private FileCreator fileCreator;
+
+    private FunctionProviderGenerator generator;
+
+    @Before
+    public void setup() {
+        generator = spy(new FunctionProviderGenerator());
+
+        when(context.getTypeOracle()).thenReturn(typeOracle);
+    }
+
+    @Test
+    public void testGenerate() {
+
+        final String requestedClass = "requestedClass";
+        final String expectedGenerate = "org.kie.dmn.feel.gwt.functions.client.FEELFunctionProviderImpl";
+
+        doReturn(fileCreator).when(generator).getFileCreator(logger, context);
+        doNothing().when(generator).assertFEELFunctionProviderClass(any());
+
+        final String actualGenerate = generator.generate(logger, context, requestedClass);
+
+        verify(fileCreator).write();
+        assertThat(actualGenerate).isEqualTo(expectedGenerate);
+    }
+
+    @Test
+    public void testGenerateWhenFunctionProviderClassAssertFails() {
+
+        final String requestedClass = "requestedClass";
+
+        doThrow(new RuntimeException()).when(generator).assertFEELFunctionProviderClass(any());
+
+        final String actualGenerate = generator.generate(logger, context, requestedClass);
+
+        verify(fileCreator, never()).write();
+        assertThat(actualGenerate).isNull();
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplatesTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt-functions/src/test/java/org/kie/dmn/feel/gwt/functions/rebind/MethodTemplatesTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.gwt.functions.rebind;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.parser.feel11.profiles.KieExtendedFEELProfile;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.functions.BuiltInFunctions;
+import org.kie.dmn.feel.runtime.functions.extended.KieExtendedDMNFunctions;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MethodTemplatesTest {
+
+    private static final List<FEELProfile> profiles = new ArrayList<>();
+
+    static {
+        profiles.add(new KieExtendedFEELProfile());
+    }
+
+    @Test
+    public void testTemplate() {
+
+        final String template = MethodTemplates.getTemplate();
+        final String[] templateLines = template.split("\n");
+
+        assertThat(templateLines[0]).isEqualTo("public List<FunctionOverrideVariation> getDefinitions() {");
+        assertThat(templateLines[1]).isEqualTo("    ArrayList definitions = new ArrayList();");
+        assertTemplateBody(templateLines);
+        assertThat(templateLines[templateLines.length - 2]).isEqualTo("    return definitions;");
+        assertThat(templateLines[templateLines.length - 1]).isEqualTo("}");
+    }
+
+    @Test
+    public void testTemplatedFunctionsCanBeEvaluated() {
+        final FEEL feel = FEEL.newInstance(profiles);
+
+        final List<FEELFunction> templatedFunctions = MethodTemplates.getFeelFunctions();
+        assertThat(templatedFunctions.stream().allMatch(fn -> feel.evaluate(fn.getName()) instanceof FEELFunction)).isTrue();
+    }
+
+    @Test
+    public void testTemplatedFunctionsIncludeBuiltInAndKieExtendedFunctions() {
+        final List<FEELFunction> templatedFunctions = MethodTemplates.getFeelFunctions();
+
+        assertThat(templatedFunctions).containsAll(asList(BuiltInFunctions.getFunctions()));
+        assertThat(templatedFunctions).containsAll(asList(KieExtendedDMNFunctions.getFunctions()));
+    }
+
+    private void assertTemplateBody(final String[] templateLines) {
+
+        final List<String> lines = asList(templateLines);
+
+        assertLine(lines, "BuiltInType.DATE, \"date\", new Parameter( \"year\", BuiltInType.NUMBER ), new Parameter( \"month\", BuiltInType.NUMBER ), new Parameter( \"day\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DATE, \"date\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DATE, \"date\", new Parameter( \"from\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.TIME, \"time\", new Parameter( \"from\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.TIME, \"time\", new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.TIME, \"time\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.TIME, \"time\", new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ), new Parameter( \"offset\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date and time\", new Parameter( \"year\", BuiltInType.NUMBER ), new Parameter( \"month\", BuiltInType.NUMBER ), new Parameter( \"day\", BuiltInType.NUMBER ), new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ), new Parameter( \"hour offset\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date and time\", new Parameter( \"year\", BuiltInType.NUMBER ), new Parameter( \"month\", BuiltInType.NUMBER ), new Parameter( \"day\", BuiltInType.NUMBER ), new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ), new Parameter( \"timezone\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date and time\", new Parameter( \"date\", BuiltInType.DATE_TIME ), new Parameter( \"time\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date and time\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date and time\", new Parameter( \"year\", BuiltInType.NUMBER ), new Parameter( \"month\", BuiltInType.NUMBER ), new Parameter( \"day\", BuiltInType.NUMBER ), new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"duration\", new Parameter( \"from\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"duration\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"years and months duration\", new Parameter( \"from\", BuiltInType.DATE_TIME ), new Parameter( \"to\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.STRING, \"string\", new Parameter( \"from\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.STRING, \"string\", new Parameter( \"mask\", BuiltInType.STRING ), new Parameter( \"p\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"number\", new Parameter( \"from\", BuiltInType.STRING ), new Parameter( \"grouping separator\", BuiltInType.STRING ), new Parameter( \"decimal separator\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"substring\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"start position\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.STRING, \"substring\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"start position\", BuiltInType.NUMBER ), new Parameter( \"length\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.STRING, \"substring before\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"match\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"substring after\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"match\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"string length\", new Parameter( \"string\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"upper case\", new Parameter( \"string\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"lower case\", new Parameter( \"string\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"contains\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"match\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"starts with\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"match\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"ends with\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"match\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"matches\", new Parameter( \"input\", BuiltInType.STRING ), new Parameter( \"pattern\", BuiltInType.STRING ), new Parameter( \"flags\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"matches\", new Parameter( \"input\", BuiltInType.STRING ), new Parameter( \"pattern\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"replace\", new Parameter( \"input\", BuiltInType.STRING ), new Parameter( \"pattern\", BuiltInType.STRING ), new Parameter( \"replacement\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.STRING, \"replace\", new Parameter( \"input\", BuiltInType.STRING ), new Parameter( \"pattern\", BuiltInType.STRING ), new Parameter( \"replacement\", BuiltInType.STRING ), new Parameter( \"flags\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"list contains\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"element\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"count\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"count\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"min\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"min\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"max\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"max\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"sum\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"sum\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"sum\", new Parameter( \"list\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"mean\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"mean\", new Parameter( \"list\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"mean\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"sublist\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"start position\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.LIST, \"sublist\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"start position\", BuiltInType.NUMBER ), new Parameter( \"length\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.LIST, \"append\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"item\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"append\", new Parameter( \"list\", BuiltInType.UNKNOWN ), new Parameter( \"item\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"concatenate\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"insert before\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"position\", BuiltInType.NUMBER ), new Parameter( \"newItem\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"remove\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"position\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.LIST, \"reverse\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"index of\", new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"match\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"union\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"distinct values\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"flatten\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"decimal\", new Parameter( \"n\", BuiltInType.NUMBER ), new Parameter( \"scale\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"floor\", new Parameter( \"n\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"ceiling\", new Parameter( \"n\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"decision table\", new Parameter( \"ctx\", BuiltInType.UNKNOWN ), new Parameter( \"outputs\", BuiltInType.UNKNOWN ), new Parameter( \"input expression list\", BuiltInType.UNKNOWN ), new Parameter( \"input values list\", BuiltInType.LIST ), new Parameter( \"output values\", BuiltInType.UNKNOWN ), new Parameter( \"rule list\", BuiltInType.LIST ), new Parameter( \"hit policy\", BuiltInType.STRING ), new Parameter( \"default output value\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"not\", new Parameter( \"negand\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"sort\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"sort\", new Parameter( \"ctx\", BuiltInType.UNKNOWN ), new Parameter( \"list\", BuiltInType.LIST ), new Parameter( \"precedes\", BuiltInType.FUNCTION ) )");
+        assertLine(lines, "BuiltInType.LIST, \"get entries\", new Parameter( \"m\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"get value\", new Parameter( \"m\", BuiltInType.UNKNOWN ), new Parameter( \"key\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"all\", new Parameter( \"b\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"all\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"all\", new Parameter( \"list\", BuiltInType.BOOLEAN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"any\", new Parameter( \"b\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"any\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"any\", new Parameter( \"list\", BuiltInType.BOOLEAN ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"abs\", new Parameter( \"n\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"abs\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"abs\", new Parameter( \"n\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"abs\", new Parameter( \"n\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"modulo\", new Parameter( \"dividend\", BuiltInType.NUMBER ), new Parameter( \"divisor\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"product\", new Parameter( \"list\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"product\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"product\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"split\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"delimiter\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.LIST, \"split\", new Parameter( \"string\", BuiltInType.STRING ), new Parameter( \"delimiter\", BuiltInType.STRING ), new Parameter( \"flags\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"stddev\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"stddev\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"stddev\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.LIST, \"mode\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"mode\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"sqrt\", new Parameter( \"number\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"log\", new Parameter( \"number\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"exp\", new Parameter( \"number\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"even\", new Parameter( \"number\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"odd\", new Parameter( \"number\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"median\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"median\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.STRING, \"day of week\", new Parameter( \"date\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"day of year\", new Parameter( \"date\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.STRING, \"month of year\", new Parameter( \"date\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"week of year\", new Parameter( \"date\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"is\", new Parameter( \"value1\", BuiltInType.UNKNOWN ), new Parameter( \"value2\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"after\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"after\", new Parameter( \"point\", BuiltInType.UNKNOWN ), new Parameter( \"range\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"after\", new Parameter( \"point1\", BuiltInType.UNKNOWN ), new Parameter( \"point2\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"after\", new Parameter( \"range\", BuiltInType.RANGE ), new Parameter( \"point\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"before\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"before\", new Parameter( \"point\", BuiltInType.UNKNOWN ), new Parameter( \"range\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"before\", new Parameter( \"point1\", BuiltInType.UNKNOWN ), new Parameter( \"point2\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"before\", new Parameter( \"range\", BuiltInType.RANGE ), new Parameter( \"point\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"coincides\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"coincides\", new Parameter( \"point1\", BuiltInType.UNKNOWN ), new Parameter( \"point2\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"starts\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"starts\", new Parameter( \"point\", BuiltInType.UNKNOWN ), new Parameter( \"range\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"started by\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"started by\", new Parameter( \"range\", BuiltInType.RANGE ), new Parameter( \"point\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"finishes\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"finishes\", new Parameter( \"point\", BuiltInType.UNKNOWN ), new Parameter( \"range\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"finished by\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"finished by\", new Parameter( \"range\", BuiltInType.RANGE ), new Parameter( \"point\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"during\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"during\", new Parameter( \"point\", BuiltInType.UNKNOWN ), new Parameter( \"range\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"includes\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"includes\", new Parameter( \"range\", BuiltInType.RANGE ), new Parameter( \"point\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"overlaps\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"overlaps before\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"overlaps after\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"meets\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"met by\", new Parameter( \"range1\", BuiltInType.RANGE ), new Parameter( \"range2\", BuiltInType.RANGE ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"time\", new Parameter( \"from\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"time\", new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ), new Parameter( \"offset\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"time\", new Parameter( \"hour\", BuiltInType.NUMBER ), new Parameter( \"minute\", BuiltInType.NUMBER ), new Parameter( \"second\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"time\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date\", new Parameter( \"from\", BuiltInType.DATE_TIME ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date\", new Parameter( \"year\", BuiltInType.NUMBER ), new Parameter( \"month\", BuiltInType.NUMBER ), new Parameter( \"day\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"date\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"duration\", new Parameter( \"from\", BuiltInType.DURATION ) )");
+        assertLine(lines, "BuiltInType.DURATION, \"duration\", new Parameter( \"from\", BuiltInType.STRING ) )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"now\" )");
+        assertLine(lines, "BuiltInType.DATE_TIME, \"today\" )");
+        assertLine(lines, "BuiltInType.STRING, \"code\", new Parameter( \"value\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"invoke\", new Parameter( \"ctx\", BuiltInType.UNKNOWN ), new Parameter( \"namespace\", BuiltInType.STRING ), new Parameter( \"model name\", BuiltInType.STRING ), new Parameter( \"decision name\", BuiltInType.STRING ), new Parameter( \"parameters\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn any\", new Parameter( \"list\", BuiltInType.BOOLEAN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn any\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn any\", new Parameter( \"b\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn all\", new Parameter( \"list\", BuiltInType.BOOLEAN ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn all\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.BOOLEAN, \"nn all\", new Parameter( \"b\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn count\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn count\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"nn max\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"nn max\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn mean\", new Parameter( \"list\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn mean\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn mean\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn median\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn median\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"nn min\", new Parameter( \"c\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.UNKNOWN, \"nn min\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"nn mode\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.LIST, \"nn mode\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn stddev\", new Parameter( \"list\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn stddev\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn stddev\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn sum\", new Parameter( \"list\", BuiltInType.NUMBER ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn sum\", new Parameter( \"list\", BuiltInType.LIST ) )");
+        assertLine(lines, "BuiltInType.NUMBER, \"nn sum\", new Parameter( \"n\", BuiltInType.UNKNOWN ) )");
+    }
+
+    private void assertLine(final List<String> lines,
+                            final String line) {
+        assertThat(lines).contains(String.format("definitions.add( new FunctionOverrideVariation( %s );", line));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.kie.kogito.stunner.editors</groupId>
+    <artifactId>kie-wb-common-dmn</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>kie-dmn-feel-gwt</artifactId>
+
+  <name>Kie Workbench - Common - DMN - FEEL DMN GWT</name>
+
+  <properties>
+    <surefire.forkCount>2</surefire.forkCount>
+    <enforcer.skip>true</enforcer.skip>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.jresearch.gwt.time</groupId>
+      <artifactId>org.jresearch.gwt.time</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.antlr4gwt</groupId>
+      <artifactId>antlr4gwt-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-feel</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dominokit</groupId>
+      <artifactId>domino-slf4j-logger</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-user</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>     
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <additionalClasspathElements>
+            <additionalClasspathElement>${basedir}/target/classes/</additionalClasspathElement>
+            <additionalClasspathElement>${basedir}/src/main/java/</additionalClasspathElement>
+            <additionalClasspathElement>${basedir}/src/test/java/</additionalClasspathElement>
+          </additionalClasspathElements>
+
+          <useManifestOnlyJar>false</useManifestOnlyJar>
+          <forkMode>pertest</forkMode>
+
+          <argLine>-Xmx1500m -Derrai.devel.nocache=true -Derrai.codegen.permissive=false -Derrai.dynamic_validation.enabled=true</argLine>
+
+          <systemProperties>
+            <!-- Must disable long polling for automated tests to succeed -->
+            <property>
+              <name>errai.hosted_mode_testing</name>
+              <value>true</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/FEEL.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/FEEL.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.lang.CompiledExpression;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.impl.FEELImpl;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+/**
+ * FEEL expression language engine interface
+ * <p>
+ * This class is the entry point for the engine use
+ */
+public interface FEEL {
+
+    /**
+     * Factory method to create a new FEEL engine instance
+     * @return a newly instantiated FEEL engine instance
+     */
+    static FEEL newInstance() {
+        return new FEELImpl();
+    }
+
+    /**
+     * Factory method to create a new FEEL engine instance using custom FEELProfile(s)
+     * @return a newly instantiated FEEL engine instance
+     */
+    static FEEL newInstance(final List<FEELProfile> profiles) {
+        return new FEELImpl(profiles);
+    }
+
+    /**
+     * Factory method to create a new compiler context
+     * @return compiler context with default options set
+     */
+    CompilerContext newCompilerContext();
+
+    /**
+     * Compiles the string expression using the given
+     * compiler context.
+     * @param expression a FEEL expression
+     * @param ctx a compiler context
+     * @return the compiled expression
+     */
+    CompiledExpression compile(final String expression,
+                               final CompilerContext ctx);
+
+    /**
+     * Compiles the string expression using the given
+     * compiler context.
+     * @param expression a FEEL expression for unary tests
+     * @param ctx a compiler context
+     * @return the compiled unary tests
+     */
+    CompiledExpression compileUnaryTests(final String expression,
+                                         final CompilerContext ctx);
+
+    /**
+     * Evaluates the given FEEL expression and returns
+     * the result
+     * @param expression a FEEL expression
+     * @return the result of the evaluation of the expression
+     */
+    Object evaluate(final String expression);
+
+    String parseTest(final String value);
+
+    /**
+     * Evaluates the given FEEL expression using the
+     * given EvaluationContext, and returns the result
+     * @param expression a FEEL expression
+     * @param ctx the EvaluationContext to be used for defining
+     * input variables and additional feel event listeners
+     * contextual to this method call
+     * @return the result of the evaluation of the expression.
+     */
+    Object evaluate(final String expression,
+                    final EvaluationContext ctx);
+
+    /**
+     * Evaluates the given FEEL expression using the
+     * given input variables, and returns the result
+     * @param expression a FEEL expression
+     * @param inputVariables a map of input Variables. The keys
+     * on the map are the variable names,
+     * that need to follow the naming rules
+     * for the FEEL language. The values on
+     * the map are the corresponding values
+     * for the variables. It is completely
+     * fine to use a previously returned FEEL
+     * context as inputVariables.
+     * @return the result of the evaluation of the expression.
+     */
+    Object evaluate(final String expression,
+                    final Map<String, Object> inputVariables);
+
+    /**
+     * Evaluates the given compiled FEEL expression using the
+     * given input variables, and returns the result
+     * @param expression a FEEL expression
+     * @param inputVariables a map of input Variables. The keys
+     * on the map are the variable names,
+     * that need to follow the naming rules
+     * for the FEEL language. The values on
+     * the map are the corresponding values
+     * for the variables. It is completely
+     * fine to use a previously returned FEEL
+     * context as inputVariables.
+     * @return the result of the evaluation of the expression.
+     */
+    Object evaluate(final CompiledExpression expression,
+                    final Map<String, Object> inputVariables);
+
+    /**
+     * Evaluates the given compiled FEEL expression using the
+     * given EvaluationContext, and returns the result
+     * @param expr a FEEL expression
+     * @param ctx the EvaluationContext to be used for defining
+     * input variables and additional feel event listeners
+     * contextual to this method call
+     * @return the result of the evaluation of the expression.
+     */
+    Object evaluate(final CompiledExpression expr,
+                    final EvaluationContext ctx);
+
+    /**
+     * Evaluates the given expression as a list of of unary tests.
+     * The syntax for this is defined in the FEEL grammar rule #17,
+     * i.e., a list of unary tests separated by commas.
+     * @param expression a unary test list expression
+     * @return a List of compiled UnaryTests
+     */
+    List<UnaryTest> evaluateUnaryTests(final String expression);
+
+    /**
+     * Evaluates the given expression as a list of of unary tests.
+     * The syntax for this is defined in the FEEL grammar rule #17,
+     * i.e., a list of unary tests separated by commas.
+     * @param expression a unary test list expression
+     * @param variableTypes map of variable names and corresponding types,
+     * necessary to compile the unary tests
+     * @return a List of compiled UnaryTests
+     */
+    List<UnaryTest> evaluateUnaryTests(final String expression,
+                                       final Map<String, Type> variableTypes);
+
+    /**
+     * Registers a new event listener into this FEEL instance.
+     * The event listeners are notified about signitificative
+     * events during compilation or evaluation of expressions.
+     * @param listener the listener to register
+     */
+    void addListener(final FEELEventListener listener);
+
+    /**
+     * Removes a listener from the list of event listeners.
+     * @param listener the listener to remove
+     */
+    void removeListener(final FEELEventListener listener);
+
+    /**
+     * Retrieves the set of registered event listeners
+     * @return the set of listeners
+     */
+    Set<FEELEventListener> getListeners();
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenStringUtil.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/CodegenStringUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.codegen.feel11;
+
+public class CodegenStringUtil {
+
+    /**
+     * Escape for identifier part (not beginning)
+     * <p>
+     * Similar to drools-model's StringUtil
+     */
+    public static String escapeIdentifier(final String partOfIdentifier) {
+        final StringBuilder result = new StringBuilder();
+        final char[] cs = partOfIdentifier.toCharArray();
+        for (final char c : cs) {
+            if (isJavaIdentifierPart(c)) {
+                result.append(c);
+            } else {
+                result.append("_" + Integer.valueOf(c));
+            }
+        }
+        return result.toString();
+    }
+
+    private static boolean isJavaIdentifierPart(final char c) {
+        return false;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/CompiledFEELSemanticMappings.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.codegen.feel11;
+
+import org.kie.dmn.feel.lang.ast.InfixOpNode;
+import org.kie.dmn.feel.util.AssignableFromUtil;
+
+/**
+ * The purpose of this class is to offer import .* methods to compiled FEEL classes compiling expressions.
+ * Implementing DMN FEEL spec chapter 10.3.2.12 Semantic mappings
+ */
+public abstract class CompiledFEELSemanticMappings {
+
+    private static boolean compatible(final Comparable left,
+                                      final Comparable right) {
+        final Class<?> leftClass = left.getClass();
+        final Class<?> rightClass = right.getClass();
+        return AssignableFromUtil.isAssignableFrom(leftClass, rightClass)
+                || AssignableFromUtil.isAssignableFrom(rightClass, leftClass);
+    }
+
+    public static <T> T coerceTo(final Class<?> paramType,
+                                 final Object value) {
+        final Object actual;
+        if (AssignableFromUtil.isAssignableFrom(paramType, value.getClass())) {
+            actual = value;
+        } else {
+            if (value instanceof Number) {
+                if (paramType == byte.class || paramType == Byte.class) {
+                    actual = ((Number) value).byteValue();
+                } else if (paramType == short.class || paramType == Short.class) {
+                    actual = ((Number) value).shortValue();
+                } else if (paramType == int.class || paramType == Integer.class) {
+                    actual = ((Number) value).intValue();
+                } else if (paramType == long.class || paramType == Long.class) {
+                    actual = ((Number) value).longValue();
+                } else if (paramType == float.class || paramType == Float.class) {
+                    actual = ((Number) value).floatValue();
+                } else if (paramType == double.class || paramType == Double.class) {
+                    actual = ((Number) value).doubleValue();
+                } else if (paramType == Object[].class) {
+                    actual = new Object[]{value};
+                } else {
+                    throw new IllegalArgumentException("Unable to coerce parameter " + value + ". Expected " + paramType + " but found " + value.getClass());
+                }
+            } else if (value instanceof String
+                    && ((String) value).length() == 1
+                    && (paramType == char.class || paramType == Character.class)) {
+                actual = ((String) value).charAt(0);
+            } else if (value instanceof Boolean && paramType == boolean.class) {
+                // Because Boolean can be also null, boolean.class is not assignable from Boolean.class. So we must coerce this.
+                actual = value;
+            } else {
+                throw new IllegalArgumentException("Unable to coerce parameter " + value + ". Expected " + paramType + " but found " + value.getClass());
+            }
+        }
+        return (T) actual;
+    }
+
+    public static Object pow(final Object left,
+                             final Object right) {
+        return InfixOpNode.math(left, right, null, (l, r) -> l.pow(r.intValue()));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/codegen/feel11/ProcessedExpression.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.feel.codegen.feel11;
+
+import java.util.List;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.visitor.ASTHeuristicCheckerVisitor;
+import org.kie.dmn.feel.lang.impl.CompiledExpressionImpl;
+import org.kie.dmn.feel.lang.impl.InterpretedExecutableExpression;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
+
+import static org.kie.dmn.feel.codegen.feel11.ProcessedFEELUnit.DefaultMode.Compiled;
+
+public abstract class ProcessedExpression extends ProcessedFEELUnit {
+
+    private final BaseNode ast;
+    private final DefaultMode defaultBackend;
+    private CompiledFEELExpression defaultResult;
+
+    public ProcessedExpression(final String expression,
+                               final CompilerContext ctx,
+                               final DefaultMode defaultBackend,
+                               final List<FEELProfile> profiles) {
+
+        super(expression, ctx, profiles);
+        this.defaultBackend = defaultBackend;
+
+        final ParseTree tree = getFEELParser(expression, ctx, profiles).compilation_unit();
+        ast = tree.accept(new ASTBuilderVisitor(ctx.getInputVariableTypes(), ctx.getFEELFeelTypeRegistry()));
+
+        final boolean isParseTreeAstInvalid = ast == null;
+        if (isParseTreeAstInvalid) {
+            // No need of further processing
+            return;
+        }
+
+        final List<FEELEvent> heuristicChecks = ast.accept(new ASTHeuristicCheckerVisitor());
+        if (!heuristicChecks.isEmpty()) {
+            for (FEELEventListener listener : ctx.getListeners()) {
+                heuristicChecks.forEach(listener::onEvent);
+            }
+        }
+    }
+
+    public CompiledFEELExpression getResult() {
+        if (defaultBackend == Compiled) {
+            throw new UnsupportedOperationException("Cannot jit class-load on this platform.");
+        } else {
+            // "legacy" interpreted AST compilation:
+            defaultResult = getInterpreted();
+        }
+
+        return this;
+    }
+
+    public InterpretedExecutableExpression getInterpreted() {
+        return new InterpretedExecutableExpression(new CompiledExpressionImpl(ast));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/entrypoint/FEELEntryPoint.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/entrypoint/FEELEntryPoint.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.feel.entrypoint;
+
+import com.google.gwt.core.client.EntryPoint;
+import org.jresearch.threetenbp.gwt.time.client.Support;
+
+public class FEELEntryPoint implements EntryPoint {
+
+    @Override
+    public void onModuleLoad() {
+        Support.init();
+        Support.initTzData();
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/ContextNode.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.impl.MapBackedType;
+import org.kie.dmn.feel.runtime.functions.CustomFEELFunction;
+import org.kie.dmn.feel.runtime.functions.DTInvokerFunction;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public class ContextNode extends BaseNode {
+
+    private List<ContextEntryNode> entries = new ArrayList<>();
+    private MapBackedType parsedResultType = new MapBackedType();
+
+    public ContextNode(final ParserRuleContext ctx) {
+        super(ctx);
+    }
+
+    public ContextNode(final ParserRuleContext ctx,
+                       final ListNode list) {
+        super(ctx);
+        for (final BaseNode node : list.getElements()) {
+            final ContextEntryNode entry = (ContextEntryNode) node;
+            entries.add(entry);
+            parsedResultType.addField(entry.getName().getText(), entry.getResultType());
+        }
+    }
+
+    public List<ContextEntryNode> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(final List<ContextEntryNode> entries) {
+        this.entries = entries;
+    }
+
+    @Override
+    public Object evaluate(final EvaluationContext ctx) {
+        try {
+            ctx.enterFrame();
+            final Map<String, Object> c = new LinkedHashMap<>();
+
+            for (final ContextEntryNode cen : entries) {
+                final String name = EvalHelper.normalizeVariableName(cen.evaluateName(ctx));
+                final Object value = cen.evaluate(ctx);
+
+                if (value instanceof CustomFEELFunction) {
+                    ((CustomFEELFunction) value).setName(name);
+                } else if (value instanceof DTInvokerFunction) {
+                    ((DTInvokerFunction) value).setName(name);
+                }
+
+                ctx.setValue(name, value);
+                c.put(name, value);
+            }
+            return c;
+        } finally {
+            ctx.exitFrame();
+        }
+    }
+
+    @Override
+    public Type getResultType() {
+        return parsedResultType;
+    }
+
+    @Override
+    public ASTNode[] getChildrenNode() {
+        return entries.toArray(new ASTNode[entries.size()]);
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/FunctionDefNode.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.runtime.FEELFunction.Param;
+import org.kie.dmn.feel.runtime.functions.CustomFEELFunction;
+import org.kie.dmn.feel.util.Msg;
+
+public class FunctionDefNode extends BaseNode {
+
+    private static final String ANONYMOUS = "<anonymous>";
+    private static final RegExp METHOD_PARSER = RegExp.compile("(.+)\\((.*)\\)");
+    private static final RegExp PARAMETER_PARSER = RegExp.compile("([^, ]+)");
+
+    private List<FormalParameterNode> formalParameters;
+    private boolean external;
+    private BaseNode body;
+
+    public FunctionDefNode(final ParserRuleContext ctx,
+                           final ListNode formalParameters,
+                           final boolean external, BaseNode body) {
+        super(ctx);
+        this.formalParameters = new ArrayList<>();
+        this.external = external;
+        this.body = body;
+        if (formalParameters != null) {
+            for (final BaseNode name : formalParameters.getElements()) {
+                this.formalParameters.add((FormalParameterNode) name);
+            }
+        }
+    }
+
+    public List<FormalParameterNode> getFormalParameters() {
+        return formalParameters;
+    }
+
+    public void setFormalParameters(final List<FormalParameterNode> formalParameters) {
+        this.formalParameters = formalParameters;
+    }
+
+    public boolean isExternal() {
+        return external;
+    }
+
+    public void setExternal(final boolean external) {
+        this.external = external;
+    }
+
+    public BaseNode getBody() {
+        return body;
+    }
+
+    public void setBody(final BaseNode body) {
+        this.body = body;
+    }
+
+    @Override
+    public Object evaluate(final EvaluationContext ctx) {
+        final List<Param> params = formalParameters.stream().map(p -> p.evaluate(ctx)).collect(Collectors.toList());
+        if (external) {
+            try {
+                // creating a simple algorithm to find the method in java
+                // without using any external libraries in this initial implementation
+                final Map<String, Object> conf = (Map<String, Object>) this.body.evaluate(ctx);
+                final Map<String, Object> java = (Map<String, Object>) conf.get("java");
+                if (java != null) {
+                    // this is a java function
+                    String clazzName = (String) java.get("class");
+                    String methodSignature = (String) java.get("method signature");
+                    if (clazzName != null && methodSignature != null) {
+                        ctx.notifyEvt(astEvent(Severity.ERROR, Msg.createMessage(Msg.PARAMETER_COUNT_MISMATCH_ON_FUNCTION_DEFINITION, getText())));
+                        return null;
+                    }
+                }
+                ctx.notifyEvt(astEvent(Severity.ERROR, Msg.createMessage(Msg.UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY, getText())));
+            } catch (Exception e) {
+                ctx.notifyEvt(astEvent(Severity.ERROR, Msg.createMessage(Msg.ERROR_RESOLVING_EXTERNAL_FUNCTION_AS_DEFINED_BY, getText()), e));
+            }
+            return null;
+        } else {
+            return new CustomFEELFunction(ANONYMOUS, params, body, ctx.current()); // DMN spec, 10.3.2.13.2 User-defined functions: FEEL functions are lexical closures
+        }
+    }
+
+    public static String[] parseMethod(final String signature) {
+        final MatchResult m = METHOD_PARSER.exec(signature);
+        if (m != null) {
+            String[] result = new String[2];
+            result[0] = m.getGroup(1);
+            result[1] = m.getGroup(2);
+            return result;
+        }
+        return null;
+    }
+
+    public static String[] parseParams(final String params) {
+        final List<String> ps = new ArrayList<>();
+        if (params.trim().length() > 0) {
+            final MatchResult m = PARAMETER_PARSER.exec(params.trim());
+            if (m != null) {
+                for (int i = 0; i < m.getGroupCount(); i++) {
+                    ps.add(m.getGroup(i).trim());
+                }
+            }
+        }
+        return ps.toArray(new String[ps.size()]);
+    }
+
+    private static Class<?> convertPrimitiveNameToType(final String typeName) {
+        if (typeName.equals("int")) {
+            return int.class;
+        }
+        if (typeName.equals("boolean")) {
+            return boolean.class;
+        }
+        if (typeName.equals("char")) {
+            return char.class;
+        }
+        if (typeName.equals("byte")) {
+            return byte.class;
+        }
+        if (typeName.equals("short")) {
+            return short.class;
+        }
+        if (typeName.equals("float")) {
+            return float.class;
+        }
+        if (typeName.equals("long")) {
+            return long.class;
+        }
+        if (typeName.equals("double")) {
+            return double.class;
+        }
+        return null;
+    }
+
+    @Override
+    public Type getResultType() {
+        return BuiltInType.FUNCTION;
+    }
+
+    @Override
+    public ASTNode[] getChildrenNode() {
+        final ASTNode[] children = new ASTNode[formalParameters.size() + 1];
+        System.arraycopy(formalParameters.toArray(new ASTNode[]{}), 0, children, 0, formalParameters.size());
+        children[children.length - 1] = body;
+        return children;
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/InfixOpNode.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoPeriod;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.util.function.BinaryOperator;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public class InfixOpNode extends BaseNode {
+
+    public static enum InfixOperator {
+        ADD("+"),
+        SUB("-"),
+        MULT("*"),
+        DIV("/"),
+        POW("**"),
+        LTE("<="),
+        LT("<"),
+        GT(">"),
+        GTE(">="),
+        EQ("="),
+        NE("!="),
+        AND("and"),
+        OR("or");
+
+        public final String symbol;
+
+        InfixOperator(final String symbol) {
+            this.symbol = symbol;
+        }
+
+        public static InfixOperator determineOperator(final String symbol) {
+            for (InfixOperator op : InfixOperator.values()) {
+                if (op.symbol.equals(symbol)) {
+                    return op;
+                }
+            }
+            throw new IllegalArgumentException("No operator found for symbol '" + symbol + "'");
+        }
+
+        public boolean isBoolean() {
+            return this == LTE || this == LT || this == GT || this == GTE || this == EQ || this == NE || this == AND || this == OR;
+        }
+    }
+
+    private InfixOperator operator;
+    private BaseNode left;
+    private BaseNode right;
+
+    public InfixOpNode(final ParserRuleContext ctx,
+                       final BaseNode left,
+                       final String op,
+                       final BaseNode right) {
+        super(ctx);
+        this.left = left;
+        this.operator = InfixOperator.determineOperator(op);
+        this.right = right;
+    }
+
+    public InfixOperator getOperator() {
+        return operator;
+    }
+
+    public void setOperator(InfixOperator operator) {
+        this.operator = operator;
+    }
+
+    public boolean isBoolean() {
+        return this.operator.isBoolean();
+    }
+
+    public BaseNode getLeft() {
+        return left;
+    }
+
+    public void setLeft(final BaseNode left) {
+        this.left = left;
+    }
+
+    public BaseNode getRight() {
+        return right;
+    }
+
+    public void setRight(final BaseNode right) {
+        this.right = right;
+    }
+
+    @Override
+    public Type getResultType() {
+        // see FEEL spec Table 45.
+        if (operator.isBoolean()) {
+            return BuiltInType.BOOLEAN;
+        }
+        switch (operator) {
+            case ADD:
+            case SUB: {
+                if (left.getResultType() == BuiltInType.NUMBER && right.getResultType() == BuiltInType.NUMBER) {
+                    return BuiltInType.NUMBER;
+                } else if (left.getResultType() == BuiltInType.DATE_TIME && right.getResultType() == BuiltInType.DATE_TIME) {
+                    return BuiltInType.DATE_TIME;
+                } else if (left.getResultType() == BuiltInType.TIME && right.getResultType() == BuiltInType.TIME) {
+                    return BuiltInType.TIME;
+                } else if (left.getResultType() == BuiltInType.DURATION || right.getResultType() == BuiltInType.DURATION) {
+                    if (left.getResultType() == BuiltInType.DATE_TIME || right.getResultType() == BuiltInType.DATE_TIME) {
+                        return BuiltInType.DATE_TIME;
+                    } else if (left.getResultType() == BuiltInType.TIME || right.getResultType() == BuiltInType.TIME) {
+                        return BuiltInType.TIME;
+                    } else if (left.getResultType() == BuiltInType.DURATION && right.getResultType() == BuiltInType.DURATION) {
+                        return BuiltInType.DURATION;
+                    }
+                } else if (left.getResultType() == BuiltInType.STRING && right.getResultType() == BuiltInType.STRING) {
+                    return BuiltInType.STRING;
+                }
+            }
+            case MULT:
+            case DIV: {
+                if (left.getResultType() == BuiltInType.NUMBER && right.getResultType() == BuiltInType.NUMBER) {
+                    return BuiltInType.NUMBER;
+                } else if (left.getResultType() == BuiltInType.DURATION || right.getResultType() == BuiltInType.DURATION) {
+                    if (left.getResultType() == BuiltInType.NUMBER || right.getResultType() == BuiltInType.NUMBER) {
+                        return BuiltInType.NUMBER;
+                    }
+                }
+            }
+            case POW: {
+                if (left.getResultType() == BuiltInType.NUMBER && right.getResultType() == BuiltInType.NUMBER) {
+                    return BuiltInType.NUMBER;
+                }
+            }
+            default:
+                return BuiltInType.UNKNOWN;
+        }
+    }
+
+    @Override
+    public Object evaluate(final EvaluationContext ctx) {
+        if (left == null) {
+            return null;
+        }
+        final Object left = this.left.evaluate(ctx);
+        final Object right = this.right.evaluate(ctx);
+        switch (operator) {
+            case ADD:
+                return add(left, right, ctx);
+            case SUB:
+                return sub(left, right, ctx);
+            case MULT:
+                return mult(left, right, ctx);
+            case DIV:
+                return div(left, right, ctx);
+            case POW:
+                return math(left, right, ctx, (l, r) -> l.pow(r.intValue()));
+            case AND:
+                return and(left, right, ctx);
+            case OR:
+                return or(left, right, ctx);
+            case LTE:
+                return or(EvalHelper.compare(left, right, ctx, (l, r) -> l.compareTo(r) < 0),
+                          EvalHelper.isEqual(left, right, ctx),
+                          ctx); // do not use Java || to avoid potential NPE due to FEEL 3vl.
+            case LT:
+                return EvalHelper.compare(left, right, ctx, (l, r) -> l.compareTo(r) < 0);
+            case GT:
+                return EvalHelper.compare(left, right, ctx, (l, r) -> l.compareTo(r) > 0);
+            case GTE:
+                return or(EvalHelper.compare(left, right, ctx, (l, r) -> l.compareTo(r) > 0),
+                          EvalHelper.isEqual(left, right, ctx),
+                          ctx); // do not use Java || to avoid potential NPE due to FEEL 3vl.
+            case EQ:
+                return EvalHelper.isEqual(left, right, ctx);
+            case NE:
+                Boolean result = EvalHelper.isEqual(left, right, ctx);
+                return result != null ? !result : null;
+            default:
+                return null;
+        }
+    }
+
+    public static Object add(final Object left,
+                             final Object right,
+                             final EvaluationContext ctx) {
+        if (left == null || right == null) {
+            return null;
+        } else if (left instanceof String && right instanceof String) {
+            return left + ((String) right);
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            return new ComparablePeriod(((ChronoPeriod) left).plus((ChronoPeriod) right));
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return ((Duration) left).plus((Duration) right);
+        } else if (left instanceof ZonedDateTime && right instanceof ChronoPeriod) {
+            return ((ZonedDateTime) left).plus((ChronoPeriod) right);
+        } else if (left instanceof OffsetDateTime && right instanceof ChronoPeriod) {
+            return ((OffsetDateTime) left).plus((ChronoPeriod) right);
+        } else if (left instanceof LocalDateTime && right instanceof ChronoPeriod) {
+            return ((LocalDateTime) left).plus((ChronoPeriod) right);
+        } else if (left instanceof LocalDate && right instanceof ChronoPeriod) {
+            return ((LocalDate) left).plus((ChronoPeriod) right);
+        } else if (left instanceof ZonedDateTime && right instanceof Duration) {
+            return ((ZonedDateTime) left).plus((Duration) right);
+        } else if (left instanceof OffsetDateTime && right instanceof Duration) {
+            return ((OffsetDateTime) left).plus((Duration) right);
+        } else if (left instanceof LocalDateTime && right instanceof Duration) {
+            return ((LocalDateTime) left).plus((Duration) right);
+        } else if (left instanceof LocalDate && right instanceof Duration) {
+            return ((LocalDate) left).plusDays(((Duration) right).toDays());
+        } else if (left instanceof ChronoPeriod && right instanceof ZonedDateTime) {
+            return ((ZonedDateTime) right).plus((ChronoPeriod) left);
+        } else if (left instanceof ChronoPeriod && right instanceof OffsetDateTime) {
+            return ((OffsetDateTime) right).plus((ChronoPeriod) left);
+        } else if (left instanceof ChronoPeriod && right instanceof LocalDateTime) {
+            return ((LocalDateTime) right).plus((ChronoPeriod) left);
+        } else if (left instanceof ChronoPeriod && right instanceof LocalDate) {
+            return ((LocalDate) right).plus((ChronoPeriod) left);
+        } else if (left instanceof Duration && right instanceof ZonedDateTime) {
+            return ((ZonedDateTime) right).plus((Duration) left);
+        } else if (left instanceof Duration && right instanceof OffsetDateTime) {
+            return ((OffsetDateTime) right).plus((Duration) left);
+        } else if (left instanceof Duration && right instanceof LocalDateTime) {
+            return ((LocalDateTime) right).plus((Duration) left);
+        } else if (left instanceof Duration && right instanceof LocalDate) {
+            return ((LocalDate) right).plusDays(((Duration) left).toDays());
+        } else if (left instanceof LocalTime && right instanceof Duration) {
+            return ((LocalTime) left).plus((Duration) right);
+        } else if (left instanceof Duration && right instanceof LocalTime) {
+            return ((LocalTime) right).plus((Duration) left);
+        } else if (left instanceof OffsetTime && right instanceof Duration) {
+            return ((OffsetTime) left).plus((Duration) right);
+        } else if (left instanceof Duration && right instanceof OffsetTime) {
+            return ((OffsetTime) right).plus((Duration) left);
+        } else {
+            return math(left, right, ctx, (l, r) -> l.add(r, MathContext.DECIMAL128));
+        }
+    }
+
+    public static Object sub(Object left,
+                             Object right,
+                             final EvaluationContext ctx) {
+        if (left == null || right == null) {
+            return null;
+        } else if (left instanceof Temporal && right instanceof Temporal) {
+            if (left instanceof ZonedDateTime || left instanceof OffsetDateTime) {
+                if (right instanceof LocalDateTime) {
+                    right = ZonedDateTime.of((LocalDateTime) right, ZoneId.systemDefault());
+                }
+            } else if (right instanceof ZonedDateTime || right instanceof OffsetDateTime) {
+                if (left instanceof LocalDateTime) {
+                    left = ZonedDateTime.of((LocalDateTime) left, ZoneId.systemDefault());
+                }
+            } else if (right instanceof LocalDate && left instanceof LocalDate) {
+                return Duration.ofDays(ChronoUnit.DAYS.between((LocalDate) right, (LocalDate) left));
+            }
+            return Duration.between((Temporal) right, (Temporal) left);
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            return new ComparablePeriod(((ChronoPeriod) left).minus((ChronoPeriod) right));
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return ((Duration) left).minus((Duration) right);
+        } else if (left instanceof ZonedDateTime && right instanceof ChronoPeriod) {
+            return ((ZonedDateTime) left).minus((ChronoPeriod) right);
+        } else if (left instanceof OffsetDateTime && right instanceof ChronoPeriod) {
+            return ((OffsetDateTime) left).minus((ChronoPeriod) right);
+        } else if (left instanceof LocalDateTime && right instanceof ChronoPeriod) {
+            return ((LocalDateTime) left).minus((ChronoPeriod) right);
+        } else if (left instanceof LocalDate && right instanceof ChronoPeriod) {
+            return ((LocalDate) left).minus((ChronoPeriod) right);
+        } else if (left instanceof ZonedDateTime && right instanceof Duration) {
+            return ((ZonedDateTime) left).minus((Duration) right);
+        } else if (left instanceof OffsetDateTime && right instanceof Duration) {
+            return ((OffsetDateTime) left).minus((Duration) right);
+        } else if (left instanceof LocalDateTime && right instanceof Duration) {
+            return ((LocalDateTime) left).minus((Duration) right);
+        } else if (left instanceof LocalDate && right instanceof Duration) {
+            return ((LocalDate) left).minusDays(((Duration) right).toDays());
+        } else if (left instanceof LocalTime && right instanceof Duration) {
+            return ((LocalTime) left).minus((Duration) right);
+        } else if (left instanceof OffsetTime && right instanceof Duration) {
+            return ((OffsetTime) left).minus((Duration) right);
+        } else {
+            return math(left, right, ctx, (l, r) -> l.subtract(r, MathContext.DECIMAL128));
+        }
+    }
+
+    public static Object mult(final Object left,
+                              final Object right,
+                              final EvaluationContext ctx) {
+        if (left == null || right == null) {
+            return null;
+        } else if (left instanceof Duration && right instanceof Number) {
+            return ((Duration) left).multipliedBy(((Number) right).longValue());
+        } else if (left instanceof Number && right instanceof Duration) {
+            return Duration.ofSeconds(EvalHelper.getBigDecimalOrNull(left).multiply(EvalHelper.getBigDecimalOrNull(((Duration) right).getSeconds()), MathContext.DECIMAL128).longValue());
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return EvalHelper.getBigDecimalOrNull(((Duration) left).getSeconds()).multiply(EvalHelper.getBigDecimalOrNull(((Duration) right).getSeconds()), MathContext.DECIMAL128);
+        } else if (left instanceof ChronoPeriod && right instanceof Number) {
+            return ComparablePeriod.ofMonths(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) left)).multiply(EvalHelper.getBigDecimalOrNull(((Number) right).longValue()), MathContext.DECIMAL128).intValue());
+        } else if (left instanceof Number && right instanceof ChronoPeriod) {
+            return ComparablePeriod.ofMonths(EvalHelper.getBigDecimalOrNull(left).multiply(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) right)), MathContext.DECIMAL128).intValue());
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            return EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) left)).multiply(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) right)), MathContext.DECIMAL128);
+        } else {
+            return math(left, right, ctx, (l, r) -> l.multiply(r, MathContext.DECIMAL128));
+        }
+    }
+
+    public static Object div(final Object left,
+                             final Object right,
+                             final EvaluationContext ctx) {
+        if (left == null || right == null) {
+            return null;
+        } else if (left instanceof Duration && right instanceof Number) {
+            return ((Duration) left).dividedBy(((Number) right).longValue());
+        } else if (left instanceof Number && right instanceof Duration) {
+            return Duration.ofSeconds(EvalHelper.getBigDecimalOrNull(left).divide(EvalHelper.getBigDecimalOrNull(((Duration) right).getSeconds()), MathContext.DECIMAL128).longValue());
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return EvalHelper.getBigDecimalOrNull(((Duration) left).getSeconds()).divide(EvalHelper.getBigDecimalOrNull(((Duration) right).getSeconds()), MathContext.DECIMAL128);
+        } else if (left instanceof ChronoPeriod && right instanceof Number) {
+            return ComparablePeriod.ofMonths(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) left)).divide(EvalHelper.getBigDecimalOrNull(((Number) right).longValue()), MathContext.DECIMAL128).intValue());
+        } else if (left instanceof Number && right instanceof ChronoPeriod) {
+            return ComparablePeriod.ofMonths(EvalHelper.getBigDecimalOrNull(left).divide(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) right)), MathContext.DECIMAL128).intValue());
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            return EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) left)).divide(EvalHelper.getBigDecimalOrNull(ComparablePeriod.toTotalMonths((ChronoPeriod) right)), MathContext.DECIMAL128);
+        } else {
+            return math(left, right, ctx, (l, r) -> l.divide(r, MathContext.DECIMAL128));
+        }
+    }
+
+    public static Object math(final Object left,
+                              final Object right,
+                              final EvaluationContext ctx,
+                              final BinaryOperator<BigDecimal> op) {
+        final BigDecimal l = EvalHelper.getBigDecimalOrNull(left);
+        final BigDecimal r = EvalHelper.getBigDecimalOrNull(right);
+        if (l == null || r == null) {
+            return null;
+        }
+        try {
+            return op.apply(l, r);
+        } catch (ArithmeticException e) {
+            // happens in cases like division by 0
+            return null;
+        }
+    }
+
+    /**
+     * Implements the ternary logic AND operation
+     */
+    public static Object and(final Object left,
+                             final Object right,
+                             final EvaluationContext ctx) {
+        final Boolean l = EvalHelper.getBooleanOrNull(left);
+        final Boolean r = EvalHelper.getBooleanOrNull(right);
+        // have to check for all nulls first to avoid NPE
+        if ((l == null && r == null) || (l == null && r == true) || (r == null && l == true)) {
+            return null;
+        } else if (l == null || r == null) {
+            return false;
+        }
+        return l && r;
+    }
+
+    /**
+     * Implements the ternary logic OR operation
+     */
+    public static Object or(final Object left,
+                            final Object right,
+                            final EvaluationContext ctx) {
+        Boolean l = EvalHelper.getBooleanOrNull(left);
+        Boolean r = EvalHelper.getBooleanOrNull(right);
+        // have to check for all nulls first to avoid NPE
+        if ((l == null && r == null) || (l == null && r == false) || (r == null && l == false)) {
+            return null;
+        } else if (l == null || r == null) {
+            return true;
+        }
+        return l || r;
+    }
+
+    @Override
+    public ASTNode[] getChildrenNode() {
+        return new ASTNode[]{left, right};
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/RangeNode.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast;
+
+import java.time.Period;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.impl.RangeImpl;
+import org.kie.dmn.feel.util.AssignableFromUtil;
+import org.kie.dmn.feel.util.Msg;
+
+public class RangeNode extends BaseNode {
+
+    public static enum IntervalBoundary {
+        OPEN,
+        CLOSED;
+
+        public static IntervalBoundary low(final String input) {
+            switch (input) {
+                case "[":
+                    return CLOSED;
+                case "]":
+                default:
+                    return OPEN;
+            }
+        }
+
+        public static IntervalBoundary high(final String input) {
+            switch (input) {
+                case "]":
+                    return CLOSED;
+                case "[":
+                default:
+                    return OPEN;
+            }
+        }
+    }
+
+    private IntervalBoundary lowerBound;
+    private IntervalBoundary upperBound;
+    private BaseNode start;
+    private BaseNode end;
+
+    public RangeNode(final ParserRuleContext ctx,
+                     final IntervalBoundary lowerBound,
+                     final BaseNode start,
+                     final BaseNode end,
+                     final IntervalBoundary upperBound) {
+        super(ctx);
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.start = start;
+        this.end = end;
+    }
+
+    public IntervalBoundary getLowerBound() {
+        return lowerBound;
+    }
+
+    public void setLowerBound(final IntervalBoundary lowerBound) {
+        this.lowerBound = lowerBound;
+    }
+
+    public IntervalBoundary getUpperBound() {
+        return upperBound;
+    }
+
+    public void setUpperBound(final IntervalBoundary upperBound) {
+        this.upperBound = upperBound;
+    }
+
+    public BaseNode getStart() {
+        return start;
+    }
+
+    public void setStart(final BaseNode start) {
+        this.start = start;
+    }
+
+    public BaseNode getEnd() {
+        return end;
+    }
+
+    public void setEnd(BaseNode end) {
+        this.end = end;
+    }
+
+    @Override
+    public Range evaluate(final EvaluationContext ctx) {
+        final Object s = start.evaluate(ctx);
+        final Object e = end.evaluate(ctx);
+
+        final Type sType = BuiltInType.determineTypeFromInstance(s);
+        final Type eType = BuiltInType.determineTypeFromInstance(e);
+        if (s != null && e != null && sType != eType && !AssignableFromUtil.isAssignableFrom(s.getClass(), e.getClass())) {
+            ctx.notifyEvt(astEvent(Severity.ERROR, Msg.createMessage(Msg.X_TYPE_INCOMPATIBLE_WITH_Y_TYPE, "Start", "End")));
+            return null;
+        }
+
+        final Comparable start = convertToComparable(ctx, s);
+        final Comparable end = convertToComparable(ctx, e);
+
+        return new RangeImpl(lowerBound == IntervalBoundary.OPEN ? Range.RangeBoundary.OPEN : Range.RangeBoundary.CLOSED,
+                             start,
+                             end,
+                             upperBound == IntervalBoundary.OPEN ? Range.RangeBoundary.OPEN : Range.RangeBoundary.CLOSED);
+    }
+
+    private Comparable convertToComparable(final EvaluationContext ctx,
+                                           final Object s) {
+        final Comparable start;
+        if (s == null) {
+            start = null;
+        } else if (s instanceof Comparable) {
+            start = (Comparable) s;
+        } else if (s instanceof Period) {
+            // period has special semantics
+            start = new ComparablePeriod((Period) s);
+        } else {
+            ctx.notifyEvt(astEvent(Severity.ERROR, Msg.createMessage(Msg.INCOMPATIBLE_TYPE_FOR_RANGE, s.getClass().getSimpleName())));
+            start = null;
+        }
+        return start;
+    }
+
+    @Override
+    public Type getResultType() {
+        return BuiltInType.RANGE;
+    }
+
+    @Override
+    public ASTNode[] getChildrenNode() {
+        return new ASTNode[]{start, end};
+    }
+
+    @Override
+    public <T> T accept(Visitor<T> v) {
+        return v.visit(this);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTTemporalConstantVisitor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/visitor/ASTTemporalConstantVisitor.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast.visitor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Symbol;
+import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.ContextEntryNode;
+import org.kie.dmn.feel.lang.ast.ContextNode;
+import org.kie.dmn.feel.lang.ast.ForExpressionNode;
+import org.kie.dmn.feel.lang.ast.FormalParameterNode;
+import org.kie.dmn.feel.lang.ast.FunctionDefNode;
+import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
+import org.kie.dmn.feel.lang.ast.IterationContextNode;
+import org.kie.dmn.feel.lang.ast.NameRefNode;
+import org.kie.dmn.feel.lang.ast.QualifiedNameNode;
+import org.kie.dmn.feel.lang.ast.QuantifiedExpressionNode;
+import org.kie.dmn.feel.lang.ast.TemporalConstantNode;
+import org.kie.dmn.feel.parser.feel11.ScopeHelper;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.functions.BuiltInFunctions;
+import org.kie.dmn.feel.runtime.functions.DateAndTimeFunction;
+import org.kie.dmn.feel.runtime.functions.DateFunction;
+import org.kie.dmn.feel.runtime.functions.DurationFunction;
+import org.kie.dmn.feel.runtime.functions.TimeFunction;
+import org.kie.dmn.feel.util.EvalHelper;
+
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DATE;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DATE_AND_TIME;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DURATION;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.TIME;
+
+public class ASTTemporalConstantVisitor extends DefaultedVisitor<ASTNode> {
+
+    private final ScopeHelper<FEELFunction> scopeHelper = new ScopeHelper<>();
+
+    private static final FEELFunction MASKED = new DUMMY();
+
+    public static final List<FEELFunction> TEMPORAL_FNS = Arrays.asList(DateFunction.INSTANCE,
+                                                                        TimeFunction.INSTANCE,
+                                                                        DateAndTimeFunction.INSTANCE,
+                                                                        DurationFunction.INSTANCE);
+    public static final Set<String> TEMPORAL_FNS_NAMES = TEMPORAL_FNS.stream().map(FEELFunction::getName).collect(Collectors.toSet());
+
+    public ASTTemporalConstantVisitor(final CompilerContext ctx) {
+
+        Stream.of(BuiltInFunctions.getFunctions()).forEach(f -> scopeHelper.addInScope(f.getName(), f));
+
+        for (final FEELFunction f : ctx.getFEELFunctions()) {
+            scopeHelper.addInScope(f.getName(), f);
+        }
+
+        ctx.getInputVariables().keySet().forEach(this::processNameInScope);
+        ctx.getInputVariableTypes().keySet().forEach(this::processNameInScope);
+    }
+
+    private void processNameInScope(final String n) {
+        if (TEMPORAL_FNS_NAMES.contains(n)) {
+            scopeHelper.addInScope(n, MASKED);
+        }
+    }
+
+    @Override
+    public ASTNode defaultVisit(final ASTNode n) {
+        for (final ASTNode children : n.getChildrenNode()) {
+            if (children != null) {
+                children.accept(this);
+            }
+        }
+        return n;
+    }
+
+    @Override
+    public ASTNode visit(final ASTNode n) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ASTNode visit(final ForExpressionNode n) {
+        scopeHelper.pushScope();
+
+        for (final IterationContextNode ic : n.getIterationContexts()) {
+            ic.accept(this);
+            scopeHelper.addInScope(EvalHelper.normalizeVariableName(ic.getName().getText()), MASKED);
+        }
+
+        n.getExpression().accept(this);
+        scopeHelper.popScope();
+        return n;
+    }
+
+    @Override
+    public ASTNode visit(final ContextNode n) {
+        scopeHelper.pushScope();
+        for (final ContextEntryNode ce : n.getEntries()) {
+            ce.accept(this);
+            scopeHelper.addInScope(ce.getName().getText(), MASKED);
+        }
+        scopeHelper.popScope();
+        return n;
+    }
+
+    @Override
+    public ASTNode visit(final QuantifiedExpressionNode n) {
+        scopeHelper.pushScope();
+        for (final IterationContextNode ic : n.getIterationContexts()) {
+            ic.accept(this);
+            scopeHelper.addInScope(EvalHelper.normalizeVariableName(ic.getName().getText()), MASKED);
+        }
+        n.getExpression().accept(this);
+        scopeHelper.popScope();
+        return n;
+    }
+
+    @Override
+    public ASTNode visit(final FunctionDefNode n) {
+        scopeHelper.pushScope();
+        for (final FormalParameterNode fp : n.getFormalParameters()) {
+            scopeHelper.addInScope(EvalHelper.normalizeVariableName(fp.getName().getText()), MASKED);
+        }
+        n.getBody().accept(this);
+        scopeHelper.popScope();
+        return n;
+    }
+
+    @Override
+    public ASTNode visit(final FunctionInvocationNode n) {
+        final Optional<FEELFunction> fnOpt;
+        if (n.getName() instanceof NameRefNode) {
+            fnOpt = scopeHelper.resolve(n.getName().getText());
+        } else if (n.getName() instanceof QualifiedNameNode) {
+            QualifiedNameNode qnn = (QualifiedNameNode) n.getName();
+            String[] qns = qnn.getPartsAsStringArray();
+            String qn = Stream.of(qns).collect(Collectors.joining(" "));
+            fnOpt = scopeHelper.resolve(qn);
+        } else {
+            fnOpt = Optional.empty();
+        }
+        if (fnOpt.isPresent()) {
+            FEELFunction fn = fnOpt.get();
+            if (TEMPORAL_FNS.contains(fn)) {
+                try {
+                    TemporalConstantNode tcNode = buildTemporalConstantNode(n, fn);
+                    n.setTcFolded(tcNode);
+                } catch (final Exception e) {
+                    // Temporal constant inlining failed - not an issue, simply not memoized.
+                }
+            }
+        }
+        return super.visit(n);
+    }
+
+    private TemporalConstantNode buildTemporalConstantNode(final FunctionInvocationNode n,
+                                                           final FEELFunction fn) {
+        switch (fn.getName()) {
+            case DATE:
+                return buildTCNodeForDate(n, fn);
+            case DATE_AND_TIME:
+                return buildTCNodeForDateAndTime(n, fn);
+            case TIME:
+                return buildTCNodeForTime(n, fn);
+            case DURATION:
+                return buildTCNodeForDuration(n, fn);
+            default:
+                return null;
+        }
+    }
+
+    private TemporalConstantNode buildTCNodeForDuration(final FunctionInvocationNode n,
+                                                        final FEELFunction fn) {
+        return null;
+    }
+
+    private TemporalConstantNode buildTCNodeForTime(final FunctionInvocationNode n,
+                                                    final FEELFunction fn) {
+        return null;
+    }
+
+    private TemporalConstantNode buildTCNodeForDateAndTime(final FunctionInvocationNode n,
+                                                           final FEELFunction fn) {
+        return null;
+    }
+
+    private TemporalConstantNode buildTCNodeForDate(final FunctionInvocationNode n,
+                                                    final FEELFunction fn) {
+        return null;
+    }
+
+    private static final class DUMMY implements FEELFunction {
+
+        @Override
+        public String getName() {
+            return "DUMMY";
+        }
+
+        @Override
+        public Symbol getSymbol() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<List<Param>> getParameters() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object invokeReflectively(final EvaluationContext ctx,
+                                         final Object[] params) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/visitor/DMNDTAnalyserValueFromNodeVisitor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/ast/visitor/DMNDTAnalyserValueFromNodeVisitor.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.ast.visitor;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import jsinterop.base.Js;
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.ast.ASTNode;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.lang.ast.BooleanNode;
+import org.kie.dmn.feel.lang.ast.FunctionInvocationNode;
+import org.kie.dmn.feel.lang.ast.NameRefNode;
+import org.kie.dmn.feel.lang.ast.NumberNode;
+import org.kie.dmn.feel.lang.ast.SignedUnaryNode;
+import org.kie.dmn.feel.lang.ast.StringNode;
+import org.kie.dmn.feel.lang.impl.FEELImpl;
+import org.kie.dmn.feel.util.EvalHelper;
+
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DATE;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DATE_AND_TIME;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.DURATION;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.NUMBER;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.STRING;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.TIME;
+import static org.kie.dmn.feel.runtime.functions.FEELConversionFunctionNames.YEARS_AND_MONTHS_DURATION;
+
+public class DMNDTAnalyserValueFromNodeVisitor extends DefaultedVisitor<Comparable<?>> {
+
+    private final FEELImpl FEEL;
+
+    public DMNDTAnalyserValueFromNodeVisitor(final List<FEELProfile> feelProfiles) {
+        FEEL = Js.uncheckedCast(org.kie.dmn.feel.FEEL.newInstance(feelProfiles));
+    }
+
+    @Override
+    public Comparable<?> visit(final ASTNode n) {
+        return super.visit(n);
+    }
+
+    @Override
+    public Comparable<?> visit(final SignedUnaryNode n) {
+        return super.visit(n);
+    }
+
+    @Override
+    public Comparable<?> defaultVisit(final ASTNode n) {
+        final List<FEELEventListener> listeners = Collections.emptyList();
+        final Map<String, Object> inputVariables = Collections.emptyMap();
+        final EvaluationContext ctx = FEEL.newEvaluationContext(listeners, inputVariables);
+        final Object evaluate = n.evaluate(ctx);
+        return (Comparable<?>) evaluate;
+    }
+
+    @Override
+    public Comparable<?> visit(final FunctionInvocationNode n) {
+        return defaultVisit(n);
+    }
+
+    @Override
+    public Boolean visit(final BooleanNode n) {
+        return n.getValue();
+    }
+
+    @Override
+    public BigDecimal visit(final NumberNode n) {
+        return n.getValue();
+    }
+
+    @Override
+    public String visit(final StringNode n) {
+        return EvalHelper.unescapeString(n.getText());
+    }
+
+    public static class DMNDTAnalyserOutputClauseVisitor extends DMNDTAnalyserValueFromNodeVisitor {
+
+        public DMNDTAnalyserOutputClauseVisitor(final List<FEELProfile> feelProfiles) {
+            super(feelProfiles);
+        }
+
+        @Override
+        public Comparable<?> defaultVisit(final ASTNode n) {
+            return n.getText();
+        }
+    }
+
+    private static class SupportedConstantValueVisitor extends DefaultedVisitor<Boolean> {
+
+        public boolean areAllSupported(final List<BaseNode> nodes) {
+            return nodes.stream().allMatch(n -> n.accept(this));
+        }
+
+        @Override
+        public Boolean defaultVisit(final ASTNode n) {
+            return false;
+        }
+
+        @Override
+        public Boolean visit(final BooleanNode n) {
+            return true;
+        }
+
+        @Override
+        public Boolean visit(final NumberNode n) {
+            return true;
+        }
+
+        @Override
+        public Boolean visit(final StringNode n) {
+            return true;
+        }
+
+        @Override
+        public Boolean visit(final SignedUnaryNode n) {
+            final BaseNode signedExpr = n.getExpression();
+            if (signedExpr instanceof NumberNode) {
+                return true;
+            } else {
+                return defaultVisit(n);
+            }
+        }
+
+        @Override
+        public Boolean visit(final FunctionInvocationNode n) {
+            final String fnName;
+            if (n.getName() instanceof NameRefNode) {
+                fnName = n.getName().getText();
+            } else {
+                throw new IllegalStateException("Name of function is not instance of NameRefNode: " + n.toString());
+            }
+            final List<BaseNode> params = n.getParams().getElements();
+            switch (fnName) {
+                case DATE:
+                    if (params.size() == 1 || params.size() == 3) {
+                        return areAllSupported(params);
+                    }
+                    break;
+                case DATE_AND_TIME:
+                    if (params.size() == 2 || params.size() == 1) {
+                        return areAllSupported(params);
+                    }
+                    break;
+                case TIME:
+                    if (params.size() == 1 || params.size() == 4) {
+                        return areAllSupported(params);
+                    }
+                    break;
+                case NUMBER:
+                    if (params.size() == 3) {
+                        return areAllSupported(params);
+                    }
+                    break;
+                case STRING:
+                    if (params.size() == 1) {
+                        return areAllSupported(params);
+                    }
+                    break;
+                case DURATION:
+                    if (params.size() == 1) {
+                        return areAllSupported(params);
+                    }
+                case YEARS_AND_MONTHS_DURATION:
+                    if (params.size() == 2) {
+                        return areAllSupported(params);
+                    }
+                default:
+                    return false;
+            }
+            return false;
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/impl/EvaluationContextImpl.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.util.EvalHelper;
+import org.kie.dmn.model.api.GwtIncompatible;
+
+public class EvaluationContextImpl implements EvaluationContext {
+
+    private final FEELEventListenersManager eventsManager;
+    private ArrayDeque<ExecutionFrame> stack;
+    private DMNRuntime dmnRuntime;
+    private boolean performRuntimeTypeCheck = false;
+
+    private EvaluationContextImpl(final FEELEventListenersManager eventsManager,
+                                  final Deque<ExecutionFrame> stack) {
+        this.eventsManager = eventsManager;
+        this.stack = new ArrayDeque<>(stack);
+    }
+
+    public EvaluationContextImpl(final FEELEventListenersManager eventsManager) {
+        this(eventsManager, 32);
+    }
+
+    public EvaluationContextImpl(final FEELEventListenersManager eventsManager,
+                                 final int size) {
+        this(eventsManager, new ArrayDeque<>());
+        // we create a rootFrame to hold all the built in functions
+        push(RootExecutionFrame.INSTANCE);
+        // and then create a global frame to be the starting frame
+        // for function evaluation
+        final ExecutionFrameImpl global = new ExecutionFrameImpl(RootExecutionFrame.INSTANCE, size);
+        push(global);
+    }
+
+    @Override
+    public EvaluationContext current() {
+        final EvaluationContextImpl ec = new EvaluationContextImpl(eventsManager, new ArrayDeque<>(stack));
+        ec.dmnRuntime = this.dmnRuntime;
+        ec.performRuntimeTypeCheck = this.performRuntimeTypeCheck;
+        return ec;
+    }
+
+    public void push(ExecutionFrame obj) {
+        stack.push(obj);
+    }
+
+    public ExecutionFrame pop() {
+        return stack.pop();
+    }
+
+    public ExecutionFrame peek() {
+        return stack.peek();
+    }
+
+    public Deque<ExecutionFrame> getStack() {
+        return this.stack;
+    }
+
+    @Override
+    public void enterFrame() {
+        push(new ExecutionFrameImpl(peek() /*, symbols, scope*/));
+    }
+
+    public void enterFrame(int size) {
+        push(new ExecutionFrameImpl(peek(), size));
+    }
+
+    @Override
+    public void exitFrame() {
+        pop();
+    }
+
+    @Override
+    public void setValue(String name, Object value) {
+        peek().setValue(name, EvalHelper.coerceNumber(value));
+    }
+
+    public void setValues(Map<String, Object> values) {
+        values.forEach(this::setValue);
+    }
+
+    @Override
+    public Object getValue(String name) {
+        return peek().getValue(name);
+    }
+
+    @Override
+    public Object getValue(final String[] name) {
+        if (name.length == 1) {
+            return getValue(name[0]);
+        } else if (name.length > 1) {
+            Map actualObject = (Map) peek().getValue(name[0]);
+            // Each sublevel must be a context until the last one.
+            for (int i = 1; i < name.length - 1; i++) {
+                actualObject = (Map) actualObject.get(name[i]);
+                if (actualObject == null) {
+                    return null;
+                }
+            }
+            return actualObject.get(name[name.length - 1]);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isDefined(String name) {
+        return peek().isDefined(name);
+    }
+
+    @Override
+    public boolean isDefined(final String[] name) {
+        if (name.length == 1) {
+            return isDefined(name[0]);
+        } else if (name.length > 1) {
+            Map actualObject = (Map) peek().getValue(name[0]);
+            // Each sublevel must be a context until the last one.
+            for (int i = 1; i < name.length - 1; i++) {
+                actualObject = (Map) actualObject.get(name[i]);
+                if (actualObject == null) {
+                    return false;
+                }
+            }
+            return actualObject.get(name[name.length - 1]) != null;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public Map<String, Object> getAllValues() {
+        if (stack.peek().getRootObject() != null) {
+            throw new RuntimeException();
+        }
+        final int initialCapacity = (stack.peek().getAllValues().size() + stack.peekLast().getAllValues().size()) * 2;
+        final Map<String, Object> values = new HashMap<>(initialCapacity);
+        final Iterator<ExecutionFrame> it = stack.descendingIterator();
+        while (it.hasNext()) {
+            values.putAll(it.next().getAllValues());
+        }
+        return values;
+    }
+
+    @Override
+    public void notifyEvt(final Supplier<FEELEvent> event) {
+        FEELEventListenersManager.notifyListeners(eventsManager, event);
+    }
+
+    @Override
+    public Collection<FEELEventListener> getListeners() {
+        return eventsManager.getListeners();
+    }
+
+    @Override
+    public DMNRuntime getDMNRuntime() {
+        return dmnRuntime;
+    }
+
+    @Override
+    @GwtIncompatible
+    public ClassLoader getRootClassLoader() {
+        return null;
+    }
+
+    public void setDMNRuntime(final DMNRuntime runtime) {
+        this.dmnRuntime = runtime;
+    }
+
+    public void setPerformRuntimeTypeCheck(final boolean performRuntimeTypeCheck) {
+        this.performRuntimeTypeCheck = performRuntimeTypeCheck;
+    }
+
+    public boolean isPerformRuntimeTypeCheck() {
+        return performRuntimeTypeCheck;
+    }
+
+    @Override
+    public void setRootObject(final Object v) {
+        peek().setRootObject(v);
+    }
+
+    @Override
+    public Object getRootObject() {
+        return peek().getRootObject();
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/impl/FEELImpl.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.kie.dmn.api.feel.runtime.events.FEELEventListener;
+import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.lang.CompiledExpression;
+import org.kie.dmn.feel.lang.CompilerContext;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.ast.BaseNode;
+import org.kie.dmn.feel.parser.feel11.ASTBuilderVisitor;
+import org.kie.dmn.feel.parser.feel11.FEELParser;
+import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser;
+import org.kie.dmn.feel.parser.feel11.profiles.DoCompileFEELProfile;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.UnaryTest;
+
+/**
+ * Language runtime entry point
+ */
+public class FEELImpl implements FEEL {
+
+    private static final Map<String, Object> EMPTY_INPUT = Collections.emptyMap();
+
+    private Set<FEELEventListener> instanceEventListeners = new HashSet<>();
+
+    private final List<FEELProfile> profiles;
+    // pre-cached results from the above profiles...
+    private final Optional<ExecutionFrameImpl> customFrame;
+    private final Collection<FEELFunction> customFunctions;
+    private final boolean doCompile;
+
+    public FEELImpl() {
+        this(Collections.emptyList());
+    }
+
+    public FEELImpl(final List<FEELProfile> profiles) {
+        this.profiles = Collections.unmodifiableList(profiles);
+        ExecutionFrameImpl frame = null;
+        final Map<String, FEELFunction> functions = new HashMap<>();
+        for (FEELProfile p : profiles) {
+            for (FEELFunction f : p.getFEELFunctions()) {
+                if (frame == null) {
+                    frame = new ExecutionFrameImpl(null);
+                }
+                frame.setValue(f.getName(), f);
+                functions.put(f.getName(), f);
+            }
+        }
+        doCompile = profiles.stream().anyMatch(x -> x instanceof DoCompileFEELProfile);
+        customFrame = Optional.ofNullable(frame);
+        customFunctions = Collections.unmodifiableCollection(functions.values());
+    }
+
+    @Override
+    public CompilerContext newCompilerContext() {
+        return newCompilerContext(Collections.emptySet());
+    }
+
+    public CompilerContext newCompilerContext(final Collection<FEELEventListener> contextListeners) {
+        return new CompilerContextImpl(getEventsManager(contextListeners)).addFEELFunctions(customFunctions);
+    }
+
+    @Override
+    public CompiledExpression compile(final String expression,
+                                      final CompilerContext ctx) {
+        throw new UnsupportedOperationException("Not supported in GWT (yet)");
+    }
+
+    @Override
+    public CompiledExpression compileUnaryTests(final String expression,
+                                                final CompilerContext ctx) {
+        throw new UnsupportedOperationException("Not supported in GWT (yet)");
+    }
+
+    @Override
+    public Object evaluate(String expression) {
+        return evaluate(expression, FEELImpl.EMPTY_INPUT);
+    }
+
+    @Override
+    public String parseTest(final String value) {
+        final FEEL_1_1Parser parser = FEELParser.parse(null, value, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), null);
+
+        final ParseTree tree = parser.expression();
+
+        final ASTBuilderVisitor v = new ASTBuilderVisitor(Collections.emptyMap(), null);
+        final BaseNode expr = v.visit(tree);
+
+        return expr.getText() + " - " + expr.getResultType() + " - " + expr.toString();
+    }
+
+    @Override
+    public Object evaluate(final String expression,
+                           final EvaluationContext ctx) {
+        final CompilerContext compilerCtx = newCompilerContext(ctx.getListeners());
+        final Map<String, Object> inputVariables = ctx.getAllValues();
+        if (inputVariables != null) {
+            inputVariables.entrySet().stream().forEach(e -> compilerCtx.addInputVariable(e.getKey(), e.getValue()));
+        }
+        final CompiledExpression expr = compile(expression, compilerCtx);
+        return evaluate(expr, ctx);
+    }
+
+    @Override
+    public Object evaluate(final String expression,
+                           final Map<String, Object> inputVariables) {
+        final CompilerContext ctx = newCompilerContext();
+        if (inputVariables != null) {
+            inputVariables.entrySet().stream().forEach(e -> ctx.addInputVariable(e.getKey(), e.getValue()));
+        }
+        final CompiledExpression expr = compile(expression, ctx);
+        if (inputVariables == null) {
+            return evaluate(expr, EMPTY_INPUT);
+        } else {
+            return evaluate(expr, inputVariables);
+        }
+    }
+
+    @Override
+    public Object evaluate(final CompiledExpression expr,
+                           final Map<String, Object> inputVariables) {
+        throw new UnsupportedOperationException("Not supported in GWT (yet)");
+    }
+
+    @Override
+    public Object evaluate(final CompiledExpression expr,
+                           final EvaluationContext ctx) {
+        throw new UnsupportedOperationException("Not supported in GWT (yet)");
+    }
+
+    public EvaluationContext newEvaluationContext(final Collection<FEELEventListener> listeners,
+                                                  final Map<String, Object> inputVariables) {
+        final FEELEventListenersManager eventsManager = getEventsManager(listeners);
+        final EvaluationContextImpl ctx = new EvaluationContextImpl(eventsManager, inputVariables.size());
+        if (customFrame.isPresent()) {
+            final ExecutionFrameImpl globalFrame = (ExecutionFrameImpl) ctx.pop();
+            final ExecutionFrameImpl interveawedFrame = customFrame.get();
+            interveawedFrame.setParentFrame(ctx.peek());
+            globalFrame.setParentFrame(interveawedFrame);
+            ctx.push(interveawedFrame);
+            ctx.push(globalFrame);
+        }
+        ctx.setValues(inputVariables);
+        return ctx;
+    }
+
+    @Override
+    public List<UnaryTest> evaluateUnaryTests(final String expression) {
+        return evaluateUnaryTests(expression, Collections.emptyMap());
+    }
+
+    @Override
+    public List<UnaryTest> evaluateUnaryTests(final String expression,
+                                              final Map<String, Type> variableTypes) {
+        throw new UnsupportedOperationException("Not supported in GWT (yet)");
+    }
+
+    @Override
+    public void addListener(final FEELEventListener listener) {
+        instanceEventListeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(final FEELEventListener listener) {
+        instanceEventListeners.remove(listener);
+    }
+
+    @Override
+    public Set<FEELEventListener> getListeners() {
+        return Collections.unmodifiableSet(instanceEventListeners);
+    }
+
+    public FEELEventListenersManager getEventsManager(final Collection<FEELEventListener> contextListeners) {
+        final FEELEventListenersManager listenerMgr = new FEELEventListenersManager();
+        listenerMgr.addListeners(instanceEventListeners);
+        listenerMgr.addListeners(contextListeners);
+        return listenerMgr;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJO.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/lang/types/impl/ImmutableFPAWrappingPOJO.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.lang.types.impl;
+
+import java.util.Map;
+
+import org.kie.dmn.api.core.FEELPropertyAccessible;
+
+public class ImmutableFPAWrappingPOJO implements FEELPropertyAccessible {
+
+    public ImmutableFPAWrappingPOJO(Object wrapping) {
+        throw new UnsupportedOperationException("reflection FPA not required and not supported on GWT platform");
+    }
+
+    @Override
+    public AbstractPropertyValueResult getFEELProperty(String property) {
+        throw new UnsupportedOperationException("reflection FPA not required and not supported on GWT platform");
+    }
+
+    @Override
+    public void setFEELProperty(String key, Object value) {
+        throw new UnsupportedOperationException("reflection FPA not required and not supported on GWT platform");
+    }
+
+    @Override
+    public Map<String, Object> allFEELProperties() {
+        throw new UnsupportedOperationException("reflection FPA not required and not supported on GWT platform");
+    }
+
+    @Override
+    public void fromMap(Map<String, Object> values) {
+        throw new UnsupportedOperationException("reflection FPA not required and not supported on GWT platform");
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/marshaller/FEELCodeMarshaller.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/marshaller/FEELCodeMarshaller.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.marshaller;
+
+import java.util.function.Function;
+
+import org.kie.dmn.feel.FEEL;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.runtime.functions.extended.CodeFunction;
+
+import static org.kie.dmn.feel.lang.types.BuiltInType.justNull;
+
+/**
+ * An implementation of the FEEL marshaller interface
+ * that converts FEEL objects into it's string representation
+ * and vice versa
+ */
+public class FEELCodeMarshaller implements FEELMarshaller<String> {
+
+    public static final FEELCodeMarshaller INSTANCE = new FEELCodeMarshaller();
+    private FEEL feel = FEEL.newInstance();
+
+    private FEELCodeMarshaller() {
+    }
+
+    /**
+     * Marshalls the given value into FEEL code that can be executed to
+     * reconstruct the value. For instance, here are some examples of the marshalling process:
+     * <p>
+     * * number 10 marshalls as: 10
+     * * string foo marshalls as: "foo"
+     * * duration P1D marshalls as: duration( "P1D" )
+     * * context { x : 10, y : foo } marshalls as: { x : 10, y : "foo" }
+     * @param value the FEEL value to be marshalled
+     * @return a string representing the FEEL code that needs to be executed to reconstruct the value
+     */
+    @Override
+    public String marshall(final Object value) {
+        if (value == null) {
+            return "null";
+        }
+        return new CodeFunction().invoke(value).cata(justNull(), Function.identity());
+    }
+
+    /**
+     * Unmarshalls the string into a FEEL value by executing it.
+     * @param feelType this parameter is ignored by this marshaller and can be set to null
+     * @param value the FEEL code to execute for unmarshalling
+     * @return the value resulting from executing the code
+     */
+    @Override
+    public Object unmarshall(final Type feelType, final String value) {
+        return feel.evaluate(value);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/marshaller/FEELStringMarshaller.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/marshaller/FEELStringMarshaller.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.marshaller;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.kie.dmn.feel.lang.Type;
+
+import static org.kie.dmn.feel.runtime.functions.DateFunction.FEEL_DATE;
+
+/**
+ * An implementation of the FEEL marshaller interface
+ * that converts FEEL objects into it's string representation
+ * and vice versa
+ */
+public class FEELStringMarshaller implements FEELMarshaller<String> {
+
+    public static final FEELStringMarshaller INSTANCE = new FEELStringMarshaller();
+
+    private FEELStringMarshaller() {
+    }
+
+    /**
+     * Marshalls the give FEEL value into a String. The result is similar to
+     * calling the string() function in a FEEL expression, with the difference
+     * that a null value is returned as the "null" string instead of the null
+     * value itself.
+     * @param value the FEEL value to be marshalled
+     * @return the string representation of the value
+     */
+    @Override
+    public String marshall(final Object value) {
+        if (value == null) {
+            return "null";
+        }
+        return value.toString();
+    }
+
+    /**
+     * Unmarshalls the given string into a FEEL value.
+     * <p>
+     * IMPORTANT: please note that it is only possible to unmarshall simple
+     * values, like strings and numbers. Complex values like lists and contexts
+     * don't have enough metadata marshalled in the string to enable them to be
+     * unmarshalled.
+     * @param feelType the expected type of the value to be unmarshalled
+     * @param value the marshalled value to unmarshall
+     * @return the value resulting from the unmarshalling of the string
+     * @throws UnsupportedOperationException in case the type is a complex type,
+     * i.e. RANGE, FUNCTION, CONTEXT, LIST or UNARY_TEST, the implementation
+     * raises the exception.
+     */
+    @Override
+    public Object unmarshall(final Type feelType,
+                             final String value) {
+
+        if ("null".equals(value)) {
+            return null;
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.NUMBER)) {
+            return new BigDecimal(value);
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.STRING)) {
+            return value;
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.DATE)) {
+            return LocalDate.from(FEEL_DATE.parse(value));
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.TIME)) {
+            return null;
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.DATE_TIME)) {
+            return null;
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.DURATION)) {
+            return null;
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.BOOLEAN)) {
+            return Boolean.parseBoolean(value);
+        } else if (feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.RANGE) || feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.FUNCTION) || feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.LIST)
+                || feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.CONTEXT) || feelType.equals(org.kie.dmn.feel.lang.types.BuiltInType.UNARY_TEST)) {
+            throw new UnsupportedOperationException("FEELStringMarshaller is unable to unmarshall complex types like: " + feelType.getName());
+        }
+        return null;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELErrorHandler.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELErrorHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.parser.feel11;
+
+import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.FailedPredicateException;
+import org.antlr.v4.runtime.Parser;
+
+public class FEELErrorHandler extends DefaultErrorStrategy {
+
+    @Override
+    protected void reportFailedPredicate(final Parser recognizer,
+                                         final FailedPredicateException e) {
+        // Do not do anything.
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParser.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.parser.feel11;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gwt.regexp.shared.RegExp;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.FEELProfile;
+import org.kie.dmn.feel.lang.Scope;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.lang.types.BuiltInTypeSymbol;
+import org.kie.dmn.feel.lang.types.FEELTypeRegistry;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
+import org.kie.dmn.feel.util.Msg;
+
+public class FEELParser {
+
+    static final List<String> REUSABLE_KEYWORDS = Arrays.asList(
+            "for", "return", "if", "then", "else", "some", "every", "satisfies", "instance", "of",
+            "function", "external", "or", "and", "between", "not", "null", "true", "false"
+    );
+    private static final RegExp DIGITS_PATTERN = RegExp.compile("[0-9]*");
+
+    public static FEEL_1_1Parser parse(final FEELEventListenersManager eventsManager,
+                                       final String source,
+                                       final Map<String, Type> inputVariableTypes,
+                                       final Map<String, Object> inputVariables,
+                                       final Collection<FEELFunction> additionalFunctions,
+                                       final List<FEELProfile> profiles,
+                                       final FEELTypeRegistry typeRegistry) {
+
+        final CharStream input = CharStreams.fromString(source);
+        final FEEL_1_1Lexer lexer = new FEEL_1_1Lexer(input);
+        final CommonTokenStream tokens = new CommonTokenStream(lexer);
+        final FEEL_1_1Parser parser = new FEEL_1_1Parser(tokens);
+
+        final ParserHelper parserHelper = new ParserHelper(eventsManager);
+        additionalFunctions.forEach(f -> parserHelper.getSymbolTable().getBuiltInScope().define(f.getSymbol()));
+        parser.setHelper(parserHelper);
+        parser.setErrorHandler(new FEELErrorHandler());
+        parser.removeErrorListeners(); // removes the error listener that prints to the console
+        parser.addErrorListener(new FEELParserErrorListener(eventsManager));
+
+        // pre-loads the parser with symbols
+        defineVariables(inputVariableTypes, inputVariables, parser);
+
+        if (typeRegistry != null) {
+            parserHelper.setTypeRegistry(typeRegistry);
+        }
+
+        return parser;
+    }
+
+    /**
+     * Either namePart is a string of digits, or it must be a valid name itself
+     */
+    public static boolean isVariableNamePartValid(final String namePart,
+                                                  final Scope scope) {
+        if (DIGITS_PATTERN.exec(namePart) != null) {
+            return true;
+        }
+        if (REUSABLE_KEYWORDS.contains(namePart)) {
+            return scope.followUp(namePart, true);
+        }
+        return isVariableNameValid(namePart);
+    }
+
+    public static boolean isVariableNameValid(final String source) {
+        return checkVariableName(source).isEmpty();
+    }
+
+    public static List<FEELEvent> checkVariableName(final String source) {
+
+        if (source == null || source.isEmpty()) {
+            return Collections.singletonList(new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                                                  Msg.createMessage(Msg.INVALID_VARIABLE_NAME_EMPTY),
+                                                                  null,
+                                                                  0,
+                                                                  0,
+                                                                  null));
+        }
+
+        final CharStream input = CharStreams.fromString(source);
+        final FEEL_1_1Lexer lexer = new FEEL_1_1Lexer(input);
+        final CommonTokenStream tokens = new CommonTokenStream(lexer);
+        final FEEL_1_1Parser parser = new FEEL_1_1Parser(tokens);
+
+        parser.setHelper(new ParserHelper());
+        parser.setErrorHandler(new FEELErrorHandler());
+
+        final FEELParserErrorListener errorChecker = new FEELParserErrorListener(null);
+        parser.removeErrorListeners(); // removes the error listener that prints to the console
+        parser.addErrorListener(errorChecker);
+
+        final FEEL_1_1Parser.NameDefinitionWithEOFContext nameDef = parser.nameDefinitionWithEOF(); // be sure to align below parser.getRuleInvocationStack().contains("nameDefinition...
+
+        if (!errorChecker.hasErrors() &&
+                nameDef != null &&
+                source.trim().equals(parser.getHelper().getOriginalText(nameDef))) {
+            return Collections.emptyList();
+        }
+        return errorChecker.getErrors();
+    }
+
+    public static void defineVariables(final Map<String, Type> inputVariableTypes,
+                                       final Map<String, Object> inputVariables,
+                                       final FEEL_1_1Parser parser) {
+        inputVariableTypes.forEach((name, type) -> {
+            parser.getHelper().defineVariable(name, type);
+            if (type.getName() != null) {
+                parser.getHelper().getSymbolTable().getGlobalScope().define(new BuiltInTypeSymbol(type.getName(), type));
+            }
+        });
+
+        inputVariables.forEach((name, value) -> {
+            parser.getHelper().defineVariable(name);
+            if (value instanceof Map) {
+                try {
+                    parser.getHelper().pushName(name);
+                    parser.getHelper().pushScope();
+                    defineVariables(Collections.EMPTY_MAP, (Map<String, Object>) value, parser);
+                } finally {
+                    parser.getHelper().popScope();
+                    parser.getHelper().popName();
+                }
+            }
+        });
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParserErrorListener.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/FEELParserErrorListener.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.parser.feel11;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.IntervalSet;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.runtime.events.SyntaxErrorEvent;
+import org.kie.dmn.feel.util.Msg;
+
+import static org.kie.dmn.feel.parser.feel11.FEELParser.REUSABLE_KEYWORDS;
+
+public class FEELParserErrorListener extends BaseErrorListener {
+
+    private final FEELEventListenersManager eventsManager;
+    private List<FEELEvent> errors = null;
+
+    public FEELParserErrorListener(final FEELEventListenersManager eventsManager) {
+        this.eventsManager = eventsManager;
+    }
+
+    @Override
+    public void syntaxError(final Recognizer<?, ?> recognizer,
+                            final Object offendingSymbol,
+                            final int line,
+                            final int charPositionInLine,
+                            final String msg,
+                            final RecognitionException e) {
+
+        final SyntaxErrorEvent error;
+        final CommonToken token = (CommonToken) offendingSymbol;
+        final int tokenIndex = token.getTokenIndex();
+        final Parser parser = (Parser) recognizer;
+
+        if (parser.getRuleInvocationStack().contains("nameDefinitionWithEOF")) {
+            error = generateInvalidVariableError(offendingSymbol, line, charPositionInLine, e, token);
+        } else if ("}".equals(token.getText()) && tokenIndex > 1 && ":".equals(parser.getTokenStream().get(tokenIndex - 1).getText())) {
+            error = new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                         Msg.createMessage(Msg.MISSING_EXPRESSION, parser.getTokenStream().get(tokenIndex - 2).getText()),
+                                         e,
+                                         line,
+                                         charPositionInLine,
+                                         offendingSymbol);
+        } else if (e != null && parser.getRuleInvocationStack().get(0).equals("ifExpression")) {
+            final List<String> expected = toList(e.getExpectedTokens(), e.getRecognizer().getVocabulary());
+            if (expected.contains("ELSE")) {
+                error = new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                             Msg.createMessage(Msg.IF_MISSING_ELSE, token.getText(), msg),
+                                             e,
+                                             line,
+                                             charPositionInLine,
+                                             offendingSymbol);
+            } else if (expected.contains("THEN")) {
+                error = new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                             Msg.createMessage(Msg.IF_MISSING_THEN, token.getText(), msg),
+                                             e,
+                                             line,
+                                             charPositionInLine,
+                                             offendingSymbol);
+            } else { // fallback.
+                error = new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                             msg,
+                                             e,
+                                             line,
+                                             charPositionInLine,
+                                             offendingSymbol);
+            }
+        } else {
+            error = new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                         msg,
+                                         e,
+                                         line,
+                                         charPositionInLine,
+                                         offendingSymbol);
+        }
+
+        // if the event manager is set, notify listeners, otherwise store the error in the errors list
+        if (eventsManager != null) {
+            FEELEventListenersManager.notifyListeners(eventsManager, () -> error);
+        } else {
+            if (errors == null) {
+                errors = new ArrayList<>();
+            }
+            errors.add(error);
+        }
+    }
+
+    public boolean hasErrors() {
+        return this.errors != null && !this.errors.isEmpty();
+    }
+
+    public List<FEELEvent> getErrors() {
+        return errors == null ? Collections.emptyList() : errors;
+    }
+
+    private static SyntaxErrorEvent generateInvalidVariableError(final Object offendingSymbol,
+                                                                 final int line,
+                                                                 final int charPositionInLine,
+                                                                 final RecognitionException e,
+                                                                 final CommonToken token) {
+        final String chars = token.getText().length() == 1 ? "character" : "sequence of characters";
+        if (charPositionInLine == 0) {
+            if ("in".equals(token.getText()) || REUSABLE_KEYWORDS.contains(token.getText())) {
+                return new SyntaxErrorEvent(
+                        FEELEvent.Severity.ERROR,
+                        Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, "keyword", token.getText()),
+                        e,
+                        line,
+                        charPositionInLine,
+                        offendingSymbol);
+            } else {
+                return new SyntaxErrorEvent(
+                        FEELEvent.Severity.ERROR,
+                        Msg.createMessage(Msg.INVALID_VARIABLE_NAME_START, chars, token.getText()),
+                        e,
+                        line,
+                        charPositionInLine,
+                        offendingSymbol);
+            }
+        } else if ("in".equals(token.getText())) {
+            return new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                        Msg.createMessage(Msg.INVALID_VARIABLE_NAME, "keyword", token.getText()),
+                                        e,
+                                        line,
+                                        charPositionInLine,
+                                        offendingSymbol);
+        } else if ("}".equals(token.getText()) && e != null && e.getRecognizer() instanceof Parser && ((Parser) e.getRecognizer()).getRuleInvocationStack().contains("key")) {
+            return new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                        Msg.createMessage(Msg.MISSING_EXPRESSION, e.getCtx().getText()),
+                                        e,
+                                        line,
+                                        charPositionInLine,
+                                        offendingSymbol);
+        } else {
+            return new SyntaxErrorEvent(FEELEvent.Severity.ERROR,
+                                        Msg.createMessage(Msg.INVALID_VARIABLE_NAME, chars, token.getText()),
+                                        e,
+                                        line,
+                                        charPositionInLine,
+                                        offendingSymbol);
+        }
+    }
+
+    private static List<String> toList(final IntervalSet intervals,
+                                       final Vocabulary vocabulary) {
+
+        final List<String> result = new ArrayList<>();
+        if (intervals == null || intervals.getIntervals() == null || intervals.getIntervals().isEmpty()) {
+            return result;
+        }
+
+        final Iterator<Interval> iter = intervals.getIntervals().iterator();
+        while (iter.hasNext()) {
+            Interval I = iter.next();
+            int a = I.a;
+            int b = I.b;
+            if (a == b) {
+                result.add(elementName(vocabulary, a));
+            } else {
+                for (int i = a; i <= b; i++) {
+                    result.add(elementName(vocabulary, i));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String elementName(final Vocabulary vocabulary,
+                                      final int a) {
+        if (a == Token.EOF) {
+            return "<EOF>";
+        } else if (a == Token.EPSILON) {
+            return "<EPSILON>";
+        } else {
+            return vocabulary.getSymbolicName(a);
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/parser/feel11/ParserHelper.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.parser.feel11;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.stream.Collectors;
+
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.CompositeType;
+import org.kie.dmn.feel.lang.Scope;
+import org.kie.dmn.feel.lang.SimpleType;
+import org.kie.dmn.feel.lang.Symbol;
+import org.kie.dmn.feel.lang.Type;
+import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
+import org.kie.dmn.feel.lang.types.AliasFEELType;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.lang.types.DefaultBuiltinFEELTypeRegistry;
+import org.kie.dmn.feel.lang.types.FEELTypeRegistry;
+import org.kie.dmn.feel.lang.types.GenListType;
+import org.kie.dmn.feel.lang.types.ScopeImpl;
+import org.kie.dmn.feel.lang.types.SymbolTable;
+import org.kie.dmn.feel.lang.types.VariableSymbol;
+import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser.FilterPathExpressionContext;
+import org.kie.dmn.feel.parser.feel11.FEEL_1_1Parser.QualifiedNameContext;
+import org.kie.dmn.feel.runtime.events.UnknownVariableErrorEvent;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public class ParserHelper {
+
+    private FEELEventListenersManager eventsManager;
+    private SymbolTable symbols = new SymbolTable();
+    private Scope currentScope = symbols.getGlobalScope();
+    private Stack<String> currentName = new Stack<>();
+    private int dynamicResolution = 0;
+    private boolean featDMN12EnhancedForLoopEnabled = true; // DROOLS-2307 DMN enhanced for loop
+    private boolean featDMN12weekday = true; // DROOLS-2648 DMN v1.2 weekday on 'date', 'date and time'
+    private FEELTypeRegistry typeRegistry = DefaultBuiltinFEELTypeRegistry.INSTANCE;
+
+    public ParserHelper() {
+        this(null);
+    }
+
+    public ParserHelper(final FEELEventListenersManager eventsManager) {
+        this.eventsManager = eventsManager;
+
+        // Initial context is loaded
+        currentName.push(Scope.LOCAL);
+    }
+
+    public SymbolTable getSymbolTable() {
+        return symbols;
+    }
+
+    public void pushScope() {
+        currentScope = new ScopeImpl(currentName.peek(), currentScope);
+    }
+
+    public void pushScope(final Type type) {
+        currentScope = new ScopeImpl(currentName.peek(), currentScope, type);
+    }
+
+    public void setTypeRegistry(final FEELTypeRegistry typeRegistry) {
+        this.typeRegistry = typeRegistry;
+    }
+
+    public void pushTypeScope() {
+        currentScope = typeRegistry.getItemDefScope(currentScope);
+    }
+
+    public void popScope() {
+        currentScope = currentScope.getParentScope();
+    }
+
+    public void pushName(final String name) {
+        this.currentName.push(name);
+    }
+
+    public void pushName(final ParserRuleContext ctx) {
+        this.currentName.push(getName(ctx));
+    }
+
+    private String getName(final ParserRuleContext ctx) {
+        String key = getOriginalText(ctx);
+        if (ctx instanceof FEEL_1_1Parser.KeyStringContext) {
+            key = EvalHelper.unescapeString(key);
+        }
+        return key;
+    }
+
+    public void popName() {
+        this.currentName.pop();
+    }
+
+    public void recoverScope() {
+        recoverScope(currentName.peek());
+    }
+
+    public void recoverScope(final String name) {
+        final Scope s = this.currentScope.getChildScopes().get(name);
+        if (s != null) {
+            currentScope = s;
+            if (currentScope.getType() != null && currentScope.getType().equals(BuiltInType.UNKNOWN)) {
+                enableDynamicResolution();
+            }
+        } else {
+            final Symbol resolved = this.currentScope.resolve(name);
+            Type scopeType = resolved != null ? resolved.getType() : null;
+            if (scopeType instanceof GenListType) {
+                scopeType = ((GenListType) scopeType).getGen();
+            }
+
+            if (resolved != null && scopeType instanceof CompositeType) {
+                pushName(name);
+                pushScope(scopeType);
+                final CompositeType type = (CompositeType) scopeType;
+                for (Map.Entry<String, Type> f : type.getFields().entrySet()) {
+                    this.currentScope.define(new VariableSymbol(f.getKey(), f.getValue()));
+                }
+            } else if (resolved != null && scopeType instanceof SimpleType) {
+                BuiltInType resolvedBIType = null;
+                if (scopeType instanceof BuiltInType) {
+                    resolvedBIType = (BuiltInType) scopeType;
+                } else if (scopeType instanceof AliasFEELType) {
+                    resolvedBIType = ((AliasFEELType) scopeType).getBuiltInType();
+                } else {
+                    throw new UnsupportedOperationException("Unsupported BIType " + scopeType + "!");
+                }
+                pushName(name);
+                pushScope(resolvedBIType);
+                switch (resolvedBIType) {
+                    // FEEL spec table 53
+                    case DATE:
+                        this.currentScope.define(new VariableSymbol("year", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("month", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("day", BuiltInType.NUMBER));
+                        if (isFeatDMN12weekday()) {
+                            // Table 60 spec DMN v1.2
+                            this.currentScope.define(new VariableSymbol("weekday", BuiltInType.NUMBER));
+                        }
+                        break;
+                    case TIME:
+                        this.currentScope.define(new VariableSymbol("hour", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("minute", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("second", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("time offset", BuiltInType.DURATION));
+                        this.currentScope.define(new VariableSymbol("timezone", BuiltInType.NUMBER));
+                        break;
+                    case DATE_TIME:
+                        this.currentScope.define(new VariableSymbol("year", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("month", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("day", BuiltInType.NUMBER));
+                        if (isFeatDMN12weekday()) {
+                            // Table 60 spec DMN v1.2
+                            this.currentScope.define(new VariableSymbol("weekday", BuiltInType.NUMBER));
+                        }
+                        this.currentScope.define(new VariableSymbol("hour", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("minute", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("second", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("time offset", BuiltInType.DURATION));
+                        this.currentScope.define(new VariableSymbol("timezone", BuiltInType.NUMBER));
+                        break;
+                    case DURATION:
+                        this.currentScope.define(new VariableSymbol("years", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("months", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("days", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("hours", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("minutes", BuiltInType.NUMBER));
+                        this.currentScope.define(new VariableSymbol("seconds", BuiltInType.NUMBER));
+                        break;
+                    case RANGE:
+                        this.currentScope.define(new VariableSymbol("start included", BuiltInType.BOOLEAN));
+                        this.currentScope.define(new VariableSymbol("start", BuiltInType.UNKNOWN));
+                        this.currentScope.define(new VariableSymbol("end", BuiltInType.UNKNOWN));
+                        this.currentScope.define(new VariableSymbol("end included", BuiltInType.BOOLEAN));
+                        break;
+                    // table 53 applies only to type(e) is a date/time/duration
+                    case UNKNOWN:
+                        enableDynamicResolution();
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                pushScope();
+            }
+        }
+    }
+
+    public void dismissScope() {
+        if (currentScope.getType() != null && currentScope.getType().equals(BuiltInType.UNKNOWN)) {
+            disableDynamicResolution();
+        }
+        popScope();
+    }
+
+    public void validateVariable(final ParserRuleContext ctx,
+                                 final List<String> qn,
+                                 final String name) {
+        if (eventsManager != null && !isDynamicResolution()) {
+            if (this.currentScope.getChildScopes().get(name) == null && this.currentScope.resolve(name) == null) {
+                FEELEventListenersManager.notifyListeners(eventsManager, () -> {
+                                                              final String varName = qn.stream().collect(Collectors.joining("."));
+                                                              return new UnknownVariableErrorEvent(FEELEvent.Severity.ERROR,
+                                                                                                   "Unknown variable '" + varName + "'",
+                                                                                                   ctx.getStart().getLine(),
+                                                                                                   ctx.getStart().getCharPositionInLine(),
+                                                                                                   varName);
+                                                          }
+                );
+            }
+        }
+    }
+
+    public boolean isDynamicResolution() {
+        return dynamicResolution > 0;
+    }
+
+    public void disableDynamicResolution() {
+        if (dynamicResolution > 0) {
+            this.dynamicResolution--;
+        }
+    }
+
+    public void enableDynamicResolution() {
+        this.dynamicResolution++;
+    }
+
+    public void defineVariable(final ParserRuleContext ctx) {
+        defineVariable(getName(ctx));
+    }
+
+    public void defineVariable(final String variable) {
+        this.currentScope.define(new VariableSymbol(variable));
+    }
+
+    public void defineVariable(final String variable,
+                               final Type type) {
+        this.currentScope.define(new VariableSymbol(variable, type));
+    }
+
+    public void startVariable(final Token t) {
+        this.currentScope.start(t.getText());
+    }
+
+    public boolean followUp(final Token t,
+                            final boolean isPredict) {
+        boolean dynamicResolutionResult = isDynamicResolution() && FEELParser.isVariableNamePartValid(t.getText(), currentScope);
+        boolean follow = dynamicResolutionResult || this.currentScope.followUp(t.getText(), isPredict);
+        // in case isPredict == false, will need to followUp in the currentScope, so that the TokenTree currentNode is updated as per expectations,
+        // this is because the `follow` variable above, in the case of short-circuited on `dynamicResolutionResult`,
+        // would skip performing any necessary update in the second part of the || predicate
+        if (dynamicResolutionResult && !isPredict) {
+            this.currentScope.followUp(t.getText(), isPredict);
+        }
+        return follow;
+    }
+
+    public static String getOriginalText(final ParserRuleContext ctx) {
+        int a = ctx.start.getStartIndex();
+        int b = ctx.stop.getStopIndex();
+        Interval interval = new Interval(a, b);
+        return ctx.getStart().getInputStream().getText(interval);
+    }
+    
+    /**
+     * a specific heuristic for scope retrieval for filterPathExpression
+     */
+    public int fphStart(ParserRuleContext ctx, Parser parser) {
+        if (!(ctx instanceof FEEL_1_1Parser.FilterPathExpressionContext)) { // I expect in `var[1].name` for this param ctx=`var[1]` to be a filterPathExpression
+            return 0;
+        }
+        FilterPathExpressionContext ctx0 = (FEEL_1_1Parser.FilterPathExpressionContext) ctx;
+        boolean ctxSquared = ctx0.filter != null && ctx0.n0 != null;
+        if (!ctxSquared) { // I expect `var[1]` to be in the squared form `...[...]`
+            return 0;
+        }
+        ParserRuleContext ctx1 = ctx0.n0.getRuleContext(FEEL_1_1Parser.NonSignedUnaryExpressionContext.class, 0);
+        if (ctx1 == null) {
+            return 0;
+        }
+        ParserRuleContext ctx2 = ctx1.getRuleContext(FEEL_1_1Parser.UenpmPrimaryContext.class, 0);
+        if (ctx2 == null) {
+            return 0;
+        }
+        ParserRuleContext ctx3 = ctx2.getRuleContext(FEEL_1_1Parser.PrimaryNameContext.class, 0);
+        if (ctx3 == null) {
+            return 0;
+        }
+        QualifiedNameContext ctx4 = ctx3.getRuleContext(FEEL_1_1Parser.QualifiedNameContext.class, 0);
+        if (ctx4 == null) {
+            return 0;
+        } // I expect in this param ctx=`var[1]` for `var` to be a qualifiedName
+        for (String n : ctx4.qns) {
+            recoverScope(n);
+        }
+        return ctx4.qns.size();
+    }
+    
+    public void fphEnd(int times) {
+        for (int i = 0; i < times; i++) {
+            dismissScope();
+        }
+    }
+
+    public static List<Token> getAllTokens(final ParseTree ctx,
+                                           final List<Token> tokens) {
+        for (int i = 0; i < ctx.getChildCount(); i++) {
+            final ParseTree child = ctx.getChild(i);
+            if (child instanceof TerminalNode) {
+                tokens.add(((TerminalNode) child).getSymbol());
+            } else {
+                getAllTokens(child, tokens);
+            }
+        }
+        return tokens;
+    }
+
+    public boolean isFeatDMN12EnhancedForLoopEnabled() {
+        return featDMN12EnhancedForLoopEnabled;
+    }
+
+    public void setFeatDMN12EnhancedForLoopEnabled(final boolean featDMN12EnhancedForLoopEnabled) {
+        this.featDMN12EnhancedForLoopEnabled = featDMN12EnhancedForLoopEnabled;
+    }
+
+    public boolean isFeatDMN12weekday() {
+        return featDMN12weekday;
+    }
+
+    public void setFeatDMN12weekday(final boolean featDMN12weekday) {
+        this.featDMN12weekday = featDMN12weekday;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/decisiontables/DecisionTableImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.decisiontables;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+
+public abstract class DecisionTableImpl implements DecisionTable {
+
+    private String name;
+    private List<String> parameterNames;
+
+    public FEELFnResult<Object> evaluate(final EvaluationContext ctx,
+                                         final Object[] params) {
+        throw new UnsupportedOperationException("Not supported in GWT.");
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getParameterNames() {
+        return parameterNames;
+    }
+
+    public String getSignature() {
+        return getName() + "( " + parameterNames.stream().collect(Collectors.joining(", ")) + " )";
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/BaseFEELFunction.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.Symbol;
+import org.kie.dmn.feel.lang.impl.NamedParameter;
+import org.kie.dmn.feel.lang.types.FunctionSymbol;
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public abstract class BaseFEELFunction implements FEELFunction {
+
+    Logger logger = Logger.getLogger("NameOfYourLogger");
+
+    private String name;
+    private Symbol symbol;
+
+    public BaseFEELFunction(final String name) {
+        this.name = name;
+        this.symbol = new FunctionSymbol(name, this);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+        ((FunctionSymbol) this.symbol).setId(name);
+    }
+
+    @Override
+    public Symbol getSymbol() {
+        return symbol;
+    }
+
+    @Override
+    public Object invokeReflectively(final EvaluationContext ctx,
+                                     final Object[] params) {
+
+        logger.log(Level.SEVERE, "params count: " + params.length);
+        logger.log(Level.SEVERE, "params are: " + Arrays.toString(params));
+        for (Object param : params) {
+            if (param == null) {
+                logger.log(Level.SEVERE, "param null: " + null);
+            } else {
+                logger.log(Level.SEVERE, "param: " + param.getClass() + " --- " + param);
+            }
+        }
+
+        if (this instanceof DateFunction) {
+            return doCata(ctx, invokeDateFunction(params));
+        } else if (this instanceof TimeFunction) {
+            return doCata(ctx, invokeTimeFunction(params));
+        } else if (this instanceof DateAndTimeFunction) {
+            return doCata(ctx, invokeDateAndTimeFunction(params));
+        } else if (this instanceof DurationFunction) {
+            return doCata(ctx, invokeDurationFunction(params));
+        } else if (this instanceof YearsAndMonthsFunction) {
+            return doCata(ctx, invokeYearsAndMonthsFunction(params));
+        } else if (this instanceof StringFunction) {
+            return doCata(ctx, invokeStringFunction(params));
+        } else if (this instanceof NumberFunction) {
+            return doCata(ctx, invokeNumberFunction(params));
+        } else if (this instanceof SubstringFunction) {
+            return doCata(ctx, invokeSubstringFunction(params));
+        } else if (this instanceof SubstringBeforeFunction) {
+            return doCata(ctx, invokeSubstringBeforeFunction(params));
+        } else if (this instanceof SubstringAfterFunction) {
+            return doCata(ctx, invokeSubstringAfterFunction(params));
+        } else if (this instanceof StringLengthFunction) {
+            return doCata(ctx, invokeStringLengthFunction(params));
+        } else if (this instanceof StringUpperCaseFunction) {
+            return doCata(ctx, invokeStringUpperCaseFunction(params));
+        } else if (this instanceof StringLowerCaseFunction) {
+            return doCata(ctx, invokeStringLowerCaseFunction(params));
+        } else if (this instanceof ContainsFunction) {
+            return doCata(ctx, invokeContainsFunction(params));
+        } else if (this instanceof StartsWithFunction) {
+            return doCata(ctx, invokeStartsWithFunction(params));
+        } else if (this instanceof EndsWithFunction) {
+            return doCata(ctx, invokeEndsWithFunction(params));
+        } else if (this instanceof MatchesFunction) {
+            return doCata(ctx, invokeMatchesFunction(params));
+        } else if (this instanceof ReplaceFunction) {
+            return doCata(ctx, invokeReplaceFunction(params));
+        } else if (this instanceof ListContainsFunction) {
+            return doCata(ctx, invokeListContainsFunction(params));
+        } else if (this instanceof CountFunction) {
+            return doCata(ctx, invokeCount(params));
+        } else if (this instanceof MinFunction) {
+            return doCata(ctx, invokeMinFunction(params));
+        } else if (this instanceof SumFunction) {
+            return doCata(ctx, invokeSum(params));
+        } else if (this instanceof MeanFunction) {
+            return doCata(ctx, invokeMeanFunction(params));
+        } else if (this instanceof SublistFunction) {
+            return doCata(ctx, invokeSublistFunction(params));
+        } else if (this instanceof AppendFunction) {
+            return doCata(ctx, invokeAppendFunction(params));
+        } else if (this instanceof ConcatenateFunction) {
+            return doCata(ctx, invokeConcatenateFunction(params));
+        }
+        return null;
+    }
+
+    private FEELFnResult<List<Object>> invokeConcatenateFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object list = getParam("list", params);
+            final Object item = getParam("item", params);
+            if (list instanceof List) {
+                return ((AppendFunction) this).invoke((List) list, (Object[]) item);
+            } else {
+                return ((AppendFunction) this).invoke(list, (Object[]) item);
+            }
+        } else if (params[0] instanceof List) {
+            return ((AppendFunction) this).invoke((List) params[0], (Object[]) params[1]);
+        }
+        return ((AppendFunction) this).invoke(params[0], (Object[]) params[1]);
+    }
+
+    private FEELFnResult<List<Object>> invokeAppendFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object list = getParam("list", params);
+            final Object item = getParam("item", params);
+            if (list instanceof List) {
+                return ((AppendFunction) this).invoke((List) list, (Object[]) item);
+            } else {
+                return ((AppendFunction) this).invoke(list, (Object[]) item);
+            }
+        } else if (params[0] instanceof List) {
+            return ((AppendFunction) this).invoke((List) params[0], (Object[]) params[1]);
+        }
+        return ((AppendFunction) this).invoke(params[0], (Object[]) params[1]);
+    }
+
+    private FEELFnResult<List> invokeSublistFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object list = getParam("list", params);
+            final Object startPosition = getParam("start position", params);
+            final Object length = getParam("length", params);
+            return ((SublistFunction) this).invoke((List) list, (BigDecimal) startPosition, (BigDecimal) length);
+        } else if (params.length == 2) {
+            return ((SublistFunction) this).invoke((List) params[0], (BigDecimal) params[1]);
+        }
+        return ((SublistFunction) this).invoke((List) params[0], (BigDecimal) params[1], (BigDecimal) params[2]);
+    }
+
+    private FEELFnResult<BigDecimal> invokeMeanFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object list = getParam("list", params);
+            if (list instanceof List) {
+                return ((MeanFunction) this).invoke((List) list);
+            } else if (list instanceof Number) {
+                return ((MeanFunction) this).invoke((Number) list);
+            }
+        } else {
+            if (params[0] instanceof List) {
+                return ((MeanFunction) this).invoke((List) params[0]);
+            } else if (params[0] instanceof Number) {
+                return ((MeanFunction) this).invoke((Number) params[0]);
+            }
+        }
+        return ((MeanFunction) this).invoke((Object[]) params[0]);
+    }
+
+    private FEELFnResult<Boolean> invokeListContainsFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object list = getParam("list", params);
+            final Object element = getParam("element", params);
+            return ((ListContainsFunction) this).invoke((List) list, element);
+        } else {
+            return ((ListContainsFunction) this).invoke((List) params[0], params[1]);
+        }
+    }
+
+    private FEELFnResult<Object> invokeReplaceFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object input = getParam("input", params);
+            final Object pattern = getParam("pattern", params);
+            final Object replacement = getParam("replacement", params);
+            final Object flags = getParam("flags", params);
+            return ((ReplaceFunction) this).invoke((String) input, (String) pattern, (String) replacement, (String) flags);
+        } else {
+            if (params.length == 3) {
+                return ((ReplaceFunction) this).invoke((String) params[0], (String) params[1], (String) params[2]);
+            }
+            return ((ReplaceFunction) this).invoke((String) params[0], (String) params[1], (String) params[2], (String) params[3]);
+        }
+    }
+
+    private FEELFnResult<Boolean> invokeMatchesFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object input = getParam("input", params);
+            final Object pattern = getParam("pattern", params);
+            final Object flags = getParam("flags", params);
+            return ((MatchesFunction) this).invoke((String) input, (String) pattern, (String) flags);
+        } else {
+            if (params.length == 2) {
+                return ((MatchesFunction) this).invoke((String) params[0], (String) params[1]);
+            }
+            return ((MatchesFunction) this).invoke((String) params[0], (String) params[1], (String) params[2]);
+        }
+    }
+
+    private FEELFnResult<Boolean> invokeEndsWithFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object match = getParam("match", params);
+            return ((EndsWithFunction) this).invoke((String) string, (String) match);
+        } else {
+            return ((EndsWithFunction) this).invoke((String) params[0], (String) params[1]);
+        }
+    }
+
+    private FEELFnResult<Boolean> invokeStartsWithFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object match = getParam("match", params);
+            return ((StartsWithFunction) this).invoke((String) string, (String) match);
+        } else {
+            return ((StartsWithFunction) this).invoke((String) params[0], (String) params[1]);
+        }
+    }
+
+    private FEELFnResult<Boolean> invokeContainsFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object match = getParam("match", params);
+            return ((ContainsFunction) this).invoke((String) string, (String) match);
+        } else {
+            return ((ContainsFunction) this).invoke((String) params[0], (String) params[1]);
+        }
+    }
+
+    private FEELFnResult<String> invokeStringLowerCaseFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            return ((StringLowerCaseFunction) this).invoke((String) string);
+        } else {
+            return ((StringLowerCaseFunction) this).invoke((String) params[0]);
+        }
+    }
+
+    private FEELFnResult<String> invokeStringUpperCaseFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            return ((StringUpperCaseFunction) this).invoke((String) string);
+        } else {
+            return ((StringUpperCaseFunction) this).invoke((String) params[0]);
+        }
+    }
+
+    private FEELFnResult<BigDecimal> invokeStringLengthFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            return ((StringLengthFunction) this).invoke((String) string);
+        } else {
+            return ((StringLengthFunction) this).invoke((String) params[0]);
+        }
+    }
+
+    private FEELFnResult<String> invokeSubstringAfterFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object match = getParam("match", params);
+            return ((SubstringAfterFunction) this).invoke((String) string, (String) match);
+        } else {
+            return ((SubstringAfterFunction) this).invoke((String) params[0], (String) params[1]);
+        }
+    }
+
+    private FEELFnResult<String> invokeSubstringBeforeFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object match = getParam("match", params);
+            return ((SubstringBeforeFunction) this).invoke((String) string, (String) match);
+        } else {
+            return ((SubstringBeforeFunction) this).invoke((String) params[0], (String) params[1]);
+        }
+    }
+
+    private FEELFnResult<String> invokeSubstringFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object string = getParam("string", params);
+            final Object startPosition = getParam("start position", params);
+            final Object length = getParam("length", params);
+            return ((SubstringFunction) this).invoke((String) string, (Number) startPosition, (Number) length);
+        } else {
+            if (params.length == 2) {
+                return ((SubstringFunction) this).invoke((String) params[0], (Number) params[1]);
+            } else {
+                return ((SubstringFunction) this).invoke((String) params[0], (Number) params[1], (Number) params[2]);
+            }
+        }
+    }
+
+    private FEELFnResult<String> invokeStringFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            if (params.length == 1) {
+                final Object from = getParam("from", params);
+                return ((StringFunction) this).invoke(from);
+            } else {
+                final Object mask = getParam("mask", params);
+                final Object p = getParam("p", params);
+                return ((StringFunction) this).invoke((String) mask, (Object[]) p);
+            }
+        } else {
+            if (params.length == 1) {
+                return ((StringFunction) this).invoke(params[0]);
+            } else {
+                return ((StringFunction) this).invoke((String) params[0], (Object[]) params[1]);
+            }
+        }
+    }
+
+    private FEELFnResult<TemporalAmount> invokeYearsAndMonthsFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object from = getParam("from", params);
+            final Object to = getParam("to", params);
+            return ((YearsAndMonthsFunction) this).invoke((Temporal) from, (Temporal) to);
+        } else {
+            return ((YearsAndMonthsFunction) this).invoke((Temporal) params[0], (Temporal) params[1]);
+        }
+    }
+
+    private FEELFnResult<TemporalAmount> invokeDurationFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            final Object from = getParam("from", params);
+            if (from instanceof String) {
+                return ((DurationFunction) this).invoke((String) from);
+            } else if (from instanceof TemporalAmount) {
+                return ((DurationFunction) this).invoke((TemporalAmount) from);
+            }
+        }
+
+        if (params[0] instanceof String) {
+            return ((DurationFunction) this).invoke((String) params[0]);
+        } else {
+            return ((DurationFunction) this).invoke((TemporalAmount) params[0]);
+        }
+    }
+
+    private FEELFnResult<TemporalAccessor> invokeDateAndTimeFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            if (params.length == 1) {
+                final Object from = getParam("from", params);
+                if (from instanceof String) {
+                    return ((DateAndTimeFunction) this).invoke((String) from);
+                }
+            } else if (params.length == 2) {
+                final Object date = getParam("date", params);
+                final Object time = getParam("time", params);
+                return ((DateAndTimeFunction) this).invoke((TemporalAccessor) date, (TemporalAccessor) time);
+            } else {
+                final Object year = getParam("year", params);
+                final Object month = getParam("month", params);
+                final Object day = getParam("day", params);
+                final Object hour = getParam("hour", params);
+                final Object minute = getParam("minute", params);
+                final Object second = getParam("second", params);
+
+                final Object hourOffset = getParam("hour offset", params);
+                final Object timezone = getParam("timezone", params);
+
+                if (hourOffset == null && timezone == null) {
+                    return ((DateAndTimeFunction) this).invoke((Number) year, (Number) month, (Number) day,
+                                                               (Number) hour, (Number) minute, (Number) second);
+                } else if (hourOffset == null) {
+                    return ((DateAndTimeFunction) this).invoke((Number) year, (Number) month, (Number) day,
+                                                               (Number) hour, (Number) minute, (Number) second,
+                                                               (String) timezone);
+                } else {
+                    return ((DateAndTimeFunction) this).invoke((Number) year, (Number) month, (Number) day,
+                                                               (Number) hour, (Number) minute, (Number) second,
+                                                               (Number) hourOffset);
+                }
+            }
+        } else {
+            if (params.length == 6) {
+                return ((DateAndTimeFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2],
+                                                           (Number) params[3], (Number) params[4], (Number) params[5]);
+            } else if (params.length == 7) {
+                if (params[6] instanceof Number) {
+                    return ((DateAndTimeFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2],
+                                                               (Number) params[3], (Number) params[4], (Number) params[5],
+                                                               (Number) params[6]);
+                } else {
+                    return ((DateAndTimeFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2],
+                                                               (Number) params[3], (Number) params[4], (Number) params[5],
+                                                               (String) params[6]);
+                }
+            }
+        }
+        return ((DateAndTimeFunction) this).invoke((String) params[0]);
+    }
+
+    private FEELFnResult<TemporalAccessor> invokeTimeFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            if (params.length == 1) {
+                final Object from = getParam("from", params);
+                if (from instanceof String) {
+                    return ((TimeFunction) this).invoke((String) from);
+                } else if (from instanceof TemporalAccessor) {
+                    return ((TimeFunction) this).invoke((TemporalAccessor) from);
+                }
+            } else {
+                final Object hour = getParam("hour", params);
+                final Object minute = getParam("minute", params);
+                final Object second = getParam("second", params);
+                final Object offset = getParam("offset", params);
+                return ((TimeFunction) this).invoke((Number) hour, (Number) minute, (Number) second, (Duration) offset);
+            }
+        } else {
+            if (params.length == 1) {
+                final Object from = params[0];
+                if (from instanceof String) {
+                    return ((TimeFunction) this).invoke((String) from);
+                } else if (from instanceof TemporalAccessor) {
+                    return ((TimeFunction) this).invoke((TemporalAccessor) from);
+                }
+            }
+        }
+        if (params.length == 3) {
+            return ((TimeFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2]);
+        } else {
+            return ((TimeFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2], (Duration) params[3]);
+        }
+    }
+
+    private FEELFnResult<TemporalAccessor> invokeDateFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            if (params.length == 1) {
+                final Object from = getParam("from", params);
+                if (from instanceof String) {
+                    return ((DateFunction) this).invoke((String) from);
+                } else if (from instanceof TemporalAccessor) {
+                    return ((DateFunction) this).invoke((TemporalAccessor) from);
+                }
+            } else {
+                final Object year = getParam("year", params);
+                final Object month = getParam("month", params);
+                final Object day = getParam("day", params);
+                return ((DateFunction) this).invoke((Number) year, (Number) month, (Number) day);
+            }
+        } else {
+            if (params.length == 1) {
+                final Object from = params[0];
+                if (from instanceof String) {
+                    return ((DateFunction) this).invoke((String) from);
+                } else if (from instanceof TemporalAccessor) {
+                    return ((DateFunction) this).invoke((TemporalAccessor) from);
+                }
+            }
+        }
+        return ((DateFunction) this).invoke((Number) params[0], (Number) params[1], (Number) params[2]);
+    }
+
+    private FEELFnResult<BigDecimal> invokeNumberFunction(final Object[] params) {
+        if (isNamedParams(params)) {
+            return ((NumberFunction) this).invoke((String) getParam("from", params),
+                                                  (String) getParam("grouping separator", params),
+                                                  (String) getParam("decimal separator", params));
+        } else {
+            return ((NumberFunction) this).invoke((String) params[0],
+                                                  (String) params[1],
+                                                  (String) params[2]);
+        }
+    }
+
+    private FEELFnResult<Object> invokeMaxFunction(final Object[] params) {
+        return null;
+    }
+
+    private FEELFnResult<Object> invokeMinFunction(final Object[] params) {
+        if (params.length == 1) {
+            final Object param = resolveListParamOrDefault(params);
+
+            if (param instanceof List) {
+                return ((MinFunction) this).invoke((List) param);
+            }
+        }
+
+        return ((MinFunction) this).invoke(params);
+    }
+
+    private FEELFnResult<BigDecimal> invokeCount(final Object[] params) {
+        if (params.length == 1) {
+            final Object param = resolveListParamOrDefault(params);
+
+            if (param instanceof List) {
+                return ((CountFunction) this).invoke((List) param);
+            }
+        }
+
+        return ((CountFunction) this).invoke(params);
+    }
+
+    private FEELFnResult<BigDecimal> invokeSum(final Object[] params) {
+        if (params.length == 1) {
+            final Object param = resolveListParamOrDefault(params);
+
+            if (param instanceof List) {
+                return ((SumFunction) this).invoke((List) param);
+            } else if (param instanceof Number) {
+                return ((SumFunction) this).invoke((Number) param);
+            }
+        }
+
+        return ((SumFunction) this).invoke(params);
+    }
+
+    private Object resolveListParamOrDefault(final Object[] params) {
+        if (isNamedParams(params)) {
+            return getParam("list", params);
+        } else {
+            return params[0];
+        }
+    }
+
+    protected Object getParam(final String paramName,
+                              final Object[] params) {
+
+        for (Object param : params) {
+            if (Objects.equals(paramName, ((NamedParameter) param).getName())) {
+                return ((NamedParameter) param).getValue();
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isNamedParams(final Object[] params) {
+        return params.length > 0 && params[0] instanceof NamedParameter;
+    }
+
+    private Object doCata(EvaluationContext ctx, FEELFnResult<?> either) {
+        Object eitherResult = either.cata((left) -> {
+            ctx.notifyEvt(() -> {
+                              return left;
+                          }
+            );
+            return null;
+        }, Function.identity());
+
+        return eitherResult;
+    }
+
+    /**
+     * this method should be overriden by custom function implementations that should be invoked reflectively
+     * @param ctx
+     * @param params
+     * @return
+     */
+    public Object invoke(EvaluationContext ctx, Object[] params) {
+        throw new RuntimeException("This method should be overriden by classes that implement custom feel functions");
+    }
+
+    @Override
+    public List<List<Param>> getParameters() {
+        // but it is not used at the moment
+        return Collections.emptyList();
+    }
+
+    private Object normalizeResult(Object result) {
+        // this is to normalize types returned by external functions
+        if (result != null && result.getClass().isArray()) {
+            List<Object> objs = new ArrayList<>();
+            for (int i = 0; i < Array.getLength(result); i++) {
+                objs.add(EvalHelper.coerceNumber(Array.get(result, i)));
+            }
+            return objs;
+        } else {
+            return EvalHelper.coerceNumber(result);
+        }
+    }
+
+    protected boolean isCustomFunction() {
+        return false;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctions.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/BuiltInFunctions.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.util.stream.Stream;
+
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.model.api.GwtIncompatible;
+
+public class BuiltInFunctions {
+
+    protected static final FEELFunction[] FUNCTIONS = new FEELFunction[]{
+            new DateFunction(),
+            new TimeFunction(),
+            new DateAndTimeFunction(),
+            new DurationFunction(),
+            new YearsAndMonthsFunction(),
+            new StringFunction(),
+            new NumberFunction(),
+            new SubstringFunction(),
+            new SubstringBeforeFunction(),
+            new SubstringAfterFunction(),
+            new StringLengthFunction(),
+            new StringUpperCaseFunction(),
+            new StringLowerCaseFunction(),
+            new ContainsFunction(),
+            new StartsWithFunction(),
+            new EndsWithFunction(),
+            new MatchesFunction(),
+            new ReplaceFunction(),
+            new ListContainsFunction(),
+            new CountFunction(),
+            new MinFunction(),
+            new SumFunction(),
+            new MeanFunction(),
+            new SublistFunction(),
+            new AppendFunction(),
+            new ConcatenateFunction(),
+
+            AbsFunction.INSTANCE,
+            ModuloFunction.INSTANCE,
+            ProductFunction.INSTANCE,
+            ModeFunction.INSTANCE,
+
+            EvenFunction.INSTANCE,
+            OddFunction.INSTANCE,
+            MedianFunction.INSTANCE,
+
+            DayOfWeekFunction.INSTANCE,
+            DayOfYearFunction.INSTANCE,
+            MonthOfYearFunction.INSTANCE,
+            IsFunction.INSTANCE,
+    };
+
+    public static FEELFunction[] getFunctions() {
+        return FUNCTIONS;
+    }
+
+    @GwtIncompatible
+    public static <T extends FEELFunction> T getFunction(final Class<T> functionClazz) {
+        return (T) Stream.of(FUNCTIONS)
+                .filter(f -> functionClazz.isAssignableFrom(f.getClass()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find function by class " + functionClazz.getCanonicalName() + "!"));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DateAndTimeFunction.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DateAndTimeFunction extends BaseFEELFunction {
+
+    public static final DateTimeFormatter FEEL_DATE_TIME;
+    public static final DateTimeFormatter REGION_DATETIME_FORMATTER;
+    public static final DateAndTimeFunction INSTANCE = new DateAndTimeFunction();
+
+    static {
+        FEEL_DATE_TIME = new DateTimeFormatterBuilder().parseCaseInsensitive()
+                .append(DateFunction.FEEL_DATE)
+                .appendLiteral('T')
+                .append(TimeFunction.FEEL_TIME)
+                .toFormatter();
+        REGION_DATETIME_FORMATTER = new DateTimeFormatterBuilder().parseCaseInsensitive()
+                .append(DateFunction.FEEL_DATE)
+                .appendLiteral('T')
+                .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                .appendLiteral("@")
+                .appendZoneRegionId()
+                .toFormatter();
+    }
+
+    public DateAndTimeFunction() {
+        super(FEELConversionFunctionNames.DATE_AND_TIME);
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("from") String val) {
+        if (val == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "cannot be null"));
+        }
+        if (DateFunction.BEGIN_YEAR.exec(val) == null) { // please notice the regex strictly requires the beginning, so we can use find.
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "year not compliant with XML Schema Part 2 Datatypes"));
+        }
+
+        try {
+            if (val.contains("T")) {
+                return FEELFnResult.ofResult(FEEL_DATE_TIME.parseBest(val, ZonedDateTime::from, OffsetDateTime::from, LocalDateTime::from));
+            } else {
+                LocalDate value = DateTimeFormatter.ISO_DATE.parse(val, LocalDate::from);
+                return FEELFnResult.ofResult(LocalDateTime.of(value, LocalTime.of(0, 0)));
+            }
+        } catch (final Exception e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "date-parsing exception", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(@ParameterName("date") TemporalAccessor date,
+                                                 @ParameterName("time") TemporalAccessor time) {
+        if (date == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "date", "cannot be null"));
+        }
+        if (!(date instanceof LocalDate)) {
+            // FEEL Spec Table 58 "date is a date or date time [...] creates a date time from the given date (ignoring any time component)" [that means ignoring any TZ from `date` parameter, too]
+            // I try to convert `date` to a LocalDate, if the query method returns null would signify conversion is not possible.
+            date = date.query(TemporalQueries.localDate());
+
+            if (date == null) {
+                return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "date", "must be an instance of LocalDate (or must be possible to convert to a FEEL date using built-in date(date) )"));
+            }
+        }
+        if (time == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "time", "cannot be null"));
+        }
+        if (!(time instanceof LocalTime || (time.query(TemporalQueries.localTime()) != null && time.query(TemporalQueries.zone()) != null))) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "time", "must be an instance of LocalTime or (it must contain localTime AND zone)"));
+        }
+
+        try {
+            if (date instanceof LocalDate && time instanceof LocalTime) {
+                return FEELFnResult.ofResult(LocalDateTime.of((LocalDate) date, (LocalTime) time));
+            } else if (date instanceof LocalDate && (time.query(TemporalQueries.localTime()) != null && time.query(TemporalQueries.zone()) != null)) {
+                return FEELFnResult.ofResult(ZonedDateTime.of((LocalDate) date, LocalTime.from(time), ZoneId.from(time)));
+            }
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "cannot invoke function for the input parameters"));
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("year") Number year,
+                                                 final @ParameterName("month") Number month,
+                                                 final @ParameterName("day") Number day,
+                                                 final @ParameterName("hour") Number hour,
+                                                 final @ParameterName("minute") Number minute,
+                                                 final @ParameterName("second") Number second) {
+        return invoke(year, month, day, hour, minute, second, (Number) null);
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("year") Number year,
+                                                 final @ParameterName("month") Number month,
+                                                 final @ParameterName("day") Number day,
+                                                 final @ParameterName("hour") Number hour,
+                                                 final @ParameterName("minute") Number minute,
+                                                 final @ParameterName("second") Number second,
+                                                 final @ParameterName("hour offset") Number hourOffset) {
+        if (year == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "year", "cannot be null"));
+        }
+        if (month == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "month", "cannot be null"));
+        }
+        if (day == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "day", "cannot be null"));
+        }
+        if (hour == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "hour", "cannot be null"));
+        }
+        if (minute == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "minute", "cannot be null"));
+        }
+        if (second == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "second", "cannot be null"));
+        }
+
+        try {
+            if (hourOffset != null) {
+                return FEELFnResult.ofResult(OffsetDateTime.of(year.intValue(), month.intValue(), day.intValue(),
+                                                               hour.intValue(), minute.intValue(), second.intValue(),
+                                                               0, ZoneOffset.ofHours(hourOffset.intValue())));
+            } else {
+                return FEELFnResult.ofResult(LocalDateTime.of(year.intValue(), month.intValue(), day.intValue(),
+                                                              hour.intValue(), minute.intValue(), second.intValue()));
+            }
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("year") Number year,
+                                                 final @ParameterName("month") Number month,
+                                                 final @ParameterName("day") Number day,
+                                                 final @ParameterName("hour") Number hour,
+                                                 final @ParameterName("minute") Number minute,
+                                                 final @ParameterName("second") Number second,
+                                                 final @ParameterName("timezone") String timezone) {
+        if (year == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "year", "cannot be null"));
+        }
+        if (month == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "month", "cannot be null"));
+        }
+        if (day == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "day", "cannot be null"));
+        }
+        if (hour == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "hour", "cannot be null"));
+        }
+        if (minute == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "minute", "cannot be null"));
+        }
+        if (second == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "second", "cannot be null"));
+        }
+
+        try {
+            return FEELFnResult.ofResult(ZonedDateTime.of(year.intValue(), month.intValue(), day.intValue(),
+                                                          hour.intValue(), minute.intValue(), second.intValue(), 0, ZoneId.of(timezone)));
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DateFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DateFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.TemporalAccessor;
+
+import com.google.gwt.regexp.shared.RegExp;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+public class DateFunction extends BaseFEELFunction {
+
+    public static final RegExp BEGIN_YEAR = RegExp.compile("^-?(([1-9]\\d\\d\\d+)|(0\\d\\d\\d))-"); // FEEL spec, "specified by XML Schema Part 2 Datatypes", hence: yearFrag ::= '-'? (([1-9] digit digit digit+)) | ('0' digit digit digit))
+    public static final DateTimeFormatter FEEL_DATE;
+    public static final DateFunction INSTANCE = new DateFunction();
+
+    static {
+        FEEL_DATE = new DateTimeFormatterBuilder().appendValue(YEAR, 4, 9, SignStyle.NORMAL)
+                .appendLiteral('-')
+                .appendValue(MONTH_OF_YEAR, 2)
+                .appendLiteral('-')
+                .appendValue(DAY_OF_MONTH, 2)
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
+    }
+
+    public DateFunction() {
+        super(FEELConversionFunctionNames.DATE);
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("from") String val) {
+        if (val == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "cannot be null"));
+        }
+        if (BEGIN_YEAR.exec(val) == null) { // please notice the regex strictly requires the beginning, so we can use find.
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "year not compliant with XML Schema Part 2 Datatypes"));
+        }
+
+        try {
+            return FEELFnResult.ofResult(LocalDate.from(FEEL_DATE.parse(val)));
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "date", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("year") Number year,
+                                                 final @ParameterName("month") Number month,
+                                                 final @ParameterName("day") Number day) {
+        if (year == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "year", "cannot be null"));
+        }
+        if (month == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "month", "cannot be null"));
+        }
+        if (day == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "day", "cannot be null"));
+        }
+
+        try {
+            return FEELFnResult.ofResult(LocalDate.of(year.intValue(), month.intValue(), day.intValue()));
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input parameters date-parsing exception", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("from") TemporalAccessor date) {
+        if (date == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "cannot be null"));
+        }
+
+        try {
+            return FEELFnResult.ofResult(LocalDate.from(date));
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "date-parsing exception", e));
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DurationFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/DurationFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAmount;
+import java.util.Arrays;
+import java.util.List;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class DurationFunction extends BaseFEELFunction {
+
+    public static final DurationFunction INSTANCE = new DurationFunction();
+
+    DurationFunction() {
+        super(FEELConversionFunctionNames.DURATION);
+    }
+
+    public FEELFnResult<TemporalAmount> invoke(final @ParameterName("from") String val) {
+        if (val == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "cannot be null"));
+        }
+
+        try {
+            // try to parse as days/hours/minute/seconds
+            return FEELFnResult.ofResult(Duration.parse(val));
+        } catch (final DateTimeParseException e) {
+            // if it failed, try to parse as years/months
+            try {
+                return FEELFnResult.ofResult(ComparablePeriod.parse(val).normalized());
+            } catch (final DateTimeParseException e2) {
+                // failed to parse, so return null according to the spec
+                return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "date-parsing exception",
+                                                                       new RuntimeException(new Throwable() {
+                                                                           public final List<Throwable> causes = Arrays.asList(new Throwable[]{e, e2});
+                                                                       })));
+            }
+        }
+    }
+
+    public FEELFnResult<TemporalAmount> invoke(final @ParameterName("from") TemporalAmount val) {
+        if (val == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "from", "cannot be null"));
+        }
+        return FEELFnResult.ofResult(val);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/MatchesFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class MatchesFunction extends BaseFEELFunction {
+
+    public MatchesFunction() {
+        super("matches");
+    }
+
+    public FEELFnResult<Boolean> invoke(final @ParameterName("input") String input,
+                                        final @ParameterName("pattern") String pattern) {
+        return invoke(input, pattern, null);
+    }
+
+    public FEELFnResult<Boolean> invoke(final @ParameterName("input") String input,
+                                        final @ParameterName("pattern") String pattern,
+                                        final @ParameterName("flags") String flags) {
+        if (input == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "input", "cannot be null"));
+        }
+        if (pattern == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "pattern", "cannot be null"));
+        }
+        try {
+            final RegExp p = RegExp.compile(pattern, flags);
+            final MatchResult m = p.exec(input);
+            return FEELFnResult.ofResult(m != null);
+        } catch (final IllegalArgumentException t) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "flags", "contains unknown flags", t));
+        } catch (final Throwable t) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "pattern", "is invalid and can not be compiled", t));
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/StringFunction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+import org.kie.dmn.feel.util.TypeUtil;
+
+public class StringFunction extends BaseFEELFunction {
+
+    public StringFunction() {
+        super(FEELConversionFunctionNames.STRING);
+    }
+
+    public FEELFnResult<String> invoke(final @ParameterName("from") Object val) {
+        if (val == null) {
+            return FEELFnResult.ofResult(null);
+        } else {
+            return FEELFnResult.ofResult(TypeUtil.formatValue(val, false));
+        }
+    }
+
+    public FEELFnResult<String> invoke(final @ParameterName("mask") String mask,
+                                       final @ParameterName("p") Object[] params) {
+        if (mask == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "mask", "cannot be null"));
+        } else {
+            return FEELFnResult.ofResult(format(mask, params));
+        }
+    }
+
+    public static native String format(final String format,
+                                       final Object[] values) /*-{
+        return vsprintf(format, values);
+    }-*/;
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/SubstringFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class SubstringFunction extends BaseFEELFunction {
+
+    public SubstringFunction() {
+        super("substring");
+    }
+
+    public FEELFnResult<String> invoke(final @ParameterName("string") String string,
+                                       final @ParameterName("start position") Number start) {
+        return invoke(string, start, null);
+    }
+
+    public FEELFnResult<String> invoke(final @ParameterName("string") String string,
+                                       final @ParameterName("start position") Number start,
+                                       final @ParameterName("length") Number length) {
+        if (string == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "string", "cannot be null"));
+        }
+        if (start == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "start position", "cannot be null"));
+        }
+        if (length != null && length.intValue() <= 0) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "length", "must be a positive number when specified"));
+        }
+        if (start.intValue() == 0) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "start position", "cannot be zero"));
+        }
+        final int stringLength = string.codePointCount(0, string.length());
+        if (Math.abs(start.intValue()) > stringLength) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "parameter 'start position' inconsistent with the actual length of the parameter 'string'"));
+        }
+
+        return FEELFnResult.ofResult(string.substring(start.intValue(), start.intValue() + length.intValue()));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/TimeFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/TimeFunction.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+
+import org.kie.dmn.api.feel.runtime.events.FEELEvent.Severity;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+
+public class TimeFunction extends BaseFEELFunction {
+
+    public static final DateTimeFormatter FEEL_TIME;
+    public static final TimeFunction INSTANCE = new TimeFunction();
+
+    static {
+        FEEL_TIME = new DateTimeFormatterBuilder().parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                .optionalStart()
+                .appendLiteral("@")
+                .appendZoneRegionId()
+                .optionalEnd()
+                .optionalStart()
+                .appendOffsetId()
+                .optionalEnd()
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
+    }
+
+    public TimeFunction() {
+        super(FEELConversionFunctionNames.TIME);
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("from") String val) {
+        if (val == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "cannot be null"));
+        }
+
+        try {
+            final TemporalAccessor parsed = FEEL_TIME.parse(val);
+
+            if (parsed.query(TemporalQueries.offset()) != null) {
+                // it is an offset-zoned time, so I can know for certain an OffsetTime
+                OffsetTime asOffSetTime = parsed.query(OffsetTime::from);
+                return FEELFnResult.ofResult(asOffSetTime);
+            } else if (parsed.query(TemporalQueries.zone()) == null) {
+                // if it does not contain any zone information at all, then I know for certain is a local time.
+                LocalTime asLocalTime = parsed.query(LocalTime::from);
+                return FEELFnResult.ofResult(asLocalTime);
+            }
+
+            return FEELFnResult.ofResult(parsed);
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", e));
+        }
+    }
+
+    private static final BigDecimal NANO_MULT = BigDecimal.valueOf(1000000000);
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("hour") Number hour,
+                                                 final @ParameterName("minute") Number minute,
+                                                 final @ParameterName("second") Number seconds) {
+        return invoke(hour, minute, seconds, null);
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("hour") Number hour,
+                                                 final @ParameterName("minute") Number minute,
+                                                 final @ParameterName("second") Number seconds,
+                                                 final @ParameterName("offset") Duration offset) {
+        if (hour == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "hour", "cannot be null"));
+        }
+        if (minute == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "minute", "cannot be null"));
+        }
+        if (seconds == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "seconds", "cannot be null"));
+        }
+
+        try {
+            int nanosecs = 0;
+            if (seconds instanceof BigDecimal) {
+                final BigDecimal secs = (BigDecimal) seconds;
+                nanosecs = secs.subtract(secs.setScale(0, RoundingMode.DOWN)).multiply(NANO_MULT).intValue();
+            }
+
+            if (offset == null) {
+                return FEELFnResult.ofResult(LocalTime.of(hour.intValue(), minute.intValue(), seconds.intValue(),
+                                                          nanosecs));
+            } else {
+                return FEELFnResult.ofResult(OffsetTime.of(hour.intValue(), minute.intValue(), seconds.intValue(),
+                                                           nanosecs,
+                                                           ZoneOffset.ofTotalSeconds((int) offset.getSeconds())));
+            }
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "time-parsing exception", e));
+        }
+    }
+
+    public FEELFnResult<TemporalAccessor> invoke(final @ParameterName("from") TemporalAccessor date) {
+        if (date == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "cannot be null"));
+        }
+
+        try {
+            // If the temporal accessor type doesn't support time, try to parse it as a date with UTC midnight.
+            if (!date.isSupported(ChronoField.HOUR_OF_DAY)) {
+                return new DateAndTimeFunction().invoke(date, OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC))
+                        .cata(overrideLeft -> FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "time-parsing exception")),
+                              this::invoke
+                        );
+            } else if (date.query(TemporalQueries.offset()) == null) {
+                return FEELFnResult.ofResult(LocalTime.from(date));
+            } else {
+                final ZoneId zone = date.query(TemporalQueries.zoneId());
+                if (!(zone instanceof ZoneOffset)) {
+                    // TZ is a ZoneRegion, so do NOT normalize (although the result will be unreversible, but will keep what was supplied originally).
+                    // Unfortunately java.time.Parsed is a package-private class, hence will need to re-parse in order to have it instantiated. 
+                    return invoke(date.query(TemporalQueries.localTime()) + "@" + zone);
+                } else {
+                    return FEELFnResult.ofResult(OffsetTime.from(date));
+                }
+            }
+        } catch (final DateTimeException e) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(Severity.ERROR, "from", "time-parsing exception", e));
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/extended/InvokeFunction.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/extended/InvokeFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions.extended;
+
+import java.util.Map;
+
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.api.feel.runtime.events.FEELEvent;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.runtime.events.FEELEventBase;
+import org.kie.dmn.feel.runtime.events.InvalidParametersEvent;
+import org.kie.dmn.feel.runtime.functions.BaseFEELFunction;
+import org.kie.dmn.feel.runtime.functions.FEELFnResult;
+import org.kie.dmn.feel.runtime.functions.ParameterName;
+
+public class InvokeFunction extends BaseFEELFunction {
+
+    public InvokeFunction() {
+        super("invoke");
+    }
+
+    public FEELFnResult<Object> invoke(final @ParameterName("ctx") EvaluationContext ctx,
+                                       final @ParameterName("namespace") String namespace,
+                                       final @ParameterName("model name") String modelName,
+                                       final @ParameterName("decision name") String decisionName,
+                                       final @ParameterName("parameters") Map<String, Object> parameters) {
+
+        final DMNRuntime dmnRuntime = ctx.getDMNRuntime();
+
+        if (namespace == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "namespace", "cannot be null"));
+        }
+
+        if (modelName == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "model name", "cannot be null"));
+        }
+
+        if (decisionName == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "decision name", "cannot be null"));
+        }
+
+        if (parameters == null) {
+            return FEELFnResult.ofError(new InvalidParametersEvent(FEELEvent.Severity.ERROR, "parameters", "cannot be null"));
+        }
+
+        FEELEvent capturedException;
+        try {
+            ctx.enterFrame();
+
+            final DMNModel dmnModel = dmnRuntime.getModel(namespace, modelName);
+            if (dmnModel == null) {
+                return FEELFnResult.ofError(
+                        new FEELEventBase(FEELEvent.Severity.ERROR, "Cannot find model '" + modelName + "' in namespace " + namespace, null)
+                );
+            }
+
+            if (dmnModel.getDecisionByName(decisionName) == null) {
+                return FEELFnResult.ofError(
+                        new FEELEventBase(FEELEvent.Severity.ERROR, "Cannot find decision '" + decisionName + "' in the model", null)
+                );
+            }
+
+            final DMNContext dmnContext = dmnRuntime.newContext();
+            dmnContext.getAll().putAll(parameters);
+
+            final DMNResult requiredDecisionResult = dmnRuntime.evaluateByName(dmnModel, dmnContext, decisionName);
+
+            return FEELFnResult.ofResult(requiredDecisionResult.getContext().get(decisionName));
+        } catch (final Exception e) {
+            capturedException = new FEELEventBase(FEELEvent.Severity.ERROR, "Error invoking function", new RuntimeException("Error invoking function " + getName() + ".", e));
+        } finally {
+            ctx.exitFrame();
+        }
+
+        return FEELFnResult.ofError(capturedException);
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/extended/KieExtendedDMNFunctions.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/functions/extended/KieExtendedDMNFunctions.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.functions.extended;
+
+import java.util.stream.Stream;
+
+import org.kie.dmn.feel.runtime.FEELFunction;
+import org.kie.dmn.feel.runtime.functions.DateFunction;
+import org.kie.dmn.feel.runtime.functions.DurationFunction;
+import org.kie.dmn.feel.runtime.functions.TimeFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNAllFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNAnyFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNCountFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNMaxFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNMeanFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNMinFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNModeFunction;
+import org.kie.dmn.feel.runtime.functions.twovaluelogic.NNSumFunction;
+import org.kie.dmn.model.api.GwtIncompatible;
+
+/**
+ * additional functions not part of the spec version 1.1
+ */
+public class KieExtendedDMNFunctions {
+
+    protected static final FEELFunction[] FUNCTIONS = new FEELFunction[]{
+
+            TimeFunction.INSTANCE,
+            DateFunction.INSTANCE,
+            DurationFunction.INSTANCE,
+
+            new NowFunction(),
+            new TodayFunction(),
+            new CodeFunction(),
+            new InvokeFunction(),
+
+            NNAnyFunction.INSTANCE,
+            NNAllFunction.INSTANCE,
+            NNCountFunction.INSTANCE,
+            NNMaxFunction.INSTANCE,
+            NNMeanFunction.INSTANCE,
+            NNMinFunction.INSTANCE,
+            NNModeFunction.INSTANCE,
+            NNSumFunction.INSTANCE,
+    };
+
+    public static FEELFunction[] getFunctions() {
+        return FUNCTIONS;
+    }
+
+    @GwtIncompatible
+    public static <T extends FEELFunction> T getFunction(final Class<T> functionClazz) {
+        return (T) Stream.of(FUNCTIONS)
+                .filter(f -> functionClazz.isAssignableFrom(f.getClass()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find function by class " + functionClazz.getCanonicalName() + "!"));
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/runtime/impl/RangeImpl.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.runtime.impl;
+
+import java.util.function.BiPredicate;
+
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.util.AssignableFromUtil;
+import org.kie.dmn.feel.util.EvalHelper;
+
+public class RangeImpl
+        implements Range {
+
+    private RangeBoundary lowBoundary;
+    private RangeBoundary highBoundary;
+    private Comparable    lowEndPoint;
+    private Comparable    highEndPoint;
+
+
+    public RangeImpl() {
+    }
+
+    public RangeImpl(RangeBoundary lowBoundary, Comparable lowEndPoint, Comparable highEndPoint, RangeBoundary highBoundary) {
+        this.lowBoundary = lowBoundary;
+        this.highBoundary = highBoundary;
+        this.lowEndPoint = lowEndPoint;
+        this.highEndPoint = highEndPoint;
+    }
+
+    @Override
+    public RangeBoundary getLowBoundary() {
+        return lowBoundary;
+    }
+
+    @Override
+    public Comparable getLowEndPoint() {
+        return lowEndPoint;
+    }
+
+    @Override
+    public Comparable getHighEndPoint() {
+        return highEndPoint;
+    }
+
+    @Override
+    public RangeBoundary getHighBoundary() {
+        return highBoundary;
+    }
+
+    @Override
+    public Boolean includes(Object param) {
+        if (param == null) {
+            return null;
+        }
+        if (lowEndPoint == null) {
+            if (highEndPoint == null) {
+                return null;
+            } else {
+                return negInfRangeIncludes(param);
+            }
+        } else {
+            if (highEndPoint == null) {
+                return posInfRangeIncludes(param);
+            } else {
+                return finiteRangeIncludes(param);
+            }
+        }
+    }
+
+    private Boolean finiteRangeIncludes(Object param) {
+        if (lowBoundary == RangeBoundary.OPEN && highBoundary == RangeBoundary.OPEN) {
+            return bothOrThrow(compare(lowEndPoint, param, (l, r) -> l.compareTo(r) < 0) , compare(highEndPoint, param,  (l, r) -> l.compareTo(r) > 0), param);
+        } else if (lowBoundary == RangeBoundary.OPEN && highBoundary == RangeBoundary.CLOSED) {
+            return bothOrThrow(compare(lowEndPoint, param, (l, r) -> l.compareTo(r) < 0) , compare(highEndPoint, param,  (l, r) -> l.compareTo(r) >= 0), param);
+        } else if (lowBoundary == RangeBoundary.CLOSED && highBoundary == RangeBoundary.OPEN) {
+            return bothOrThrow(compare(lowEndPoint, param, (l, r) -> l.compareTo(r) <= 0) , compare(highEndPoint, param,  (l, r) -> l.compareTo(r) > 0), param);
+        } else if (lowBoundary == RangeBoundary.CLOSED && highBoundary == RangeBoundary.CLOSED) {
+            return bothOrThrow(compare(lowEndPoint, param, (l, r) -> l.compareTo(r) <= 0) , compare(highEndPoint, param,  (l, r) -> l.compareTo(r) >= 0), param);
+        }
+        throw new RuntimeException("unknown boundary combination");
+    }
+
+    private Boolean posInfRangeIncludes(Object param) {
+        if (lowBoundary == RangeBoundary.OPEN) {
+            return compare(lowEndPoint, param, (l, r) -> l.compareTo(r) < 0);
+        } else {
+            return compare(lowEndPoint, param, (l, r) -> l.compareTo(r) <= 0);
+        }
+    }
+
+    private Boolean negInfRangeIncludes(Object param) {
+        if (highBoundary == RangeBoundary.OPEN) {
+            return compare(highEndPoint, param,  (l, r) -> l.compareTo(r) > 0);
+        } else {
+            return compare(highEndPoint, param,  (l, r) -> l.compareTo(r) >= 0);
+        }
+    }
+    
+    private Boolean bothOrThrow(Boolean left, Boolean right, Object param) {
+        if (left == null || right == null) {
+            throw new IllegalArgumentException("Range.include("+classOf(param)+") not comparable with "+classOf(lowEndPoint)+", "+classOf(highEndPoint));
+        }
+        return left && right;
+    }
+    
+    private static String classOf(Object p) {
+        return p != null ? p.getClass().toString() : "null";
+    }
+    
+    private static Boolean compare(Comparable left, Object right, BiPredicate<Comparable, Comparable> op) {
+        if (AssignableFromUtil.isAssignableFrom(left.getClass(), right.getClass())) { // short path
+                return op.test(left, (Comparable) right);
+        }
+        return EvalHelper.compare(left, right, null, op); // defer to full DMN/FEEL semantic
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) return true;
+        if ( !(o instanceof RangeImpl) ) return false;
+
+        RangeImpl range = (RangeImpl) o;
+
+        if ( lowBoundary != range.lowBoundary ) return false;
+        if ( highBoundary != range.highBoundary ) return false;
+        if ( lowEndPoint != null ? !lowEndPoint.equals( range.lowEndPoint ) : range.lowEndPoint != null ) return false;
+        return highEndPoint != null ? highEndPoint.equals( range.highEndPoint ) : range.highEndPoint == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lowBoundary != null ? lowBoundary.hashCode() : 0;
+        result = 31 * result + (highBoundary != null ? highBoundary.hashCode() : 0);
+        result = 31 * result + (lowEndPoint != null ? lowEndPoint.hashCode() : 0);
+        result = 31 * result + (highEndPoint != null ? highEndPoint.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return (lowBoundary == RangeBoundary.OPEN ? "(" : "[") +
+               " " + lowEndPoint +
+               " .. " + highEndPoint +
+               " " + ( highBoundary == RangeBoundary.OPEN ? ")" : "]" );
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/super/org/dominokit/domino/logger/ConsoleLoggerAdapter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/super/org/dominokit/domino/logger/ConsoleLoggerAdapter.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dominokit.domino.logger;
+
+import java.time.format.TextStyle;
+import java.time.temporal.TemporalField;
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+public class ConsoleLoggerAdapter implements Logger {
+
+    private final String name;
+
+    public ConsoleLoggerAdapter(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDebugEnabled(final Marker marker) {
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isErrorEnabled(final Marker marker) {
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isInfoEnabled(final Marker marker) {
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isTraceEnabled(final Marker marker) {
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isWarnEnabled(final Marker marker) {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void debug(final Marker marker,
+                      final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void debug(final Marker marker,
+                      final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void debug(final Marker marker,
+                      final String format,
+                      final Object... arguments) {
+
+    }
+
+    @Override
+    public void debug(final Marker marker,
+                      final String msg) {
+
+    }
+
+    @Override
+    public void debug(final Marker marker,
+                      final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void debug(final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void debug(final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void debug(final String format,
+                      final Object... arguments) {
+
+    }
+
+    @Override
+    public void debug(final String msg) {
+
+    }
+
+    @Override
+    public void debug(final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void error(final Marker marker,
+                      final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void error(final Marker marker,
+                      final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void error(final Marker marker,
+                      final String format,
+                      final Object... arguments) {
+
+    }
+
+    @Override
+    public void error(final Marker marker,
+                      final String msg) {
+
+    }
+
+    @Override
+    public void error(final Marker marker,
+                      final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void error(final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void error(final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void error(final String format,
+                      final Object... arguments) {
+
+    }
+
+    @Override
+    public void error(final String msg) {
+
+    }
+
+    @Override
+    public void error(final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void info(final Marker marker,
+                     final String format,
+                     final Object arg) {
+
+    }
+
+    @Override
+    public void info(final Marker marker,
+                     final String format,
+                     final Object arg1,
+                     final Object arg2) {
+
+    }
+
+    @Override
+    public void info(final Marker marker,
+                     final String format,
+                     final Object... arguments) {
+
+    }
+
+    @Override
+    public void info(final Marker marker,
+                     final String msg) {
+
+    }
+
+    @Override
+    public void info(final Marker marker,
+                     final String msg,
+                     final Throwable t) {
+
+    }
+
+    @Override
+    public void info(final String format,
+                     final Object arg) {
+
+    }
+
+    @Override
+    public void info(final String format,
+                     final Object arg1,
+                     final Object arg2) {
+
+    }
+
+    @Override
+    public void info(final String format,
+                     final Object... arguments) {
+
+    }
+
+    @Override
+    public void info(final String msg) {
+
+    }
+
+    @Override
+    public void info(final String msg,
+                     final Throwable t) {
+
+    }
+
+    @Override
+    public void trace(final Marker marker,
+                      final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void trace(final Marker marker,
+                      final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void trace(final Marker marker,
+                      final String format,
+                      final Object... argArray) {
+
+    }
+
+    @Override
+    public void trace(final Marker marker,
+                      final String msg) {
+
+    }
+
+    @Override
+    public void trace(final Marker marker,
+                      final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void trace(final String format,
+                      final Object arg) {
+
+    }
+
+    @Override
+    public void trace(final String format,
+                      final Object arg1,
+                      final Object arg2) {
+
+    }
+
+    @Override
+    public void trace(final String format,
+                      final Object... arguments) {
+
+    }
+
+    @Override
+    public void trace(final String msg) {
+
+    }
+
+    @Override
+    public void trace(final String msg,
+                      final Throwable t) {
+
+    }
+
+    @Override
+    public void warn(final Marker marker,
+                     final String format,
+                     final Object arg) {
+
+    }
+
+    @Override
+    public void warn(final Marker marker,
+                     final String format,
+                     final Object arg1,
+                     final Object arg2) {
+
+    }
+
+    @Override
+    public void warn(final Marker marker,
+                     final String format,
+                     final Object... arguments) {
+
+    }
+
+    @Override
+    public void warn(final Marker marker,
+                     final String msg) {
+
+    }
+
+    @Override
+    public void warn(final Marker marker,
+                     final String msg,
+                     final Throwable t) {
+
+    }
+
+    @Override
+    public void warn(final String format,
+                     final Object arg) {
+
+    }
+
+    @Override
+    public void warn(final String format,
+                     final Object arg1,
+                     final Object arg2) {
+
+    }
+
+    @Override
+    public void warn(final String format,
+                     final Object... arguments) {
+
+    }
+
+    @Override
+    public void warn(final String msg) {
+
+    }
+
+    @Override
+    public void warn(final String msg,
+                     final Throwable t) {
+
+    }
+
+    public void debug(String s, TemporalField tf, long l, TextStyle ts, Locale lc) {
+
+    }
+
+    public void debug(final String format,
+                      final Object arg1,
+                      final Object arg2,
+                      final Object arg3) {
+
+    }
+
+    public void debug(final String format,
+                      final Object arg1,
+                      final Object arg2,
+                      final Object arg3,
+                      final Object arg4) {
+
+    }
+
+    public void debug(final String format,
+                      final Object arg1,
+                      final Object arg2,
+                      final Object arg3,
+                      final Object arg4,
+                      final Object arg5) {
+
+    }
+
+    public void setTemperature(final Integer temperature) {
+
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/super/org/slf4j/Logger.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/super/org/slf4j/Logger.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.slf4j;
+
+import java.time.format.TextStyle;
+import java.time.temporal.TemporalField;
+import java.util.Locale;
+
+public interface Logger {
+
+    public final String ROOT_LOGGER_NAME = "ROOT";
+
+    boolean isDebugEnabled();
+
+    boolean isDebugEnabled(final org.slf4j.Marker marker);
+
+    boolean isErrorEnabled();
+
+    boolean isErrorEnabled(final org.slf4j.Marker marker);
+
+    boolean isInfoEnabled();
+
+    boolean isInfoEnabled(final org.slf4j.Marker marker);
+
+    boolean isTraceEnabled();
+
+    boolean isTraceEnabled(final org.slf4j.Marker marker);
+
+    boolean isWarnEnabled();
+
+    boolean isWarnEnabled(final org.slf4j.Marker marker);
+
+    String getName();
+
+    void debug(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg);
+
+    void debug(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void debug(final org.slf4j.Marker marker,
+               final String format,
+               final Object... arguments);
+
+    void debug(final org.slf4j.Marker marker,
+               final String msg);
+
+    void debug(final org.slf4j.Marker marker,
+               final String msg,
+               final Throwable t);
+
+    void debug(final String format,
+               final Object arg);
+
+    default void debug(final String s,
+                       final TemporalField tf,
+                       final long l,
+                       final TextStyle ts,
+                       final Locale lc) {
+    }
+
+    default void debug(final String s,
+                       final CharSequence cs,
+                       final int i,
+                       final Object obj) {
+    }
+
+    default void debug(final String format,
+                       final Object arg1,
+                       final Object arg2,
+                       final Object arg3) {
+    }
+
+    default void debug(final String format,
+                       final Object arg1,
+                       final Object arg2,
+                       final Object arg3,
+                       final Object arg4) {
+    }
+
+    default void debug(final String format,
+                       final Object arg1,
+                       final Object arg2,
+                       final Object arg3,
+                       final Object arg4,
+                       final Object arg5) {
+    }
+
+    void debug(final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void debug(final String format,
+               final Object... arguments);
+
+    void debug(final String msg);
+
+    void debug(final String msg,
+               final Throwable t);
+
+    void error(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg);
+
+    void error(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void error(final org.slf4j.Marker marker,
+               final String format,
+               final Object... arguments);
+
+    void error(final org.slf4j.Marker marker,
+               final String msg);
+
+    void error(final org.slf4j.Marker marker,
+               final String msg,
+               final Throwable t);
+
+    void error(final String format,
+               final Object arg);
+
+    void error(final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void error(final String format,
+               final Object... arguments);
+
+    void error(final String msg);
+
+    void error(final String msg,
+               final Throwable t);
+
+    void info(final org.slf4j.Marker marker,
+              final String format,
+              final Object arg);
+
+    void info(final org.slf4j.Marker marker,
+              final String format,
+              final Object arg1,
+              final Object arg2);
+
+    void info(final org.slf4j.Marker marker,
+              final String format,
+              final Object... arguments);
+
+    void info(final org.slf4j.Marker marker,
+              final String msg);
+
+    void info(final org.slf4j.Marker marker,
+              final String msg,
+              final Throwable t);
+
+    void info(final String format,
+              final Object arg);
+
+    void info(final String format,
+              final Object arg1,
+              final Object arg2);
+
+    void info(final String format,
+              final Object... arguments);
+
+    void info(final String msg);
+
+    void info(final String msg,
+              final Throwable t);
+
+    default void setTemperature(final Integer temperature) {
+    }
+
+    void trace(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg);
+
+    void trace(final org.slf4j.Marker marker,
+               final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void trace(final org.slf4j.Marker marker,
+               final String format,
+               final Object... argArray);
+
+    void trace(final org.slf4j.Marker marker,
+               final String msg);
+
+    void trace(final org.slf4j.Marker marker,
+               final String msg,
+               final Throwable t);
+
+    void trace(final String format,
+               final Object arg);
+
+    void trace(final String format,
+               final Object arg1,
+               final Object arg2);
+
+    void trace(final String format,
+               final Object... arguments);
+
+    void trace(final String msg);
+
+    void trace(final String msg,
+               final Throwable t);
+
+    void warn(final org.slf4j.Marker marker,
+              final String format,
+              final Object arg);
+
+    void warn(final org.slf4j.Marker marker,
+              final String format,
+              final Object arg1,
+              final Object arg2);
+
+    void warn(final org.slf4j.Marker marker,
+              final String format,
+              final Object... arguments);
+
+    void warn(final org.slf4j.Marker marker,
+              final String msg);
+
+    void warn(final org.slf4j.Marker marker,
+              final String msg,
+              final Throwable t);
+
+    void warn(final String format,
+              final Object arg);
+
+    void warn(final String format,
+              final Object arg1,
+              final Object arg2);
+
+    void warn(final String format,
+              final Object... arguments);
+
+    void warn(final String msg);
+
+    void warn(final String msg,
+              final Throwable t);
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/AssignableFromUtil.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/AssignableFromUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.dmn.feel.util;
+
+public class AssignableFromUtil {
+
+    public static boolean isAssignableFrom(final Class thisClass,
+                                           final Class otherClass) {
+
+        if (otherClass == null) {
+            return false;
+        }
+
+        if (otherClass.equals(thisClass)) {
+            return true;
+        }
+
+        return isAssignableFrom(thisClass, otherClass.getSuperclass());
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/EvalHelper.java
@@ -1,0 +1,708 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoPeriod;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+import org.kie.dmn.api.core.FEELPropertyAccessible;
+import org.kie.dmn.feel.lang.EvaluationContext;
+import org.kie.dmn.feel.lang.FEELProperty;
+import org.kie.dmn.feel.lang.types.BuiltInType;
+import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.Range.RangeBoundary;
+import org.kie.dmn.model.api.GwtIncompatible;
+
+public class EvalHelper {
+
+    @GwtIncompatible
+    private static final Map<String, Method> accessorCache = new ConcurrentHashMap<>();
+
+    public static String normalizeVariableName(final String name) {
+
+        if (name == null || name.isEmpty()) {
+            return name;
+        }
+
+        // Find the first valid char, used to skip leading spaces
+        int firstValid = 0, size = name.length();
+
+        for (; firstValid < size; firstValid++) {
+            if (isValidChar(name.charAt(firstValid))) {
+                break;
+            }
+        }
+        if (firstValid == size) {
+            return "";
+        }
+
+        // Finds the last valid char, either before a non-regular space, the first of multiple spaces or the last char
+        int lastValid = 0, trailing = 0;
+        boolean inWhitespace = false;
+
+        for (int i = firstValid; i < size; i++) {
+            if (isValidChar(name.charAt(i))) {
+                lastValid = i + 1;
+                inWhitespace = false;
+            } else {
+                if (inWhitespace) {
+                    break;
+                }
+                inWhitespace = true;
+                if (name.charAt(i) != ' ') {
+                    break;
+                }
+            }
+        }
+
+        // Counts the number of spaces after 'lastValid' (to remove possible trailing spaces)
+        for (int i = lastValid; i < size && !isValidChar(name.charAt(i)); i++) {
+            trailing++;
+        }
+        if (lastValid + trailing == size) {
+            return firstValid != 0 || trailing != 0 ? name.substring(firstValid, lastValid) : name;
+        }
+
+        // There are valid chars after 'lastValid' and substring won't do (full normalization is required)
+        int pos = 0;
+        char[] target = new char[size - firstValid];
+
+        // Copy the chars know to be valid to the new array
+        for (int i = firstValid; i < lastValid; i++) {
+            target[pos++] = name.charAt(i);
+        }
+
+        // Copy valid chars after 'lastValid' to new array
+        // Many whitespaces are collapsed into one and trailing spaces are ignored
+        for (int i = lastValid + 1; i < size; i++) {
+            char c = name.charAt(i);
+            if (isValidChar(c)) {
+                if (inWhitespace) {
+                    target[pos++] = ' ';
+                }
+                target[pos++] = c;
+                inWhitespace = false;
+            } else {
+                inWhitespace = true;
+            }
+        }
+        return new String(target, 0, pos);
+    }
+
+    /**
+     * This method defines what characters are valid for the output of normalizeVariableName. Spaces and control characters are invalid.
+     * There is a fast-path for well known characters
+     */
+    private static boolean isValidChar(final char c) {
+        if (c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') {
+            return true;
+        }
+        return c != ' ' && c != '\u00A0' && !Character.isWhitespace(c);
+    }
+
+    public static BigDecimal getBigDecimalOrNull(Object value) {
+        if (!(value instanceof Number
+              || value instanceof String)
+            || (value instanceof Double
+                && (value.toString().equals("NaN") || value.toString().equals("Infinity") || value.toString().equals("-Infinity")))) {
+            return null;
+        }
+        if (!AssignableFromUtil.isAssignableFrom(BigDecimal.class, value.getClass())) {
+            if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte ||
+                    value instanceof AtomicLong || value instanceof AtomicInteger) {
+                value = new BigDecimal(((Number) value).longValue(), MathContext.DECIMAL128);
+            } else if (value instanceof BigInteger) {
+                value = new BigDecimal((BigInteger) value, MathContext.DECIMAL128);
+            } else if (value instanceof String) {
+                try {
+                    // we need to remove leading zeros to prevent octal conversion
+                    value = new BigDecimal(((String) value).replaceFirst("^0+(?!$)", ""), MathContext.DECIMAL128);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            } else {
+                // doubleValue() sometimes produce rounding errors, so we need to use toString() instead
+                // We also need to remove trailing zeros, if there are some so for 10d we get BigDecimal.valueOf(10)
+                // instead of BigDecimal.valueOf(10.0).
+                value = new BigDecimal(removeTrailingZeros(value.toString()), MathContext.DECIMAL128);
+            }
+        }
+        return (BigDecimal) value;
+    }
+
+    public static Object coerceNumber(final Object value) {
+        if (value instanceof Number && !(value instanceof BigDecimal)) {
+            return getBigDecimalOrNull(value);
+        } else {
+            return value;
+        }
+    }
+
+    public static Boolean getBooleanOrNull(final Object value) {
+        if (!(value instanceof Boolean)) {
+            return null;
+        }
+        return (Boolean) value;
+    }
+
+    public static String unescapeString(String text) {
+        if (text == null) {
+            return null;
+        }
+        if (text.length() >= 2 && text.startsWith("\"") && text.endsWith("\"")) {
+            // remove the quotes
+            text = text.substring(1, text.length() - 1);
+        }
+        if (text.indexOf('\\') >= 0) {
+            // might require un-escaping
+            StringBuilder r = new StringBuilder();
+            for (int i = 0; i < text.length(); i++) {
+                char c = text.charAt(i);
+                if (c == '\\') {
+                    if (text.length() > i + 1) {
+                        i++;
+                        char cn = text.charAt(i);
+                        switch (cn) {
+                            case 'b':
+                                r.append('\b');
+                                break;
+                            case 't':
+                                r.append('\t');
+                                break;
+                            case 'n':
+                                r.append('\n');
+                                break;
+                            case 'f':
+                                r.append('\f');
+                                break;
+                            case 'r':
+                                r.append('\r');
+                                break;
+                            case '"':
+                                r.append('"');
+                                break;
+                            case '\'':
+                                r.append('\'');
+                                break;
+                            case '\\':
+                                r.append('\\');
+                                break;
+                            case 'u':
+                                if (text.length() >= i + 5) {
+                                    // escape unicode
+                                    String hex = text.substring(i + 1, i + 5);
+                                    char[] chars = Character.toChars(Integer.parseInt(hex, 16));
+                                    r.append(chars);
+                                    i += 4;
+                                } else {
+                                    // not really unicode
+                                    r.append("\\").append(cn);
+                                }
+                                break;
+                            case 'U':
+                                if (text.length() >= i + 7) {
+                                    // escape unicode
+                                    String hex = text.substring(i + 1, i + 7);
+                                    char[] chars = Character.toChars(Integer.parseInt(hex, 16));
+                                    r.append(chars);
+                                    i += 6;
+                                } else {
+                                    // not really unicode
+                                    r.append("\\").append(cn);
+                                }
+                                break;
+                            default:
+                                r.append("\\").append(cn);
+                        }
+                    } else {
+                        r.append(c);
+                    }
+                } else {
+                    r.append(c);
+                }
+            }
+            text = r.toString();
+        }
+        return text;
+    }
+
+    public static class PropertyValueResult implements FEELPropertyAccessible.AbstractPropertyValueResult {
+
+        private final boolean defined;
+        private final Either<Exception, Object> valueResult;
+
+        private PropertyValueResult(final boolean isDefined,
+                                    final Either<Exception, Object> value) {
+            this.defined = isDefined;
+            this.valueResult = value;
+        }
+
+        public static PropertyValueResult notDefined() {
+            return new PropertyValueResult(false, Either.ofLeft(new UnsupportedOperationException("Property was not defined.")));
+        }
+
+        public static PropertyValueResult of(final Either<Exception, Object> valueResult) {
+            return new PropertyValueResult(true, valueResult);
+        }
+
+        public static PropertyValueResult ofValue(final Object value) {
+            return new PropertyValueResult(true, Either.ofRight(value));
+        }
+
+        public boolean isDefined() {
+            return defined;
+        }
+
+        public Either<Exception, Object> getValueResult() {
+            return valueResult;
+        }
+
+        @Override
+        public Optional<Object> toOptional() {
+            return valueResult.cata(l -> Optional.empty(), Optional::of);
+        }
+    }
+
+    public static PropertyValueResult getDefinedValue(final Object current,
+                                                      final String property) {
+        Object result;
+        if (current == null) {
+            return PropertyValueResult.notDefined();
+        } else if (current instanceof Map) {
+            result = ((Map) current).get(property);
+            if (result == null) {
+                // most cases "result" will be defined, so checking here only in case null was to signify missing key altogether.
+                if (!((Map) current).containsKey(property)) {
+                    return PropertyValueResult.notDefined();
+                }
+            }
+        } else if (current instanceof ChronoPeriod) {
+            switch (property) {
+                case "years":
+                    result = ((ChronoPeriod) current).get(ChronoUnit.YEARS);
+                    break;
+                case "months":
+                    result = ((ChronoPeriod) current).get(ChronoUnit.MONTHS) % 12;
+                    break;
+                default:
+                    return PropertyValueResult.notDefined();
+            }
+        } else if (current instanceof Duration) {
+            switch (property) {
+                case "days":
+                    result = ((Duration) current).toDays();
+                    break;
+                case "hours":
+                    result = ((Duration) current).toHours() % 24;
+                    break;
+                case "minutes":
+                    result = ((Duration) current).toMinutes() % 60;
+                    break;
+                case "seconds":
+                    result = ((Duration) current).getSeconds() % 60;
+                    break;
+                default:
+                    return PropertyValueResult.notDefined();
+            }
+        } else if (current instanceof TemporalAccessor) {
+            switch (property) {
+                case "year":
+                    result = ((TemporalAccessor) current).get(ChronoField.YEAR);
+                    break;
+                case "month":
+                    result = ((TemporalAccessor) current).get(ChronoField.MONTH_OF_YEAR);
+                    break;
+                case "day":
+                    result = ((TemporalAccessor) current).get(ChronoField.DAY_OF_MONTH);
+                    break;
+                case "hour":
+                    result = ((TemporalAccessor) current).get(ChronoField.HOUR_OF_DAY);
+                    break;
+                case "minute":
+                    result = ((TemporalAccessor) current).get(ChronoField.MINUTE_OF_HOUR);
+                    break;
+                case "second":
+                    result = ((TemporalAccessor) current).get(ChronoField.SECOND_OF_MINUTE);
+                    break;
+                case "time offset":
+                    if (((TemporalAccessor) current).isSupported(ChronoField.OFFSET_SECONDS)) {
+                        result = Duration.ofSeconds(((TemporalAccessor) current).get(ChronoField.OFFSET_SECONDS));
+                    } else {
+                        result = null;
+                    }
+                    break;
+                case "weekday":
+                    result = ((TemporalAccessor) current).get(ChronoField.DAY_OF_WEEK);
+                    break;
+                default:
+                    return PropertyValueResult.notDefined();
+            }
+        } else if (current instanceof Range) {
+            switch (property) {
+                case "start included":
+                    result = ((Range) current).getLowBoundary() == RangeBoundary.CLOSED ? Boolean.TRUE : Boolean.FALSE;
+                    break;
+                case "start":
+                    result = ((Range) current).getLowEndPoint();
+                    break;
+                case "end":
+                    result = ((Range) current).getHighEndPoint();
+                    break;
+                case "end included":
+                    result = ((Range) current).getHighBoundary() == RangeBoundary.CLOSED ? Boolean.TRUE : Boolean.FALSE;
+                    break;
+                default:
+                    return PropertyValueResult.notDefined();
+            }
+        } else {
+            return PropertyValueResult.notDefined();
+        }
+
+        // before returning, coerce "result" into number.
+        result = coerceNumber(result);
+
+        return PropertyValueResult.ofValue(result);
+    }
+
+    /**
+     * {@link #getDefinedValue(Object, String)} method instead.
+     * @deprecated this method cannot distinguish null because: 1. property undefined for current, 2. an error, 3. a properly defined property value valorized to null.
+     */
+    public static Object getValue(final Object current,
+                                  final String property) {
+        return getDefinedValue(current, property).getValueResult().getOrElse(null);
+    }
+
+    /**
+     * FEEL annotated or else Java accessor.
+     * @param clazz
+     * @param field
+     * @return
+     */
+    @GwtIncompatible
+    public static Method getGenericAccessor(final Class<?> clazz,
+                                            final String field) {
+
+        final String accessorQualifiedName = new StringBuilder(clazz.getCanonicalName())
+                .append(".").append(field).toString();
+
+        return accessorCache.computeIfAbsent(accessorQualifiedName, key ->
+                Stream.of(clazz.getMethods())
+                        .filter(m -> Optional.ofNullable(m.getAnnotation(FEELProperty.class))
+                                .map(ann -> ann.value().equals(field))
+                                .orElse(false)
+                        )
+                        .findFirst()
+                        .orElse(getAccessor(clazz, field)));
+    }
+
+    @GwtIncompatible
+    public static void clearGenericAccessorCache() {
+        accessorCache.clear();
+    }
+
+    /**
+     * JavaBean -spec compliant accessor.
+     * @param clazz
+     * @param field
+     * @return
+     */
+    @GwtIncompatible
+    public static Method getAccessor(final Class<?> clazz,
+                                     final String field) {
+        try {
+            return clazz.getMethod("get" + ucFirst(field));
+        } catch (NoSuchMethodException e) {
+            try {
+                return clazz.getMethod(field);
+            } catch (NoSuchMethodException e1) {
+                try {
+                    return clazz.getMethod("is" + ucFirst(field));
+                } catch (NoSuchMethodException e2) {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Inverse of {@link #getAccessor(Class, String)}
+     */
+    @GwtIncompatible
+    public static Optional<String> propertyFromAccessor(final Method accessor) {
+
+        if (accessor.getParameterCount() != 0 || accessor.getReturnType().equals(Void.class)) {
+            return Optional.empty();
+        }
+
+        final String methodName = accessor.getName();
+        if (methodName.startsWith("get")) {
+            return Optional.of(lcFirst(methodName.substring(3)));
+        } else if (methodName.startsWith("is")) {
+            return Optional.of(lcFirst(methodName.substring(2)));
+        } else {
+            return Optional.of(lcFirst(methodName));
+        }
+    }
+
+    public static String ucFirst(final String name) {
+        return name.toUpperCase().charAt(0) + name.substring(1);
+    }
+
+    public static String lcFirst(final String name) {
+        return name.toLowerCase().charAt(0) + name.substring(1);
+    }
+
+    /**
+     * Compares left and right operands using the given predicate and returns TRUE/FALSE accordingly
+     * @param left
+     * @param right
+     * @param ctx
+     * @param op
+     * @return
+     */
+    public static Boolean compare(final Object left,
+                                  final Object right,
+                                  final EvaluationContext ctx,
+                                  final BiPredicate<Comparable, Comparable> op) {
+        if (left == null || right == null) {
+            return null;
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            // periods have special compare semantics in FEEL as it ignores "days". Only months and years are compared
+            Long l = ComparablePeriod.toTotalMonths((ChronoPeriod) left);
+            Long r = ComparablePeriod.toTotalMonths((ChronoPeriod) right);
+            return op.test(l, r);
+        } else if (left instanceof TemporalAccessor && right instanceof TemporalAccessor) {
+            // Handle specific cases when both time / datetime
+            TemporalAccessor l = (TemporalAccessor) left;
+            TemporalAccessor r = (TemporalAccessor) right;
+            if (BuiltInType.determineTypeFromInstance(left) == BuiltInType.TIME && BuiltInType.determineTypeFromInstance(right) == BuiltInType.TIME) {
+                return op.test(valuet(l), valuet(r));
+            } else if (BuiltInType.determineTypeFromInstance(left) == BuiltInType.DATE_TIME && BuiltInType.determineTypeFromInstance(right) == BuiltInType.DATE_TIME) {
+                return op.test(valuedt(l, r.query(TemporalQueries.zone())), valuedt(r, l.query(TemporalQueries.zone())));
+            } // fallback; continue:
+        }
+        // last fallback:
+        if ((left instanceof String && right instanceof String) ||
+                (left instanceof Number && right instanceof Number) ||
+                (left instanceof Boolean && right instanceof Boolean) ||
+                (left instanceof Comparable && AssignableFromUtil.isAssignableFrom(left.getClass(), right.getClass()))) {
+            Comparable l = (Comparable) left;
+            Comparable r = (Comparable) right;
+            return op.test(l, r);
+        }
+        return null;
+    }
+
+    /**
+     * Compares left and right for equality applying FEEL semantics to specific data types
+     * @param left
+     * @param right
+     * @param ctx
+     * @return
+     */
+    public static Boolean isEqual(Object left,
+                                  Object right,
+                                  final EvaluationContext ctx) {
+        if (left == null || right == null) {
+            return left == right;
+        }
+
+        // spec defines that "a=[a]", i.e., singleton collections should be treated as the single element
+        // and vice-versa
+        if (left instanceof Collection && !(right instanceof Collection) && ((Collection) left).size() == 1) {
+            left = ((Collection) left).toArray()[0];
+        } else if (right instanceof Collection && !(left instanceof Collection) && ((Collection) right).size() == 1) {
+            right = ((Collection) right).toArray()[0];
+        }
+
+        if (left instanceof Range && right instanceof Range) {
+            return isEqual((Range) left, (Range) right);
+        } else if (left instanceof Iterable && right instanceof Iterable) {
+            return isEqual((Iterable) left, (Iterable) right);
+        } else if (left instanceof Map && right instanceof Map) {
+            return isEqual((Map) left, (Map) right);
+        } else if (left instanceof ChronoPeriod && right instanceof ChronoPeriod) {
+            // periods have special compare semantics in FEEL as it ignores "days". Only months and years are compared
+            Long l = ComparablePeriod.toTotalMonths((ChronoPeriod) left);
+            Long r = ComparablePeriod.toTotalMonths((ChronoPeriod) right);
+            return isEqual(l, r);
+        } else if (left instanceof TemporalAccessor && right instanceof TemporalAccessor) {
+            // Handle specific cases when both time / datetime
+            TemporalAccessor l = (TemporalAccessor) left;
+            TemporalAccessor r = (TemporalAccessor) right;
+            if (BuiltInType.determineTypeFromInstance(left) == BuiltInType.TIME && BuiltInType.determineTypeFromInstance(right) == BuiltInType.TIME) {
+                return isEqual(valuet(l), valuet(r));
+            } else if (BuiltInType.determineTypeFromInstance(left) == BuiltInType.DATE_TIME && BuiltInType.determineTypeFromInstance(right) == BuiltInType.DATE_TIME) {
+                return isEqual(valuedt(l, r.query(TemporalQueries.zone())), valuedt(r, l.query(TemporalQueries.zone())));
+            } // fallback; continue:
+        }
+        return compare(left, right, ctx, (l, r) -> l.compareTo(r) == 0);
+    }
+
+    /**
+     * DMNv1.2 10.3.2.3.6 date-time, valuedt(date and time), for use in this {@link EvalHelper#compare(Object, Object, EvaluationContext, BiPredicate)}
+     * DMNv1.3 also used for equality DMN13-35
+     */
+    private static long valuedt(final TemporalAccessor datetime,
+                                final ZoneId otherTimezoneOffset) {
+        final ZoneId alternativeTZ = Optional.ofNullable(otherTimezoneOffset).orElse(ZoneOffset.UTC);
+        if (datetime instanceof LocalDateTime) {
+            return ((LocalDateTime) datetime).atZone(alternativeTZ).toEpochSecond();
+        } else if (datetime instanceof ZonedDateTime) {
+            return ((ZonedDateTime) datetime).toEpochSecond();
+        } else if (datetime instanceof OffsetDateTime) {
+            return ((OffsetDateTime) datetime).toEpochSecond();
+        } else {
+            throw new RuntimeException("valuedt() for " + datetime + " but is not a FEEL date and time " + datetime.getClass());
+        }
+    }
+
+    /**
+     * DMNv1.2 10.3.2.3.4 time, valuet(time), for use in this {@link EvalHelper#compare(Object, Object, EvaluationContext, BiPredicate)}
+     * DMNv1.3 also used for equality DMN13-35
+     */
+    private static long valuet(final TemporalAccessor time) {
+        long result = 0;
+        result += time.get(ChronoField.HOUR_OF_DAY) * (60 * 60);
+        result += time.get(ChronoField.MINUTE_OF_HOUR) * (60);
+        result += time.get(ChronoField.SECOND_OF_MINUTE);
+        return result;
+    }
+
+    /**
+     * DMNv1.2 Table 48: Specific semantics of equality
+     * DMNv1.3 Table 71: Semantic of date and time functions
+     */
+    public static Boolean isEqualDateTimeInSemanticD(final TemporalAccessor left,
+                                                     final TemporalAccessor right) {
+        boolean result = true;
+        Optional<Integer> lY = Optional.ofNullable(left.isSupported(ChronoField.YEAR) ? left.get(ChronoField.YEAR) : null);
+        Optional<Integer> rY = Optional.ofNullable(right.isSupported(ChronoField.YEAR) ? right.get(ChronoField.YEAR) : null);
+        result &= lY.equals(rY);
+        Optional<Integer> lM = Optional.ofNullable(left.isSupported(ChronoField.MONTH_OF_YEAR) ? left.get(ChronoField.MONTH_OF_YEAR) : null);
+        Optional<Integer> rM = Optional.ofNullable(right.isSupported(ChronoField.MONTH_OF_YEAR) ? right.get(ChronoField.MONTH_OF_YEAR) : null);
+        result &= lM.equals(rM);
+        Optional<Integer> lD = Optional.ofNullable(left.isSupported(ChronoField.DAY_OF_MONTH) ? left.get(ChronoField.DAY_OF_MONTH) : null);
+        Optional<Integer> rD = Optional.ofNullable(right.isSupported(ChronoField.DAY_OF_MONTH) ? right.get(ChronoField.DAY_OF_MONTH) : null);
+        result &= lD.equals(rD);
+        result &= isEqualTimeInSemanticD(left, right);
+        return result;
+    }
+
+    /**
+     * DMNv1.2 Table 48: Specific semantics of equality
+     * DMNv1.3 Table 71: Semantic of date and time functions
+     */
+    public static Boolean isEqualTimeInSemanticD(final TemporalAccessor left,
+                                                 final TemporalAccessor right) {
+        boolean result = true;
+        Optional<Integer> lH = Optional.ofNullable(left.isSupported(ChronoField.HOUR_OF_DAY) ? left.get(ChronoField.HOUR_OF_DAY) : null);
+        Optional<Integer> rH = Optional.ofNullable(right.isSupported(ChronoField.HOUR_OF_DAY) ? right.get(ChronoField.HOUR_OF_DAY) : null);
+        result &= lH.equals(rH);
+        Optional<Integer> lM = Optional.ofNullable(left.isSupported(ChronoField.MINUTE_OF_HOUR) ? left.get(ChronoField.MINUTE_OF_HOUR) : null);
+        Optional<Integer> rM = Optional.ofNullable(right.isSupported(ChronoField.MINUTE_OF_HOUR) ? right.get(ChronoField.MINUTE_OF_HOUR) : null);
+        result &= lM.equals(rM);
+        Optional<Integer> lS = Optional.ofNullable(left.isSupported(ChronoField.SECOND_OF_MINUTE) ? left.get(ChronoField.SECOND_OF_MINUTE) : null);
+        Optional<Integer> rS = Optional.ofNullable(right.isSupported(ChronoField.SECOND_OF_MINUTE) ? right.get(ChronoField.SECOND_OF_MINUTE) : null);
+        result &= lS.equals(rS);
+        Optional<ZoneId> lTZ = Optional.ofNullable(left.query(TemporalQueries.zone()));
+        Optional<ZoneId> rTZ = Optional.ofNullable(right.query(TemporalQueries.zone()));
+        result &= lTZ.equals(rTZ);
+        return result;
+    }
+
+    private static Boolean isEqual(final Range left,
+                                   final Range right) {
+        return left.equals(right);
+    }
+
+    private static Boolean isEqual(final Iterable left,
+                                   final Iterable right) {
+        final Iterator li = left.iterator();
+        final Iterator ri = right.iterator();
+        while (li.hasNext() && ri.hasNext()) {
+            Object l = li.next();
+            Object r = ri.next();
+            if (!isEqual(l, r)) {
+                return false;
+            }
+        }
+        return li.hasNext() == ri.hasNext();
+    }
+
+    private static Boolean isEqual(final Map<?, ?> left,
+                                   final Map<?, ?> right) {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (Map.Entry le : left.entrySet()) {
+            Object l = le.getValue();
+            Object r = right.get(le.getKey());
+            if (!isEqual(l, r)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Boolean isEqual(final Object l,
+                                   final Object r) {
+        if (l instanceof Iterable && r instanceof Iterable && !isEqual((Iterable) l, (Iterable) r)) {
+            return false;
+        } else if (l instanceof Map && r instanceof Map && !isEqual((Map) l, (Map) r)) {
+            return false;
+        } else if (l != null && r != null && !l.equals(r)) {
+            return false;
+        } else if ((l == null || r == null) && l != r) {
+            return false;
+        }
+        return true;
+    }
+
+    private static String removeTrailingZeros(final String stringNumber) {
+        final String stringWithoutZeros = stringNumber.replaceAll("0*$", "");
+        if (Character.isDigit(stringWithoutZeros.charAt(stringWithoutZeros.length() - 1))) {
+            return stringWithoutZeros;
+        } else {
+            return stringWithoutZeros.substring(0, stringWithoutZeros.length() - 1);
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/Msg.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/Msg.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+/**
+ * Utility class for I18N messages.
+ */
+public final class Msg {
+
+    public static final Message0 NULL_OR_UNKNOWN_OPERATOR = new Message0("Null or unknown operator");
+    public static final Message1 UNKNOWN_VARIABLE_REFERENCE = new Message1("Unknown variable name '%s'");
+    public static final Message0 NEGATING_A_NULL = new Message0("Negating a null");
+    public static final Message0 CANNOT_BE_SIGNED = new Message0("Cannot sign a value which is not a number");
+    public static final Message1 ERROR_ACCESSING_QUALIFIED_NAME = new Message1("Error accessing qualified name: %s");
+    public static final Message2 ERROR_EVALUATING_PATH_EXPRESSION = new Message2("Error evaluating path expression: %s. %s");
+    public static final Message0 VALUE_NULL_EXPR_NOT_NULL_AND_NOT_UNARY_TEST_EVALUATING_THIS_NODE_AS_FALSE = new Message0("value == null, expr != null and not Unary test, Evaluating this node as FALSE.");
+    public static final Message2 EXPRESSION_IS_RANGE_BUT_VALUE_IS_NOT_COMPARABLE = new Message2("Value '%s' is not comparable with range '%s'");
+    public static final Message0 CONDITION_WAS_NOT_A_BOOLEAN = new Message0("Condition was not a Boolean");
+    public static final Message1 FUNCTION_NOT_FOUND = new Message1("Function not found: '%s'");
+    public static final Message1 ERROR_EXECUTING_LIST_FILTER = new Message1("Error executing list filter: %s");
+    public static final Message2 INDEX_OUT_OF_BOUND = new Message2("Index out of bound: list of %s elements, index %s; will evaluate as FEEL null");
+    public static final Message2 X_TYPE_INCOMPATIBLE_WITH_Y_TYPE = new Message2("%s type incompatible with %s type");
+    public static final Message1 INCOMPATIBLE_TYPE_FOR_RANGE = new Message1("Type %s can not be used in a range unary test");
+    public static final Message1 VALUE_X_NOT_A_VALID_ENDPOINT_FOR_RANGE_BECAUSE_NOT_A_NUMBER = new Message1("Value %s is not a valid endpoint for range, because not a feel:number");
+    public static final Message1 EVALUATED_TO_NULL = new Message1("%s evaluated to null");
+    public static final Message1 IS_NULL = new Message1("%s is null");
+    public static final Message0 BASE_NODE_EVALUATE_CALLED = new Message0("BaseNode evaluate called");
+    public static final Message1 ERROR_RESOLVING_EXTERNAL_FUNCTION_AS_DEFINED_BY = new Message1("Error resolving external function as defined by: %s");
+    public static final Message1 UNABLE_TO_FIND_EXTERNAL_FUNCTION_AS_DEFINED_BY = new Message1("Unable to find external function as defined by: %s");
+    public static final Message1 PARAMETER_COUNT_MISMATCH_ON_FUNCTION_DEFINITION = new Message1("Parameter count mismatch on function definition: %s");
+    public static final Message1 CAN_T_INVOKE_AN_UNARY_TEST_WITH_S_PARAMETERS_UNARY_TESTS_REQUIRE_1_SINGLE_PARAMETER = new Message1("Can't invoke an unary test with %s parameters. Unary tests require 1 single parameter.");
+    public static final Message2 INVALID_VARIABLE_NAME = new Message2("Name cannot contain the %s '%s'");
+    public static final Message2 INVALID_VARIABLE_NAME_START = new Message2("Name cannot start with the %s '%s'");
+    public static final Message0 INVALID_VARIABLE_NAME_EMPTY = new Message0("Name cannot be null or empty");
+    public static final Message1 MISSING_EXPRESSION = new Message1("The context entry for key '%s' is missing the value expression");
+    public static final Message2 ERROR_COMPILE_EXPR_DT_FUNCTION_RULE_IDX = new Message2("Error compiling output expression in decision table FEEL function, rule index %s: '%s'");
+    public static final Message2 EXTENDED_UNARY_TEST_MUST_BE_BOOLEAN = new Message2("Unary test '%s' does not return a boolean result: '%s'");
+    public static final Message2 IF_MISSING_ELSE = new Message2("Detected 'if' expression without 'else' part (near: %s) [%s]");
+    public static final Message2 IF_MISSING_THEN = new Message2("Detected 'if' expression without 'then' part (near: %s) [%s]");
+    public static final Message1 COMPARING_TO_UT = new Message1("Comparing to a unary test is not semantically defined: %s");
+    public static final Message1 UT_OF_UT = new Message1("An unary test of a unary test is not semantically defined: %s");
+    public static final Message1 MALFORMED_AT_LITERAL = new Message1("Malformed at-literal: %s");
+    public static final Message1 CANNOT_INVOKE = new Message1("Not an invocable: '%s'");
+
+    public static String createMessage(final Message0 message) {
+        return Msg.buildMessage(message);
+    }
+
+    public static String createMessage(final Message1 message,
+                                       final Object p1) {
+        return Msg.buildMessage(message, p1);
+    }
+
+    public static String createMessage(final Message2 message,
+                                       final Object p1,
+                                       final Object p2) {
+        return Msg.buildMessage(message, p1, p2);
+    }
+
+    public static String createMessage(final Message3 message,
+                                       final Object p1,
+                                       final Object p2,
+                                       final Object p3) {
+        return Msg.buildMessage(message, p1, p2, p3);
+    }
+
+    public static String createMessage(final Message4 message,
+                                       final Object p1,
+                                       final Object p2,
+                                       final Object p3,
+                                       final Object p4) {
+        return Msg.buildMessage(message, p1, p2, p3, p4);
+    }
+
+    private static String buildMessage(final Message message,
+                                       final Object... params) {
+        return message.getMask();
+    }
+
+    public static interface Message {
+
+        String getMask();
+    }
+
+    public abstract static class AbstractMessage implements Message {
+
+        private String mask;
+
+        public AbstractMessage(String mask) {
+            this.mask = mask;
+        }
+
+        public String getMask() {
+            return this.mask;
+        }
+    }
+
+    public static class Message0 extends AbstractMessage {
+
+        public Message0(String mask) {
+            super(mask);
+        }
+    }
+
+    public static class Message1 extends AbstractMessage {
+
+        public Message1(String mask) {
+            super(mask);
+        }
+    }
+
+    public static class Message2 extends AbstractMessage {
+
+        public Message2(String mask) {
+            super(mask);
+        }
+    }
+
+    public static class Message3 extends AbstractMessage {
+
+        public Message3(String mask) {
+            super(mask);
+        }
+    }
+
+    public static class Message4 extends AbstractMessage {
+
+        public Message4(String mask) {
+            super(mask);
+        }
+    }
+
+    private Msg() {
+        // Constructing instances is not allowed for this class
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/MsgUtil.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/MsgUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+/**
+ * Internal utility class.
+ */
+public final class MsgUtil {
+    
+    private MsgUtil() {
+        // Constructing instances is not allowed for this class
+    }
+
+    public static String clipToString(Object source, int maxChars) {
+        return source == null ? "null" : clipString(source.toString(), maxChars);
+    }
+    
+    public static String clipString(String source, int maxChars) {
+        if (source.length() <= maxChars) {
+            return source;
+        } else {
+            return new StringBuilder().append(source.substring(0, maxChars))
+                                      .append("... [string clipped after "+maxChars+" chars, total length is "+source.length()+"]") // GWT do not support String.format 
+                                      .toString();
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/java/org/kie/dmn/feel/util/TypeUtil.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoPeriod;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
+import org.kie.dmn.feel.runtime.Range;
+import org.kie.dmn.feel.runtime.functions.DateAndTimeFunction;
+import org.kie.dmn.feel.runtime.functions.DateFunction;
+import org.kie.dmn.feel.runtime.functions.TimeFunction;
+
+import static org.kie.dmn.feel.util.AssignableFromUtil.isAssignableFrom;
+
+public final class TypeUtil {
+
+    private static final long SECONDS_IN_A_MINUTE = 60;
+    private static final long SECONDS_IN_AN_HOUR = 60 * SECONDS_IN_A_MINUTE;
+    private static final long SECONDS_IN_A_DAY = 24 * SECONDS_IN_AN_HOUR;
+    private static final long NANOSECONDS_PER_SECOND = 1000000000;
+
+    public static boolean isCollectionTypeHomogenous(final Collection collection) {
+        if (collection.isEmpty()) {
+            return true;
+        } else {
+            return isCollectionTypeHomogenous(collection, collection.iterator().next().getClass());
+        }
+    }
+
+    public static boolean isCollectionTypeHomogenous(final Collection collection,
+                                                     final Class expectedType) {
+        for (final Object object : collection) {
+            if (object != null && !isAssignableFrom(expectedType, object.getClass())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static String formatValue(final Object val,
+                                     final boolean wrapForCodeUsage) {
+        if (val instanceof String) {
+            return formatString(val.toString(), wrapForCodeUsage);
+        } else if (val instanceof LocalDate) {
+            return formatDate((LocalDate) val, wrapForCodeUsage);
+        } else if (val instanceof LocalTime || val instanceof OffsetTime) {
+            return formatTimeString(TimeFunction.FEEL_TIME.format((TemporalAccessor) val), wrapForCodeUsage);
+        } else if (val instanceof LocalDateTime || val instanceof OffsetDateTime) {
+            return formatDateTimeString(DateAndTimeFunction.FEEL_DATE_TIME.format((TemporalAccessor) val), wrapForCodeUsage);
+        } else if (val instanceof ZonedDateTime) {
+            TemporalAccessor ta = (TemporalAccessor) val;
+            ZoneId zone = ta.query(TemporalQueries.zone());
+            if (!(zone instanceof ZoneOffset)) {
+                // it is a ZoneRegion
+                return formatDateTimeString(DateAndTimeFunction.REGION_DATETIME_FORMATTER.format((TemporalAccessor) val), wrapForCodeUsage);
+            } else {
+                return formatDateTimeString(DateAndTimeFunction.FEEL_DATE_TIME.format((TemporalAccessor) val), wrapForCodeUsage);
+            }
+        } else if (val instanceof Duration) {
+            return formatDuration((Duration) val, wrapForCodeUsage);
+        } else if (val instanceof ChronoPeriod) {
+            return formatPeriod((ChronoPeriod) val, wrapForCodeUsage);
+        } else if (val instanceof TemporalAccessor) {
+            TemporalAccessor ta = (TemporalAccessor) val;
+            if (ta.query(TemporalQueries.localDate()) == null && ta.query(TemporalQueries.localTime()) != null && ta.query(TemporalQueries.zoneId()) != null) {
+                return formatTimeString(TimeFunction.FEEL_TIME.format((TemporalAccessor) val), wrapForCodeUsage);
+            } else {
+                return String.valueOf(val);
+            }
+        } else if (val instanceof List) {
+            return formatList((List) val, wrapForCodeUsage);
+        } else if (val instanceof Range) {
+            return formatRange((Range) val, wrapForCodeUsage);
+        } else if (val instanceof Map) {
+            return formatContext((Map) val, wrapForCodeUsage);
+        } else {
+            return String.valueOf(val);
+        }
+    }
+
+    public static String formatDateTimeString(final String dateTimeString,
+                                              final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "date and time( \"" + dateTimeString + "\" )";
+        } else {
+            return dateTimeString;
+        }
+    }
+
+    public static String formatTimeString(final String timeString,
+                                          final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "time( \"" + timeString + "\" )";
+        } else {
+            return timeString;
+        }
+    }
+
+    public static String formatDate(final LocalDate date,
+                                    final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "date( \"" + DateFunction.FEEL_DATE.format(date) + "\" )";
+        } else {
+            return DateFunction.FEEL_DATE.format(date);
+        }
+    }
+
+    public static String formatString(final String value,
+                                      final boolean wrapForCodeUsage) {
+        if (wrapForCodeUsage) {
+            return "\"" + value + "\"";
+        } else {
+            return value;
+        }
+    }
+
+    public static String formatList(final List list,
+                                    final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("[ ");
+        int count = 0;
+        for (final Object val : list) {
+            if (count > 0) {
+                sb.append(", ");
+            }
+            sb.append(formatValue(val, wrapDateTimeValuesInFunctions));
+            count++;
+        }
+        if (!list.isEmpty()) {
+            sb.append(" ");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    public static String formatContext(final Map context,
+                                       final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        int count = 0;
+        for (final Map.Entry<Object, Object> val : (Set<Map.Entry<Object, Object>>) context.entrySet()) {
+            if (count > 0) {
+                sb.append(", ");
+            }
+            // keys should always be strings, so do not call recursivelly to avoid the "
+            sb.append(val.getKey());
+            sb.append(" : ");
+            sb.append(formatValue(val.getValue(), wrapDateTimeValuesInFunctions));
+            count++;
+        }
+        if (!context.isEmpty()) {
+            sb.append(" ");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    public static String formatRange(final Range val,
+                                     final boolean wrapDateTimeValuesInFunctions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(val.getLowBoundary() == Range.RangeBoundary.OPEN ? "( " : "[ ");
+        sb.append(formatValue(val.getLowEndPoint(), wrapDateTimeValuesInFunctions));
+        sb.append(" .. ");
+        sb.append(formatValue(val.getHighEndPoint(), wrapDateTimeValuesInFunctions));
+        sb.append(val.getHighBoundary() == Range.RangeBoundary.OPEN ? " )" : " ]");
+        return sb.toString();
+    }
+
+    public static String formatPeriod(final ChronoPeriod period,
+                                      final boolean wrapInDurationFunction) {
+        final long totalMonths = ComparablePeriod.toTotalMonths(period);
+        if (totalMonths == 0) {
+            if (wrapInDurationFunction) {
+                return "duration( \"P0M\" )";
+            } else {
+                return "P0M";
+            }
+        }
+        final StringBuilder sb = new StringBuilder();
+        if (wrapInDurationFunction) {
+            sb.append("duration( \"");
+        }
+        if (totalMonths < 0) {
+            sb.append("-P");
+        } else {
+            sb.append('P');
+        }
+
+        final long years = Math.abs(totalMonths / 12);
+        if (years != 0) {
+            sb.append(years).append('Y');
+        }
+
+        final long months = Math.abs(totalMonths % 12);
+        if (months != 0) {
+            sb.append(months).append('M');
+        }
+
+        if (wrapInDurationFunction) {
+            sb.append("\" )");
+        }
+
+        return sb.toString();
+    }
+
+    public static String formatDuration(final Duration duration,
+                                        final boolean wrapInDurationFunction) {
+        if (duration.getSeconds() == 0 && duration.getNano() == 0) {
+            if (wrapInDurationFunction) {
+                return "duration( \"PT0S\" )";
+            } else {
+                return "PT0S";
+            }
+        }
+        final long days = duration.getSeconds() / SECONDS_IN_A_DAY;
+        final long hours = (duration.getSeconds() % SECONDS_IN_A_DAY) / SECONDS_IN_AN_HOUR;
+        final long minutes = (duration.getSeconds() % SECONDS_IN_AN_HOUR) / SECONDS_IN_A_MINUTE;
+        final long seconds = duration.getSeconds() % SECONDS_IN_A_MINUTE;
+
+        final StringBuilder sb = new StringBuilder();
+        if (wrapInDurationFunction) {
+            sb.append("duration( \"");
+        }
+        if (duration.isNegative()) {
+            sb.append("-");
+        }
+        sb.append("P");
+        if (days != 0) {
+            appendToDurationString(sb, days, "D");
+        }
+        if (hours != 0 || minutes != 0 || seconds != 0 || duration.getNano() != 0) {
+            sb.append("T");
+            if (hours != 0) {
+                appendToDurationString(sb, hours, "H");
+            }
+            if (minutes != 0) {
+                appendToDurationString(sb, minutes, "M");
+            }
+            if (seconds != 0 || duration.getNano() != 0) {
+                appendSecondsToDurationString(sb, seconds, duration.getNano());
+            }
+        }
+        if (wrapInDurationFunction) {
+            sb.append("\" )");
+        }
+        return sb.toString();
+    }
+
+    private static void appendToDurationString(final StringBuilder sb,
+                                               final long days,
+                                               final String timeSegmentChar) {
+        sb.append(Math.abs(days));
+        sb.append(timeSegmentChar);
+    }
+
+    private static void appendSecondsToDurationString(final StringBuilder sb,
+                                                      final long seconds,
+                                                      final long nanoseconds) {
+        if (seconds < 0 && nanoseconds > 0) {
+            if (seconds == -1) {
+                sb.append("0");
+            } else {
+                sb.append(Math.abs(seconds + 1));
+            }
+        } else {
+            sb.append(Math.abs(seconds));
+        }
+        if (nanoseconds > 0) {
+            final int pos = sb.length();
+            if (seconds < 0) {
+                sb.append(2 * NANOSECONDS_PER_SECOND - nanoseconds);
+            } else {
+                sb.append(nanoseconds + NANOSECONDS_PER_SECOND);
+            }
+            eliminateTrailingZeros(sb);
+            sb.setCharAt(pos, '.');
+        }
+        sb.append('S');
+    }
+
+    private static void eliminateTrailingZeros(final StringBuilder sb) {
+        while (sb.charAt(sb.length() - 1) == '0') {
+            // eliminates trailing zeros in the nanoseconds
+            sb.setLength(sb.length() - 1);
+        }
+    }
+
+    private TypeUtil() {
+        // Not allowed for util classes.
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/resources/org/kie/dmn/feel/DMNFeelGWT.gwt.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/main/resources/org/kie/dmn/feel/DMNFeelGWT.gwt.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+  <entry-point class="org.kie.dmn.feel.entrypoint.FEELEntryPoint"/>
+
+  <inherits name="org.dominokit.domino.logger.Logging"/>
+  <inherits name="org.antlr.v4.antlr4-runtime"/>
+  <inherits name="org.jresearch.threetenbp.gwt.time.module"/>
+  <inherits name="org.jresearch.gwt.time.apt.module"/>
+  <inherits name="org.jresearch.gwt.locale.langtag.module"/>
+  <inherits name="org.jresearch.gwt.locale.module"/>
+  <inherits name="org.kie.dmn.feel.DMNFeel"/>
+
+  <source path="entrypoint"/>
+  <source path="client"/>
+
+  <super-source path="" includes="FEEL.java"/>
+  <super-source path="parser"/>
+  <super-source path="util"/>
+  <super-source path="lang"/>
+  <super-source path="marshaller"/>
+  <super-source path="runtime"/>
+  <super-source path="super"/>
+</module>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/test/java/org/kie/dmn/feel/util/AssignableFromUtilTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/test/java/org/kie/dmn/feel/util/AssignableFromUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.dmn.feel.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssignableFromUtilTest {
+
+    @Test
+    public void testIsAssignableFromWhenItIsAssignable() {
+        assertThat(AssignableFromUtil.isAssignableFrom(A.class, B.class)).isTrue();
+    }
+
+    @Test
+    public void testIsAssignableFromWhenItIsNotAssignable() {
+        assertThat(AssignableFromUtil.isAssignableFrom(A.class, C.class)).isFalse();
+    }
+
+    static class A {
+        // empty.
+    }
+
+    static class B extends A {
+        // empty.
+    }
+
+    static class C {
+        // empty.
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/test/resources/META-INF/ErraiApp.properties
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-dmn-feel-gwt/src/test/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,19 @@
+#
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+
+
+

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/pom.xml
@@ -27,7 +27,19 @@
   <artifactId>kie-wb-common-dmn-client</artifactId>
   <name>Kie Workbench - Common - DMN - Client</name>
   <description>Kie Workbench - Common - DMN - Client</description>
-  <packaging>jar</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <packaging>jar</packaging>
 
   <properties>
     <java.module.name>org.kie.wb.common.dmn.client</java.module.name>
@@ -291,7 +303,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie</groupId>
+      <groupId>org.kie.kogito.stunner.editors</groupId>
       <artifactId>kie-dmn-feel-gwt-functions</artifactId>
       <exclusions>
         <exclusion>
@@ -301,7 +313,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.kie</groupId>
+      <groupId>org.kie.kogito.stunner.editors</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <scope>provided</scope>
       <exclusions>
@@ -316,7 +328,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.kie</groupId>
+      <groupId>org.kie.kogito.stunner.editors</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <classifier>sources</classifier>
       <exclusions>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/pom.xml
@@ -169,6 +169,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.gwtproject</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3</artifactId>
       <scope>provided</scope>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -464,7 +464,7 @@
 
     <!-- Client side FEEL -->
     <dependency>
-      <groupId>org.kie</groupId>
+      <groupId>org.kie.kogito.stunner.editors</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <scope>provided</scope>
       <exclusions>
@@ -479,7 +479,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.kie</groupId>
+      <groupId>org.kie.kogito.stunner.editors</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <classifier>sources</classifier>
       <scope>provided</scope>
@@ -670,8 +670,8 @@
             <compileSourcesArtifact>org.rikkola.gwt:antlr4-c3-gwt</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie:kie-dmn-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie:kie-dmn-feel</compileSourcesArtifact>
-            <compileSourcesArtifact>org.kie:kie-dmn-feel-gwt</compileSourcesArtifact>
-            <compileSourcesArtifact>org.kie:kie-dmn-feel-gwt-functions</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.kogito.stunner.editors:kie-dmn-feel-gwt</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.kogito.stunner.editors:kie-dmn-feel-gwt-functions</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie:kie-dmn-model</compileSourcesArtifact>
 
             <!-- UF-ext -->

--- a/packages/stunner-editors/kie-wb-common-dmn/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/pom.xml
@@ -35,6 +35,8 @@
   </properties>
 
   <modules>
+    <module>kie-dmn-feel-gwt</module>
+    <module>kie-dmn-feel-gwt-functions</module>
     <module>kie-wb-common-dmn-api</module>
     <module>kie-wb-common-dmn-client</module>
     <module>kie-wb-common-dmn-webapp-common</module>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -270,6 +270,7 @@
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
     <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
+    <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
     <version.enforce-managed-deps-rule>1.3</version.enforce-managed-deps-rule>
     <version.enfore-victims-rule>1.3.4</version.enfore-victims-rule>
     <version.illegal-transitive-dependency-check>1.7.4</version.illegal-transitive-dependency-check>
@@ -294,6 +295,7 @@
     <version.org.jboss.maven-jdocbook-plugin>2.3.5</version.org.jboss.maven-jdocbook-plugin>
     <version.org.jboss.pressbang>2.0.0</version.org.jboss.pressbang>
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+    <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
     <version.org.jsoup>1.15.3</version.org.jsoup>
     <version.org.ow2.asm>7.1</version.org.ow2.asm>
     <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
@@ -456,6 +458,25 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jresearch.gwt.time</groupId>
+        <artifactId>org.jresearch.gwt.time</artifactId>
+        <version>${version.org.jresearch.gwt.time}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.antlr4gwt</groupId>
+        <artifactId>antlr4gwt-runtime</artifactId>
+        <version>${version.org.antlrgwt}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.antlr4gwt</groupId>
+        <artifactId>antlr4gwt-runtime</artifactId>
+        <version>${version.org.antlrgwt}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${version.com.google.inject.guice}</version>
@@ -489,12 +510,6 @@
             <artifactId>javax.interceptor-api</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.antlr4gwt</groupId>
-        <artifactId>antlr4gwt-runtime</artifactId>
-        <version>${version.org.antlrgwt}</version>
       </dependency>
 
       <dependency>
@@ -579,6 +594,12 @@
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>${version.org.jsoup}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.dominokit</groupId>
+        <artifactId>domino-slf4j-logger</artifactId>
+        <version>${version.domino-slf4j-logger}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The scope of this PR is to move `kie-dmn-feel-gwt` and `kie-dmn-feel-gwt-function` GWT modules from [drools](https://github.com/kiegroup/drools/pull/4970) to `kie-tools`. 
The main reason is to decouple client-side modules from the drools repo, and put them in `kie-tools` repo which is the ideal location, mostly to benefit from an improved GWT modules maintenance