### PR TITLE
KOGITO-8599: Fix Table External Component paging style in Dark Mode

### DIFF
--- a/packages/dashbuilder-component-table/src/FilteredTable.tsx
+++ b/packages/dashbuilder-component-table/src/FilteredTable.tsx
@@ -164,7 +164,7 @@ export const FilteredTable = (props: Props) => {
               onClear={() => onSearch("")}
             />
           </FlexItem>
-          <FlexItem align={{ default: "alignRight" }}>
+          <FlexItem align={{ default: "alignLeft" }}>
             <Pagination
               itemCount={rows.length}
               perPage={perPage}

--- a/packages/dashbuilder-component-table/src/FilteredTable.tsx
+++ b/packages/dashbuilder-component-table/src/FilteredTable.tsx
@@ -164,7 +164,7 @@ export const FilteredTable = (props: Props) => {
               onClear={() => onSearch("")}
             />
           </FlexItem>
-          <FlexItem align={{ default: "alignLeft" }}>
+          <FlexItem align={{ default: "alignRight" }}>
             <Pagination
               itemCount={rows.length}
               perPage={perPage}

--- a/packages/dashbuilder-component-table/static/index.css
+++ b/packages/dashbuilder-component-table/static/index.css
@@ -42,9 +42,36 @@
   --pf-global--BackgroundColor--100: #100c2a !important;
 }
 
-[mode="dark"] .pf-c-options-menu__menu {
+[mode="dark"] .pf-c-options-menu__menu,
+[mode="dark"] .pf-c-pagination__nav,
+[mode="dark"] .pf-c-pagination__total-items {
   background-color: #100c2a !important;
   color: #eef1fa;
+}
+
+[mode="dark"] .pf-c-pagination__nav {
+  display: inherit;
+  visibility: inherit;
+}
+
+[mode="dark"] .pf-l-flex {
+  justify-content: center;
+}
+
+[mode="dark"] .pf-m-align-left {
+  padding-left: 20px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.pf-l-flex {
+  justify-content: center;
+}
+
+.pf-m-align-left {
+  padding-left: 20px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 [mode="dark"] .pf-c-options-menu__menu-item:hover,

--- a/packages/dashbuilder-component-table/static/index.css
+++ b/packages/dashbuilder-component-table/static/index.css
@@ -49,31 +49,6 @@
   color: #eef1fa;
 }
 
-[mode="dark"] .pf-c-pagination__nav {
-  display: inherit;
-  visibility: inherit;
-}
-
-[mode="dark"] .pf-l-flex {
-  justify-content: center;
-}
-
-[mode="dark"] .pf-m-align-left {
-  padding-left: 20px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-.pf-l-flex {
-  justify-content: center;
-}
-
-.pf-m-align-left {
-  padding-left: 20px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
 [mode="dark"] .pf-c-options-menu__menu-item:hover,
 [mode="dark"] .pf-c-table tr.pf-m-hoverable:hover {
   background-color: #393555;


### PR DESCRIPTION
The pagination section used to disappear when the screen size was decreased below 768px but now it comes down after the filter tab. This issue still needs to be addressed for light mode.
![Screenshot from 2023-02-08 10-14-31](https://user-images.githubusercontent.com/82813768/217435753-f2caa99c-3bdb-40e8-9b74-0bb17f18f6aa.png)

The pagination number which is in red used to be black in dark mode due to which it was invisible; in this PR it has been corrected and now its white in dark mode.
![Screenshot from 2023-02-08 10-12-31](https://user-images.githubusercontent.com/82813768/217435757-a2407e1c-cb04-48e2-9376-9f8cff62791b.png)


The updated code result is as in the below pic:-
![Screenshot from 2023-02-08 10-20-37](https://user-images.githubusercontent.com/82813768/217436592-9d5408a0-e9ca-4dfe-8668-697fc76ada46.png)
