### PR TITLE
kie-issues#105: Upgrade `node` from `16` to LTS (`18`) on `kie-tools`

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: "Setup Node"
       uses: actions/setup-node@v2
       with:
-        node-version: 16.13.2
+        node-version: 18.14.0
 
     - name: "Setup JDK 11"
       uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains tooling applications and libraries for KIE projects.
 
 To start building the KIE Tools project, you're going to need:
 
-- Node `16` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
+- Node `18` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Maven `3.8.6`
 - Java `11`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@kie-tools-scripts/sparse-checkout": "workspace:*",
     "@kie-tools-scripts/update-version": "workspace:*",
     "@nice-move/prettier-plugin-package-json": "^0.6.1",
-    "@types/node": "^15.0.2",
+    "@types/node": "^18.13.0",
     "filemanager-webpack-plugin": "^7.0.0",
     "husky": "^6.0.0",
     "postinstall-postinstall": "^2.1.0",
@@ -31,7 +31,7 @@
     "react-dropzone": "^11.4.2"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "pnpm": "7.26.3"
   },
   "pnpm": {

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -10,7 +10,7 @@ All the commands in this section should be performed in the monorepo root.
 
 ### Prerequisites
 
-- Node `>= 16.13.2` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
+- Node `>= 18.14.0` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Go `1.19` _(To install, follow these instructions: https://go.dev/doc/install)_
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1(prettier@2.3.0)
       "@types/node":
-        specifier: ^15.0.2
-        version: 15.6.0
+        specifier: ^18.13.0
+        version: 18.13.0
       filemanager-webpack-plugin:
         specifier: ^7.0.0
         version: 7.0.0
@@ -12949,7 +12949,7 @@ packages:
     dependencies:
       "@types/http-cache-semantics": 4.0.0
       "@types/keyv": 3.1.1
-      "@types/node": 17.0.12
+      "@types/node": 18.13.0
       "@types/responselike": 1.0.0
     dev: true
 
@@ -13120,7 +13120,7 @@ packages:
     requiresBuild: true
     dependencies:
       "@types/minimatch": 3.0.4
-      "@types/node": 17.0.12
+      "@types/node": 18.13.0
     dev: true
 
   /@types/graceful-fs@4.1.3:
@@ -13240,7 +13240,7 @@ packages:
     resolution:
       { integrity: sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw== }
     dependencies:
-      "@types/node": 17.0.12
+      "@types/node": 18.13.0
     dev: true
 
   /@types/leaflet@0.7.35:
@@ -13302,14 +13302,14 @@ packages:
       { integrity: sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA== }
     dev: true
 
-  /@types/node@15.6.0:
-    resolution:
-      { integrity: sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A== }
-    dev: true
-
   /@types/node@17.0.12:
     resolution:
       { integrity: sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA== }
+    dev: true
+
+  /@types/node@18.13.0:
+    resolution:
+      { integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg== }
     dev: true
 
   /@types/normalize-package-data@2.4.0:
@@ -13450,7 +13450,7 @@ packages:
     resolution:
       { integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA== }
     dependencies:
-      "@types/node": 17.0.12
+      "@types/node": 18.13.0
     dev: true
 
   /@types/retry@0.12.1:
@@ -13529,7 +13529,7 @@ packages:
     resolution:
       { integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g== }
     dependencies:
-      "@types/node": 17.0.12
+      "@types/node": 18.13.0
     dev: true
 
   /@types/stack-utils@2.0.0:


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/105

Upgrade node version from `16` to `18`