### PR TITLE
kie-issues#30: Stunner - Sometimes nodes are created in duplicity using the mouse

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxView.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/toolbox/actions/AbstractActionsToolboxView.java
@@ -172,6 +172,7 @@ public abstract class AbstractActionsToolboxView<V extends AbstractActionsToolbo
                                      final IsToolboxActionDraggable toolboxAction,
                                      final ButtonItem button,
                                      final NodeMouseMoveEvent event) {
+        button.disable();
         toolboxAction.onMoveStart(toolbox.getCanvasHandler(),
                                   toolbox.getElementUUID(),
                                   new MouseMoveEvent(event.getX(),


### PR DESCRIPTION
**[KOGITO-7095](https://issues.redhat.com/browse/KOGITO-7095) - Sometimes nodes are created in duplicity using the mouse**

**Closes [Issue #30](https://github.com/kiegroup/kie-issues/issues/30)**

If done quickly enough, it was possible to trigger the button click event after triggering the move start event. This executed the action two times, one for each event. Now the button is disabled after triggering the move start event. This prevents the double action execution.

**VSCode Extension: [BPMN, DMN, Test Scenario, and (PMML) Scorecard Editors](https://drive.google.com/file/d/15wFK2JxcRjcYHtTjHGYauU8gcV-rRPRM/view?usp=share_link)**