### PR TITLE
KOGITO-8719: kn-workflow-plugin tests reported as successful even if they fail

### DIFF
--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -29,7 +29,7 @@
     "build:win32": "pnpm setup:env:win32 make build-win32-amd64",
     "debug:clean": "rimraf debug",
     "go:test": "rimraf dist-tests && mkdir dist-tests && go test -v ./... | tee ./dist-tests/go-test-output.txt",
-    "go:test:report": "go run github.com/jstemmer/go-junit-report/v2 -in ./dist-tests/go-test-output.txt -out ./dist-tests/junit-report.xml",
+    "go:test:report": "go run github.com/jstemmer/go-junit-report/v2 -set-exit-code -in ./dist-tests/go-test-output.txt -out ./dist-tests/junit-report.xml",
     "install": "go mod tidy",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "setup:env": "cross-env QUARKUS_PLATFORM_GROUP_ID=$(build-env knPluginWorkflow.quarkusPlatformGroupId) QUARKUS_VERSION=$(build-env knPluginWorkflow.quarkusVersion) PLUGIN_VERSION=$(build-env knPluginWorkflow.version)",


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-8719

Add `-set-exit-code` flag to JUnit report generation.