### PR TITLE
kie-issues#85: Add more Git operations on KIE Sandbox

### DIFF
--- a/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
@@ -40,7 +40,11 @@ import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { NewFileDropdownMenu } from "./NewFileDropdownMenu";
 import { PageHeaderToolsItem, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { FileLabel } from "../../filesList/FileLabel";
-import { useWorkspacePromise } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
+import {
+  useWorkspaceGitStatusPromise,
+  useWorkspacePromise,
+  WorkspaceGitStatusType,
+} from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
 import { FileSwitcher } from "./FileSwitcher";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 import { KieSandboxExtendedServicesDropdownGroup } from "../KieSandboxExtendedServices/KieSandboxExtendedServicesDropdownGroup";
@@ -68,6 +72,8 @@ import { WorkspaceToolbar } from "./Workspace/WorkspaceToolbar";
 import { useWorkspaceNavigationBlocker } from "./Workspace/Hooks";
 import { FileStatus } from "./FileStatus";
 import { SyncDropdownMenu } from "./SyncDropdownMenu";
+import { listDeletedFiles } from "../../workspace/components/WorkspaceStatusIndicator";
+import { PromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
 
 export interface Props {
   editor: EmbeddedEditorRef | undefined;
@@ -99,7 +105,9 @@ const hideWhenTiny: ToolbarItemProps["visibility"] = {
   md: "hidden",
 };
 
-export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWorkspace }) {
+export function EditorToolbarWithWorkspace(
+  props: Props & { workspace: ActiveWorkspace; workspaceGitStatusPromise: PromiseState<WorkspaceGitStatusType> }
+) {
   const routes = useRoutes();
   const editorEnvelopeLocator = useEditorEnvelopeLocator();
   const history = useHistory();
@@ -133,13 +141,7 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
     [props.editor, props.workspaceFile, props.workspace]
   );
 
-  const deleteWorkspaceFile = useCallback(async () => {
-    if (props.workspace.files.length === 1) {
-      await workspaces.deleteWorkspace({ workspaceId: props.workspaceFile.workspaceId });
-      history.push({ pathname: routes.home.path({}) });
-      return;
-    }
-
+  const handleDeletedWorkspaceFile = useCallback(() => {
     const nextFile = props.workspace.files
       .filter((f) => {
         return (
@@ -147,11 +149,6 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
         );
       })
       .pop();
-
-    await workspaces.deleteFile({
-      file: props.workspaceFile,
-    });
-
     if (!nextFile) {
       history.push({ pathname: routes.home.path({}) });
       return;
@@ -164,7 +161,28 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
         extension: nextFile.extension,
       }),
     });
-  }, [routes, history, props.workspace, props.workspaceFile, workspaces, editorEnvelopeLocator]);
+  }, [
+    editorEnvelopeLocator,
+    history,
+    props.workspace.files,
+    props.workspaceFile.relativePath,
+    routes.home,
+    routes.workspaceWithFilePath,
+  ]);
+
+  const deleteWorkspaceFile = useCallback(async () => {
+    if (props.workspace.files.length === 1) {
+      await workspaces.deleteWorkspace({ workspaceId: props.workspaceFile.workspaceId });
+      history.push({ pathname: routes.home.path({}) });
+      return;
+    }
+
+    await workspaces.deleteFile({
+      file: props.workspaceFile,
+    });
+
+    handleDeletedWorkspaceFile();
+  }, [props.workspace.files.length, props.workspaceFile, workspaces, handleDeletedWorkspaceFile, history, routes.home]);
 
   const deleteFileDropdownItem = useMemo(() => {
     return (
@@ -223,8 +241,15 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
   ]);
 
   const canSeeWorkspaceToolbar = useMemo(
-    () => props.workspace.descriptor.origin.kind !== WorkspaceKind.LOCAL || props.workspace.files.length > 1,
-    [props.workspace.descriptor.origin.kind, props.workspace.files.length]
+    () =>
+      props.workspace.descriptor.origin.kind !== WorkspaceKind.LOCAL ||
+      props.workspace.files.length +
+        listDeletedFiles({
+          workspaceDescriptor: props.workspace.descriptor,
+          workspaceGitStatusPromise: props.workspaceGitStatusPromise,
+        }).length >
+        1,
+    [props.workspace.descriptor, props.workspace.files.length, props.workspaceGitStatusPromise]
   );
 
   return (
@@ -237,7 +262,12 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
             spaceItems={{ default: "spaceItemsMd" }}
           >
             <FlexItem style={{ minWidth: 0 }}>
-              <WorkspaceToolbar workspace={props.workspace} />
+              <WorkspaceToolbar
+                workspace={props.workspace}
+                workspaceGitStatusPromise={props.workspaceGitStatusPromise}
+                currentWorkspaceFile={props.workspaceFile}
+                onDeletedWorkspaceFile={handleDeletedWorkspaceFile}
+              />
             </FlexItem>
             <VsCodeDropdownMenu workspace={props.workspace} />
           </Flex>
@@ -253,7 +283,19 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
             <PageHeaderToolsItem visibility={{ default: "visible" }}>
               <Flex flexWrap={{ default: "nowrap" }} alignItems={{ default: "alignItemsCenter" }}>
                 <FlexItem style={{ minWidth: 0 }}>
-                  <FileSwitcher workspace={props.workspace} workspaceFile={props.workspaceFile} />
+                  <FileSwitcher
+                    workspace={props.workspace}
+                    gitStatusProps={
+                      canSeeWorkspaceToolbar
+                        ? {
+                            workspaceDescriptor: props.workspace.descriptor,
+                            workspaceGitStatusPromise: props.workspaceGitStatusPromise,
+                          }
+                        : undefined
+                    }
+                    workspaceFile={props.workspaceFile}
+                    onDeletedWorkspaceFile={handleDeletedWorkspaceFile}
+                  />
                 </FlexItem>
                 <FileStatus workspace={props.workspace} workspaceFile={props.workspaceFile} editor={props.editor} />
               </Flex>
@@ -375,14 +417,18 @@ export function EditorToolbarWithWorkspace(props: Props & { workspace: ActiveWor
 
 export function EditorToolbar(props: Props) {
   const workspacePromise = useWorkspacePromise(props.workspaceFile.workspaceId);
-
+  const workspaceGitStatusPromise = useWorkspaceGitStatusPromise(workspacePromise.data?.descriptor);
   if (!workspacePromise.data) {
     return <></>;
   }
 
   return (
     <EditorToolbarContextProvider {...props} workspace={workspacePromise.data}>
-      <EditorToolbarWithWorkspace {...props} workspace={workspacePromise.data} />
+      <EditorToolbarWithWorkspace
+        {...props}
+        workspace={workspacePromise.data}
+        workspaceGitStatusPromise={workspaceGitStatusPromise}
+      />
     </EditorToolbarContextProvider>
   );
 }

--- a/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
@@ -1012,7 +1012,7 @@ const FilesMenuItemCarouselCard = (props: {
       isRounded={true}
       isCompact={true}
       isFullHeight={true}
-      onSelect={props.onSelectFile}
+      onClick={props.displayMode === FileListItemDisplayMode.enabled ? props.onSelectFile : undefined}
       className={switchExpression(props.displayMode, {
         enabled: "kie-tools--file-list-item-enabled",
         deleted: "kie-tools--file-list-item-deleted",

--- a/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
@@ -393,7 +393,6 @@ export function FileSwitcher(props: {
                   <MenuGroup
                     style={{
                       maxHeight: `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX})` /* height of menu minus the height of Current item*/,
-                      overflowY: "auto",
                     }}
                   >
                     {workspacesMenuItems}
@@ -694,8 +693,8 @@ export function FilesMenuItems(props: {
           }}
           placeholder={`In '${props.workspace.descriptor.name}'`}
           style={{ fontSize: "small" }}
-          onClick={(ev) => {
-            ev.stopPropagation();
+          onClick={(e) => {
+            e.stopPropagation();
           }}
         />
       </MenuInput>
@@ -753,37 +752,36 @@ export function FilesMenuItems(props: {
 
   return (
     <>
-      <Grid style={{ alignItems: "center" }}>
-        <GridItem span={12}>
-          <MenuItem direction={"up"} itemId={`${props.workspace.descriptor.workspaceId}-breadcrumb`}>
-            All
-          </MenuItem>
-        </GridItem>
-        <GridItem span={12}>{searchInput}</GridItem>
-        <GridItem span={6}></GridItem>
-        <GridItem span={4}>
+      <MenuItem direction={"up"} itemId={`${props.workspace.descriptor.workspaceId}-breadcrumb`}>
+        All
+      </MenuItem>
+      {searchInput}
+      <Flex
+        justifyContent={{ default: "justifyContentFlexEnd" }}
+        alignItems={{ default: "alignItemsCenter" }}
+        style={{ paddingRight: "16px" }}
+      >
+        <FlexItem>
           {props.currentWorkspaceGitStatusProps !== undefined && (
-            <MenuInput>
-              <Tooltip content={"Filter only modified files"} position={"bottom"}>
-                <Checkbox
-                  label={"Only changed"}
-                  id={"filter-git-status-changed-locally"}
-                  aria-label={"Select to display only modified files"}
-                  isChecked={filteredGitSyncStatus === WorkspaceGitLocalChangesStatus.pending}
-                  onChange={(checked) => {
-                    setFilteredGitSyncStatus(checked ? WorkspaceGitLocalChangesStatus.pending : undefined);
-                  }}
-                />
-              </Tooltip>
-            </MenuInput>
+            <Tooltip content={"Select to display only modified, added, or deleted files"} position={"bottom"}>
+              <Checkbox
+                label={"Only modified"}
+                id={"filter-git-status-modified-locally"}
+                aria-label={"Select to display only modified, added, or deleted files"}
+                isChecked={filteredGitSyncStatus === WorkspaceGitLocalChangesStatus.pending}
+                onChange={(checked) => {
+                  setFilteredGitSyncStatus(checked ? WorkspaceGitLocalChangesStatus.pending : undefined);
+                }}
+              />
+            </Tooltip>
           )}
-        </GridItem>
-        <GridItem span={2}>
+        </FlexItem>
+        <FlexItem>
           <Flex justifyContent={{ default: "justifyContentCenter" }}>
             <FilesMenuModeIcons filesMenuMode={props.filesMenuMode} setFilesMenuMode={props.setFilesMenuMode} />
           </Flex>
-        </GridItem>
-      </Grid>
+        </FlexItem>
+      </Flex>
       <Divider component={"li"} />
 
       {props.filesMenuMode === FilesMenuMode.LIST && (
@@ -932,7 +930,7 @@ export function FilesMenuItems(props: {
                     setTopSectionHeightInPx((prev) => prev + MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX);
                   }}
                 >
-                  Back To Models
+                  Back
                 </MenuItem>
                 {searchInput}
                 <Divider component={"li"} />

--- a/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
@@ -74,7 +74,6 @@ import {
 import { WorkspaceListItem } from "../../workspace/components/WorkspaceListItem";
 import { usePreviewSvg } from "../../previewSvgs/PreviewSvgHooks";
 import { WorkspaceLoadingMenuItem } from "../../workspace/components/WorkspaceLoadingCard";
-import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
 import {
   listDeletedFiles,
   resolveGitLocalChangesStatus,
@@ -99,7 +98,7 @@ const FILE_SWITCHER_INITIAL_HEIGHT_OFFSET_IN_PX = 204;
 const MENU_HEIGHT_MAX_LIMIT_CSS = `calc(100vh - ${FILE_SWITCHER_INITIAL_HEIGHT_OFFSET_IN_PX}px)` as const;
 const DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX = 40;
 const MENU_SEARCH_HEIGHT_IN_PX = 64;
-const MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX = 53;
+const MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX = 36;
 const MENU_DIVIDER_HEIGHT_IN_PX = 17;
 
 export function FileSwitcher(props: {
@@ -392,7 +391,8 @@ export function FileSwitcher(props: {
                   </MenuItem>
                   <MenuGroup
                     style={{
-                      maxHeight: `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX})` /* height of menu minus the height of Current item*/,
+                      maxHeight: `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX}px)` /* height of menu minus the height of Current item*/,
+                      overflowY: "auto",
                     }}
                   >
                     {workspacesMenuItems}
@@ -703,11 +703,9 @@ export function FilesMenuItems(props: {
 
   const fileListMenuItemsHeightMaxLimitCss = useMemo(() => {
     return `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${
-      (!props.currentWorkspaceGitStatusProps
-        ? topSectionHeightInPx - MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX
-        : topSectionHeightInPx) + (otherFiles.length ? bottomSectionHeightInPx : 0)
+      topSectionHeightInPx + (otherFiles.length ? bottomSectionHeightInPx : 0)
     }px)`;
-  }, [bottomSectionHeightInPx, otherFiles.length, props.currentWorkspaceGitStatusProps, topSectionHeightInPx]);
+  }, [bottomSectionHeightInPx, otherFiles.length, topSectionHeightInPx]);
 
   const isCurrentWorkspaceFile = useCallback(
     (file: WorkspaceFile) => {

--- a/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/Toolbar/FileSwitcher.tsx
@@ -16,7 +16,6 @@
 
 import { ActiveWorkspace } from "@kie-tools-core/workspaces-git-fs/dist/model/ActiveWorkspace";
 import { useWorkspaces, WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
-import { useRoutes } from "../../navigation/Hooks";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { join } from "path";
@@ -46,19 +45,14 @@ import { ThLargeIcon } from "@patternfly/react-icons/dist/js/icons/th-large-icon
 import { ListIcon } from "@patternfly/react-icons/dist/js/icons/list-icon";
 import { useWorkspaceDescriptorsPromise } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspacesHooks";
 import { PromiseStateWrapper, useCombinedPromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
-import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
-import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
 import { useWorkspacesFilesPromise } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspacesFiles";
 import { Skeleton } from "@patternfly/react-core/dist/js/components/Skeleton";
 import { Card, CardBody, CardHeader, CardHeaderMain } from "@patternfly/react-core/dist/js/components/Card";
 import { Gallery } from "@patternfly/react-core/dist/js/layouts/Gallery";
-import { useHistory } from "react-router";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { EmptyState, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
-import { ArrowRightIcon } from "@patternfly/react-icons/dist/js/icons/arrow-right-icon";
-import { ArrowLeftIcon } from "@patternfly/react-icons/dist/js/icons/arrow-left-icon";
 import { useEditorEnvelopeLocator } from "../../envelopeLocator/hooks/EditorEnvelopeLocatorContext";
 import { VariableSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
@@ -66,6 +60,7 @@ import {
   FileDataList,
   FileLink,
   FileListItem,
+  FileListItemDisplayMode,
   getFileDataListHeight,
   SingleFileWorkspaceDataList,
 } from "../../filesList/FileDataList";
@@ -79,23 +74,43 @@ import {
 import { WorkspaceListItem } from "../../workspace/components/WorkspaceListItem";
 import { usePreviewSvg } from "../../previewSvgs/PreviewSvgHooks";
 import { WorkspaceLoadingMenuItem } from "../../workspace/components/WorkspaceLoadingCard";
+import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
+import {
+  listDeletedFiles,
+  resolveGitLocalChangesStatus,
+  WorkspaceGitLocalChangesStatus,
+} from "../../workspace/components/WorkspaceStatusIndicator";
+import { Checkbox } from "@patternfly/react-core/dist/js/components/Checkbox";
+import { SearchInput } from "@patternfly/react-core/dist/js/components/SearchInput";
+import { switchExpression } from "../../switchExpression/switchExpression";
+import { GitStatusProps } from "../../workspace/components/GitStatusIndicatorActions";
 
 const ROOT_MENU_ID = "rootMenu";
 
-enum FilesDropdownMode {
-  LIST_MODELS,
-  LIST_MODELS_AND_OTHERS,
+enum FilesMenuMode {
+  LIST,
   CAROUSEL,
 }
 
 const MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX = 500;
 const MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN = 40;
+// properties to be used for menu height calculation
+const FILE_SWITCHER_INITIAL_HEIGHT_OFFSET_IN_PX = 204;
+const MENU_HEIGHT_MAX_LIMIT_CSS = `calc(100vh - ${FILE_SWITCHER_INITIAL_HEIGHT_OFFSET_IN_PX}px)` as const;
+const DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX = 40;
+const MENU_SEARCH_HEIGHT_IN_PX = 64;
+const MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX = 53;
+const MENU_DIVIDER_HEIGHT_IN_PX = 17;
 
-export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile: WorkspaceFile }) {
+export function FileSwitcher(props: {
+  workspace: ActiveWorkspace;
+  gitStatusProps?: GitStatusProps;
+  workspaceFile: WorkspaceFile;
+  onDeletedWorkspaceFile: () => void;
+}) {
   const workspaces = useWorkspaces();
   const workspaceFileNameRef = useRef<HTMLInputElement>(null);
   const [newFileNameValid, setNewFileNameValid] = useState<boolean>(true);
-  const [filesDropdownMode, setFilesDropdownMode] = useState(FilesDropdownMode.LIST_MODELS);
 
   const resetWorkspaceFileName = useCallback(() => {
     if (workspaceFileNameRef.current) {
@@ -174,15 +189,11 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
   const [menuHeights, setMenuHeights] = useState<{ [key: string]: number }>({});
   const [activeMenu, setActiveMenu] = useState(ROOT_MENU_ID);
 
-  useEffect(() => {
-    setMenuHeights({});
-  }, [props.workspace, filesDropdownMode, activeMenu]);
+  const [filesMenuMode, setFilesMenuMode] = useState(FilesMenuMode.LIST);
 
   useEffect(() => {
-    setFilesDropdownMode((prev) =>
-      prev === FilesDropdownMode.LIST_MODELS_AND_OTHERS ? FilesDropdownMode.LIST_MODELS : prev
-    );
-  }, [activeMenu]);
+    setMenuHeights({});
+  }, [props.workspace, filesMenuMode, activeMenu]);
 
   useEffect(() => {
     if (isFilesDropdownOpen) {
@@ -225,11 +236,11 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
         activeMenu={activeMenu}
         currentWorkspace={props.workspace}
         onSelectFile={() => setFilesDropdownOpen(false)}
-        filesDropdownMode={filesDropdownMode}
-        setFilesDropdownMode={setFilesDropdownMode}
+        filesMenuMode={filesMenuMode}
+        setFilesMenuMode={setFilesMenuMode}
       />
     );
-  }, [activeMenu, filesDropdownMode, props.workspace]);
+  }, [activeMenu, filesMenuMode, props.workspace]);
 
   return (
     <>
@@ -340,11 +351,6 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
               style={{
                 boxShadow: "none",
                 minWidth: `${MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX}px`,
-                width: `${
-                  filesDropdownMode === FilesDropdownMode.LIST_MODELS_AND_OTHERS
-                    ? MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX * 2
-                    : MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX
-                }px`,
               }}
               id={ROOT_MENU_ID}
               containsDrilldown={true}
@@ -354,15 +360,15 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
               onDrillIn={drillIn}
               onDrillOut={drillOut}
               onGetMenuHeight={setHeight}
+              className={"kie-sandbox--files-menu"}
             >
               <MenuContent
                 // MAGIC NUMBER ALERT
                 //
                 // 204px is the exact number that allows the menu to grow to
                 // the maximum size of the screen without adding scroll to the page.
-                maxMenuHeight={`calc(100vh - 204px)`}
+                maxMenuHeight={MENU_HEIGHT_MAX_LIMIT_CSS}
                 menuHeight={activeMenu === ROOT_MENU_ID ? undefined : `${menuHeights[activeMenu]}px`}
-                style={{ overflow: "hidden" }}
               >
                 <MenuList style={{ padding: 0 }}>
                   <MenuItem
@@ -371,20 +377,27 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
                     drilldownMenu={
                       <DrilldownMenu id={`dd${props.workspace.descriptor.workspaceId}`}>
                         <FilesMenuItems
-                          shouldFocusOnSearch={activeMenu === `dd${props.workspace.descriptor.workspaceId}`}
-                          filesDropdownMode={filesDropdownMode}
-                          setFilesDropdownMode={setFilesDropdownMode}
-                          workspaceDescriptor={props.workspace.descriptor}
-                          workspaceFiles={props.workspace.files}
+                          filesMenuMode={filesMenuMode}
+                          setFilesMenuMode={setFilesMenuMode}
+                          workspace={props.workspace}
                           currentWorkspaceFile={props.workspaceFile}
                           onSelectFile={() => setFilesDropdownOpen(false)}
+                          currentWorkspaceGitStatusProps={props.gitStatusProps}
+                          onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
                         />
                       </DrilldownMenu>
                     }
                   >
                     Current
                   </MenuItem>
-                  {workspacesMenuItems}
+                  <MenuGroup
+                    style={{
+                      maxHeight: `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX})` /* height of menu minus the height of Current item*/,
+                      overflowY: "auto",
+                    }}
+                  >
+                    {workspacesMenuItems}
+                  </MenuGroup>
                 </MenuList>
               </MenuContent>
             </Menu>
@@ -399,8 +412,8 @@ export function WorkspacesMenuItems(props: {
   activeMenu: string;
   currentWorkspace: ActiveWorkspace;
   onSelectFile: () => void;
-  filesDropdownMode: FilesDropdownMode;
-  setFilesDropdownMode: React.Dispatch<React.SetStateAction<FilesDropdownMode>>;
+  filesMenuMode: FilesMenuMode;
+  setFilesMenuMode: React.Dispatch<React.SetStateAction<FilesMenuMode>>;
 }) {
   const editorEnvelopeLocator = useEditorEnvelopeLocator();
   const workspaceDescriptorsPromise = useWorkspaceDescriptorsPromise();
@@ -447,13 +460,12 @@ export function WorkspacesMenuItems(props: {
                       itemId={descriptor.workspaceId}
                       direction={"down"}
                       drilldownMenu={
-                        <DrilldownMenu id={`dd${descriptor.workspaceId}`}>
+                        <DrilldownMenu id={`dd${descriptor.workspaceId}`} style={{ position: "fixed" }}>
+                          {/* position:fixed important to render properly inside menugroup*/}
                           <FilesMenuItems
-                            shouldFocusOnSearch={props.activeMenu === `dd${descriptor.workspaceId}`}
-                            filesDropdownMode={props.filesDropdownMode}
-                            setFilesDropdownMode={props.setFilesDropdownMode}
-                            workspaceDescriptor={descriptor}
-                            workspaceFiles={workspaceFiles.get(descriptor.workspaceId) ?? []}
+                            filesMenuMode={props.filesMenuMode}
+                            setFilesMenuMode={props.setFilesMenuMode}
+                            workspace={{ descriptor, files: workspaceFiles.get(descriptor.workspaceId) ?? [] }}
                             onSelectFile={props.onSelectFile}
                           />
                         </DrilldownMenu>
@@ -507,7 +519,19 @@ export function FileSvg(props: { workspaceFile: WorkspaceFile }) {
   return (
     <>
       <PromiseStateWrapper
-        pending={<Skeleton height={"180px"} style={{ margin: "10px" }} />}
+        pending={
+          imgRef.current ? (
+            <Bullseye>
+              <img
+                style={{ height: "180px", margin: "10px" }}
+                ref={imgRef}
+                alt={`SVG for ${props.workspaceFile.relativePath}`}
+              />
+            </Bullseye>
+          ) : (
+            <Skeleton height={"180px"} style={{ margin: "10px" }} />
+          )
+        }
         rejected={() => (
           <div style={{ height: "180px", margin: "10px", borderRadius: "5px", backgroundColor: "#EEE" }}>
             <Bullseye>
@@ -530,78 +554,37 @@ export function FileSvg(props: { workspaceFile: WorkspaceFile }) {
   );
 }
 
-export function SearchableFilesMenuGroup(props: {
-  shouldFocusOnSearch: boolean;
-  filesDropdownMode: FilesDropdownMode;
-  label: string;
+export function FilteredFilesMenuGroup(props: {
+  filesMenuMode: FilesMenuMode;
   allFiles: WorkspaceFile[];
+  filteredFiles: WorkspaceFile[];
   search: string;
-  setSearch: React.Dispatch<React.SetStateAction<string>>;
   children: (args: { filteredFiles: WorkspaceFile[] }) => React.ReactNode;
+  heightMaxLimitCss: string;
+  style?: React.CSSProperties;
 }) {
-  const searchInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (props.shouldFocusOnSearch) {
-      const task = setTimeout(() => {
-        searchInputRef.current?.focus();
-      }, 500);
-      return () => {
-        clearTimeout(task);
-      };
-    }
-  }, [props.shouldFocusOnSearch, props.filesDropdownMode]);
-
-  const filteredFiles = useMemo(
-    () => props.allFiles.filter((file) => file.name.toLowerCase().includes(props.search.toLowerCase())),
-    [props.allFiles, props.search]
-  );
-
   const height = useMemo(() => {
-    if (
-      props.filesDropdownMode === FilesDropdownMode.LIST_MODELS ||
-      props.filesDropdownMode === FilesDropdownMode.LIST_MODELS_AND_OTHERS
-    ) {
+    if (props.filesMenuMode === FilesMenuMode.LIST) {
       // No reason to know the exact size.
       const sizeOfFirst50Elements = props.allFiles
         .slice(0, 50)
         .map((f) => getFileDataListHeight(f))
         .reduce((a, b) => a + b, 0);
-
-      // MAGIC NUMBER ALERT
-      //
-      // 440px is the exact number that allows the menu to grow to the end of the screen without adding scroll  to the
-      // entire page, It includes the first menu item, the search bar and the "View other files" button at the bottom.
-      return `max(300px, min(calc(100vh - 440px), ${sizeOfFirst50Elements}px))`;
-    } else if (props.filesDropdownMode === FilesDropdownMode.CAROUSEL) {
-      // MAGIC NUMBER ALERT
-      //
-      // 384px is the exact number that allows the menu to grow to the end of the screen without
-      // adding a scroll to the entire page. It includes the first menu item and the search bar.
-      //
+      return `max(300px, min(${props.heightMaxLimitCss}, ${sizeOfFirst50Elements}px))`;
+    } else if (props.filesMenuMode === FilesMenuMode.CAROUSEL) {
       // 280px is the size of a File SVG card.
-      return `min(calc(100vh - 384px), calc(${props.allFiles.length} * 280px))`;
+      return `min(${props.heightMaxLimitCss}, calc(${props.allFiles.length} * 280px))`;
     } else {
       return "";
     }
-  }, [props.allFiles, props.filesDropdownMode]);
+  }, [props.allFiles, props.filesMenuMode, props.heightMaxLimitCss]);
 
   return (
-    <MenuGroup label={props.label}>
+    <MenuGroup>
       {/* Allows for arrows to work when editing the text. */}
-      <MenuInput onKeyDown={(e) => e.stopPropagation()}>
-        <TextInput
-          ref={searchInputRef}
-          value={props.search}
-          aria-label={"Other files menu items"}
-          iconVariant={"search"}
-          type={"search"}
-          onChange={(value) => props.setSearch(value)}
-        />
-      </MenuInput>
-      <div style={{ overflowY: "auto", height }}>
-        {filteredFiles.length > 0 && props.children({ filteredFiles })}
-        {filteredFiles.length <= 0 && (
+      <div style={{ ...props.style, height }}>
+        {props.filteredFiles.length > 0 && props.children({ filteredFiles: props.filteredFiles })}
+        {props.filteredFiles.length <= 0 && (
           <Bullseye>
             <EmptyState>
               <EmptyStateIcon icon={CubesIcon} />
@@ -617,72 +600,350 @@ export function SearchableFilesMenuGroup(props: {
 }
 
 export function FilesMenuItems(props: {
-  workspaceDescriptor: WorkspaceDescriptor;
-  workspaceFiles: WorkspaceFile[];
+  workspace: ActiveWorkspace;
+  currentWorkspaceGitStatusProps?: GitStatusProps;
   currentWorkspaceFile?: WorkspaceFile;
+  onDeletedWorkspaceFile?: () => void;
   onSelectFile: () => void;
-  filesDropdownMode: FilesDropdownMode;
-  setFilesDropdownMode: React.Dispatch<React.SetStateAction<FilesDropdownMode>>;
-  shouldFocusOnSearch: boolean;
+  filesMenuMode: FilesMenuMode;
+  setFilesMenuMode: React.Dispatch<React.SetStateAction<FilesMenuMode>>;
 }) {
-  const history = useHistory();
-  const routes = useRoutes();
   const editorEnvelopeLocator = useEditorEnvelopeLocator();
 
-  const sortedAndFilteredFiles = useMemo(
-    () =>
-      props.workspaceFiles
-        .sort((a, b) => a.relativePath.localeCompare(b.relativePath))
-        .filter((file) => file.relativePath !== props.currentWorkspaceFile?.relativePath),
-    [props.workspaceFiles, props.currentWorkspaceFile]
+  const [topSectionHeightInPx, setTopSectionHeightInPx] = useState<number>(
+    DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX +
+      MENU_SEARCH_HEIGHT_IN_PX +
+      MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX +
+      MENU_DIVIDER_HEIGHT_IN_PX
+  );
+  const [bottomSectionHeightInPx, setBottomSectionHeightInPx] = useState<number>(
+    DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX + MENU_DIVIDER_HEIGHT_IN_PX
   );
 
+  const [isScrollUsingRefEnabled, setScrollUsingRefEnabled] = useState(true);
+  const [searchValue, setSearchValue] = useState("");
+  const [filteredGitSyncStatus, setFilteredGitSyncStatus] = useState<WorkspaceGitLocalChangesStatus>();
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const carouselScrollRef = useRef<HTMLDivElement>(null);
+  const listScrollRef = useRef<VariableSizeList>(null);
+
+  const deletedWorkspaceFiles = useMemo(() => {
+    if (!props.currentWorkspaceGitStatusProps) {
+      return [];
+    }
+    return listDeletedFiles(props.currentWorkspaceGitStatusProps);
+  }, [props.currentWorkspaceGitStatusProps]);
+
+  const allFiles = useMemo(() => {
+    return [...props.workspace.files, ...deletedWorkspaceFiles];
+  }, [deletedWorkspaceFiles, props.workspace.files]);
+
+  const sortedFiles = useMemo(() => allFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath)), [allFiles]);
+
   const models = useMemo(
-    () => sortedAndFilteredFiles.filter((file) => editorEnvelopeLocator.hasMappingFor(file.relativePath)),
-    [editorEnvelopeLocator, sortedAndFilteredFiles]
+    () => sortedFiles.filter((file) => editorEnvelopeLocator.hasMappingFor(file.relativePath)),
+    [editorEnvelopeLocator, sortedFiles]
   );
 
   const otherFiles = useMemo(
-    () => sortedAndFilteredFiles.filter((file) => !editorEnvelopeLocator.hasMappingFor(file.relativePath)),
-    [editorEnvelopeLocator, sortedAndFilteredFiles]
+    () => sortedFiles.filter((file) => !editorEnvelopeLocator.hasMappingFor(file.relativePath)),
+    [editorEnvelopeLocator, sortedFiles]
   );
 
-  const [search, setSearch] = useState("");
-  const [otherFilesSearch, setOtherFilesSearch] = useState("");
+  const filteredModels = useMemo(
+    () =>
+      models
+        .filter((file) => file.name.toLowerCase().includes(searchValue.toLowerCase()))
+        .filter(
+          (file) =>
+            !filteredGitSyncStatus ||
+            resolveGitLocalChangesStatus({
+              workspaceGitStatus: props.currentWorkspaceGitStatusProps?.workspaceGitStatusPromise.data,
+              file,
+            }) === filteredGitSyncStatus
+        ),
+    [filteredGitSyncStatus, models, props.currentWorkspaceGitStatusProps?.workspaceGitStatusPromise.data, searchValue]
+  );
+
+  const filteredOtherFiles = useMemo(
+    () => otherFiles.filter((file) => file.name.toLowerCase().includes(searchValue.toLowerCase())),
+    [otherFiles, searchValue]
+  );
+
+  const computedInitialScrollOffset = useMemo(() => {
+    if (props.filesMenuMode !== FilesMenuMode.LIST || !isScrollUsingRefEnabled || !props.currentWorkspaceFile) {
+      return;
+    }
+    const index = filteredModels.findIndex((it) => it.relativePath === props.currentWorkspaceFile?.relativePath);
+    if (index < 0) {
+      return 0;
+    }
+    return filteredModels.slice(0, index).reduce((sum, current) => sum + getFileDataListHeight(current), 0);
+  }, [filteredModels, isScrollUsingRefEnabled, props.currentWorkspaceFile, props.filesMenuMode]);
+
+  const searchInput = useMemo(() => {
+    return (
+      <MenuInput onKeyDown={(e) => e.stopPropagation()}>
+        <SearchInput
+          ref={searchInputRef}
+          value={searchValue}
+          type={"search"}
+          onChange={(_ev, value) => {
+            setSearchValue(value);
+          }}
+          placeholder={`In '${props.workspace.descriptor.name}'`}
+          style={{ fontSize: "small" }}
+          onClick={(ev) => {
+            ev.stopPropagation();
+          }}
+        />
+      </MenuInput>
+    );
+  }, [props.workspace.descriptor.name, searchValue]);
+
+  const fileListMenuItemsHeightMaxLimitCss = useMemo(() => {
+    return `calc(${MENU_HEIGHT_MAX_LIMIT_CSS} - ${
+      (!props.currentWorkspaceGitStatusProps
+        ? topSectionHeightInPx - MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX
+        : topSectionHeightInPx) + (otherFiles.length ? bottomSectionHeightInPx : 0)
+    }px)`;
+  }, [bottomSectionHeightInPx, otherFiles.length, props.currentWorkspaceGitStatusProps, topSectionHeightInPx]);
+
+  const isCurrentWorkspaceFile = useCallback(
+    (file: WorkspaceFile) => {
+      return (
+        props.workspace.descriptor.workspaceId === file.workspaceId &&
+        props.currentWorkspaceFile?.relativePath === file.relativePath
+      );
+    },
+    [props.currentWorkspaceFile?.relativePath, props.workspace.descriptor.workspaceId]
+  );
+
+  const getFileListItemDisplayMode = useCallback(
+    (file: WorkspaceFile) =>
+      deletedWorkspaceFiles.some((it) => it.relativePath === file.relativePath)
+        ? FileListItemDisplayMode.deleted
+        : FileListItemDisplayMode.enabled,
+    [deletedWorkspaceFiles]
+  );
+
+  useEffect(() => {
+    const task = setTimeout(() => {
+      if (props.filesMenuMode === FilesMenuMode.CAROUSEL && isScrollUsingRefEnabled) {
+        carouselScrollRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      }
+      if (props.filesMenuMode === FilesMenuMode.LIST && isScrollUsingRefEnabled) {
+        listScrollRef.current?.scrollToItem(
+          filteredModels.findIndex((it) => it.relativePath === props.currentWorkspaceFile?.relativePath)
+        );
+      }
+      searchInputRef.current?.focus({ preventScroll: true });
+    }, 500);
+    return () => {
+      clearTimeout(task);
+    };
+  }, [
+    props.filesMenuMode,
+    isScrollUsingRefEnabled,
+    filteredGitSyncStatus,
+    props.currentWorkspaceFile?.relativePath,
+    filteredModels,
+  ]);
 
   return (
     <>
-      <Split>
-        <SplitItem isFilled={true}>
-          <MenuItem direction="up" itemId={props.workspaceDescriptor.workspaceId}>
+      <Grid style={{ alignItems: "center" }}>
+        <GridItem span={12}>
+          <MenuItem direction={"up"} itemId={`${props.workspace.descriptor.workspaceId}-breadcrumb`}>
             All
           </MenuItem>
-        </SplitItem>
-        <SplitItem>
-          <FilesDropdownModeIcons
-            filesDropdownMode={props.filesDropdownMode}
-            setFilesDropdownMode={props.setFilesDropdownMode}
-          />
-          &nbsp; &nbsp;
-        </SplitItem>
-      </Split>
+        </GridItem>
+        <GridItem span={12}>{searchInput}</GridItem>
+        <GridItem span={6}></GridItem>
+        <GridItem span={4}>
+          {props.currentWorkspaceGitStatusProps !== undefined && (
+            <MenuInput>
+              <Tooltip content={"Filter only modified files"} position={"bottom"}>
+                <Checkbox
+                  label={"Only changed"}
+                  id={"filter-git-status-changed-locally"}
+                  aria-label={"Select to display only modified files"}
+                  isChecked={filteredGitSyncStatus === WorkspaceGitLocalChangesStatus.pending}
+                  onChange={(checked) => {
+                    setFilteredGitSyncStatus(checked ? WorkspaceGitLocalChangesStatus.pending : undefined);
+                  }}
+                />
+              </Tooltip>
+            </MenuInput>
+          )}
+        </GridItem>
+        <GridItem span={2}>
+          <Flex justifyContent={{ default: "justifyContentCenter" }}>
+            <FilesMenuModeIcons filesMenuMode={props.filesMenuMode} setFilesMenuMode={props.setFilesMenuMode} />
+          </Flex>
+        </GridItem>
+      </Grid>
       <Divider component={"li"} />
 
-      <Split>
-        {(props.filesDropdownMode === FilesDropdownMode.LIST_MODELS ||
-          props.filesDropdownMode === FilesDropdownMode.LIST_MODELS_AND_OTHERS) && (
-          <SplitItem isFilled={true} style={{ minWidth: `${MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX}px` }}>
-            <>
-              <SearchableFilesMenuGroup
-                search={search}
-                setSearch={setSearch}
-                filesDropdownMode={props.filesDropdownMode}
-                shouldFocusOnSearch={props.shouldFocusOnSearch}
-                label={`Models in '${props.workspaceDescriptor.name}'`}
-                allFiles={models}
+      {props.filesMenuMode === FilesMenuMode.LIST && (
+        <FilteredFilesMenuGroup
+          search={searchValue}
+          filesMenuMode={props.filesMenuMode}
+          allFiles={models}
+          filteredFiles={filteredModels}
+          heightMaxLimitCss={fileListMenuItemsHeightMaxLimitCss}
+        >
+          {({ filteredFiles }) => {
+            return (
+              <AutoSizer>
+                {({ height, width }) => (
+                  <VariableSizeList
+                    height={height}
+                    itemCount={filteredFiles.length}
+                    itemSize={(index) => getFileDataListHeight(filteredFiles[index])}
+                    width={width}
+                    initialScrollOffset={computedInitialScrollOffset}
+                    ref={listScrollRef}
+                  >
+                    {({ index, style }) => {
+                      const fileListItemDisplayMode = getFileListItemDisplayMode(filteredFiles[index]);
+                      return (
+                        <MenuItem
+                          key={filteredFiles[index].relativePath}
+                          onClick={
+                            fileListItemDisplayMode === FileListItemDisplayMode.enabled ? props.onSelectFile : undefined
+                          }
+                          className={"kie-tools--file-switcher-no-padding-menu-item"}
+                          isFocused={isCurrentWorkspaceFile(filteredFiles[index])}
+                          isActive={isCurrentWorkspaceFile(filteredFiles[index])}
+                          style={style}
+                          component={"div"}
+                        >
+                          <FileDataList
+                            file={filteredFiles[index]}
+                            displayMode={fileListItemDisplayMode}
+                            gitStatusProps={props.currentWorkspaceGitStatusProps}
+                            isCurrentWorkspaceFile={isCurrentWorkspaceFile(filteredFiles[index])}
+                            onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+                          />
+                        </MenuItem>
+                      );
+                    }}
+                  </VariableSizeList>
+                )}
+              </AutoSizer>
+            );
+          }}
+        </FilteredFilesMenuGroup>
+      )}
+
+      {props.filesMenuMode === FilesMenuMode.CAROUSEL && (
+        <FilteredFilesMenuGroup
+          search={searchValue}
+          filesMenuMode={props.filesMenuMode}
+          allFiles={models}
+          filteredFiles={filteredModels}
+          heightMaxLimitCss={fileListMenuItemsHeightMaxLimitCss}
+          style={{ overflowY: "auto" }}
+        >
+          {({ filteredFiles }) => {
+            const isCurrentFileOutsideOfShownList =
+              props.currentWorkspaceFile &&
+              filteredFiles.findIndex((file) => file.relativePath === props.currentWorkspaceFile?.relativePath) >=
+                MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN;
+            const shouldScrollToTop =
+              props.currentWorkspaceFile &&
+              filteredFiles.findIndex((file) => file.relativePath === props.currentWorkspaceFile?.relativePath) < 0;
+            return (
+              <Gallery
+                hasGutter={true}
+                style={{
+                  paddingLeft: "8px",
+                  paddingRight: "8px",
+                  borderTop: "var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100)",
+                }}
               >
-                {({ filteredFiles }) => (
+                {shouldScrollToTop && <div ref={carouselScrollRef} />}
+                {filteredFiles.slice(0, MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN).map((file, index) => (
+                  <FilesMenuItemCarouselCard
+                    key={index}
+                    file={file}
+                    gitStatusProps={props.currentWorkspaceGitStatusProps}
+                    isCurrentWorkspaceFile={isCurrentWorkspaceFile(file)}
+                    displayMode={getFileListItemDisplayMode(file)}
+                    onSelectFile={props.onSelectFile}
+                    onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+                    scrollRef={carouselScrollRef}
+                  />
+                ))}
+                {filteredFiles.length > MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN && (
                   <>
+                    {props.currentWorkspaceFile && isCurrentFileOutsideOfShownList && (
+                      <FilesMenuItemCarouselCard
+                        file={props.currentWorkspaceFile}
+                        gitStatusProps={props.currentWorkspaceGitStatusProps}
+                        isCurrentWorkspaceFile={isCurrentWorkspaceFile(props.currentWorkspaceFile)}
+                        displayMode={getFileListItemDisplayMode(props.currentWorkspaceFile)}
+                        onSelectFile={props.onSelectFile}
+                        onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+                        scrollRef={carouselScrollRef}
+                      />
+                    )}
+                    <Card style={{ border: 0 }}>
+                      <CardBody>
+                        <Bullseye>
+                          <div>
+                            ...and{" "}
+                            {filteredFiles.length -
+                              MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN -
+                              (isCurrentFileOutsideOfShownList ? 1 : 0)}{" "}
+                            more.
+                          </div>
+                        </Bullseye>
+                      </CardBody>
+                    </Card>
+                  </>
+                )}
+              </Gallery>
+            );
+          }}
+        </FilteredFilesMenuGroup>
+      )}
+      {otherFiles.length > 0 && (
+        <>
+          <Divider component={"li"} />
+          <MenuItem
+            itemId={`other-${props.workspace.descriptor.workspaceId}`}
+            direction={"down"}
+            onClick={(_event) => {
+              setScrollUsingRefEnabled(false);
+              setBottomSectionHeightInPx(0);
+              setTopSectionHeightInPx((prev) => prev - MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX);
+            }}
+            drilldownMenu={
+              <DrilldownMenu id={`dd-other-${props.workspace.descriptor.workspaceId}`} style={{ position: "fixed" }}>
+                <MenuItem
+                  itemId={"back-up"}
+                  direction={"up"}
+                  onClick={(_event) => {
+                    setScrollUsingRefEnabled(true);
+                    setBottomSectionHeightInPx(MENU_DIVIDER_HEIGHT_IN_PX + DRILLDOWN_NAVIGATION_MENU_ITEM_HEIGHT_IN_PX);
+                    setTopSectionHeightInPx((prev) => prev + MENU_SHOW_CHANGED_CHECKBOX_HEIGHT_IN_PX);
+                  }}
+                >
+                  Back To Models
+                </MenuItem>
+                {searchInput}
+                <Divider component={"li"} />
+                <FilteredFilesMenuGroup
+                  search={searchValue}
+                  filesMenuMode={FilesMenuMode.LIST} // always LIST for otherFiles, even for mode CAROUSEL
+                  allFiles={otherFiles}
+                  filteredFiles={filteredOtherFiles}
+                  heightMaxLimitCss={fileListMenuItemsHeightMaxLimitCss}
+                >
+                  {({ filteredFiles }) => (
                     <AutoSizer>
                       {({ height, width }) => (
                         <VariableSizeList
@@ -694,190 +955,112 @@ export function FilesMenuItems(props: {
                           {({ index, style }) => (
                             <MenuItem
                               key={filteredFiles[index].relativePath}
-                              onClick={props.onSelectFile}
                               style={style}
+                              component={"div"}
                               className={"kie-tools--file-switcher-no-padding-menu-item"}
                             >
-                              <FileDataList file={filteredFiles[index]} isEditable={true} />
+                              <FileDataList
+                                file={filteredFiles[index]}
+                                displayMode={FileListItemDisplayMode.readonly}
+                                gitStatusProps={props.currentWorkspaceGitStatusProps}
+                                onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+                              />
                             </MenuItem>
                           )}
                         </VariableSizeList>
                       )}
                     </AutoSizer>
-                  </>
-                )}
-              </SearchableFilesMenuGroup>
-              {otherFiles.length > 0 && (
-                <>
-                  <Divider component={"li"} />
-                  <MenuGroup>
-                    <MenuList style={{ padding: 0 }}>
-                      <MenuItem
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          props.setFilesDropdownMode((prev) =>
-                            prev === FilesDropdownMode.LIST_MODELS
-                              ? FilesDropdownMode.LIST_MODELS_AND_OTHERS
-                              : FilesDropdownMode.LIST_MODELS
-                          );
-                        }}
-                      >
-                        {props.filesDropdownMode === FilesDropdownMode.LIST_MODELS
-                          ? "View other files"
-                          : "Hide other files"}
-                        &nbsp;&nbsp;
-                        {props.filesDropdownMode === FilesDropdownMode.LIST_MODELS ? (
-                          <ArrowRightIcon />
-                        ) : (
-                          <ArrowLeftIcon />
-                        )}
-                      </MenuItem>
-                    </MenuList>
-                  </MenuGroup>
-                </>
-              )}
-            </>
-          </SplitItem>
-        )}
-
-        {props.filesDropdownMode === FilesDropdownMode.LIST_MODELS_AND_OTHERS && (
-          <SplitItem isFilled={true} style={{ minWidth: `${MIN_FILE_SWITCHER_PANEL_WIDTH_IN_PX}px` }}>
-            <SearchableFilesMenuGroup
-              search={otherFilesSearch}
-              setSearch={setOtherFilesSearch}
-              filesDropdownMode={props.filesDropdownMode}
-              shouldFocusOnSearch={props.shouldFocusOnSearch}
-              label={`Other files in '${props.workspaceDescriptor.name}'`}
-              allFiles={otherFiles}
-            >
-              {({ filteredFiles }) => (
-                <>
-                  <AutoSizer>
-                    {({ height, width }) => (
-                      <VariableSizeList
-                        height={height}
-                        itemCount={filteredFiles.length}
-                        itemSize={(index) => getFileDataListHeight(filteredFiles[index])}
-                        width={width}
-                      >
-                        {({ index, style }) => (
-                          <MenuItem
-                            component={"span"}
-                            onClick={() => {}}
-                            style={style}
-                            className={"kie-tools--file-switcher-no-padding-menu-item"}
-                          >
-                            <FileDataList file={filteredFiles[index]} isEditable={false} />
-                          </MenuItem>
-                        )}
-                      </VariableSizeList>
-                    )}
-                  </AutoSizer>
-                </>
-              )}
-            </SearchableFilesMenuGroup>
-          </SplitItem>
-        )}
-
-        {props.filesDropdownMode === FilesDropdownMode.CAROUSEL && (
-          <SplitItem isFilled={true}>
-            <SearchableFilesMenuGroup
-              search={search}
-              setSearch={setSearch}
-              filesDropdownMode={props.filesDropdownMode}
-              shouldFocusOnSearch={props.shouldFocusOnSearch}
-              label={`Models in '${props.workspaceDescriptor.name}'`}
-              allFiles={models}
-            >
-              {({ filteredFiles }) => (
-                <Gallery
-                  hasGutter={true}
-                  style={{
-                    padding: "8px",
-                    borderTop: "var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100)",
-                  }}
-                >
-                  {filteredFiles.slice(0, MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN).map((file) => (
-                    <Card
-                      key={file.relativePath}
-                      isSelectable={true}
-                      isRounded={true}
-                      isCompact={true}
-                      isHoverable={true}
-                      isFullHeight={true}
-                      onClick={() => {
-                        history.push({
-                          pathname: routes.workspaceWithFilePath.path({
-                            workspaceId: file.workspaceId,
-                            fileRelativePath: file.relativePathWithoutExtension,
-                            extension: file.extension,
-                          }),
-                        });
-
-                        props.onSelectFile();
-                      }}
-                    >
-                      <FileLink file={file}>
-                        {/* The default display:flex makes the text overflow */}
-                        <CardHeader style={{ display: "block" }}>
-                          <CardHeaderMain>
-                            <FileListItem file={file} isEditable={true} />
-                          </CardHeaderMain>
-                        </CardHeader>
-                      </FileLink>
-                      <Divider inset={{ default: "insetMd" }} />
-                      <CardBody style={{ padding: 0 }}>
-                        <FileSvg workspaceFile={file} />
-                      </CardBody>
-                    </Card>
-                  ))}
-                  {filteredFiles.length > MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN && (
-                    <Card style={{ border: 0 }}>
-                      <CardBody>
-                        <Bullseye>
-                          <div>...and {filteredFiles.length - MAX_NUMBER_OF_CAROUSEL_ITEMS_SHOWN} more.</div>
-                        </Bullseye>
-                      </CardBody>
-                    </Card>
                   )}
-                </Gallery>
-              )}
-            </SearchableFilesMenuGroup>
-          </SplitItem>
-        )}
-      </Split>
+                </FilteredFilesMenuGroup>
+              </DrilldownMenu>
+            }
+          >
+            Other files
+          </MenuItem>
+        </>
+      )}
     </>
   );
 }
 
-export function FilesDropdownModeIcons(props: {
-  filesDropdownMode: FilesDropdownMode;
-  setFilesDropdownMode: React.Dispatch<React.SetStateAction<FilesDropdownMode>>;
+const FilesMenuItemCarouselCard = (props: {
+  file: WorkspaceFile;
+  gitStatusProps?: GitStatusProps;
+  isCurrentWorkspaceFile?: boolean;
+  onDeletedWorkspaceFile?: () => void;
+  displayMode: FileListItemDisplayMode;
+  onSelectFile: () => void;
+  scrollRef: React.RefObject<HTMLDivElement>;
+}) => {
+  const cardInternals = [
+    <CardHeader style={{ display: "block" }} key={0}>
+      <CardHeaderMain>
+        <FileListItem
+          file={props.file}
+          displayMode={props.displayMode}
+          gitStatusProps={props.gitStatusProps}
+          isCurrentWorkspaceFile={props.isCurrentWorkspaceFile}
+          onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+        />
+      </CardHeaderMain>
+    </CardHeader>,
+    <Divider inset={{ default: "insetMd" }} key={1} />,
+    <CardBody style={{ padding: 0 }} key={2}>
+      <FileSvg workspaceFile={props.file} />
+    </CardBody>,
+  ];
+  return (
+    <Card
+      key={props.file.relativePath}
+      isSelectable={props.displayMode === FileListItemDisplayMode.enabled}
+      isRounded={true}
+      isCompact={true}
+      isFullHeight={true}
+      onSelect={props.onSelectFile}
+      className={switchExpression(props.displayMode, {
+        enabled: "kie-tools--file-list-item-enabled",
+        deleted: "kie-tools--file-list-item-deleted",
+        readonly: "kie-tools--file-list-item-readonly",
+      })}
+    >
+      <div id={`scrollRef-${props.file.relativePath}`} ref={props.isCurrentWorkspaceFile ? props.scrollRef : undefined}>
+        {props.displayMode === FileListItemDisplayMode.enabled ? (
+          <FileLink file={props.file}>{cardInternals}</FileLink>
+        ) : (
+          cardInternals
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export function FilesMenuModeIcons(props: {
+  filesMenuMode: FilesMenuMode;
+  setFilesMenuMode: React.Dispatch<React.SetStateAction<FilesMenuMode>>;
 }) {
   return (
     <>
-      {props.filesDropdownMode === FilesDropdownMode.CAROUSEL && (
+      {props.filesMenuMode === FilesMenuMode.CAROUSEL && (
         <Button
           className={"kie-tools--masthead-hoverable"}
           variant="plain"
           aria-label="Switch to list view"
           onClick={(e) => {
             e.stopPropagation();
-            props.setFilesDropdownMode(FilesDropdownMode.LIST_MODELS);
+            props.setFilesMenuMode(FilesMenuMode.LIST);
           }}
         >
           <ListIcon />
         </Button>
       )}
-      {(props.filesDropdownMode === FilesDropdownMode.LIST_MODELS ||
-        props.filesDropdownMode === FilesDropdownMode.LIST_MODELS_AND_OTHERS) && (
+      {props.filesMenuMode === FilesMenuMode.LIST && (
         <Button
           className={"kie-tools--masthead-hoverable"}
           variant="plain"
           aria-label="Switch to carousel view"
           onClick={(e) => {
             e.stopPropagation();
-            props.setFilesDropdownMode(FilesDropdownMode.CAROUSEL);
+            props.setFilesMenuMode(FilesMenuMode.CAROUSEL);
           }}
         >
           <ThLargeIcon />

--- a/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
@@ -29,11 +29,16 @@ import { WorkspaceLabel } from "../../../workspace/components/WorkspaceLabel";
 import FolderIcon from "@patternfly/react-icons/dist/js/icons/folder-icon";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
-import { useWorkspaces } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
+import { useWorkspaces, WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { WorkspaceStatusIndicator } from "../../../workspace/components/WorkspaceStatusIndicator";
+import { PromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
+import { WorkspaceGitStatusType } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
 
 type Props = {
   workspace: ActiveWorkspace;
+  currentWorkspaceFile: WorkspaceFile;
+  workspaceGitStatusPromise: PromiseState<WorkspaceGitStatusType>;
+  onDeletedWorkspaceFile: () => void;
 };
 
 export function WorkspaceToolbar(props: Props) {
@@ -153,7 +158,14 @@ export function WorkspaceToolbar(props: Props) {
         </div>
       </FlexItem>
       <FlexItem>
-        <WorkspaceStatusIndicator workspace={props.workspace} />
+        <WorkspaceStatusIndicator
+          gitStatusProps={{
+            workspaceDescriptor: props.workspace.descriptor,
+            workspaceGitStatusPromise: props.workspaceGitStatusPromise,
+          }}
+          currentWorkspaceFile={props.currentWorkspaceFile}
+          onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+        />
       </FlexItem>
     </Flex>
   );

--- a/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
@@ -165,6 +165,7 @@ export function WorkspaceToolbar(props: Props) {
           }}
           currentWorkspaceFile={props.currentWorkspaceFile}
           onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+          workspaceFiles={props.workspace.files}
         />
       </FlexItem>
     </Flex>

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -72,11 +72,11 @@ export function FileListItem(props: {
     <>
       <Flex
         flexWrap={{ default: "nowrap" }}
-        onClick={(ev) => {
+        onClick={(e) => {
           if (props.displayMode !== FileListItemDisplayMode.enabled) {
             // this prevents the FileSwitcher from closing on click.
-            ev.stopPropagation();
-            ev.preventDefault();
+            e.stopPropagation();
+            e.preventDefault();
           }
         }}
       >

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -34,11 +34,7 @@ import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/work
 import { WorkspaceDescriptorDates } from "../workspace/components/WorkspaceDescriptorDates";
 import { EyeIcon } from "@patternfly/react-icons/dist/js/icons/eye-icon";
 import { GitStatusIndicator } from "../workspace/components/WorkspaceStatusIndicator";
-import {
-  GitStatusIndicatorActions,
-  GitStatusIndicatorActionVariant,
-  GitStatusProps,
-} from "../workspace/components/GitStatusIndicatorActions";
+import { GitStatusIndicatorActions, GitStatusProps } from "../workspace/components/GitStatusIndicatorActions";
 import { switchExpression } from "../switchExpression/switchExpression";
 
 const FILE_DATA_LIST_HEIGHTS = {
@@ -65,8 +61,6 @@ export function FileListItem(props: {
 }) {
   const [keepGitStatusActionsDisplayed, setKeepGitStatusActionsDisplayed] = React.useState(false);
   const fileDirPath = props.file.relativeDirPath.split("/").join(" > ");
-  const fileName =
-    props.displayMode === FileListItemDisplayMode.enabled ? props.file.nameWithoutExtension : props.file.name;
 
   return (
     <>
@@ -90,11 +84,12 @@ export function FileListItem(props: {
             distance={5}
             position={"top-start"}
             content={
-              fileName + (props.displayMode === FileListItemDisplayMode.deleted ? " (Deleted in workspace.)" : "")
+              props.file.nameWithoutExtension +
+              (props.displayMode === FileListItemDisplayMode.deleted ? " (Deleted)" : "")
             }
           >
             <TextContent>
-              <Text component={TextVariants.p}>{fileName}</Text>
+              <Text component={TextVariants.p}>{props.file.nameWithoutExtension}</Text>
             </TextContent>
           </Tooltip>
         </FlexItem>
@@ -109,7 +104,6 @@ export function FileListItem(props: {
               isHoverable={!keepGitStatusActionsDisplayed}
             >
               <GitStatusIndicatorActions
-                variant={GitStatusIndicatorActionVariant.popover}
                 gitStatusProps={props.gitStatusProps}
                 workspaceFile={props.file}
                 currentWorkspaceFile={props.isCurrentWorkspaceFile ? props.file : undefined}

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -32,6 +32,14 @@ import { useRoutes } from "../navigation/Hooks";
 import { TaskIcon } from "@patternfly/react-icons/dist/js/icons/task-icon";
 import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
 import { WorkspaceDescriptorDates } from "../workspace/components/WorkspaceDescriptorDates";
+import { EyeIcon } from "@patternfly/react-icons/dist/js/icons/eye-icon";
+import { GitStatusIndicator } from "../workspace/components/WorkspaceStatusIndicator";
+import {
+  GitStatusIndicatorActions,
+  GitStatusIndicatorActionVariant,
+  GitStatusProps,
+} from "../workspace/components/GitStatusIndicatorActions";
+import { switchExpression } from "../switchExpression/switchExpression";
 
 const FILE_DATA_LIST_HEIGHTS = {
   atRoot: 55 + 24,
@@ -42,31 +50,76 @@ export function getFileDataListHeight(file: WorkspaceFile) {
   return file.relativePath.indexOf("/") >= 0 ? FILE_DATA_LIST_HEIGHTS.atSubDir : FILE_DATA_LIST_HEIGHTS.atRoot;
 }
 
-export function FileListItem(props: { file: WorkspaceFile; isEditable: boolean }) {
+export enum FileListItemDisplayMode {
+  enabled = "enabled",
+  readonly = "readonly",
+  deleted = "deleted",
+}
+
+export function FileListItem(props: {
+  file: WorkspaceFile;
+  displayMode: FileListItemDisplayMode;
+  isCurrentWorkspaceFile?: boolean;
+  onDeletedWorkspaceFile?: () => void;
+  gitStatusProps?: GitStatusProps;
+}) {
+  const [keepGitStatusActionsDisplayed, setKeepGitStatusActionsDisplayed] = React.useState(false);
   const fileDirPath = props.file.relativeDirPath.split("/").join(" > ");
-  const fileName = props.isEditable ? props.file.nameWithoutExtension : props.file.name;
+  const fileName =
+    props.displayMode === FileListItemDisplayMode.enabled ? props.file.nameWithoutExtension : props.file.name;
+
   return (
     <>
-      <Flex flexWrap={{ default: "nowrap" }}>
+      <Flex
+        flexWrap={{ default: "nowrap" }}
+        onClick={(ev) => {
+          if (props.displayMode !== FileListItemDisplayMode.enabled) {
+            // this prevents the FileSwitcher from closing on click.
+            ev.stopPropagation();
+            ev.preventDefault();
+          }
+        }}
+      >
+        {props.isCurrentWorkspaceFile && (
+          <FlexItem align={{ default: "alignLeft" }}>
+            <EyeIcon title="Currently selected file." />
+          </FlexItem>
+        )}
         <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
-          <Tooltip distance={5} position={"top-start"} content={fileName}>
+          <Tooltip
+            distance={5}
+            position={"top-start"}
+            content={
+              fileName + (props.displayMode === FileListItemDisplayMode.deleted ? " (Deleted in workspace.)" : "")
+            }
+          >
             <TextContent>
-              <Text
-                component={TextVariants.p}
-                style={{
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                {fileName}
-              </Text>
+              <Text component={TextVariants.p}>{fileName}</Text>
             </TextContent>
           </Tooltip>
         </FlexItem>
         <FlexItem>
           <FileLabel extension={props.file.extension} />
         </FlexItem>
+        {props.gitStatusProps && (
+          <FlexItem align={{ default: "alignRight" }}>
+            <GitStatusIndicator
+              gitStatusProps={props.gitStatusProps}
+              workspaceFile={props.file}
+              isHoverable={!keepGitStatusActionsDisplayed}
+            >
+              <GitStatusIndicatorActions
+                variant={GitStatusIndicatorActionVariant.popover}
+                gitStatusProps={props.gitStatusProps}
+                workspaceFile={props.file}
+                currentWorkspaceFile={props.isCurrentWorkspaceFile ? props.file : undefined}
+                onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+                isOpen={keepGitStatusActionsDisplayed}
+                setOpen={setKeepGitStatusActionsDisplayed}
+              />
+            </GitStatusIndicator>
+          </FlexItem>
+        )}
       </Flex>
       <TextContent>
         <Text
@@ -86,13 +139,25 @@ export function FileListItem(props: { file: WorkspaceFile; isEditable: boolean }
   );
 }
 
-export function FileDataListItem(props: { file: WorkspaceFile; isEditable: boolean }) {
+export function FileDataListItem(props: {
+  file: WorkspaceFile;
+  displayMode: FileListItemDisplayMode;
+  isCurrentWorkspaceFile?: boolean;
+  onDeletedWorkspaceFile?: () => void;
+  gitStatusProps?: GitStatusProps;
+}) {
   return (
-    <DataListItemRow>
+    <DataListItemRow disabled={props.displayMode !== FileListItemDisplayMode.enabled}>
       <DataListItemCells
         dataListCells={[
-          <DataListCell key="link" isFilled={false}>
-            <FileListItem file={props.file} isEditable={props.isEditable} />
+          <DataListCell key="link" isFilled={true} autoFocus={props.isCurrentWorkspaceFile}>
+            <FileListItem
+              gitStatusProps={props.gitStatusProps}
+              file={props.file}
+              displayMode={props.displayMode}
+              isCurrentWorkspaceFile={props.isCurrentWorkspaceFile}
+              onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+            />
           </DataListCell>,
         ]}
       />
@@ -100,16 +165,37 @@ export function FileDataListItem(props: { file: WorkspaceFile; isEditable: boole
   );
 }
 
-export function FileDataList(props: { file: WorkspaceFile; isEditable: boolean; style?: React.CSSProperties }) {
+export function FileDataList(props: {
+  file: WorkspaceFile;
+  displayMode: FileListItemDisplayMode;
+  style?: React.CSSProperties;
+  isCurrentWorkspaceFile?: boolean;
+  onDeletedWorkspaceFile?: () => void;
+  gitStatusProps?: GitStatusProps;
+}) {
+  const fileDataListItem = (
+    <FileDataListItem
+      gitStatusProps={props.gitStatusProps}
+      key={props.file.relativePath}
+      file={props.file}
+      displayMode={props.displayMode}
+      isCurrentWorkspaceFile={props.isCurrentWorkspaceFile}
+      onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+    />
+  );
   return (
-    <DataList aria-label="file-data-list" style={props.style}>
+    <DataList
+      aria-label="file-data-list"
+      style={props.style}
+      className={switchExpression(props.displayMode, {
+        enabled: "kie-tools--file-list-item-enabled",
+        deleted: "kie-tools--file-list-item-deleted",
+        readonly: "kie-tools--file-list-item-readonly",
+      })}
+    >
       <DataListItem style={{ border: 0 }}>
-        {(!props.isEditable && (
-          <FileDataListItem key={props.file.relativePath} file={props.file} isEditable={props.isEditable} />
-        )) || (
-          <FileLink file={props.file}>
-            <FileDataListItem file={props.file} isEditable={props.isEditable} />
-          </FileLink>
+        {(props.displayMode !== FileListItemDisplayMode.enabled && fileDataListItem) || (
+          <FileLink file={props.file}>{fileDataListItem}</FileLink>
         )}
       </DataListItem>
     </DataList>
@@ -133,9 +219,13 @@ export function FileLink(props: React.PropsWithChildren<{ file: WorkspaceFile; s
   );
 }
 
-export function SingleFileWorkspaceDataList(props: { workspaceDescriptor: WorkspaceDescriptor; file: WorkspaceFile }) {
+export function SingleFileWorkspaceDataList(props: {
+  workspaceDescriptor: WorkspaceDescriptor;
+  file: WorkspaceFile;
+  style?: React.CSSProperties;
+}) {
   return (
-    <DataList aria-label="file-data-list">
+    <DataList aria-label="file-data-list" style={props.style}>
       <DataListItem style={{ border: 0 }}>
         <FileLink file={props.file}>
           <DataListItemRow>

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -76,12 +76,19 @@ import { ErrorBoundary } from "../reactExt/ErrorBoundary";
 import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
 import { VariableSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
-import { FileDataList, FileLink, getFileDataListHeight, SingleFileWorkspaceListItem } from "../filesList/FileDataList";
+import {
+  FileDataList,
+  FileLink,
+  FileListItemDisplayMode,
+  getFileDataListHeight,
+  SingleFileWorkspaceListItem,
+} from "../filesList/FileDataList";
 import { WorkspaceListItem } from "../workspace/components/WorkspaceListItem";
 import { WorkspaceLoadingCard } from "../workspace/components/WorkspaceLoadingCard";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 import { ResponsiveDropdown } from "../ResponsiveDropdown/ResponsiveDropdown";
 import { ResponsiveDropdownToggle } from "../ResponsiveDropdown/ResponsiveDropdownToggle";
+import { listDeletedFiles } from "../workspace/components/WorkspaceStatusIndicator";
 
 export function HomePage() {
   const routes = useRoutes();
@@ -560,7 +567,9 @@ export function WorkspacesListDrawerPanelContent(props: { workspaceId: string | 
                   {({ index, style }) => (
                     <FileDataList
                       file={arrayWithModelsThenOtherFiles[index]}
-                      isEditable={index < models.length}
+                      displayMode={
+                        index < models.length ? FileListItemDisplayMode.enabled : FileListItemDisplayMode.readonly
+                      }
                       style={style}
                     />
                   )}

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -520,6 +520,7 @@ interface OnlineDictionary extends ReferenceDictionary {
   gitStatusIndicatorActions: {
     [key in SupportedActions]: {
       title: string;
+      warning: string;
       description: string;
       confirmButtonText: string;
     };

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -18,6 +18,7 @@ import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 import { DmnUnitablesI18n } from "@kie-tools/unitables-dmn/dist/i18n";
 import { GistEnabledAuthProviderType, SupportedGitAuthProviders } from "../authProviders/AuthProvidersApi";
+import { SupportedActions } from "../workspace/components/GitStatusIndicatorActions";
 
 interface OnlineDictionary extends ReferenceDictionary {
   editorPage: {
@@ -514,6 +515,13 @@ interface OnlineDictionary extends ReferenceDictionary {
     [key in SupportedGitAuthProviders]: {
       user: string;
       organizations: string;
+    };
+  };
+  gitStatusIndicatorActions: {
+    [key in SupportedActions]: {
+      title: string;
+      description: string;
+      confirmButtonText: string;
     };
   };
 }

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -628,14 +628,14 @@ export const en: OnlineI18n = {
   },
   gitStatusIndicatorActions: {
     revert: {
-      title: "Revert Changes",
+      title: "Revert",
       description: "This action is permanent. Following file will be reverted to the last commit:",
-      confirmButtonText: "Revert Permanently",
+      confirmButtonText: "Revert permanently",
     },
     revertAll: {
-      title: "Revert All Changes",
+      title: "Revert all changes",
       description: "This action is permanent. Following files will be reverted to the last commit:",
-      confirmButtonText: "Revert Permanently",
+      confirmButtonText: "Revert permanently",
     },
   },
 };

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -626,4 +626,16 @@ export const en: OnlineI18n = {
       organizations: "GitHub organizations",
     },
   },
+  gitStatusIndicatorActions: {
+    revert: {
+      title: "Revert Changes",
+      description: "This action is permanent. Following file will be reverted to the last commit:",
+      confirmButtonText: "Revert Permanently",
+    },
+    revertAll: {
+      title: "Revert All Changes",
+      description: "This action is permanent. Following files will be reverted to the last commit:",
+      confirmButtonText: "Revert Permanently",
+    },
+  },
 };

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -629,13 +629,13 @@ export const en: OnlineI18n = {
     revert: {
       title: "Revert",
       warning: "This action is permanent",
-      description: "Are you sure you want to revert local changes of",
+      description: "Are you sure you want to revert local changes to:",
       confirmButtonText: "Yes, revert permanently",
     },
     revertAll: {
       title: "Revert all changes",
       warning: "This action is permanent",
-      description: "Are you sure? Following files will be reverted to the last commit:",
+      description: "Are you sure? The following files will be reverted to the last commit:",
       confirmButtonText: "Yes, revert permanently",
     },
   },

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -18,7 +18,6 @@ import { OnlineI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 import { en as en_unitables } from "@kie-tools/unitables/dist/i18n/locales/en";
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
-import { names } from "@kie-tools/i18n-common-dictionary/dist/names";
 
 export const en: OnlineI18n = {
   ...en_common,
@@ -629,13 +628,15 @@ export const en: OnlineI18n = {
   gitStatusIndicatorActions: {
     revert: {
       title: "Revert",
-      description: "This action is permanent. Following file will be reverted to the last commit:",
-      confirmButtonText: "Revert permanently",
+      warning: "This action is permanent",
+      description: "Are you sure you want to revert local changes of",
+      confirmButtonText: "Yes, revert permanently",
     },
     revertAll: {
       title: "Revert all changes",
-      description: "This action is permanent. Following files will be reverted to the last commit:",
-      confirmButtonText: "Revert permanently",
+      warning: "This action is permanent",
+      description: "Are you sure? Following files will be reverted to the last commit:",
+      confirmButtonText: "Yes, revert permanently",
     },
   },
 };

--- a/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
+++ b/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
@@ -1,0 +1,538 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
+import { useWorkspaces, WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
+import { WorkspaceGitStatusType } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
+import {
+  FileModificationStatus,
+  UnstagedModifiedFilesStatusEntryType,
+} from "@kie-tools-core/workspaces-git-fs/dist/services/GitService";
+import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
+
+import { Alert, AlertActionLink, AlertVariant } from "@patternfly/react-core/dist/js/components/Alert";
+import {
+  Dropdown,
+  DropdownDirection,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+} from "@patternfly/react-core/dist/js/components/Dropdown";
+import { Button } from "@patternfly/react-core/dist/js/components/Button";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
+import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
+import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
+import { CaretDownIcon } from "@patternfly/react-icons/dist/js/icons/caret-down-icon";
+import { CaretLeftIcon } from "@patternfly/react-icons/dist/js/icons/caret-left-icon";
+import { CaretRightIcon } from "@patternfly/react-icons/dist/js/icons/caret-right-icon";
+import { CaretUpIcon } from "@patternfly/react-icons/dist/js/icons/caret-up-icon";
+import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
+import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
+import { InfoCircleIcon } from "@patternfly/react-icons/dist/js/icons/info-circle-icon";
+import { UndoAltIcon } from "@patternfly/react-icons/dist/js/icons/undo-alt-icon";
+import { WarningTriangleIcon } from "@patternfly/react-icons/dist/js/icons/warning-triangle-icon";
+import * as React from "react";
+import { useOnlineI18n } from "../../i18n";
+import { switchExpression } from "../../switchExpression/switchExpression";
+import { Truncate } from "@patternfly/react-core/dist/js/components/Truncate";
+import { Text, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { TooltipPosition } from "@patternfly/react-core/dist/js/components/Tooltip";
+
+type Directions = "up" | "down" | "right" | "left";
+
+export type GitStatusProps = {
+  workspaceDescriptor: WorkspaceDescriptor;
+  workspaceGitStatusPromise: PromiseState<WorkspaceGitStatusType>;
+};
+
+export enum GitStatusIndicatorActionVariant {
+  dropdown = "dropdown",
+  popover = "popover",
+}
+
+export enum SupportedActions {
+  revert = "revert",
+  revertAll = "revertAll",
+}
+
+type GitStatusIndicatorActionType = {
+  id: SupportedActions;
+  title: string;
+  titleIcon: JSX.Element;
+  description: JSX.Element;
+  alertVariant: AlertVariant;
+  confirmButtonText: string;
+  onConfirm: () => void;
+};
+
+type GitStatusIndicatorActionsPropsBase = {
+  gitStatusProps: GitStatusProps;
+  variant: string;
+  workspaceFile?: WorkspaceFile;
+  currentWorkspaceFile?: WorkspaceFile;
+  onDeletedWorkspaceFile?: () => void;
+};
+type GitStatusIndicatorActionsDropdownProps = GitStatusIndicatorActionsPropsBase & {
+  variant: GitStatusIndicatorActionVariant.dropdown;
+  expandDirection: "right" | "left";
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+  toggle?: JSX.Element;
+};
+type GitStatusIndicatorActionsPopoverProps = GitStatusIndicatorActionsPropsBase & {
+  variant: GitStatusIndicatorActionVariant.popover;
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+};
+export type GitStatusIndicatorActionsProps =
+  | GitStatusIndicatorActionsDropdownProps
+  | GitStatusIndicatorActionsPopoverProps;
+
+export const GitStatusIndicatorActions = (props: GitStatusIndicatorActionsProps) => {
+  const { i18n } = useOnlineI18n();
+  const workspaces = useWorkspaces();
+
+  const isPopoverVariant = (
+    maybePopoverProps: GitStatusIndicatorActionsProps
+  ): maybePopoverProps is GitStatusIndicatorActionsPopoverProps => {
+    return maybePopoverProps.variant === GitStatusIndicatorActionVariant.popover;
+  };
+
+  const isDropdownVariant = (
+    maybeDropdownProps: GitStatusIndicatorActionsProps
+  ): maybeDropdownProps is GitStatusIndicatorActionsDropdownProps => {
+    return maybeDropdownProps.variant === GitStatusIndicatorActionVariant.dropdown;
+  };
+
+  const stageStatusFilter = React.useCallback(
+    (applicableFor: FileModificationStatus[]) => {
+      return (stageStatusEntry: UnstagedModifiedFilesStatusEntryType) => {
+        return (
+          applicableFor.includes(stageStatusEntry.status) &&
+          (props.workspaceFile
+            ? [props.workspaceFile.relativePath]
+            : props.gitStatusProps.workspaceGitStatusPromise!.data!.unstagedModifiedFilesStatus.map(({ path }) => path)
+          ).includes(stageStatusEntry.path)
+        );
+      };
+    },
+    [props.workspaceFile, props.gitStatusProps.workspaceGitStatusPromise]
+  );
+
+  const doRevert = React.useCallback(
+    async (filepaths: string[]) => {
+      await workspaces.checkoutFilesFromLocalHead({
+        workspaceId: props.gitStatusProps.workspaceDescriptor.workspaceId,
+        ref: props.gitStatusProps.workspaceDescriptor.origin.branch,
+        filepaths,
+      });
+      if (
+        props.currentWorkspaceFile &&
+        !(await workspaces.existsFile({
+          workspaceId: props.gitStatusProps.workspaceDescriptor.workspaceId,
+          relativePath: props.currentWorkspaceFile.relativePath,
+        }))
+      ) {
+        props.onDeletedWorkspaceFile?.();
+      }
+    },
+    [props, workspaces]
+  );
+
+  const actionRevert = React.useCallback((): GitStatusIndicatorActionType | undefined => {
+    const maybeWorkspaceGitStatus = props.gitStatusProps.workspaceGitStatusPromise?.data;
+    if (!maybeWorkspaceGitStatus) {
+      return;
+    }
+    const id = props.workspaceFile ? SupportedActions.revert : SupportedActions.revertAll;
+
+    const filepaths = maybeWorkspaceGitStatus.unstagedModifiedFilesStatus
+      .filter(
+        stageStatusFilter([
+          FileModificationStatus.deleted,
+          FileModificationStatus.modified,
+          FileModificationStatus.added,
+        ])
+      )
+      .map((it) => it.path);
+
+    if (!filepaths.length) {
+      return;
+    }
+    return {
+      onConfirm: async () => await doRevert(filepaths),
+      id,
+      title: i18n.gitStatusIndicatorActions[id].title,
+      titleIcon: <UndoAltIcon />,
+      alertVariant: AlertVariant.warning,
+      description: (
+        <>
+          <span>{i18n.gitStatusIndicatorActions[id].description}</span>
+          <List>
+            {filepaths.map((it, index) => (
+              <ListItem key={id + index}>
+                <Text component={TextVariants.small}>
+                  <Truncate
+                    content={it}
+                    position={"middle"}
+                    trailingNumChars={Math.max(it.length - it.lastIndexOf("/"), 10)}
+                    tooltipPosition={TooltipPosition.leftStart}
+                  />
+                </Text>
+              </ListItem>
+            ))}
+          </List>
+        </>
+      ),
+      confirmButtonText: i18n.gitStatusIndicatorActions[id].confirmButtonText,
+    };
+  }, [
+    doRevert,
+    i18n.gitStatusIndicatorActions,
+    props.gitStatusProps.workspaceGitStatusPromise?.data,
+    props.workspaceFile,
+    stageStatusFilter,
+  ]);
+
+  const actions: GitStatusIndicatorActionType[] = React.useMemo(() => {
+    const maybeActions = [
+      // list all actions here, which (based on internal state) could be undefined
+      actionRevert(),
+    ];
+
+    const result: GitStatusIndicatorActionType[] = [];
+
+    maybeActions.forEach((action) => {
+      if (action !== undefined) {
+        result.push(action);
+      }
+    });
+
+    return result;
+  }, [actionRevert]);
+
+  return switchExpression(props.variant, {
+    dropdown: isDropdownVariant(props) ? (
+      <ActionsDropdown
+        isOpen={props.isOpen}
+        setOpen={props.setOpen}
+        dropdownPosition={DropdownPosition.left}
+        toggle={
+          props.toggle ?? (
+            <DropdownToggle
+              isPlain
+              onToggle={(value, ev) => {
+                ev.stopPropagation();
+                ev.preventDefault();
+                props.setOpen(value);
+              }}
+              title={"Git Status related operations."}
+              className={"kie-tools--no-whitespace-dropdown-toggle"}
+            />
+          )
+        }
+        dropdownItems={actions.map((it) => (
+          <ActionsDropdownItem
+            key={it.id}
+            titleText={it.title}
+            titleIcon={it.titleIcon}
+            description={it.description}
+            confirmButtonText={it.confirmButtonText}
+            alertVariant={it.alertVariant}
+            expandDirection={props.expandDirection}
+            onConfirm={() => {
+              it.onConfirm();
+              props.setOpen(false);
+            }}
+          />
+        ))}
+      />
+    ) : (
+      <></>
+    ),
+    popover: isPopoverVariant(props) ? (
+      <ActionsPopoverButtons actions={actions} isOpen={props.isOpen} setOpen={props.setOpen} />
+    ) : (
+      <></>
+    ),
+  });
+};
+
+const ActionsDropdown = (props: {
+  dropdownPosition: DropdownPosition;
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+  toggle: JSX.Element;
+  dropdownItems: JSX.Element[];
+}) => {
+  return (
+    <Dropdown
+      position={props.dropdownPosition}
+      direction={DropdownDirection.down}
+      isOpen={props.isOpen}
+      isPlain
+      isFullHeight={false}
+      toggle={props.toggle}
+      dropdownItems={props.dropdownItems}
+      className={switchExpression(props.dropdownPosition, {
+        right: "kie-tools--alert-dropdown-right",
+        left: "kie-tools--alert-dropdown-left",
+      })}
+    />
+  );
+};
+
+const ActionsDropdownItem = (props: {
+  titleText: string;
+  titleIcon: React.ReactNode;
+  description: string | JSX.Element;
+  alertVariant: AlertVariant;
+  confirmButtonText: string;
+  onConfirm: () => void;
+  expandDirection: "left" | "right";
+}) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  return (
+    <DropdownItem
+      key={props.titleText}
+      component={"span"}
+      onClick={(ev) => {
+        setIsExpanded(!isExpanded);
+        ev.stopPropagation();
+      }}
+      className={"kie-tools--alert-dropdown-item"}
+    >
+      <ActionsAlert
+        alertVariant={props.alertVariant}
+        isExpanded={isExpanded}
+        setIsExpanded={setIsExpanded}
+        expandDirection={props.expandDirection}
+        titleText={props.titleText}
+        titleIcon={props.titleIcon}
+        description={props.description}
+        confirmButtonText={props.confirmButtonText}
+        onConfirm={() => {
+          props.onConfirm();
+          setIsExpanded(false);
+        }}
+      />
+    </DropdownItem>
+  );
+};
+
+const ActionsPopoverButtons = (props: {
+  actions: GitStatusIndicatorActionType[];
+  isOpen: boolean;
+  setOpen: (value: boolean) => void;
+}) => {
+  const [openedPopoverId, setOpenedPopoverId] = React.useState<string>();
+  return (
+    <Flex spaceItems={{ default: "spaceItemsXs" }}>
+      {props.actions.map((action) => (
+        <ActionsPopover
+          key={action.id}
+          titleText={action.title}
+          titleIcon={action.titleIcon}
+          description={action.description}
+          confirmButtonText={action.confirmButtonText}
+          alertVariant={action.alertVariant}
+          onConfirm={() => {
+            action.onConfirm();
+            setOpenedPopoverId(undefined);
+            props.setOpen(false);
+          }}
+          isOpen={props.isOpen && openedPopoverId === action.id}
+          setOpen={(isOpen: boolean) => {
+            setOpenedPopoverId(isOpen ? action.id : undefined);
+            props.setOpen(isOpen);
+          }}
+        />
+      ))}
+    </Flex>
+  );
+};
+
+const ActionsPopover = (props: {
+  titleText: string;
+  titleIcon: JSX.Element;
+  description: string | JSX.Element;
+  alertVariant: AlertVariant;
+  confirmButtonText: string;
+  onConfirm: () => void;
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+}) => {
+  return (
+    <Popover
+      id={`actions-popover-${props.titleText.replace(/\s/g, "_")}`}
+      bodyContent={
+        <ActionsAlert
+          titleText={props.titleText}
+          titleIcon={props.titleIcon}
+          description={props.description}
+          alertVariant={props.alertVariant}
+          confirmButtonText={props.confirmButtonText}
+          onConfirm={props.onConfirm}
+          contentDirection={"right"}
+          isExpanded={true}
+        />
+      }
+      isVisible={props.isOpen}
+    >
+      <Button
+        className={"kie-tools--masthead-hoverable"}
+        variant={"plain"}
+        onClick={(ev) => {
+          props.setOpen(!props.isOpen);
+          ev.stopPropagation();
+          ev.preventDefault();
+        }}
+        title={props.titleText}
+      >
+        {props.titleIcon}
+      </Button>
+    </Popover>
+  );
+};
+
+const ActionsAlert = (props: {
+  titleText: string;
+  titleIcon: React.ReactNode;
+  description: string | JSX.Element;
+  alertVariant: AlertVariant;
+  confirmButtonText: string;
+  onConfirm: () => void;
+  expandDirection?: Directions;
+  contentDirection?: Directions;
+  isExpanded: boolean;
+  setIsExpanded?: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  return (
+    <Alert
+      isInline
+      variant={props.alertVariant}
+      isPlain={true}
+      customIcon={<></>}
+      title={
+        <AdjustableAlertToggle
+          isExpanded={props.isExpanded}
+          onToggle={(isExpanded: boolean) => {
+            props.setIsExpanded && props.setIsExpanded(isExpanded);
+          }}
+          contentId={props.titleText}
+          direction={"down"}
+          closedCaretDirection={props.expandDirection}
+          contentDirection={props.contentDirection}
+          title={props.titleText}
+          icon={props.titleIcon}
+        >
+          {props.titleText}
+        </AdjustableAlertToggle>
+      }
+      actionLinks={
+        props.isExpanded && (
+          <>
+            <AlertActionLink
+              onClick={(ev) => {
+                props.onConfirm();
+                ev.stopPropagation();
+                ev.preventDefault();
+              }}
+              title={props.confirmButtonText}
+            >
+              {props.confirmButtonText}
+            </AlertActionLink>
+          </>
+        )
+      }
+      className={props.isExpanded ? "kie-tools--git-status-indicator-actions-alert-expanded" : ""}
+    >
+      {props.isExpanded && (
+        <Flex direction={{ default: "row" }} flexWrap={{ default: "nowrap" }}>
+          <FlexItem>
+            {switchExpression(props.alertVariant, {
+              warning: <WarningTriangleIcon />,
+              danger: <ExclamationCircleIcon />,
+              success: <CheckCircleIcon />,
+              default: <InfoCircleIcon />,
+            })}
+          </FlexItem>
+          <FlexItem>{props.description}</FlexItem>
+        </Flex>
+      )}
+    </Alert>
+  );
+};
+
+const AdjustableAlertToggle = (props: {
+  children: React.ReactNode;
+  className?: string;
+  isExpanded: boolean;
+  onToggle?: (isOpen: boolean) => void;
+  contentId: string;
+  closedCaretDirection?: Directions;
+  contentDirection?: Directions;
+  direction?: Directions;
+  icon?: React.ReactNode;
+  title?: string;
+}) => {
+  const iconForDirection = React.useCallback((direction: Directions) => {
+    return switchExpression(direction, {
+      down: <CaretDownIcon />,
+      up: <CaretUpIcon />,
+      left: <CaretLeftIcon />,
+      right: <CaretRightIcon />,
+      default: <CaretDownIcon />,
+    });
+  }, []);
+
+  const currentCaretIcon = React.useMemo(() => {
+    if (!props.direction || !props.closedCaretDirection) {
+      return;
+    }
+    return props.isExpanded ? iconForDirection(props.direction) : iconForDirection(props.closedCaretDirection);
+  }, [iconForDirection, props.closedCaretDirection, props.direction, props.isExpanded]);
+
+  const caretIconPosition = React.useMemo(() => {
+    const position: "left" | "right" = switchExpression(props.contentDirection ?? props.closedCaretDirection, {
+      down: "right",
+      up: "left",
+      left: "left",
+      right: "right",
+      default: "right",
+    });
+    return position;
+  }, [props.closedCaretDirection, props.contentDirection]);
+
+  return (
+    <Flex
+      direction={{ default: caretIconPosition === "left" ? "row" : "rowReverse" }}
+      alignItems={{ default: "alignItemsFlexEnd" }}
+      spaceItems={{ default: "spaceItemsXs" }}
+      aria-expanded={props.isExpanded}
+      aria-controls={props.contentId}
+      onClick={(ev) => {
+        props.onToggle?.(!props.isExpanded);
+        ev.stopPropagation();
+      }}
+      flexWrap={{ default: "nowrap" }}
+      title={props.title}
+    >
+      {currentCaretIcon && <FlexItem grow={{ default: "grow" }}>{currentCaretIcon}</FlexItem>}
+      <FlexItem>{props.children}</FlexItem>
+      <FlexItem>{props.icon}</FlexItem>
+    </Flex>
+  );
+};

--- a/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
+++ b/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
@@ -219,7 +219,10 @@ export const GitStatusIndicatorActions = (
       description: (
         <>
           <span>{i18n.gitStatusIndicatorActions[id].description}</span>
+          <br />
+          <br />
           {workspaceFilesRendered}
+          <br />
         </>
       ),
       confirmButtonText: i18n.gitStatusIndicatorActions[id].confirmButtonText,
@@ -256,7 +259,10 @@ export const GitStatusIndicatorActions = (
         <Flex direction={{ default: "column" }}>
           <FlexItem>
             <TextContent>
-              <Text component="p">{`There are local changes to the following files in '${props.gitStatusProps.workspaceDescriptor.name}':`}</Text>
+              <Text component="p">
+                {`There are local changes to the following files in`}
+                <i>{`'${props.gitStatusProps.workspaceDescriptor.name}'`}</i>
+              </Text>
             </TextContent>
           </FlexItem>
           {workspaceFilesRendered}
@@ -316,6 +322,7 @@ const MultipleActionsPopoverWithDropdown = (props: {
       position={PopoverPosition.bottom}
       showClose={selectedActionId !== undefined} // showing close button just for the rendered alert
       isVisible={props.isOpen}
+      minWidth={"500px"}
       shouldClose={() => {
         // clicking close button when alert is displayed closes only alert itself
         if (selectedActionId !== undefined) {

--- a/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
+++ b/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
@@ -392,7 +392,6 @@ const MultipleActionsPopoverWithDropdown = (props: {
       <Button
         variant="link"
         icon={<CaretDownIcon />}
-        className={"kie-tools--no-whitespace-dropdown-toggle"}
         onClick={(ev) => {
           ev.stopPropagation();
           ev.preventDefault();

--- a/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
+++ b/packages/online-editor/src/workspace/components/GitStatusIndicatorActions.tsx
@@ -25,42 +25,28 @@ import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/work
 import { Alert, AlertActionLink, AlertVariant } from "@patternfly/react-core/dist/js/components/Alert";
 import {
   Dropdown,
-  DropdownDirection,
   DropdownItem,
   DropdownPosition,
-  DropdownToggle,
+  KebabToggle,
 } from "@patternfly/react-core/dist/js/components/Dropdown";
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
-import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
+import { Popover, PopoverPosition } from "@patternfly/react-core/dist/js/components/Popover";
 import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
-import { CaretDownIcon } from "@patternfly/react-icons/dist/js/icons/caret-down-icon";
-import { CaretLeftIcon } from "@patternfly/react-icons/dist/js/icons/caret-left-icon";
-import { CaretRightIcon } from "@patternfly/react-icons/dist/js/icons/caret-right-icon";
-import { CaretUpIcon } from "@patternfly/react-icons/dist/js/icons/caret-up-icon";
-import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
-import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
-import { InfoCircleIcon } from "@patternfly/react-icons/dist/js/icons/info-circle-icon";
 import { UndoAltIcon } from "@patternfly/react-icons/dist/js/icons/undo-alt-icon";
-import { WarningTriangleIcon } from "@patternfly/react-icons/dist/js/icons/warning-triangle-icon";
 import * as React from "react";
 import { useOnlineI18n } from "../../i18n";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
+import { listDeletedFiles } from "./WorkspaceStatusIndicator";
+import { FileLabel } from "../../filesList/FileLabel";
+import CaretDownIcon from "@patternfly/react-icons/dist/js/icons/caret-down-icon";
 import { switchExpression } from "../../switchExpression/switchExpression";
-import { Truncate } from "@patternfly/react-core/dist/js/components/Truncate";
-import { Text, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
-import { TooltipPosition } from "@patternfly/react-core/dist/js/components/Tooltip";
-
-type Directions = "up" | "down" | "right" | "left";
 
 export type GitStatusProps = {
   workspaceDescriptor: WorkspaceDescriptor;
   workspaceGitStatusPromise: PromiseState<WorkspaceGitStatusType>;
 };
-
-export enum GitStatusIndicatorActionVariant {
-  dropdown = "dropdown",
-  popover = "popover",
-}
 
 export enum SupportedActions {
   revert = "revert",
@@ -69,70 +55,125 @@ export enum SupportedActions {
 
 type GitStatusIndicatorActionType = {
   id: SupportedActions;
-  title: string;
+  titleText: string;
+  warningText: string;
   titleIcon: JSX.Element;
   description: JSX.Element;
   alertVariant: AlertVariant;
   confirmButtonText: string;
   onConfirm: () => void;
 };
-
-type GitStatusIndicatorActionsPropsBase = {
+interface GitStatusIndicatorActionsPropsBase {
   gitStatusProps: GitStatusProps;
-  variant: string;
-  workspaceFile?: WorkspaceFile;
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
   currentWorkspaceFile?: WorkspaceFile;
   onDeletedWorkspaceFile?: () => void;
-};
-type GitStatusIndicatorActionsDropdownProps = GitStatusIndicatorActionsPropsBase & {
-  variant: GitStatusIndicatorActionVariant.dropdown;
-  expandDirection: "right" | "left";
-  isOpen: boolean;
-  setOpen: (isOpen: boolean) => void;
-  toggle?: JSX.Element;
-};
-type GitStatusIndicatorActionsPopoverProps = GitStatusIndicatorActionsPropsBase & {
-  variant: GitStatusIndicatorActionVariant.popover;
-  isOpen: boolean;
-  setOpen: (isOpen: boolean) => void;
-};
-export type GitStatusIndicatorActionsProps =
-  | GitStatusIndicatorActionsDropdownProps
-  | GitStatusIndicatorActionsPopoverProps;
+}
 
-export const GitStatusIndicatorActions = (props: GitStatusIndicatorActionsProps) => {
+interface GitStatusIndicatorActionsSingleFileProps extends GitStatusIndicatorActionsPropsBase {
+  workspaceFile: WorkspaceFile;
+}
+interface GitStatusIndicatorActionsMultipleFilesProps extends GitStatusIndicatorActionsPropsBase {
+  workspaceFiles: WorkspaceFile[];
+}
+const isSingleFile = (
+  maybeSingleFile: GitStatusIndicatorActionsSingleFileProps | GitStatusIndicatorActionsMultipleFilesProps
+): maybeSingleFile is GitStatusIndicatorActionsSingleFileProps => {
+  return "workspaceFile" in maybeSingleFile;
+};
+
+export const GitStatusIndicatorActions = (
+  props: GitStatusIndicatorActionsSingleFileProps | GitStatusIndicatorActionsMultipleFilesProps
+) => {
   const { i18n } = useOnlineI18n();
   const workspaces = useWorkspaces();
 
-  const isPopoverVariant = (
-    maybePopoverProps: GitStatusIndicatorActionsProps
-  ): maybePopoverProps is GitStatusIndicatorActionsPopoverProps => {
-    return maybePopoverProps.variant === GitStatusIndicatorActionVariant.popover;
-  };
+  const renderFile = React.useCallback(
+    (file: WorkspaceFile) => (
+      <Flex direction={{ default: "row" }} flexWrap={{ default: "nowrap" }} spacer={{ default: "spacerMd" }}>
+        <FlexItem style={{ minWidth: 0 /* This is to make the flex parent not overflow horizontally */ }}>
+          <Tooltip distance={5} position={"top-start"} content={file.nameWithoutExtension}>
+            <TextContent>
+              <Text component={TextVariants.p}>{file.nameWithoutExtension}</Text>
+            </TextContent>
+          </Tooltip>
+        </FlexItem>
+        <FlexItem>
+          <FileLabel extension={file.extension} />
+        </FlexItem>
+        <FlexItem>
+          {switchExpression(
+            props.gitStatusProps.workspaceGitStatusPromise.data?.unstagedModifiedFilesStatus.find(
+              (entry) => entry.path === file.relativePath
+            )?.status,
+            {
+              added: (
+                <Tooltip content={"Added"} position={"right"}>
+                  <small>
+                    <i>A</i>
+                  </small>
+                </Tooltip>
+              ),
+              deleted: (
+                <Tooltip content={"Deleted"} position={"right"}>
+                  <small>
+                    <i>D</i>
+                  </small>
+                </Tooltip>
+              ),
+              modified: (
+                <Tooltip content={"Modified"} position={"right"}>
+                  <small>
+                    <i>M</i>
+                  </small>
+                </Tooltip>
+              ),
+            }
+          )}
+        </FlexItem>
+      </Flex>
+    ),
+    [props.gitStatusProps.workspaceGitStatusPromise.data?.unstagedModifiedFilesStatus]
+  );
 
-  const isDropdownVariant = (
-    maybeDropdownProps: GitStatusIndicatorActionsProps
-  ): maybeDropdownProps is GitStatusIndicatorActionsDropdownProps => {
-    return maybeDropdownProps.variant === GitStatusIndicatorActionVariant.dropdown;
-  };
+  const workspaceFilesRendered = React.useMemo(() => {
+    return isSingleFile(props) ? (
+      <b>{renderFile(props.workspaceFile)}</b>
+    ) : (
+      <b>
+        <List>
+          {[...props.workspaceFiles, ...listDeletedFiles(props.gitStatusProps)]
+            .filter((file) =>
+              props.gitStatusProps.workspaceGitStatusPromise.data?.unstagedModifiedFilesStatus.some(
+                (entry) => entry.path === file.relativePath
+              )
+            )
+            .map((file, index) => (
+              <ListItem key={index}>{renderFile(file)}</ListItem>
+            ))}
+        </List>
+      </b>
+    );
+  }, [props, renderFile]);
 
-  const stageStatusFilter = React.useCallback(
-    (applicableFor: FileModificationStatus[]) => {
+  const filterAcceptedStageStatuses = React.useCallback(
+    (acceptedValues: FileModificationStatus[]) => {
       return (stageStatusEntry: UnstagedModifiedFilesStatusEntryType) => {
         return (
-          applicableFor.includes(stageStatusEntry.status) &&
-          (props.workspaceFile
+          acceptedValues.includes(stageStatusEntry.status) &&
+          (isSingleFile(props)
             ? [props.workspaceFile.relativePath]
             : props.gitStatusProps.workspaceGitStatusPromise!.data!.unstagedModifiedFilesStatus.map(({ path }) => path)
           ).includes(stageStatusEntry.path)
         );
       };
     },
-    [props.workspaceFile, props.gitStatusProps.workspaceGitStatusPromise]
+    [props]
   );
 
-  const doRevert = React.useCallback(
-    async (filepaths: string[]) => {
+  const actionRevert = React.useCallback((): GitStatusIndicatorActionType | undefined => {
+    const doRevert = async (filepaths: string[]) => {
       await workspaces.checkoutFilesFromLocalHead({
         workspaceId: props.gitStatusProps.workspaceDescriptor.workspaceId,
         ref: props.gitStatusProps.workspaceDescriptor.origin.branch,
@@ -147,26 +188,23 @@ export const GitStatusIndicatorActions = (props: GitStatusIndicatorActionsProps)
       ) {
         props.onDeletedWorkspaceFile?.();
       }
-    },
-    [props, workspaces]
-  );
-
-  const actionRevert = React.useCallback((): GitStatusIndicatorActionType | undefined => {
+    };
     const maybeWorkspaceGitStatus = props.gitStatusProps.workspaceGitStatusPromise?.data;
+
     if (!maybeWorkspaceGitStatus) {
       return;
     }
-    const id = props.workspaceFile ? SupportedActions.revert : SupportedActions.revertAll;
+    const id = isSingleFile(props) ? SupportedActions.revert : SupportedActions.revertAll;
 
     const filepaths = maybeWorkspaceGitStatus.unstagedModifiedFilesStatus
       .filter(
-        stageStatusFilter([
+        filterAcceptedStageStatuses([
           FileModificationStatus.deleted,
           FileModificationStatus.modified,
           FileModificationStatus.added,
         ])
       )
-      .map((it) => it.path);
+      .map(({ path }) => path);
 
     if (!filepaths.length) {
       return;
@@ -174,37 +212,19 @@ export const GitStatusIndicatorActions = (props: GitStatusIndicatorActionsProps)
     return {
       onConfirm: async () => await doRevert(filepaths),
       id,
-      title: i18n.gitStatusIndicatorActions[id].title,
+      titleText: i18n.gitStatusIndicatorActions[id].title,
       titleIcon: <UndoAltIcon />,
       alertVariant: AlertVariant.warning,
+      warningText: i18n.gitStatusIndicatorActions[id].warning,
       description: (
         <>
           <span>{i18n.gitStatusIndicatorActions[id].description}</span>
-          <List>
-            {filepaths.map((it, index) => (
-              <ListItem key={id + index}>
-                <Text component={TextVariants.small}>
-                  <Truncate
-                    content={it}
-                    position={"middle"}
-                    trailingNumChars={Math.max(it.length - it.lastIndexOf("/"), 10)}
-                    tooltipPosition={TooltipPosition.leftStart}
-                  />
-                </Text>
-              </ListItem>
-            ))}
-          </List>
+          {workspaceFilesRendered}
         </>
       ),
       confirmButtonText: i18n.gitStatusIndicatorActions[id].confirmButtonText,
     };
-  }, [
-    doRevert,
-    i18n.gitStatusIndicatorActions,
-    props.gitStatusProps.workspaceGitStatusPromise?.data,
-    props.workspaceFile,
-    stageStatusFilter,
-  ]);
+  }, [i18n.gitStatusIndicatorActions, props, filterAcceptedStageStatuses, workspaceFilesRendered, workspaces]);
 
   const actions: GitStatusIndicatorActionType[] = React.useMemo(() => {
     const maybeActions = [
@@ -223,116 +243,33 @@ export const GitStatusIndicatorActions = (props: GitStatusIndicatorActionsProps)
     return result;
   }, [actionRevert]);
 
-  return switchExpression(props.variant, {
-    dropdown: isDropdownVariant(props) ? (
-      <ActionsDropdown
-        isOpen={props.isOpen}
-        setOpen={props.setOpen}
-        dropdownPosition={DropdownPosition.left}
-        toggle={
-          props.toggle ?? (
-            <DropdownToggle
-              isPlain
-              onToggle={(value, ev) => {
-                ev.stopPropagation();
-                ev.preventDefault();
-                props.setOpen(value);
-              }}
-              title={"Git Status related operations."}
-              className={"kie-tools--no-whitespace-dropdown-toggle"}
-            />
-          )
-        }
-        dropdownItems={actions.map((it) => (
-          <ActionsDropdownItem
-            key={it.id}
-            titleText={it.title}
-            titleIcon={it.titleIcon}
-            description={it.description}
-            confirmButtonText={it.confirmButtonText}
-            alertVariant={it.alertVariant}
-            expandDirection={props.expandDirection}
-            onConfirm={() => {
-              it.onConfirm();
-              props.setOpen(false);
-            }}
-          />
-        ))}
-      />
-    ) : (
-      <></>
-    ),
-    popover: isPopoverVariant(props) ? (
-      <ActionsPopoverButtons actions={actions} isOpen={props.isOpen} setOpen={props.setOpen} />
-    ) : (
-      <></>
-    ),
-  });
-};
-
-const ActionsDropdown = (props: {
-  dropdownPosition: DropdownPosition;
-  isOpen: boolean;
-  setOpen: (isOpen: boolean) => void;
-  toggle: JSX.Element;
-  dropdownItems: JSX.Element[];
-}) => {
-  return (
-    <Dropdown
-      position={props.dropdownPosition}
-      direction={DropdownDirection.down}
+  return isSingleFile(props) ? (
+    <MultipleActionsButtonsWithPopover actions={actions} isOpen={props.isOpen} setOpen={props.setOpen} />
+  ) : (
+    <MultipleActionsPopoverWithDropdown
+      title={
+        <TextContent>
+          <Text component="h3">Local Changes</Text>
+        </TextContent>
+      }
+      description={
+        <Flex direction={{ default: "column" }}>
+          <FlexItem>
+            <TextContent>
+              <Text component="p">{`There are local changes to the following files in '${props.gitStatusProps.workspaceDescriptor.name}':`}</Text>
+            </TextContent>
+          </FlexItem>
+          {workspaceFilesRendered}
+        </Flex>
+      }
+      actions={actions}
       isOpen={props.isOpen}
-      isPlain
-      isFullHeight={false}
-      toggle={props.toggle}
-      dropdownItems={props.dropdownItems}
-      className={switchExpression(props.dropdownPosition, {
-        right: "kie-tools--alert-dropdown-right",
-        left: "kie-tools--alert-dropdown-left",
-      })}
+      setOpen={props.setOpen}
     />
   );
 };
 
-const ActionsDropdownItem = (props: {
-  titleText: string;
-  titleIcon: React.ReactNode;
-  description: string | JSX.Element;
-  alertVariant: AlertVariant;
-  confirmButtonText: string;
-  onConfirm: () => void;
-  expandDirection: "left" | "right";
-}) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  return (
-    <DropdownItem
-      key={props.titleText}
-      component={"span"}
-      onClick={(ev) => {
-        setIsExpanded(!isExpanded);
-        ev.stopPropagation();
-      }}
-      className={"kie-tools--alert-dropdown-item"}
-    >
-      <ActionsAlert
-        alertVariant={props.alertVariant}
-        isExpanded={isExpanded}
-        setIsExpanded={setIsExpanded}
-        expandDirection={props.expandDirection}
-        titleText={props.titleText}
-        titleIcon={props.titleIcon}
-        description={props.description}
-        confirmButtonText={props.confirmButtonText}
-        onConfirm={() => {
-          props.onConfirm();
-          setIsExpanded(false);
-        }}
-      />
-    </DropdownItem>
-  );
-};
-
-const ActionsPopoverButtons = (props: {
+const MultipleActionsButtonsWithPopover = (props: {
   actions: GitStatusIndicatorActionType[];
   isOpen: boolean;
   setOpen: (value: boolean) => void;
@@ -341,18 +278,9 @@ const ActionsPopoverButtons = (props: {
   return (
     <Flex spaceItems={{ default: "spaceItemsXs" }}>
       {props.actions.map((action) => (
-        <ActionsPopover
+        <SingleActionPopover
           key={action.id}
-          titleText={action.title}
-          titleIcon={action.titleIcon}
-          description={action.description}
-          confirmButtonText={action.confirmButtonText}
-          alertVariant={action.alertVariant}
-          onConfirm={() => {
-            action.onConfirm();
-            setOpenedPopoverId(undefined);
-            props.setOpen(false);
-          }}
+          action={action}
           isOpen={props.isOpen && openedPopoverId === action.id}
           setOpen={(isOpen: boolean) => {
             setOpenedPopoverId(isOpen ? action.id : undefined);
@@ -364,44 +292,138 @@ const ActionsPopoverButtons = (props: {
   );
 };
 
-const ActionsPopover = (props: {
-  titleText: string;
-  titleIcon: JSX.Element;
-  description: string | JSX.Element;
-  alertVariant: AlertVariant;
-  confirmButtonText: string;
-  onConfirm: () => void;
+const MultipleActionsPopoverWithDropdown = (props: {
+  actions: GitStatusIndicatorActionType[];
+  title: React.ReactNode;
+  description: JSX.Element;
   isOpen: boolean;
   setOpen: (isOpen: boolean) => void;
 }) => {
+  const [selectedActionId, setSelectedActionId] = React.useState<string>();
+  const [isDropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
+
+  const selectedAction = React.useMemo(() => {
+    return props.actions.find((action) => action.id === selectedActionId);
+  }, [props.actions, selectedActionId]);
+
   return (
     <Popover
-      id={`actions-popover-${props.titleText.replace(/\s/g, "_")}`}
+      id={"popover-with-actions-dropdown"}
+      className={
+        "kie-tools--git-status-indicator__popover" +
+        (selectedActionId !== undefined ? " kie-tools--git-status-indicator__popover-no-padding" : "")
+      } // noPadding prop not working nice for the ActionsAlert
+      position={PopoverPosition.bottom}
+      showClose={selectedActionId !== undefined} // showing close button just for the rendered alert
+      isVisible={props.isOpen}
+      shouldClose={() => {
+        // clicking close button when alert is displayed closes only alert itself
+        if (selectedActionId !== undefined) {
+          setSelectedActionId(undefined);
+        } else {
+          props.setOpen(false);
+        }
+      }}
+      shouldOpen={() => props.setOpen(true)}
+      bodyContent={
+        selectedAction ? (
+          <ActionsAlert
+            alertVariant={selectedAction.alertVariant}
+            description={selectedAction.description}
+            titleText={selectedAction.warningText}
+            onConfirm={selectedAction.onConfirm}
+            confirmButtonText={selectedAction.confirmButtonText}
+          />
+        ) : (
+          <Flex direction={{ default: "column" }} spacer={{ default: "spacerLg" }}>
+            <Flex direction={{ default: "row" }} justifyContent={{ default: "justifyContentSpaceBetween" }}>
+              <FlexItem>{props.title}</FlexItem>
+              <FlexItem>
+                <Dropdown
+                  id="dd-popover-with-actions-dropdown"
+                  dropdownItems={props.actions.map((action) => (
+                    <DropdownItem key={action.id} onClick={() => setSelectedActionId(action.id)}>
+                      <Flex
+                        direction={{ default: "row" }}
+                        spacer={{ default: "spacerMd" }}
+                        flexWrap={{ default: "nowrap" }}
+                      >
+                        <FlexItem>{action.titleIcon}</FlexItem>
+                        <FlexItem>
+                          <TextContent>
+                            <Text component="h4">{action.titleText}</Text>
+                          </TextContent>
+                        </FlexItem>
+                      </Flex>
+                    </DropdownItem>
+                  ))}
+                  isOpen={isDropdownOpen}
+                  isPlain
+                  position={DropdownPosition.right}
+                  onSelect={() => {
+                    setDropdownOpen(false);
+                  }}
+                  toggle={
+                    <KebabToggle
+                      onToggle={(value) => {
+                        setDropdownOpen(value);
+                      }}
+                    />
+                  }
+                />
+              </FlexItem>
+            </Flex>
+            {props.description}
+          </Flex>
+        )
+      }
+    >
+      <Button
+        variant="link"
+        icon={<CaretDownIcon />}
+        className={"kie-tools--no-whitespace-dropdown-toggle"}
+        onClick={(ev) => {
+          ev.stopPropagation();
+          ev.preventDefault();
+        }}
+      />
+    </Popover>
+  );
+};
+
+const SingleActionPopover = (props: {
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+  action: GitStatusIndicatorActionType;
+}) => {
+  return (
+    <Popover
+      id={`actions-popover`}
       bodyContent={
         <ActionsAlert
-          titleText={props.titleText}
-          titleIcon={props.titleIcon}
-          description={props.description}
-          alertVariant={props.alertVariant}
-          confirmButtonText={props.confirmButtonText}
-          onConfirm={props.onConfirm}
-          contentDirection={"right"}
-          isExpanded={true}
+          titleText={props.action.warningText}
+          description={props.action.description}
+          confirmButtonText={props.action.confirmButtonText}
+          alertVariant={props.action.alertVariant}
+          onConfirm={props.action.onConfirm}
         />
       }
+      className={"kie-tools--git-status-indicator__popover kie-tools--git-status-indicator__popover-no-padding"}
       isVisible={props.isOpen}
+      showClose
+      shouldClose={() => props.setOpen(false)}
+      shouldOpen={() => props.setOpen(true)}
     >
       <Button
         className={"kie-tools--masthead-hoverable"}
         variant={"plain"}
         onClick={(ev) => {
-          props.setOpen(!props.isOpen);
           ev.stopPropagation();
           ev.preventDefault();
         }}
-        title={props.titleText}
+        title={props.action.titleText}
       >
-        {props.titleIcon}
+        {props.action.titleIcon}
       </Button>
     </Popover>
   );
@@ -409,130 +431,36 @@ const ActionsPopover = (props: {
 
 const ActionsAlert = (props: {
   titleText: string;
-  titleIcon: React.ReactNode;
   description: string | JSX.Element;
   alertVariant: AlertVariant;
   confirmButtonText: string;
   onConfirm: () => void;
-  expandDirection?: Directions;
-  contentDirection?: Directions;
-  isExpanded: boolean;
-  setIsExpanded?: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   return (
     <Alert
       isInline
       variant={props.alertVariant}
-      isPlain={true}
-      customIcon={<></>}
-      title={
-        <AdjustableAlertToggle
-          isExpanded={props.isExpanded}
-          onToggle={(isExpanded: boolean) => {
-            props.setIsExpanded && props.setIsExpanded(isExpanded);
-          }}
-          contentId={props.titleText}
-          direction={"down"}
-          closedCaretDirection={props.expandDirection}
-          contentDirection={props.contentDirection}
-          title={props.titleText}
-          icon={props.titleIcon}
-        >
-          {props.titleText}
-        </AdjustableAlertToggle>
-      }
+      title={props.titleText}
       actionLinks={
-        props.isExpanded && (
-          <>
-            <AlertActionLink
-              onClick={(ev) => {
-                props.onConfirm();
-                ev.stopPropagation();
-                ev.preventDefault();
-              }}
-              title={props.confirmButtonText}
-            >
-              {props.confirmButtonText}
-            </AlertActionLink>
-          </>
-        )
+        <>
+          <AlertActionLink
+            onClick={(ev) => {
+              props.onConfirm();
+              ev.stopPropagation();
+              ev.preventDefault();
+            }}
+            title={props.confirmButtonText}
+            variant={"link"}
+            style={{ color: "var(--pf-global--danger-color--200)", fontWeight: "bold" }}
+          >
+            {props.confirmButtonText}
+          </AlertActionLink>
+        </>
       }
-      className={props.isExpanded ? "kie-tools--git-status-indicator-actions-alert-expanded" : ""}
     >
-      {props.isExpanded && (
-        <Flex direction={{ default: "row" }} flexWrap={{ default: "nowrap" }}>
-          <FlexItem>
-            {switchExpression(props.alertVariant, {
-              warning: <WarningTriangleIcon />,
-              danger: <ExclamationCircleIcon />,
-              success: <CheckCircleIcon />,
-              default: <InfoCircleIcon />,
-            })}
-          </FlexItem>
-          <FlexItem>{props.description}</FlexItem>
-        </Flex>
-      )}
+      <Flex direction={{ default: "row" }} flexWrap={{ default: "nowrap" }}>
+        <FlexItem grow={{ default: "grow" }}>{props.description}</FlexItem>
+      </Flex>
     </Alert>
-  );
-};
-
-const AdjustableAlertToggle = (props: {
-  children: React.ReactNode;
-  className?: string;
-  isExpanded: boolean;
-  onToggle?: (isOpen: boolean) => void;
-  contentId: string;
-  closedCaretDirection?: Directions;
-  contentDirection?: Directions;
-  direction?: Directions;
-  icon?: React.ReactNode;
-  title?: string;
-}) => {
-  const iconForDirection = React.useCallback((direction: Directions) => {
-    return switchExpression(direction, {
-      down: <CaretDownIcon />,
-      up: <CaretUpIcon />,
-      left: <CaretLeftIcon />,
-      right: <CaretRightIcon />,
-      default: <CaretDownIcon />,
-    });
-  }, []);
-
-  const currentCaretIcon = React.useMemo(() => {
-    if (!props.direction || !props.closedCaretDirection) {
-      return;
-    }
-    return props.isExpanded ? iconForDirection(props.direction) : iconForDirection(props.closedCaretDirection);
-  }, [iconForDirection, props.closedCaretDirection, props.direction, props.isExpanded]);
-
-  const caretIconPosition = React.useMemo(() => {
-    const position: "left" | "right" = switchExpression(props.contentDirection ?? props.closedCaretDirection, {
-      down: "right",
-      up: "left",
-      left: "left",
-      right: "right",
-      default: "right",
-    });
-    return position;
-  }, [props.closedCaretDirection, props.contentDirection]);
-
-  return (
-    <Flex
-      direction={{ default: caretIconPosition === "left" ? "row" : "rowReverse" }}
-      alignItems={{ default: "alignItemsFlexEnd" }}
-      spaceItems={{ default: "spaceItemsXs" }}
-      aria-expanded={props.isExpanded}
-      aria-controls={props.contentId}
-      onClick={(ev) => {
-        props.onToggle?.(!props.isExpanded);
-        ev.stopPropagation();
-      }}
-      flexWrap={{ default: "nowrap" }}
-      title={props.title}
-    >
-      {currentCaretIcon && <FlexItem grow={{ default: "grow" }}>{currentCaretIcon}</FlexItem>}
-      <FlexItem>{props.children}</FlexItem>
-      <FlexItem>{props.icon}</FlexItem>
-    </Flex>
   );
 };

--- a/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -146,6 +146,7 @@ export function GitStatusIndicator(
             alignItems={{ default: "alignItemsCenter" }}
             onClick={(e) => {
               e.stopPropagation();
+              e.preventDefault();
             }}
           >
             <FlexItem>

--- a/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -28,7 +28,6 @@ import { SecurityIcon } from "@patternfly/react-icons/dist/js/icons/security-ico
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import { useNavigationBlocker, useRoutes } from "../../navigation/Hooks";
 import { matchPath } from "react-router";
-import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
 import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { switchExpression } from "../../switchExpression/switchExpression";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
@@ -41,12 +40,13 @@ import { FileModificationStatus } from "@kie-tools-core/workspaces-git-fs/dist/s
 /**
  * Indicates current git sync status either for whole Workspace or a particular WorkspaceFile, depending on the provided properties.
  */
-export function GitStatusIndicator(props: {
-  gitStatusProps: GitStatusProps;
-  workspaceFile?: WorkspaceFile;
-  children?: JSX.Element;
-  isHoverable?: boolean;
-}) {
+export function GitStatusIndicator(
+  props: React.PropsWithChildren<{
+    gitStatusProps: GitStatusProps;
+    workspaceFile?: WorkspaceFile;
+    isHoverable?: boolean;
+  }>
+) {
   // We use this trick to prevent the icon from blinking while updating.
   const prev = usePrevious(props.gitStatusProps.workspaceGitStatusPromise?.data);
 
@@ -64,21 +64,21 @@ export function GitStatusIndicator(props: {
 
     const tooltipForStageStatus = (stageStatus?: FileModificationStatus) => {
       const modifiedTooltip = (
-        <Tooltip content={"Modified."} position={"bottom"}>
+        <Tooltip content={"Modified"} position={"bottom"}>
           <small>
             <i>M</i>
           </small>
         </Tooltip>
       );
       const deletedTooltip = (
-        <Tooltip content={"Deleted file."} position={"bottom"}>
+        <Tooltip content={"Deleted"} position={"bottom"}>
           <small>
             <i>D</i>
           </small>
         </Tooltip>
       );
       const addedTooltip = (
-        <Tooltip content={"New file."} position={"bottom"}>
+        <Tooltip content={"Added"} position={"bottom"}>
           <small>
             <i>A</i>
           </small>
@@ -148,8 +148,8 @@ export function GitStatusIndicator(props: {
             flexWrap={{ default: "nowrap" }}
             spaceItems={{ default: "spaceItemsSm" }}
             alignItems={{ default: "alignItemsCenter" }}
-            onClick={(ev) => {
-              ev.stopPropagation();
+            onClick={(e) => {
+              e.stopPropagation();
             }}
           >
             <FlexItem>

--- a/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -31,11 +31,7 @@ import { matchPath } from "react-router";
 import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { switchExpression } from "../../switchExpression/switchExpression";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
-import {
-  GitStatusIndicatorActions,
-  GitStatusIndicatorActionVariant,
-  GitStatusProps,
-} from "./GitStatusIndicatorActions";
+import { GitStatusIndicatorActions, GitStatusProps } from "./GitStatusIndicatorActions";
 import { FileModificationStatus } from "@kie-tools-core/workspaces-git-fs/dist/services/GitService";
 /**
  * Indicates current git sync status either for whole Workspace or a particular WorkspaceFile, depending on the provided properties.
@@ -177,6 +173,7 @@ export function WorkspaceStatusIndicator(props: {
   gitStatusProps: GitStatusProps;
   currentWorkspaceFile: WorkspaceFile;
   onDeletedWorkspaceFile: () => void;
+  workspaceFiles: WorkspaceFile[];
 }) {
   const routes = useRoutes();
   const [isActionsDropdownOpen, setActionsDropdownOpen] = React.useState(false);
@@ -218,13 +215,12 @@ export function WorkspaceStatusIndicator(props: {
   return (
     <GitStatusIndicator gitStatusProps={props.gitStatusProps} isHoverable={!isActionsDropdownOpen}>
       <GitStatusIndicatorActions
-        variant={GitStatusIndicatorActionVariant.dropdown}
         isOpen={isActionsDropdownOpen}
         setOpen={setActionsDropdownOpen}
         currentWorkspaceFile={props.currentWorkspaceFile}
         onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
         gitStatusProps={props.gitStatusProps}
-        expandDirection={"right"}
+        workspaceFiles={props.workspaceFiles}
       />
     </GitStatusIndicator>
   );

--- a/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import * as React from "react";
-import { ActiveWorkspace } from "@kie-tools-core/workspaces-git-fs/dist/model/ActiveWorkspace";
-import { useWorkspaceGitStatusPromise } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
-import { useCallback, useMemo } from "react";
-import { WorkspaceKind } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceOrigin";
-import { PromiseStateWrapper } from "@kie-tools-core/react-hooks/dist/PromiseState";
+import { WorkspaceGitStatusType } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspaceHooks";
+import { useCallback } from "react";
+import {
+  isGitBasedWorkspaceKind,
+  WorkspaceKind,
+} from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceOrigin";
 import { usePrevious } from "@kie-tools-core/react-hooks/dist/usePrevious";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
@@ -28,15 +28,93 @@ import { SecurityIcon } from "@patternfly/react-icons/dist/js/icons/security-ico
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import { useNavigationBlocker, useRoutes } from "../../navigation/Hooks";
 import { matchPath } from "react-router";
-import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
+import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
+import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
+import { switchExpression } from "../../switchExpression/switchExpression";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
+import {
+  GitStatusIndicatorActions,
+  GitStatusIndicatorActionVariant,
+  GitStatusProps,
+} from "./GitStatusIndicatorActions";
+import { FileModificationStatus } from "@kie-tools-core/workspaces-git-fs/dist/services/GitService";
+/**
+ * Indicates current git sync status either for whole Workspace or a particular WorkspaceFile, depending on the provided properties.
+ */
+export function GitStatusIndicator(props: {
+  gitStatusProps: GitStatusProps;
+  workspaceFile?: WorkspaceFile;
+  children?: JSX.Element;
+  isHoverable?: boolean;
+}) {
+  // We use this trick to prevent the icon from blinking while updating.
+  const prev = usePrevious(props.gitStatusProps.workspaceGitStatusPromise?.data);
 
-function Indicator(props: { workspace: ActiveWorkspace; isSynced: boolean; hasLocalChanges: boolean }) {
+  const localChangesStatus = React.useMemo(() => {
+    return resolveGitLocalChangesStatus({
+      workspaceGitStatus: props.gitStatusProps.workspaceGitStatusPromise?.data ?? prev,
+      file: props.workspaceFile,
+    });
+  }, [prev, props]);
+
+  const indicatorTooltip = React.useMemo(() => {
+    if (!props.gitStatusProps.workspaceGitStatusPromise?.data?.hasLocalChanges) {
+      return [];
+    }
+
+    const tooltipForStageStatus = (stageStatus?: FileModificationStatus) => {
+      const modifiedTooltip = (
+        <Tooltip content={"Modified."} position={"bottom"}>
+          <small>
+            <i>M</i>
+          </small>
+        </Tooltip>
+      );
+      const deletedTooltip = (
+        <Tooltip content={"Deleted file."} position={"bottom"}>
+          <small>
+            <i>D</i>
+          </small>
+        </Tooltip>
+      );
+      const addedTooltip = (
+        <Tooltip content={"New file."} position={"bottom"}>
+          <small>
+            <i>A</i>
+          </small>
+        </Tooltip>
+      );
+      return switchExpression(stageStatus, {
+        added: addedTooltip,
+        modified: modifiedTooltip,
+        deleted: deletedTooltip,
+        default: <></>,
+      });
+    };
+    return props.workspaceFile
+      ? tooltipForStageStatus(
+          props.gitStatusProps.workspaceGitStatusPromise?.data?.unstagedModifiedFilesStatus.find(
+            ({ path }) => path === props.workspaceFile?.relativePath
+          )?.status
+        )
+      : tooltipForStageStatus(FileModificationStatus.modified);
+  }, [
+    props.gitStatusProps.workspaceGitStatusPromise?.data?.hasLocalChanges,
+    props.gitStatusProps.workspaceGitStatusPromise?.data?.unstagedModifiedFilesStatus,
+    props.workspaceFile,
+  ]);
+
   return (
-    <Flex flexWrap={{ default: "nowrap" }} spaceItems={{ default: "spaceItemsMd" }}>
-      {(props.workspace.descriptor.origin.kind === WorkspaceKind.GITHUB_GIST ||
-        props.workspace.descriptor.origin.kind === WorkspaceKind.GIT) && (
-        <>
-          {(!props.isSynced && (
+    <Flex
+      flexWrap={{ default: "nowrap" }}
+      spaceItems={{ default: "spaceItemsMd" }}
+      className={"kie-tools--git-status-indicator"}
+    >
+      {(isGitBasedWorkspaceKind(props.gitStatusProps.workspaceDescriptor.origin.kind) ||
+        props.gitStatusProps.workspaceDescriptor.origin.kind === WorkspaceKind.LOCAL) &&
+        !props.workspaceFile &&
+        switchExpression(resolveGitSyncStatus(props.gitStatusProps.workspaceGitStatusPromise?.data ?? prev), {
+          pending: (
             <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
               <Tooltip content={`There are new changes since your last sync.`} position={"bottom"}>
                 <small>
@@ -44,7 +122,8 @@ function Indicator(props: { workspace: ActiveWorkspace; isSynced: boolean; hasLo
                 </small>
               </Tooltip>
             </Title>
-          )) || (
+          ),
+          synced: (
             <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
               <Tooltip content={`All files are synced.`} position={"bottom"}>
                 <small>
@@ -52,37 +131,64 @@ function Indicator(props: { workspace: ActiveWorkspace; isSynced: boolean; hasLo
                 </small>
               </Tooltip>
             </Title>
-          )}
-        </>
-      )}
-      {props.hasLocalChanges && (
-        <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
-          <Tooltip content={"You have local changes."} position={"bottom"}>
-            <small>
-              <i>M</i>
-            </small>
-          </Tooltip>
-        </Title>
-      )}
+          ),
+          unknown: (
+            <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
+              <Tooltip content={"Checking status..."} position={"right"}>
+                <small>
+                  <OutlinedClockIcon color={"gray"} />
+                </small>
+              </Tooltip>
+            </Title>
+          ),
+        })}
+      {switchExpression(localChangesStatus, {
+        pending: (
+          <Flex
+            flexWrap={{ default: "nowrap" }}
+            spaceItems={{ default: "spaceItemsSm" }}
+            alignItems={{ default: "alignItemsCenter" }}
+            onClick={(ev) => {
+              ev.stopPropagation();
+            }}
+          >
+            <FlexItem>
+              <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
+                <Flex spaceItems={{ default: "spaceItemsXs" }} direction={{ default: "row" }}>
+                  {indicatorTooltip}
+                </Flex>
+              </Title>
+            </FlexItem>
+            <FlexItem
+              alignSelf={{ default: "alignSelfCenter" }}
+              className={props.isHoverable ? "kie-tools--git-status-indicator-children-hoverable" : ""}
+            >
+              {props.children}
+            </FlexItem>
+          </Flex>
+        ),
+        default: <></>,
+      })}
     </Flex>
   );
 }
 
-export function WorkspaceStatusIndicator(props: { workspace: ActiveWorkspace }) {
+export function WorkspaceStatusIndicator(props: {
+  gitStatusProps: GitStatusProps;
+  currentWorkspaceFile: WorkspaceFile;
+  onDeletedWorkspaceFile: () => void;
+}) {
   const routes = useRoutes();
-  const workspaceGitStatusPromise = useWorkspaceGitStatusPromise(props.workspace);
+  const [isActionsDropdownOpen, setActionsDropdownOpen] = React.useState(false);
 
-  const isEverythingPersistedByTheUser = useMemo(() => {
-    return (
-      workspaceGitStatusPromise.data &&
-      workspaceGitStatusPromise.data.isSynced &&
-      !workspaceGitStatusPromise.data.hasLocalChanges
-    );
-  }, [workspaceGitStatusPromise]);
+  const isEverythingPersistedByTheUser =
+    props.gitStatusProps.workspaceGitStatusPromise &&
+    props.gitStatusProps.workspaceGitStatusPromise.data?.isSynced &&
+    !props.gitStatusProps.workspaceGitStatusPromise.data?.hasLocalChanges;
 
   // Prevent from navigating away
   useNavigationBlocker(
-    `block-navigation-for-${props.workspace.descriptor.workspaceId}`,
+    `block-navigation-for-${props.gitStatusProps.workspaceDescriptor.workspaceId}`,
     useCallback(
       ({ location }) => {
         const match = matchPath<{ workspaceId: string }>(location.pathname, {
@@ -96,46 +202,91 @@ export function WorkspaceStatusIndicator(props: { workspace: ActiveWorkspace }) 
           }),
         });
 
-        if (match?.params.workspaceId === props.workspace.descriptor.workspaceId) {
+        if (match?.params.workspaceId === props.gitStatusProps.workspaceDescriptor.workspaceId) {
           return false;
         }
 
         return !isEverythingPersistedByTheUser;
       },
-      [routes, isEverythingPersistedByTheUser, props.workspace.descriptor.workspaceId]
+      [
+        routes.workspaceWithFilePath,
+        props.gitStatusProps.workspaceDescriptor.workspaceId,
+        isEverythingPersistedByTheUser,
+      ]
     )
   );
-
-  // We use this trick to prevent the icon from blinking while updating.
-  const prev = usePrevious(workspaceGitStatusPromise);
-
   return (
-    <PromiseStateWrapper
-      promise={workspaceGitStatusPromise}
-      pending={
-        <>
-          {(prev?.data && (
-            <Indicator
-              workspace={props.workspace}
-              hasLocalChanges={prev.data.hasLocalChanges}
-              isSynced={prev.data.isSynced}
-            />
-          )) || (
-            <Flex flexWrap={{ default: "nowrap" }} spaceItems={{ default: "spaceItemsNone" }}>
-              <Title headingLevel={"h6"} style={{ display: "inline", cursor: "default" }}>
-                <Tooltip content={"Checking status..."} position={"right"}>
-                  <small>
-                    <OutlinedClockIcon color={"gray"} />
-                  </small>
-                </Tooltip>
-              </Title>
-            </Flex>
-          )}
-        </>
-      }
-      resolved={({ hasLocalChanges, isSynced }) => (
-        <Indicator workspace={props.workspace} hasLocalChanges={hasLocalChanges} isSynced={isSynced} />
-      )}
-    />
+    <GitStatusIndicator gitStatusProps={props.gitStatusProps} isHoverable={!isActionsDropdownOpen}>
+      <GitStatusIndicatorActions
+        variant={GitStatusIndicatorActionVariant.dropdown}
+        isOpen={isActionsDropdownOpen}
+        setOpen={setActionsDropdownOpen}
+        currentWorkspaceFile={props.currentWorkspaceFile}
+        onDeletedWorkspaceFile={props.onDeletedWorkspaceFile}
+        gitStatusProps={props.gitStatusProps}
+        expandDirection={"right"}
+      />
+    </GitStatusIndicator>
   );
 }
+
+export enum WorkspaceGitSyncStatus {
+  synced = "synced",
+  unknown = "unknown",
+  pending = "pending",
+}
+
+export enum WorkspaceGitLocalChangesStatus {
+  synced = "synced",
+  unknown = "unknown",
+  pending = "pending",
+}
+
+export const resolveGitLocalChangesStatus = (args: {
+  workspaceGitStatus?: WorkspaceGitStatusType;
+  file?: WorkspaceFile;
+}) => {
+  if (args.workspaceGitStatus === undefined) {
+    return WorkspaceGitLocalChangesStatus.unknown;
+  }
+
+  if (args.file) {
+    return args.workspaceGitStatus.unstagedModifiedFilesStatus.some(
+      (stageStatus) => stageStatus.path === args.file?.relativePath
+    )
+      ? WorkspaceGitLocalChangesStatus.pending
+      : WorkspaceGitLocalChangesStatus.synced;
+  }
+
+  return args.workspaceGitStatus.hasLocalChanges
+    ? WorkspaceGitLocalChangesStatus.pending
+    : WorkspaceGitLocalChangesStatus.synced;
+};
+
+export const resolveGitSyncStatus = (workspaceGitStatus?: WorkspaceGitStatusType) => {
+  if (workspaceGitStatus === undefined) {
+    return WorkspaceGitSyncStatus.unknown;
+  }
+
+  return workspaceGitStatus.isSynced ? WorkspaceGitSyncStatus.synced : WorkspaceGitSyncStatus.pending;
+};
+
+/**
+ * Based on Git status, returns files that were removed from repository, but changes not yet commited.
+ * @returns array of WorkspaceFile instances with empty file contents
+ */
+export const listDeletedFiles = (args: GitStatusProps) => {
+  if (!args.workspaceGitStatusPromise.data) {
+    return [];
+  }
+
+  return args.workspaceGitStatusPromise.data.unstagedModifiedFilesStatus
+    .filter((stageStatusEntry) => stageStatusEntry.status === FileModificationStatus.deleted)
+    .map((status) => {
+      return new WorkspaceFile({
+        workspaceId: args.workspaceDescriptor.workspaceId,
+        relativePath: status.path,
+        getFileContents: () => Promise.resolve(new Uint8Array()),
+      });
+    });
+};

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -698,11 +698,6 @@ section.kie-tools--settings-tab {
 .kie-tools--git-status-indicator:hover .kie-tools--git-status-indicator-children-hoverable {
   visibility: visible;
 }
-/* GitStatusIndicatorActions dropdown render*/
-.kie-tools--git-status-indicator .kie-tools--no-whitespace-dropdown-toggle {
-  --pf-c-dropdown__toggle--PaddingLeft: 0;
-  --pf-c-dropdown__toggle-icon--MarginLeft: 0;
-}
 /* GitStatusIndicatorActions popover render */
 
 /* remove padding so that inline alert fills whole popover */

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -657,9 +657,6 @@ section.kie-tools--settings-tab {
 }
 
 /* FilesMenu */
-.kie-sandbox--files-menu.pf-c-menu.pf-m-drilldown > .pf-c-menu__content {
-  overflow-y: auto;
-}
 
 .kie-sandbox--files-menu .kie-sandbox--files-menu--label {
   --kie-sandbox--files-menu--title-padding: var(--pf-global--spacer--md);
@@ -702,50 +699,22 @@ section.kie-tools--settings-tab {
   visibility: visible;
 }
 /* GitStatusIndicatorActions dropdown render*/
-.kie-tools--git-status-indicator .pf-c-dropdown__toggle.kie-tools--no-whitespace-dropdown-toggle {
+.kie-tools--git-status-indicator .kie-tools--no-whitespace-dropdown-toggle {
   --pf-c-dropdown__toggle--PaddingLeft: 0;
   --pf-c-dropdown__toggle-icon--MarginLeft: 0;
 }
-.pf-c-dropdown__menu-item.kie-tools--alert-dropdown-item .pf-c-alert__description {
-  white-space: normal; /* override pf-c-dropdown__menu-item no-wrap*/
-  min-width: 200px;
-}
-.kie-tools--alert-dropdown-item {
-  display: flex;
-  align-items: baseline;
-  cursor: default;
-}
-.kie-tools--alert-dropdown-item .pf-c-alert {
-  display: flex;
-  flex-direction: column;
-}
-.kie-tools--alert-dropdown-item .pf-c-alert__action-group {
-  display: flex;
-  flex-direction: row;
-  align-self: flex-end;
-}
-.kie-tools--alert-dropdown-item .pf-c-alert__description {
-  white-space: normal;
-  min-width: 200px;
-}
-.kie-tools--alert-dropdown-right .kie-tools--alert-dropdown-item {
-  flex-direction: row-reverse;
-}
-.kie-tools--alert-dropdown-left .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
-  flex-direction: column;
-  align-items: flex-start;
-}
-.kie-tools--alert-dropdown-right .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
-  flex-direction: column;
-  align-items: flex-end;
-}
 /* GitStatusIndicatorActions popover render */
-.pf-c-popover[data-popper-placement="left"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded,
-.pf-c-popover[data-popper-placement="top"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded,
-.pf-c-popover[data-popper-placement="top-end"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
-  flex-direction: column;
-  align-items: flex-start;
-  display: flex;
+
+/* Override styles from PopoverMenu.css which were hiding the close popover button */
+.kie-tools--git-status-indicator__popover > .pf-c-popover__content > .pf-c-button {
+  display: inline-block;
+  z-index: 9999;
+}
+
+/* remove padding so that inline alert fills whole popover */
+.kie-tools--git-status-indicator__popover-no-padding > .pf-c-popover__content,
+.kie-tools--git-status-indicator__popover-no-padding > .pf-c-popover__content > .pf-c-popover__body {
+  padding: 0;
 }
 .kie-sandbox--files-menu .kie-tools--git-status-indicator button {
   /* For the padding not to mess with surrounding layout */

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -655,3 +655,99 @@ section.kie-tools--settings-tab {
 .pf-c-menu__item-description {
   word-break: normal !important;
 }
+
+/* FilesMenu */
+.kie-sandbox--files-menu.pf-c-menu.pf-m-drilldown > .pf-c-menu__content > .pf-c-menu__group {
+  overflow-y: auto;
+}
+.kie-sandbox--files-menu .kie-sandbox--files-menu--label {
+  --kie-sandbox--files-menu--title-padding: var(--pf-global--spacer--md);
+  padding-left: var(--kie-sandbox--files-menu--title-padding);
+  padding-right: var(--kie-sandbox--files-menu--title-padding);
+}
+
+.kie-sandbox--files-menu .pf-c-menu__group-title {
+  display: none;
+}
+
+/* FileSwitcher menu items display mode */
+.kie-tools--file-list-item-enabled a,
+.kie-tools--file-list-item-deleted a,
+.kie-tools--file-list-item-readonly a {
+  text-decoration: none;
+  color: var(--pf-global--Color--100);
+}
+
+.kie-tools--file-list-item-enabled {
+  cursor: pointer;
+}
+.kie-tools--file-list-item-enabled:hover .pf-c-content {
+  text-decoration: underline;
+}
+.kie-tools--file-list-item-deleted {
+  cursor: not-allowed;
+}
+
+.kie-tools--file-list-item-readonly:hover {
+  cursor: default;
+}
+
+/* GitStatusIndicator, GitStatusIndicatorActions */
+/* GitStatusIndicatorActions hoverable */
+.kie-tools--git-status-indicator-children-hoverable {
+  visibility: hidden;
+}
+.kie-tools--git-status-indicator:hover .kie-tools--git-status-indicator-children-hoverable {
+  visibility: visible;
+}
+/* GitStatusIndicatorActions dropdown render*/
+.kie-tools--git-status-indicator .pf-c-dropdown__toggle.kie-tools--no-whitespace-dropdown-toggle {
+  --pf-c-dropdown__toggle--PaddingLeft: 0;
+  --pf-c-dropdown__toggle-icon--MarginLeft: 0;
+}
+.pf-c-dropdown__menu-item.kie-tools--alert-dropdown-item .pf-c-alert__description {
+  white-space: normal; /* override pf-c-dropdown__menu-item no-wrap*/
+  min-width: 200px;
+}
+.kie-tools--alert-dropdown-item {
+  display: flex;
+  align-items: baseline;
+  cursor: default;
+}
+.kie-tools--alert-dropdown-item .pf-c-alert {
+  display: flex;
+  flex-direction: column;
+}
+.kie-tools--alert-dropdown-item .pf-c-alert__action-group {
+  display: flex;
+  flex-direction: row;
+  align-self: flex-end;
+}
+.kie-tools--alert-dropdown-item .pf-c-alert__description {
+  white-space: normal;
+  min-width: 200px;
+}
+.kie-tools--alert-dropdown-right .kie-tools--alert-dropdown-item {
+  flex-direction: row-reverse;
+}
+.kie-tools--alert-dropdown-left .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
+  flex-direction: column;
+  align-items: flex-start;
+}
+.kie-tools--alert-dropdown-right .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
+  flex-direction: column;
+  align-items: flex-end;
+}
+/* GitStatusIndicatorActions popover render */
+.pf-c-popover[data-popper-placement="left"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded,
+.pf-c-popover[data-popper-placement="top"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded,
+.pf-c-popover[data-popper-placement="top-end"] .pf-c-alert.kie-tools--git-status-indicator-actions-alert-expanded {
+  flex-direction: column;
+  align-items: flex-start;
+  display: flex;
+}
+.kie-sandbox--files-menu .kie-tools--git-status-indicator button {
+  /* For the padding not to mess with surrounding layout */
+  margin-top: -4px;
+  margin-bottom: -4px;
+}

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -705,12 +705,6 @@ section.kie-tools--settings-tab {
 }
 /* GitStatusIndicatorActions popover render */
 
-/* Override styles from PopoverMenu.css which were hiding the close popover button */
-.kie-tools--git-status-indicator__popover > .pf-c-popover__content > .pf-c-button {
-  display: inline-block;
-  z-index: 9999;
-}
-
 /* remove padding so that inline alert fills whole popover */
 .kie-tools--git-status-indicator__popover-no-padding > .pf-c-popover__content,
 .kie-tools--git-status-indicator__popover-no-padding > .pf-c-popover__content > .pf-c-popover__body {

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -657,9 +657,10 @@ section.kie-tools--settings-tab {
 }
 
 /* FilesMenu */
-.kie-sandbox--files-menu.pf-c-menu.pf-m-drilldown > .pf-c-menu__content > .pf-c-menu__group {
+.kie-sandbox--files-menu.pf-c-menu.pf-m-drilldown > .pf-c-menu__content {
   overflow-y: auto;
 }
+
 .kie-sandbox--files-menu .kie-sandbox--files-menu--label {
   --kie-sandbox--files-menu--title-padding: var(--pf-global--spacer--md);
   padding-left: var(--kie-sandbox--files-menu--title-padding);

--- a/packages/serverless-logic-web-tools/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/serverless-logic-web-tools/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -69,7 +69,7 @@ function Indicator(props: { workspace: ActiveWorkspace; isSynced: boolean; hasLo
 
 export function WorkspaceStatusIndicator(props: { workspace: ActiveWorkspace }) {
   const routes = useRoutes();
-  const workspaceGitStatusPromise = useWorkspaceGitStatusPromise(props.workspace);
+  const workspaceGitStatusPromise = useWorkspaceGitStatusPromise(props.workspace.descriptor);
 
   const isEverythingPersistedByTheUser = useMemo(() => {
     return (

--- a/packages/workspaces-git-fs/src/context/WorkspacesContext.tsx
+++ b/packages/workspaces-git-fs/src/context/WorkspacesContext.tsx
@@ -29,6 +29,7 @@ import { decoder } from "../encoderdecoder/EncoderDecoder";
 import { parseWorkspaceFileRelativePath } from "../relativePath/WorkspaceFileRelativePathParser";
 import { WorkspacesSharedWorker } from "../worker/WorkspacesSharedWorker";
 import { GitServerRef } from "../worker/api/GitServerRef";
+import { UnstagedModifiedFilesStatusEntryType } from "../services/GitService";
 
 export class WorkspaceFile {
   private readonly parsedRelativePath;
@@ -132,6 +133,8 @@ export interface WorkspacesContextType {
 
   checkout(args: { workspaceId: string; ref: string; remote: string }): Promise<void>;
 
+  checkoutFilesFromLocalHead(args: { workspaceId: string; ref?: string; filepaths?: string[] }): Promise<void>;
+
   addRemote(args: { workspaceId: string; name: string; url: string; force: boolean }): Promise<void>;
 
   deleteRemote(args: { workspaceId: string; name: string }): Promise<void>;
@@ -147,6 +150,8 @@ export interface WorkspacesContextType {
   }): Promise<GitServerRef[]>;
 
   hasLocalChanges(args: { workspaceId: string }): Promise<boolean>;
+
+  getUnstagedModifiedFilesStatus(args: { workspaceId: string }): Promise<UnstagedModifiedFilesStatusEntryType[]>;
 
   isFileModified(args: { workspaceId: string; relativePath: string }): Promise<boolean>;
 

--- a/packages/workspaces-git-fs/src/context/WorkspacesContextProvider.tsx
+++ b/packages/workspaces-git-fs/src/context/WorkspacesContextProvider.tsx
@@ -67,6 +67,14 @@ export function WorkspacesContextProvider(props: Props) {
     [workspacesSharedWorker]
   );
 
+  const getUnstagedModifiedFilesStatus = useCallback(
+    async (args: { workspaceId: string }) =>
+      workspacesSharedWorker.withBus((workspacesWorkerBus) =>
+        workspacesWorkerBus.clientApi.requests.kieSandboxWorkspacesGit_getUnstagedModifiedFilesStatus(args)
+      ),
+    [workspacesSharedWorker]
+  );
+
   const pull = useCallback(
     async (args: {
       workspaceId: string;
@@ -133,6 +141,14 @@ export function WorkspacesContextProvider(props: Props) {
     async (args: { workspaceId: string; ref: string; remote: string }) =>
       workspacesSharedWorker.withBus((workspacesWorkerBus) =>
         workspacesWorkerBus.clientApi.requests.kieSandboxWorkspacesGit_checkout(args)
+      ),
+    [workspacesSharedWorker]
+  );
+
+  const checkoutFilesFromLocalHead = useCallback(
+    async (args: { workspaceId: string; ref?: string; filepaths: string[] }) =>
+      workspacesSharedWorker.withBus((workspacesWorkerBus) =>
+        workspacesWorkerBus.clientApi.requests.kieSandboxWorkspacesGit_checkoutFilesFromLocalHead(args)
       ),
     [workspacesSharedWorker]
   );
@@ -503,10 +519,12 @@ export function WorkspacesContextProvider(props: Props) {
       push,
       branch,
       checkout,
+      checkoutFilesFromLocalHead,
       fetch,
       resolveRef,
       getFiles,
       hasLocalChanges,
+      getUnstagedModifiedFilesStatus,
       moveFile,
       addEmptyFile,
       addFile,
@@ -541,6 +559,7 @@ export function WorkspacesContextProvider(props: Props) {
       getFiles,
       getUniqueFileIdentifier,
       hasLocalChanges,
+      getUnstagedModifiedFilesStatus,
       moveFile,
       prepareZip,
       pull,
@@ -549,6 +568,7 @@ export function WorkspacesContextProvider(props: Props) {
       push,
       branch,
       checkout,
+      checkoutFilesFromLocalHead,
       fetch,
       resolveRef,
       renameFile,

--- a/packages/workspaces-git-fs/src/hooks/WorkspaceFileHooks.tsx
+++ b/packages/workspaces-git-fs/src/hooks/WorkspaceFileHooks.tsx
@@ -96,6 +96,9 @@ export function useWorkspaceFilePromise(workspaceId: string | undefined, relativ
             if (data.type === "WS_PULL") {
               refresh(workspaceId, relativePath, canceled);
             }
+            if (data.type === "WS_CHECKOUT_FILES_FROM_LOCAL_HEAD" && data.relativePaths.includes(relativePath)) {
+              refresh(workspaceId, relativePath, canceled);
+            }
           };
 
           return () => {

--- a/packages/workspaces-git-fs/src/hooks/WorkspaceHooks.tsx
+++ b/packages/workspaces-git-fs/src/hooks/WorkspaceHooks.tsx
@@ -23,48 +23,62 @@ import { GIT_ORIGIN_REMOTE_NAME } from "../constants/GitConstants";
 import { WorkspaceBroadcastEvents } from "../worker/api/WorkspaceBroadcastEvents";
 import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancelableEffect";
 import { Holder } from "@kie-tools-core/react-hooks/dist/Holder";
+import { WorkspaceDescriptor } from "../worker/api/WorkspaceDescriptor";
+import { UnstagedModifiedFilesStatusEntryType } from "../services/GitService";
 
-export function useWorkspaceGitStatusPromise(workspace: ActiveWorkspace | undefined) {
+export type WorkspaceGitStatusType = {
+  hasLocalChanges: boolean;
+  unstagedModifiedFilesStatus: UnstagedModifiedFilesStatusEntryType[];
+  isSynced: boolean;
+};
+
+export function useWorkspaceGitStatusPromise(workspaceDescriptor: WorkspaceDescriptor | undefined) {
   const workspaces = useWorkspaces();
-  const [isModifiedPromise, setModifiedPromise] = usePromiseState<{ hasLocalChanges: boolean; isSynced: boolean }>();
+  const [isModifiedPromise, setModifiedPromise] = usePromiseState<WorkspaceGitStatusType>();
 
   const refresh = useCallback(
     async (canceled: Holder<boolean>) => {
       setModifiedPromise({ loading: true });
 
-      if (!workspace) {
+      if (!workspaceDescriptor) {
         return;
       }
 
-      const hasLocalChanges = await workspaces.hasLocalChanges({ workspaceId: workspace.descriptor.workspaceId });
+      const unstagedModifiedFilesStatus = await workspaces.getUnstagedModifiedFilesStatus({
+        workspaceId: workspaceDescriptor.workspaceId,
+      });
+
+      const hasLocalChanges = unstagedModifiedFilesStatus.length > 0;
       if (canceled.get()) {
         return;
       }
 
-      if (workspace.descriptor.origin.kind === WorkspaceKind.LOCAL) {
-        setModifiedPromise({ data: { hasLocalChanges, isSynced: true } });
+      if (workspaceDescriptor.origin.kind === WorkspaceKind.LOCAL) {
+        setModifiedPromise({ data: { hasLocalChanges, unstagedModifiedFilesStatus, isSynced: true } });
         return;
       }
 
-      if (isGitBasedWorkspaceKind(workspace.descriptor.origin.kind)) {
+      if (isGitBasedWorkspaceKind(workspaceDescriptor.origin.kind)) {
         const head = await workspaces.resolveRef({
-          workspaceId: workspace.descriptor.workspaceId,
+          workspaceId: workspaceDescriptor.workspaceId,
           ref: "HEAD",
         });
 
         const remote = await workspaces.resolveRef({
-          workspaceId: workspace.descriptor.workspaceId,
-          ref: `${GIT_ORIGIN_REMOTE_NAME}/${workspace.descriptor.origin.branch}`,
+          workspaceId: workspaceDescriptor.workspaceId,
+          ref: `${GIT_ORIGIN_REMOTE_NAME}/${workspaceDescriptor.origin.branch}`,
         });
 
         if (canceled.get()) {
           return;
         }
 
-        setModifiedPromise({ data: { hasLocalChanges, isSynced: head === remote } });
+        setModifiedPromise({
+          data: { hasLocalChanges, unstagedModifiedFilesStatus, isSynced: head === remote },
+        });
       }
     },
-    [workspace, workspaces, setModifiedPromise]
+    [setModifiedPromise, workspaceDescriptor, workspaces]
   );
 
   useCancelableEffect(

--- a/packages/workspaces-git-fs/src/services/GitService.tsx
+++ b/packages/workspaces-git-fs/src/services/GitService.tsx
@@ -68,6 +68,15 @@ export interface RemoteRefArgs {
   };
 }
 
+export enum FileModificationStatus {
+  added = "added",
+  modified = "modified",
+  deleted = "deleted",
+}
+export type UnstagedModifiedFilesStatusEntryType = {
+  path: string;
+  status: FileModificationStatus;
+};
 export class GitService {
   public constructor(private readonly corsProxy: Promise<string>) {}
 
@@ -155,6 +164,22 @@ export class GitService {
       dir: args.dir,
       ref: args.ref,
       remote: args.remote,
+    });
+  }
+
+  public async checkoutFilesFromLocalHead(args: {
+    fs: KieSandboxWorkspacesFs;
+    dir: string;
+    ref?: string;
+    filepaths: string[];
+  }) {
+    await git.checkout({
+      fs: args.fs,
+      dir: args.dir,
+      ref: args.ref,
+      filepaths: args.filepaths,
+      noUpdateHead: true,
+      force: true,
     });
   }
 
@@ -319,15 +344,15 @@ export class GitService {
   }
 
   async hasLocalChanges(args: { fs: KieSandboxWorkspacesFs; dir: string; exclude: (filepath: string) => boolean }) {
-    const files = await this.unstagedModifiedFileRelativePaths(args);
+    const files = await this.unstagedModifiedFilesStatus(args);
     return files.length > 0;
   }
 
-  public async unstagedModifiedFileRelativePaths(args: {
+  public async unstagedModifiedFilesStatus(args: {
     fs: KieSandboxWorkspacesFs;
     dir: string;
     exclude: (filepath: string) => boolean;
-  }): Promise<string[]> {
+  }): Promise<UnstagedModifiedFilesStatusEntryType[]> {
     const now = performance.now();
     console.time(`${now}: hasLocalChanges`);
     const pseudoStatusMatrix = await git.walk({
@@ -374,7 +399,26 @@ export class GitService {
     const _WORKDIR = 2;
     const _STAGE = 3;
     const _FILE = 0;
-    const ret = pseudoStatusMatrix.filter((row: any) => row[_WORKDIR] !== row[_STAGE]).map((row: any) => row[_FILE]);
+    const ret = pseudoStatusMatrix
+      .filter((row: any) => row[_WORKDIR] !== row[_STAGE]) // filter differences with staged state
+      .map((row: any[]) => {
+        // if both _WORKDIR and _STAGE are set, the file is staged and modified (from above filter)
+        // if _WORKDIR is set only, it means the file is not yet staged
+        // if _STAGE is set only, it means the file has been deleted in workspace
+        let status: FileModificationStatus;
+        if (row[_WORKDIR] && !row[_STAGE]) {
+          status = FileModificationStatus.added;
+        } else if (!row[_WORKDIR] && row[_STAGE]) {
+          status = FileModificationStatus.deleted;
+        } else {
+          status = FileModificationStatus.modified;
+        }
+        const result: UnstagedModifiedFilesStatusEntryType = {
+          path: row[_FILE],
+          status,
+        };
+        return result;
+      });
     console.timeEnd(`${now}: hasLocalChanges`);
     return ret;
   }

--- a/packages/workspaces-git-fs/src/services/WorkspaceDescriptorService.tsx
+++ b/packages/workspaces-git-fs/src/services/WorkspaceDescriptorService.tsx
@@ -55,11 +55,6 @@ export class WorkspaceDescriptorService {
       lastUpdatedDateISO: new Date().toISOString(),
     });
     await this.storageService.updateFile(fs, file.path, file.getFileContents);
-
-    new Broadcaster().broadcast({
-      channel: workspaceId,
-      message: async () => ({ type: "WS_UPDATE_DESCRIPTOR" }),
-    });
   }
 
   public async get(fs: KieSandboxWorkspacesFs, workspaceId: string): Promise<WorkspaceDescriptor> {

--- a/packages/workspaces-git-fs/src/worker/api/WorkspaceBroadcastEvents.ts
+++ b/packages/workspaces-git-fs/src/worker/api/WorkspaceBroadcastEvents.ts
@@ -18,6 +18,7 @@ export type WorkspaceBroadcastEvents =
   | { type: "WS_ADD"; workspaceId: string }
   | { type: "WS_CREATE_SAVE_POINT"; workspaceId: string }
   | { type: "WS_PULL"; workspaceId: string }
+  | { type: "WS_CHECKOUT_FILES_FROM_LOCAL_HEAD"; workspaceId: string; relativePaths: string[] }
   | { type: "WS_RENAME"; workspaceId: string }
   | { type: "WS_DELETE"; workspaceId: string }
   | { type: "WS_ADD_FILE"; relativePath: string }

--- a/packages/workspaces-git-fs/src/worker/api/WorkspacesWorkerGitApi.ts
+++ b/packages/workspaces-git-fs/src/worker/api/WorkspacesWorkerGitApi.ts
@@ -19,6 +19,7 @@ import { BitbucketOrigin, GistOrigin, GitHubOrigin, SnippetOrigin } from "./Work
 import { LocalFile } from "./LocalFile";
 import { WorkspaceWorkerFileDescriptor } from "./WorkspaceWorkerFileDescriptor";
 import { GitServerRef } from "./GitServerRef";
+import { UnstagedModifiedFilesStatusEntryType } from "../../services/GitService";
 
 export interface WorkspacesWorkerGitApi {
   kieSandboxWorkspacesGit_getGitServerRefs(args: {
@@ -92,6 +93,12 @@ export interface WorkspacesWorkerGitApi {
 
   kieSandboxWorkspacesGit_checkout(args: { workspaceId: string; ref: string; remote: string }): Promise<void>;
 
+  kieSandboxWorkspacesGit_checkoutFilesFromLocalHead(args: {
+    workspaceId: string;
+    ref?: string;
+    filepaths: string[];
+  }): Promise<void>;
+
   kieSandboxWorkspacesGit_addRemote(args: {
     workspaceId: string;
     name: string;
@@ -101,7 +108,9 @@ export interface WorkspacesWorkerGitApi {
 
   kieSandboxWorkspacesGit_deleteRemote(args: { workspaceId: string; name: string }): Promise<void>;
 
-  kieSandboxWorkspacesGit_getUnstagedModifiedFileRelativePaths(args: { workspaceId: string }): Promise<string[]>;
+  kieSandboxWorkspacesGit_getUnstagedModifiedFilesStatus(args: {
+    workspaceId: string;
+  }): Promise<UnstagedModifiedFilesStatusEntryType[]>;
 
   kieSandboxWorkspacesGit_commit(args: {
     workspaceId: string;


### PR DESCRIPTION
Resolves kiegroup/kie-issues#85 .

New:
* FileSwitcher menuItems contain git status indicator (Modified, Deleted, Added) and a hoverable icon for reverting the change. On hover a popover appears with inline alert contents.
* New Component `GitStatusIndicatorActions.tsx` implements two variants of how actions are presented: popover vs. dropdown based design, details hidden under the component itself. It's passed to GitStatusIndicator.tsx as children.
* WorkspaceStatusIndicator contains statuses for all files in workspace, e.g. `M | A | D` in case there are files in such states.
* WorkspaceStatusIndicator contains a dropdown variant of the git actions.
* Implemented revert operation as checkout of files from HEAD using isomorphic-git in `GitService.ts`. Invoked through the GitStatusIndicatorActions.tsx passing
  * single file in FileSwitcher menu item
  * all modified files in WorkspaceStatusIndicator dropdown
* Introduced event type `WS_CHECKOUT_HEAD_FILES` to signal changes to the workspace itself. The message contains relativePaths to all the files that were processed - allows for checking if update of current Editor contents should be refreshed.

Noteworthy refactoring:
* FileSwitcher now shows also the active file, to be able to display git operations related just to the current file.
* FilesMenuItems component reused in HomePage.tsx - reduction of duplicated code and unification - it was not possible to show the files as SVG cards on HomePage before.
* `WorkspaceHooks.tsx` signature changed to `useWorkspaceGitStatusPromise(workspace: WorkspaceDescriptor | undefined)` to enable reusing in HomePage.tsx
* Workspace toolbar is shown also for Local WorkspaceKind now, it enables the additional git actions also for Local workspaces.