### PR TITLE
KOGITO-8503: Dark mode implementation in victory-charts-component

### DIFF
--- a/packages/dashbuilder-component-victory-charts/dev-webapp/manifest.dev.json
+++ b/packages/dashbuilder-component-victory-charts/dev-webapp/manifest.dev.json
@@ -87,6 +87,10 @@
     {
       "key": "barOffset",
       "value": "10"
+    },
+    {
+      "key": "mode",
+      "value": "dark"
     }
   ],
   "dataSet": {

--- a/packages/dashbuilder-component-victory-charts/src/VictoryChartComponent.tsx
+++ b/packages/dashbuilder-component-victory-charts/src/VictoryChartComponent.tsx
@@ -39,6 +39,10 @@ export function VictoryChartComponent(props: Props) {
 
   useEffect(() => {
     props.controller.setOnInit((params: Map<string, any>) => {
+      const mode = params.get("mode");
+      if (mode) {
+        document.body.setAttribute("mode", mode.toLowerCase());
+      }
       setVictoryChartProps((props: VictoryChartProps) => {
         return {
           ...props,

--- a/packages/dashbuilder-component-victory-charts/static/index.css
+++ b/packages/dashbuilder-component-victory-charts/static/index.css
@@ -3,9 +3,9 @@
 }
 
 [mode="dark"] .pf-c-chart g text tspan {
-  fill: white !important;
+  fill: #eef1fa !important;
 }
 
 [mode="dark"] .pf-c-chart g line {
-  stroke: white !important;
+  stroke: #eef1fa !important;
 }

--- a/packages/dashbuilder-component-victory-charts/static/index.css
+++ b/packages/dashbuilder-component-victory-charts/static/index.css
@@ -1,0 +1,11 @@
+[mode="dark"] .pf-c-chart {
+  background-color: #100c2a;
+}
+
+[mode="dark"] .pf-c-chart g text tspan {
+  fill: white !important;
+}
+
+[mode="dark"] .pf-c-chart g line {
+  stroke: white !important;
+}

--- a/packages/dashbuilder-component-victory-charts/static/index.html
+++ b/packages/dashbuilder-component-victory-charts/static/index.html
@@ -18,6 +18,7 @@
   <head>
     <title>Chart</title>
     <link rel="stylesheet" href="patternfly.min.css" />
+    <link rel="stylesheet" href="index.css" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
All the charts mode are now also available in dark mode.

![Screenshot from 2023-02-10 21-31-07](https://user-images.githubusercontent.com/82813768/218141140-57a98d42-fa51-44ac-a1ce-49926a2a9411.png)
![Screenshot from 2023-02-10 21-30-55](https://user-images.githubusercontent.com/82813768/218141148-35d6c37c-c2e5-4141-b1ea-c38587412469.png)
![Screenshot from 2023-02-10 21-30-44](https://user-images.githubusercontent.com/82813768/218141155-61ff99d8-fe90-49d6-a4f0-cc7eb5d61cdb.png)
![Screenshot from 2023-02-10 21-30-31](https://user-images.githubusercontent.com/82813768/218141167-a1afa16a-add6-4064-99b7-9900b34d925a.png)
![Screenshot from 2023-02-10 21-30-18](https://user-images.githubusercontent.com/82813768/218141177-a614adbc-d677-4db0-bfbd-91d5b3b4530d.png)
![Screenshot from 2023-02-10 21-30-03](https://user-images.githubusercontent.com/82813768/218141188-b21a11d4-2fca-4dd9-966c-33aadead4acf.png)
![Screenshot from 2023-02-10 21-29-50](https://user-images.githubusercontent.com/82813768/218141193-80546282-003c-4dc2-a543-cab0eefcb504.png)
