### PR TITLE
Set up Maven with version to 3.8.6 on GitHub actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -38,6 +38,11 @@ runs:
       with:
         go-version: "1.19"
 
+    - name: "Set up Maven"
+      uses: stCarolas/setup-maven@417e1a9899611c0350621d1fb0c2770f35105c69
+      with:
+        maven-version: 3.8.6
+
     - name: "Setup network timeout"
       shell: bash
       run: |


### PR DESCRIPTION
Version 3.8.7 was being used by default since its release, causing an error for Windows builds:
```
Error: verless-workflow-diagram-editor build:dev: [ERROR] Error executing Maven.
.../serverless-workflow-diagram-editor build:dev: org.apache.commons.cli.ParseException: Unrecognized maven.config file entries: [ -ntp -Drevision=0.0.0]
.../serverless-workflow-diagram-editor build:dev: 	at org.apache.maven.cli.MavenCli.cli(MavenCli.java:342)
.../serverless-workflow-diagram-editor build:dev: 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:258)
.../serverless-workflow-diagram-editor build:dev: 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
.../serverless-workflow-diagram-editor build:dev: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
.../serverless-workflow-diagram-editor build:dev: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
.../serverless-workflow-diagram-editor build:dev: 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
.../serverless-workflow-diagram-editor build:dev: 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
.../serverless-workflow-diagram-editor build:dev: 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
.../serverless-workflow-diagram-editor build:dev: 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
.../serverless-workflow-diagram-editor build:dev: 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
.../serverless-workflow-diagram-editor build:dev: 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
.../serverless-workflow-diagram-editor build:dev:  ELIFECYCLE  Command failed with exit code 1.
.../serverless-workflow-diagram-editor build:dev: Failed
```

This PR forces the usage of the 3.8.6 version (and prevents from new releases causing errors again).