### PR TITLE
kie-issues#125: Remove unnecessary FieldName type from PMML Marshaller

### DIFF
--- a/packages/pmml-editor-marshaller/src/marshaller/Marshaller.ts
+++ b/packages/pmml-editor-marshaller/src/marshaller/Marshaller.ts
@@ -38,7 +38,7 @@ import { textModelFactory } from "./jsonata/json2ui/TextModel";
 import { timeSeriesModelFactory } from "./jsonata/json2ui/TimeSeriesModel";
 import { treeModelFactory } from "./jsonata/json2ui/TreeModel";
 import { UI2JSON_TRANSFORMATION as ui2json } from "./jsonata/UI2JSON";
-import { CompoundPredicate, False, FieldName, PMML, SimplePredicate, True } from "./model/pmml4_4";
+import { CompoundPredicate, False, PMML, SimplePredicate, True } from "./model/pmml4_4";
 
 export function XML2PMML(xml: string): PMML {
   const doc: XMLJS.Element = XMLJS.xml2js(xml) as XMLJS.Element;
@@ -124,7 +124,7 @@ function singletonArray(value: any): any[] {
 }
 
 function json2uiSimplePredicateFactory(): SimplePredicate {
-  return new SimplePredicate({ field: "" as FieldName, operator: "equal" });
+  return new SimplePredicate({ field: "", operator: "equal" });
 }
 
 function json2uiCompoundPredicateFactory(): CompoundPredicate {

--- a/packages/pmml-editor-marshaller/src/marshaller/jsonata/json2ui/BaselineModel.ts
+++ b/packages/pmml-editor-marshaller/src/marshaller/jsonata/json2ui/BaselineModel.ts
@@ -49,7 +49,7 @@ elements.elements[(name = "BaselineModel")] ~> $map(function($v, $i) {
 export function baselineModelFactory(): BaselineModel {
   return new BaselineModel({
     MiningSchema: new MiningSchema({ MiningField: [] }),
-    TestDistributions: new TestDistributions({ Baseline: {}, field: {}, testStatistic: "CUSUM" }),
+    TestDistributions: new TestDistributions({ Baseline: {}, field: "", testStatistic: "CUSUM" }),
     functionName: "regression",
   });
 }

--- a/packages/pmml-editor-marshaller/src/marshaller/jsonata/json2ui/NaiveBayesModel.ts
+++ b/packages/pmml-editor-marshaller/src/marshaller/jsonata/json2ui/NaiveBayesModel.ts
@@ -52,7 +52,7 @@ export function naiveBayesModelFactory(): NaiveBayesModel {
   return new NaiveBayesModel({
     MiningSchema: new MiningSchema({ MiningField: [] }),
     BayesInputs: { BayesInput: [] },
-    BayesOutput: { TargetValueCounts: { TargetValueCount: [] }, fieldName: {} },
+    BayesOutput: { TargetValueCounts: { TargetValueCount: [] }, fieldName: "" },
     threshold: 0,
     functionName: "regression",
   });

--- a/packages/pmml-editor-marshaller/src/marshaller/model/pmml4_4.ts
+++ b/packages/pmml-editor-marshaller/src/marshaller/model/pmml4_4.ts
@@ -30,9 +30,9 @@ export class Expression extends PMMLObject {
 
 export class Aggregate extends Expression {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   function: Function;
-  groupField?: FieldName;
+  groupField?: string;
   sqlWhere?: string;
 
   constructor(data: Aggregate) {
@@ -57,7 +57,7 @@ export class Annotation extends PMMLObject {
 export class Anova extends PMMLObject {
   Extension?: Extension[];
   AnovaRow: AnovaRow[];
-  target?: FieldName;
+  target?: string;
 
   constructor(data: Anova) {
     super(data);
@@ -197,7 +197,7 @@ export class BinarySimilarity extends Similarity {
 
 export class BlockIndicator extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
 
   constructor(data: BlockIndicator) {
     super(data);
@@ -495,7 +495,7 @@ export class DataField extends Field<DataField> {
   Extension?: Extension[];
   Interval?: Interval[];
   Value?: Value[];
-  name: FieldName;
+  name: string;
   displayName?: string;
   optype: OpType;
   dataType: DataType;
@@ -570,7 +570,7 @@ export class DerivedField extends Field<DerivedField> {
   expression?: Expression;
   Interval?: Interval[];
   Value?: Value[];
-  name?: FieldName;
+  name?: string;
   displayName?: string;
   optype: OpType;
   dataType: DataType;
@@ -610,7 +610,7 @@ export class DiscreteDistribution extends Distribution {
 export class Discretize extends Expression {
   Extension?: Extension[];
   DiscretizeBin?: DiscretizeBin[];
-  field: FieldName;
+  field: string;
   mapMissingTo?: any;
   defaultValue?: any;
   dataType?: DataType;
@@ -686,7 +686,7 @@ export class False extends Predicate {
 
 export class FieldColumnPair extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   column: string;
 
   constructor(data: FieldColumnPair) {
@@ -696,18 +696,9 @@ export class FieldColumnPair extends PMMLObject {
     this.column = data.column;
   }
 }
-
-export class FieldName {
-  value?: string;
-
-  constructor(data: FieldName) {
-    this.value = data.value;
-  }
-}
-
 export class FieldRef extends Expression {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   mapMissingTo?: string;
 
   constructor(data: FieldRef) {
@@ -811,7 +802,7 @@ export class Jaccard extends Similarity {
 export class Lag extends Expression {
   Extension?: Extension[];
   BlockIndicator?: BlockIndicator[];
-  field: FieldName;
+  field: string;
   n?: number;
   aggregate?: string;
 
@@ -955,7 +946,7 @@ export class MiningBuildTask extends PMMLObject {
 
 export class MiningField extends PMMLObject {
   Extension?: Extension[];
-  name: FieldName;
+  name: string;
   usageType?: UsageType;
   optype?: OpType;
   importance?: number;
@@ -1126,7 +1117,7 @@ export class NormContinuous extends Expression {
   Extension?: Extension[];
   LinearNorm: LinearNorm[];
   mapMissingTo?: number;
-  field: FieldName;
+  field: string;
   outliers?: OutlierTreatmentMethod;
 
   constructor(data: NormContinuous) {
@@ -1141,7 +1132,7 @@ export class NormContinuous extends Expression {
 
 export class NormDiscrete extends Expression {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   method?: Method;
   value: any;
   mapMissingTo?: number;
@@ -1206,12 +1197,12 @@ export class OutputField extends Field<OutputField> {
   Decisions?: Decisions;
   expression?: Expression;
   Value?: Value[];
-  name: FieldName;
+  name: string;
   displayName?: string;
   optype?: OpType;
   dataType: DataType;
-  targetField?: FieldName;
-  "x-reportField"?: FieldName;
+  targetField?: string;
+  "x-reportField"?: string;
   feature?: ResultFeature;
   value?: any;
   ruleFeature?: RuleFeature;
@@ -1274,7 +1265,7 @@ export class PMML extends PMMLObject {
 export interface PMMLFunctions {}
 
 export class ParameterField extends Field<ParameterField> {
-  name: FieldName;
+  name: string;
   optype?: OpType;
   dataType?: DataType;
   displayName?: string;
@@ -1308,7 +1299,7 @@ export class PartitionFieldStats extends PMMLObject {
   Counts?: Counts;
   NumericInfo?: NumericInfo;
   Array?: Array[];
-  field: FieldName;
+  field: string;
   weighted?: PartitionFieldStatsWeighted;
 
   constructor(data: PartitionFieldStats) {
@@ -1338,7 +1329,7 @@ export class PredictiveModelQuality extends PMMLObject {
   ConfusionMatrix?: ConfusionMatrix;
   LiftData?: LiftData[];
   ROC?: ROC;
-  targetField: FieldName;
+  targetField: string;
   dataName?: string;
   dataUsage?: DataUsage;
   meanError?: number;
@@ -1461,7 +1452,7 @@ export class RealSparseArray extends SparseArray<number> {
 
 export class ResultField extends Field<ResultField> {
   Extension?: Extension[];
-  name: FieldName;
+  name: string;
   displayName?: string;
   optype?: OpType;
   dataType?: DataType;
@@ -1517,7 +1508,7 @@ export class SimpleMatching extends Similarity {
 
 export class SimplePredicate extends Predicate {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   operator: SimplePredicateOperator;
   value?: any;
 
@@ -1533,7 +1524,7 @@ export class SimplePredicate extends Predicate {
 export class SimpleSetPredicate extends Predicate {
   Extension?: Extension[];
   Array: Array;
-  field: FieldName;
+  field: string;
   booleanOperator: SimpleSetPredicate$BooleanOperator;
 
   constructor(data: SimpleSetPredicate) {
@@ -1577,7 +1568,7 @@ export class Tanimoto extends Similarity {
 export class Target extends PMMLObject {
   Extension?: Extension[];
   TargetValue?: TargetValue[];
-  field?: FieldName;
+  field?: string;
   optype?: OpType;
   castInteger?: CastInteger;
   min?: number;
@@ -1646,7 +1637,7 @@ export class TextIndex extends Expression {
   Extension?: Extension[];
   TextIndexNormalization?: TextIndexNormalization[];
   expression?: Expression;
-  textField: FieldName;
+  textField: string;
   localTermWeights?: TextIndexLocalTermWeights;
   isCaseSensitive?: boolean;
   maxLevenshteinDistance?: number;
@@ -1749,7 +1740,7 @@ export class UnivariateStats extends PMMLObject {
   DiscrStats?: DiscrStats;
   ContStats?: ContStats;
   Anova?: Anova;
-  field?: FieldName;
+  field?: string;
   weighted?: UnivariateStatsWeighted;
 
   constructor(data: UnivariateStats) {
@@ -1782,7 +1773,7 @@ export class Value extends PMMLObject {
 
 export class VerificationField extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   column?: string;
   precision?: number;
   zeroThreshold?: number;
@@ -1958,7 +1949,7 @@ export class Item extends PMMLObject {
   Extension?: Extension[];
   id: string;
   value: string;
-  field?: FieldName;
+  field?: string;
   category?: string;
   mappedValue?: string;
   weight?: number;
@@ -2081,7 +2072,7 @@ export class FieldValue extends PMMLObject {
   Extension?: Extension[];
   FieldValue?: FieldValue[];
   FieldValueCount?: FieldValueCount[];
-  field: FieldName;
+  field: string;
   value: any;
 
   constructor(data: FieldValue) {
@@ -2096,7 +2087,7 @@ export class FieldValue extends PMMLObject {
 
 export class FieldValueCount extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   value: any;
   count: number;
 
@@ -2113,11 +2104,11 @@ export class TestDistributions extends PMMLObject {
   Extension?: Extension[];
   Baseline: Baseline;
   Alternate?: Alternate;
-  field: FieldName;
+  field: string;
   testStatistic: TestStatistic;
   resetValue?: number;
   windowSize?: number;
-  weightField?: FieldName;
+  weightField?: string;
   normalizationScheme?: string;
 
   constructor(data: TestDistributions) {
@@ -2220,7 +2211,7 @@ export class ContinuousNode extends PMMLObject {
   Extension?: Extension[];
   DerivedField?: DerivedField[];
   content?: PMMLObject[];
-  name: FieldName;
+  name: string;
   count?: number;
 
   constructor(data: ContinuousNode) {
@@ -2252,7 +2243,7 @@ export class DiscreteNode extends PMMLObject {
   Extension?: Extension[];
   DerivedField?: DerivedField[];
   content?: PMMLObject[];
-  name: FieldName;
+  name: string;
   count?: number;
 
   constructor(data: DiscreteNode) {
@@ -2315,7 +2306,7 @@ export class NormalDistribution extends PMMLObject {
 
 export class ParentValue extends PMMLObject {
   Extension?: Extension[];
-  parent: FieldName;
+  parent: string;
   value: any;
 
   constructor(data: ParentValue) {
@@ -2424,7 +2415,7 @@ export class Cluster extends Entity<string> {
 export class ClusteringField extends ComparisonField<ClusteringField> {
   Extension?: Extension[];
   Comparisons?: Comparisons;
-  field: FieldName;
+  field: string;
   isCenterField?: CenterField;
   fieldWeight?: number;
   similarityScale?: number;
@@ -2786,7 +2777,7 @@ export class GeneralRegressionModel extends Model {
   EventValues?: EventValues;
   BaseCumHazardTables?: BaseCumHazardTables;
   ModelVerification?: ModelVerification;
-  targetVariableName?: FieldName;
+  targetVariableName?: string;
   modelType: GeneralRegressionModelType;
   modelName?: string;
   functionName: MiningFunction;
@@ -2795,18 +2786,18 @@ export class GeneralRegressionModel extends Model {
   cumulativeLink?: CumulativeLinkFunction;
   linkFunction?: LinkFunction;
   linkParameter?: number;
-  trialsVariable?: FieldName;
+  trialsVariable?: string;
   trialsValue?: number;
   distribution?: GeneralRegressionModelDistribution;
   distParameter?: number;
-  offsetVariable?: FieldName;
+  offsetVariable?: string;
   offsetValue?: number;
   modelDF?: number;
-  endTimeVariable?: FieldName;
-  startTimeVariable?: FieldName;
-  subjectIDVariable?: FieldName;
-  statusVariable?: FieldName;
-  baselineStrataVariable?: FieldName;
+  endTimeVariable?: string;
+  startTimeVariable?: string;
+  subjectIDVariable?: string;
+  statusVariable?: string;
+  baselineStrataVariable?: string;
   isScorable?: boolean;
   "x-mathContext"?: MathContext;
 
@@ -2914,7 +2905,7 @@ export class PCovMatrix extends PMMLObject {
 export class PPCell extends ParameterCell {
   Extension?: Extension[];
   value: any;
-  predictorName: FieldName;
+  predictorName: string;
   parameterName: string;
   targetCategory?: any;
 
@@ -2980,7 +2971,7 @@ export class Predictor extends PMMLObject {
   Extension?: Extension[];
   Categories?: Categories;
   Matrix?: Matrix;
-  name: FieldName;
+  name: string;
   contrastMatrixType?: string;
 
   constructor(data: Predictor) {
@@ -3070,7 +3061,7 @@ export class Segmentation extends PMMLObject {
 
 export class VariableWeight extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
 
   constructor(data: VariableWeight) {
     super(data);
@@ -3084,7 +3075,7 @@ export class BayesInput extends PMMLObject {
   TargetValueStats?: TargetValueStats;
   DerivedField?: DerivedField;
   PairCounts?: PairCounts[];
-  fieldName: FieldName;
+  fieldName: string;
 
   constructor(data: BayesInput) {
     super(data);
@@ -3110,7 +3101,7 @@ export class BayesInputs extends PMMLObject {
 export class BayesOutput extends PMMLObject {
   Extension?: Extension[];
   TargetValueCounts: TargetValueCounts;
-  fieldName: FieldName;
+  fieldName: string;
 
   constructor(data: BayesOutput) {
     super(data);
@@ -3222,7 +3213,7 @@ export class TargetValueStats extends PMMLObject {
 
 export class InstanceField extends PMMLObject {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   column?: string;
 
   constructor(data: InstanceField) {
@@ -3246,7 +3237,7 @@ export class InstanceFields extends PMMLObject {
 
 export class KNNInput extends ComparisonField<KNNInput> {
   Extension?: Extension[];
-  field: FieldName;
+  field: string;
   fieldWeight?: number;
   compareFunction?: CompareFunction;
 
@@ -3288,7 +3279,7 @@ export class NearestNeighborModel extends Model {
   numberOfNeighbors: number;
   continuousScoringMethod?: ContinuousScoringMethod;
   categoricalScoringMethod?: CategoricalScoringMethod;
-  instanceIdVariable?: FieldName;
+  instanceIdVariable?: string;
   threshold?: number;
   isScorable?: boolean;
   "x-mathContext"?: MathContext;
@@ -3512,7 +3503,7 @@ export class Term extends PMMLObject {
 
 export class CategoricalPredictor extends Term {
   Extension?: Extension[];
-  name: FieldName;
+  name: string;
   value: any;
   coefficient: number;
 
@@ -3527,7 +3518,7 @@ export class CategoricalPredictor extends Term {
 
 export class NumericPredictor extends Term {
   Extension?: Extension[];
-  name: FieldName;
+  name: string;
   exponent?: number;
   coefficient: number;
 
@@ -3543,7 +3534,7 @@ export class NumericPredictor extends Term {
 export class PredictorTerm extends Term {
   Extension?: Extension[];
   FieldRef: FieldRef[];
-  name?: FieldName;
+  name?: string;
   coefficient: number;
 
   constructor(data: PredictorTerm) {
@@ -3598,7 +3589,7 @@ export class RegressionModel extends Model {
   functionName: MiningFunction;
   algorithmName?: string;
   modelType?: RegressionModelType;
-  targetFieldName?: FieldName;
+  targetFieldName?: string;
   normalizationMethod?: RegressionModelNormalizationMethod;
   isScorable?: boolean;
   "x-mathContext"?: MathContext;
@@ -4064,7 +4055,7 @@ export class SetPredicate extends PMMLObject {
   Extension?: Extension[];
   Array?: Array;
   id: string;
-  field: FieldName;
+  field: string;
   operator?: SetPredicateOperator;
 
   constructor(data: SetPredicate) {
@@ -4536,11 +4527,11 @@ export class DynamicRegressor extends PMMLObject {
   Numerator?: Numerator;
   Denominator?: Denominator;
   RegressorValues?: RegressorValues;
-  field: FieldName;
+  field: string;
   transformation?: string;
   delay?: number;
   futureValuesMethod?: string;
-  targetField?: FieldName;
+  targetField?: string;
 
   constructor(data: DynamicRegressor) {
     super(data);
@@ -5063,7 +5054,7 @@ export class TimeSeries extends PMMLObject {
   startTime?: number;
   endTime?: number;
   interpolationMethod?: InterpolationMethod;
-  field?: FieldName;
+  field?: string;
 
   constructor(data: TimeSeries) {
     super(data);

--- a/packages/pmml-editor-marshaller/tests/marshaller/DataDictionary.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/DataDictionary.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DataDictionary, DataField, FieldName, PMML, PMML2XML, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary, DataField, PMML, PMML2XML, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
 
 describe("DataDictionary tests", () => {
   test("Empty", () => {
@@ -46,7 +46,7 @@ describe("DataDictionary tests", () => {
 
     const dataDictionary: DataDictionary = pmml.DataDictionary;
     const dataField: DataField = new DataField({
-      name: "field1" as FieldName,
+      name: "field1",
       dataType: "string",
       optype: "categorical",
     });
@@ -77,7 +77,7 @@ describe("DataDictionary tests", () => {
     expect(dataDictionary.DataField[0].optype).toBe("categorical");
     expect(dataDictionary.DataField[0].dataType).toBe("string");
 
-    dataDictionary.DataField[0].name = "field1-changed" as FieldName;
+    dataDictionary.DataField[0].name = "field1-changed";
     dataDictionary.DataField[0].optype = "continuous";
     dataDictionary.DataField[0].dataType = "integer";
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/Scorecard.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/Scorecard.test.ts
@@ -21,7 +21,6 @@ import {
   CompoundPredicate,
   DataDictionary,
   False,
-  FieldName,
   MiningField,
   Model,
   Output,
@@ -195,22 +194,22 @@ describe("Scorecard tests", () => {
     const characteristic1Attributes: Attribute[] = characteristics[1].Attribute as Attribute[];
 
     assertSimplePredicate(characteristic0Attributes[0].predicate, {
-      field: "input1" as FieldName,
+      field: "input1",
       operator: "lessOrEqual",
       value: "10",
     });
     assertSimplePredicate(characteristic0Attributes[1].predicate, {
-      field: "input1" as FieldName,
+      field: "input1",
       operator: "greaterThan",
       value: "10",
     });
     assertSimplePredicate(characteristic1Attributes[0].predicate, {
-      field: "input2" as FieldName,
+      field: "input2",
       operator: "lessOrEqual",
       value: "-5",
     });
     assertSimplePredicate(characteristic1Attributes[1].predicate, {
-      field: "input2" as FieldName,
+      field: "input2",
       operator: "greaterThan",
       value: "-5",
     });
@@ -224,7 +223,7 @@ describe("Scorecard tests", () => {
     const characteristic0Attributes: Attribute[] = characteristics[0].Attribute as Attribute[];
 
     assertSimplePredicate(characteristic0Attributes[0].predicate, {
-      field: "input1" as FieldName,
+      field: "input1",
       operator: "lessOrEqual",
       value: "10",
     });
@@ -277,14 +276,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic0Attributes[0].predicate, { booleanOperator: "and" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input1" as FieldName,
+          field: "input1",
           operator: "lessOrEqual",
           value: "-5",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input2" as FieldName,
+          field: "input2",
           operator: "lessOrEqual",
           value: "-5",
         });
@@ -295,14 +294,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic0Attributes[1].predicate, { booleanOperator: "and" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input1" as FieldName,
+          field: "input1",
           operator: "greaterThan",
           value: "-5",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input2" as FieldName,
+          field: "input2",
           operator: "greaterThan",
           value: "-5",
         });
@@ -318,14 +317,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic1Attributes[0].predicate, { booleanOperator: "or" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input3" as FieldName,
+          field: "input3",
           operator: "equal",
           value: "classA",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input4" as FieldName,
+          field: "input4",
           operator: "equal",
           value: "classA",
         });
@@ -336,14 +335,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic1Attributes[1].predicate, { booleanOperator: "or" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input3" as FieldName,
+          field: "input3",
           operator: "equal",
           value: "classB",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input4" as FieldName,
+          field: "input4",
           operator: "equal",
           value: "classB",
         });
@@ -358,14 +357,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic2Attributes[0].predicate, { booleanOperator: "xor" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input3" as FieldName,
+          field: "input3",
           operator: "equal",
           value: "classA",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input4" as FieldName,
+          field: "input4",
           operator: "equal",
           value: "classA",
         });
@@ -412,14 +411,14 @@ describe("Scorecard tests", () => {
           },
           (cp: Predicate) => {
             assertSimplePredicate(cp, {
-              field: "input1" as FieldName,
+              field: "input1",
               operator: "greaterThan",
               value: "-15",
             });
           },
           (cp: Predicate) => {
             assertSimplePredicate(cp, {
-              field: "input1" as FieldName,
+              field: "input1",
               operator: "lessOrEqual",
               value: "25.4",
             });
@@ -428,7 +427,7 @@ describe("Scorecard tests", () => {
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input2" as FieldName,
+          field: "input2",
           operator: "notEqual",
           value: "classA",
         });
@@ -443,14 +442,14 @@ describe("Scorecard tests", () => {
     assertCompoundPredicate(characteristic1Attributes[0].predicate, { booleanOperator: "or" }, [
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input1" as FieldName,
+          field: "input1",
           operator: "lessOrEqual",
           value: "-20",
         });
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input2" as FieldName,
+          field: "input2",
           operator: "equal",
           value: "classA",
         });
@@ -465,14 +464,14 @@ describe("Scorecard tests", () => {
             assertCompoundPredicate(cp, { booleanOperator: "and" }, [
               (cp2: Predicate) => {
                 assertSimplePredicate(cp2, {
-                  field: "input1" as FieldName,
+                  field: "input1",
                   operator: "greaterOrEqual",
                   value: "5",
                 });
               },
               (cp2: Predicate) => {
                 assertSimplePredicate(cp2, {
-                  field: "input1" as FieldName,
+                  field: "input1",
                   operator: "lessThan",
                   value: "12",
                 });
@@ -481,7 +480,7 @@ describe("Scorecard tests", () => {
           },
           (cp: Predicate) => {
             assertSimplePredicate(cp, {
-              field: "input2" as FieldName,
+              field: "input2",
               operator: "equal",
               value: "classB",
             });
@@ -490,7 +489,7 @@ describe("Scorecard tests", () => {
       },
       (predicate: Predicate) => {
         assertSimplePredicate(predicate, {
-          field: "input2" as FieldName,
+          field: "input2",
           operator: "equal",
           value: "classC",
         });
@@ -624,13 +623,13 @@ describe("Scorecard tests", () => {
     expect(Object.getPrototypeOf(miningSchema)).toBe(Object.prototype);
     expect(Object.getPrototypeOf(miningFields)).toBe(Array.prototype);
     expect(Object.getPrototypeOf(miningFields[0])).toBe(Object.prototype);
-    miningFields.push({ name: "mf" as FieldName });
+    miningFields.push({ name: "mf" });
     expect(Object.getPrototypeOf(miningFields[1])).toBe(Object.prototype);
 
     expect(Object.getPrototypeOf(output)).toBe(Object.prototype);
     expect(Object.getPrototypeOf(outputFields)).toBe(Array.prototype);
     expect(Object.getPrototypeOf(outputFields[0])).toBe(Object.prototype);
-    outputFields.push({ name: "mf" as FieldName, dataType: "string" });
+    outputFields.push({ name: "mf", dataType: "string" });
     expect(Object.getPrototypeOf(outputFields[1])).toBe(Object.prototype);
 
     expect(Object.getPrototypeOf(characteristics)).toBe(Object.prototype);

--- a/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryHandler/DataDictionaryHandler.tsx
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/DataDictionaryHandler/DataDictionaryHandler.tsx
@@ -23,7 +23,7 @@ import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/M
 import { Title, TitleSizes } from "@patternfly/react-core/dist/js/components/Title";
 import { CloseIcon } from "@patternfly/react-icons/dist/js/icons/close-icon";
 import { WarningTriangleIcon } from "@patternfly/react-icons/dist/js/icons/warning-triangle-icon";
-import { DataDictionary, FieldName, PMML } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary, PMML } from "@kie-tools/pmml-editor-marshaller";
 import { Actions } from "../../../reducers";
 import DataDictionaryContainer, { DDDataField } from "../DataDictionaryContainer/DataDictionaryContainer";
 import { convertPMML2DD, convertToDataField } from "../dataDictionaryUtils";
@@ -95,7 +95,7 @@ const DataDictionaryHandler = () => {
       payload: {
         dataDictionaryIndex: index,
         dataField: convertToDataField(field),
-        originalName: originalName as FieldName,
+        originalName: originalName,
       },
     });
   };

--- a/packages/pmml-editor/src/editor/components/DataDictionary/dataDictionaryUtils.ts
+++ b/packages/pmml-editor/src/editor/components/DataDictionary/dataDictionaryUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Closure, DataDictionary, DataField, FieldName, Interval } from "@kie-tools/pmml-editor-marshaller";
+import { Closure, DataDictionary, DataField, Interval } from "@kie-tools/pmml-editor-marshaller";
 import { ConstraintType, DDDataField } from "./DataDictionaryContainer/DataDictionaryContainer";
 
 export const convertPMML2DD = (PMMLDataDictionary: DataDictionary | undefined): DDDataField[] => {
@@ -29,7 +29,7 @@ export const convertPMML2DD = (PMMLDataDictionary: DataDictionary | undefined): 
 
 export const convertToDataField = (item: DDDataField): DataField => {
   const convertedField: DataField = {
-    name: item.name as FieldName,
+    name: item.name,
     dataType: item.type,
     optype: item.optype,
   };

--- a/packages/pmml-editor/src/editor/components/EditorCore/molecules/EditorHeader.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorCore/molecules/EditorHeader.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import DataDictionaryHandler from "../../DataDictionary/DataDictionaryHandler/DataDictionaryHandler";
 import { OutputsHandler } from "../../Outputs/organisms";
-import { FieldName, MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
 import MiningSchemaHandler from "../../MiningSchema/MiningSchemaHandler/MiningSchemaHandler";
 import "./EditorHeader.scss";
 
@@ -30,7 +30,7 @@ interface EditorHeaderViewerProps {
 interface EditorHeaderEditorProps extends EditorHeaderViewerProps {
   output?: Output;
   miningSchema?: MiningSchema;
-  validateOutputFieldName: (index: number | undefined, name: FieldName) => boolean;
+  validateOutputFieldName: (index: number | undefined, name: string) => boolean;
   deleteOutputField: (index: number) => void;
   commitOutputField: (index: number | undefined, outputField: OutputField) => void;
   commitModelName: (modelName: string) => void;

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/PredicateConverter.ts
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/organisms/PredicateConverter.ts
@@ -19,7 +19,6 @@ import {
   DataField,
   DataType,
   False,
-  FieldName,
   Predicate,
   SimplePredicate,
   SimplePredicateOperator,
@@ -39,15 +38,11 @@ const SimplePredicateOperatorMap: Map<SimplePredicateOperator, string> = new Map
 ]);
 
 export const toText = (predicate: Predicate | undefined, fields: DataField[]): string => {
-  const fieldToDataType: Map<FieldName, DataType> = new Map(fields.map((field) => [field.name, field.dataType]));
+  const fieldToDataType: Map<string, DataType> = new Map(fields.map((field) => [field.name, field.dataType]));
   return _toText(predicate, fieldToDataType, 0);
 };
 
-const _toText = (
-  predicate: Predicate | undefined,
-  fieldToDataType: Map<FieldName, DataType>,
-  nesting: number
-): string => {
+const _toText = (predicate: Predicate | undefined, fieldToDataType: Map<string, DataType>, nesting: number): string => {
   if (predicate instanceof True) {
     return "True";
   } else if (predicate instanceof False) {
@@ -87,13 +82,13 @@ const FalsePredicate = () => {
   return predicate;
 };
 
-const UnarySimplePredicate = (field: FieldName, operator: SimplePredicateOperator) => {
+const UnarySimplePredicate = (field: string, operator: SimplePredicateOperator) => {
   const predicate: SimplePredicate = new SimplePredicate({ field: field, operator: operator });
   (predicate as any)._type = "SimplePredicate";
   return predicate;
 };
 
-const BinarySimplePredicate = (field: FieldName, operator: SimplePredicateOperator, value: any) => {
+const BinarySimplePredicate = (field: string, operator: SimplePredicateOperator, value: any) => {
   const predicate: SimplePredicate = new SimplePredicate({ field: field, operator: operator, value: value });
   (predicate as any)._type = "SimplePredicate";
   return predicate;
@@ -109,7 +104,7 @@ const SimpleCompoundPredicate = (
   return predicate;
 };
 
-const _value = (field: FieldName, value: any, fieldToDataType: Map<FieldName, DataType>): string => {
+const _value = (field: string, value: any, fieldToDataType: Map<string, DataType>): string => {
   if (value === undefined) {
     return "";
   }
@@ -156,13 +151,13 @@ export const fromText = (text: string | undefined): Predicate | undefined => {
 
   const unaryMatches = regUnaryOperator.exec(text);
   if (unaryMatches !== null) {
-    return UnarySimplePredicate(unaryMatches[1] as FieldName, unaryMatches[2] as SimplePredicateOperator);
+    return UnarySimplePredicate(unaryMatches[1], unaryMatches[2] as SimplePredicateOperator);
   }
 
   const binaryMatches = regBinaryOperator.exec(text);
   if (binaryMatches !== null) {
     return BinarySimplePredicate(
-      binaryMatches[1] as FieldName,
+      binaryMatches[1],
       _operator(binaryMatches[2]) as SimplePredicateOperator,
       binaryMatches[3]
     );

--- a/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorScorecard/templates/ScorecardEditorPage.tsx
@@ -19,7 +19,6 @@ import { PageSection, PageSectionVariants } from "@patternfly/react-core/dist/js
 import { EditorHeader } from "../../EditorCore/molecules";
 import {
   Characteristics,
-  FieldName,
   MiningSchema,
   Model,
   Output,
@@ -61,7 +60,7 @@ export const ScorecardEditorPage = (props: ScorecardEditorPageProps) => {
   const output: Output | undefined = useMemo(() => model?.Output, [model]);
 
   const validateOutputName = useCallback(
-    (index: number | undefined, name: FieldName): boolean => {
+    (index: number | undefined, name: string): boolean => {
       if (name.toString().trim().length === 0) {
         return false;
       }

--- a/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
+++ b/packages/pmml-editor/src/editor/components/LinearRegressionViewer/molecules/LinearRegressionViewAdaptor.tsx
@@ -18,7 +18,6 @@ import {
   CategoricalPredictor,
   DataDictionary,
   DataField,
-  FieldName,
   Interval,
   MiningField,
   MiningSchema,
@@ -137,7 +136,7 @@ const getXRange = (dataDictionary: DataDictionary, numericPredictor: NumericPred
   return getIntervalsMaximumRange(predictorFieldIntervals);
 };
 
-const getMiningFieldIntervals = (dataDictionary: DataDictionary, fieldName: FieldName): Interval[] => {
+const getMiningFieldIntervals = (dataDictionary: DataDictionary, fieldName: string): Interval[] => {
   const dataFields: DataField[] = dataDictionary.DataField.filter(
     (df) => df.name === fieldName && df.optype === "continuous"
   );

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.tsx
@@ -28,7 +28,7 @@ import MiningSchemaAddFields from "../MiningSchemaAddFields/MiningSchemaAddField
 import MiningSchemaPropertiesEdit from "../MiningSchemaPropertiesEdit/MiningSchemaPropertiesEdit";
 import "./MiningSchemaContainer.scss";
 
-import { DataDictionary, FieldName, MiningField, MiningSchema } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary, MiningField, MiningSchema } from "@kie-tools/pmml-editor-marshaller";
 import { useValidationRegistry } from "../../../validation";
 import { Builder } from "../../../paths";
 import { Interaction } from "../../../types";
@@ -40,7 +40,7 @@ interface MiningSchemaContainerProps {
   miningSchema?: MiningSchema;
   onAddField: (name: string[]) => void;
   onDeleteField: (index: number) => void;
-  onUpdateField: (index: number, originalName: FieldName | undefined, field: MiningField) => void;
+  onUpdateField: (index: number, originalName: string | undefined, field: MiningField) => void;
 }
 
 const MiningSchemaContainer = (props: MiningSchemaContainerProps) => {

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaFields/MiningSchemaFields.tsx
@@ -140,7 +140,7 @@ const MiningSchemaItem: React.FC<MiningSchemaFieldProps> = (props) => {
           data-ouia-component-id={field.name}
           data-ouia-component-type="edit-mining-field-row-"
           className={`editable-item ${editing === index ? "editable-item--editing" : ""}`}
-          key={field.name.value}
+          key={field.name}
           ref={ref}
           tabIndex={0}
           onKeyDown={(event) => {
@@ -175,7 +175,7 @@ const MiningSchemaItem: React.FC<MiningSchemaFieldProps> = (props) => {
           data-ouia-component-id={field.name}
           data-ouia-component-type="mining-field-row"
           className={`editable-item ${editing === index ? "editable-item--editing" : ""}`}
-          key={field.name.value}
+          key={field.name}
           onClick={(event) => handleEdit(event)}
           ref={ref}
           tabIndex={0}

--- a/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaHandler/MiningSchemaHandler.tsx
+++ b/packages/pmml-editor/src/editor/components/MiningSchema/MiningSchemaHandler/MiningSchemaHandler.tsx
@@ -23,7 +23,7 @@ import { Title, TitleSizes } from "@patternfly/react-core/dist/js/components/Tit
 import { CloseIcon } from "@patternfly/react-icons/dist/js/icons/close-icon";
 import { WarningTriangleIcon } from "@patternfly/react-icons/dist/js/icons/warning-triangle-icon";
 import MiningSchemaContainer from "../MiningSchemaContainer/MiningSchemaContainer";
-import { DataDictionary, FieldName, MiningField, MiningSchema, PMML } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary, MiningField, MiningSchema, PMML } from "@kie-tools/pmml-editor-marshaller";
 import { useSelector } from "react-redux";
 import { Actions } from "../../../reducers";
 import { useBatchDispatch, useHistoryService } from "../../../history";
@@ -68,7 +68,7 @@ const MiningSchemaHandler = (props: MiningSchemaHandlerProps) => {
     // }
   };
 
-  const updateField = (index: number, originalName: FieldName | undefined, field: MiningField) => {
+  const updateField = (index: number, originalName: string | undefined, field: MiningField) => {
     dispatch({
       type: Actions.UpdateMiningSchemaField,
       payload: {

--- a/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabels.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabels.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 import * as React from "react";
-import { FieldName, OpType, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
+import { OpType, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
 import { OutputFieldLabel } from "./OutputFieldLabel";
 import { ValidationEntry } from "../../../validation";
 import { ValidationIndicatorLabel } from "../../EditorCore/atoms";
 
 interface OutputLabelsProps {
   optype: OpType | undefined;
-  targetField: FieldName | undefined;
+  targetField: string | undefined;
   targetFieldValidation: ValidationEntry[];
   feature: ResultFeature | undefined;
   value: any | undefined;

--- a/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabelsEditMode.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/atoms/OutputLabelsEditMode.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 import { CSSProperties } from "react";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
-import { FieldName, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
+import { OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
 import { ArrowAltCircleRightIcon } from "@patternfly/react-icons/dist/js/icons/arrow-alt-circle-right-icon";
 import { OutputFieldLabel } from "./OutputFieldLabel";
 import { ValidationEntry } from "../../../validation";
@@ -25,8 +25,8 @@ import { ValidationIndicatorLabel } from "../../EditorCore/atoms";
 interface OutputLabelsEditModeProps {
   optype: OpType | undefined;
   setOptype: (optype: OpType | undefined) => void;
-  targetField: FieldName | undefined;
-  setTargetField: (targetField: FieldName | undefined) => void;
+  targetField: string | undefined;
+  setTargetField: (targetField: string | undefined) => void;
   targetFieldValidation: ValidationEntry[];
   feature: ResultFeature | undefined;
   setFeature: (feature: ResultFeature | undefined) => void;

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldEditRow.tsx
@@ -21,7 +21,7 @@ import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import { FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/js/components/Select";
 import "./OutputFieldRow.scss";
-import { DataType, FieldName, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
+import { DataType, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
 import { OutputLabelsEditMode } from "../atoms";
 import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
 import { ValidatedType } from "../../../types";
@@ -34,7 +34,7 @@ interface OutputFieldEditRowProps {
   modelIndex: number;
   outputField: OutputField;
   outputFieldIndex: number;
-  validateOutputName: (name: FieldName) => boolean;
+  validateOutputName: (name: string) => boolean;
   viewExtendedProperties: () => void;
   onCommitAndClose: () => void;
   onCommit: (partial: Partial<OutputField>) => void;
@@ -75,10 +75,10 @@ const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
 
   const { activeOperation } = useOperation();
 
-  const [name, setName] = useState<ValidatedType<FieldName>>({ value: "" as FieldName, valid: false });
+  const [name, setName] = useState<ValidatedType<string>>({ value: "", valid: false });
   const [dataType, setDataType] = useState<DataType>("boolean");
   const [optype, setOptype] = useState<OpType | undefined>();
-  const [targetField, setTargetField] = useState<FieldName | undefined>();
+  const [targetField, setTargetField] = useState<string | undefined>();
   const [feature, setFeature] = useState<ResultFeature | undefined>();
   const [value, setValue] = useState<any | undefined>();
   const [rank, setRank] = useState<number | undefined>();
@@ -166,14 +166,14 @@ const OutputFieldEditRow = (props: OutputFieldEditRowProps) => {
                   autoFocus={true}
                   onChange={(e) => {
                     setName({
-                      value: e as FieldName,
-                      valid: validateOutputName(e as FieldName),
+                      value: e,
+                      valid: validateOutputName(e),
                     });
                   }}
                   onBlur={(e) => {
                     if (name?.valid) {
                       onCommit({
-                        name: name.value as FieldName,
+                        name: name.value,
                       });
                     } else {
                       setName({

--- a/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/molecules/OutputFieldRow.tsx
@@ -18,7 +18,7 @@ import { BaseSyntheticEvent, useMemo } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
-import { DataType, FieldName, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
+import { DataType, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
 import { OutputFieldRowAction, OutputLabels } from "../atoms";
 import "./OutputFieldRow.scss";
 import { ValidationIndicator } from "../../EditorCore/atoms";
@@ -35,10 +35,10 @@ interface OutputFieldRowProps {
 }
 
 interface Values {
-  name: FieldName | undefined;
+  name: string | undefined;
   dataType: DataType | undefined;
   optype?: OpType;
-  targetField?: FieldName;
+  targetField?: string;
   feature?: ResultFeature;
   value?: any;
   rank?: number;

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldExtendedProperties.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldExtendedProperties.tsx
@@ -20,7 +20,7 @@ import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { Form, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/js/components/FormSelect";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
-import { FieldName, OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
+import { OpType, OutputField, RankOrder, ResultFeature } from "@kie-tools/pmml-editor-marshaller";
 import { GenericSelector, GenericSelectorOption } from "../../EditorScorecard/atoms";
 import { HelpIcon } from "@patternfly/react-icons/dist/js/icons/help-icon";
 import { useValidationRegistry } from "../../../validation";
@@ -38,7 +38,7 @@ export const OutputFieldExtendedProperties = (props: OutputFieldExtendedProperti
   const { activeOutputField, activeOutputFieldIndex, modelIndex, targetFields, commit } = props;
 
   const [optype, setOptype] = useState<OpType | undefined>();
-  const [targetField, setTargetField] = useState<FieldName | undefined>();
+  const [targetField, setTargetField] = useState<string | undefined>();
   const [feature, setFeature] = useState<ResultFeature | undefined>();
   const [value, setValue] = useState<any | undefined>();
   const [rank, setRank] = useState<number | undefined>();
@@ -181,9 +181,9 @@ export const OutputFieldExtendedProperties = (props: OutputFieldExtendedProperti
           id="output-targetField"
           value={(targetField ?? "").toString()}
           onChange={(selection) => {
-            if (selection !== targetField?.value) {
-              setTargetField(selection === "" ? undefined : (selection as FieldName));
-              commit({ targetField: selection === "" ? undefined : (selection as FieldName) });
+            if (selection !== targetField) {
+              setTargetField(selection === "" ? undefined : selection);
+              commit({ targetField: selection === "" ? undefined : selection });
             }
           }}
           isDisabled={!targetFieldsOptions.length}

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputFieldsTable.tsx
@@ -17,7 +17,7 @@ import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { Form } from "@patternfly/react-core/dist/js/components/Form";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
-import { FieldName, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { OutputField } from "@kie-tools/pmml-editor-marshaller";
 import { Operation, useOperation } from "../../EditorScorecard";
 import { EmptyStateNoOutput } from "./EmptyStateNoOutput";
 import OutputFieldRow from "../molecules/OutputFieldRow";
@@ -30,7 +30,7 @@ interface OutputFieldsTableProps {
   outputs: OutputField[];
   selectedOutputIndex: number | undefined;
   setSelectedOutputIndex: (index: number | undefined) => void;
-  validateOutputFieldName: (index: number | undefined, name: FieldName) => boolean;
+  validateOutputFieldName: (index: number | undefined, name: string) => boolean;
   viewExtendedProperties: () => void;
   onAddOutputField: () => void;
   onDeleteOutputField: (index: number) => void;
@@ -110,7 +110,7 @@ const OutputFieldsTable = (props: OutputFieldsTableProps) => {
     }
   };
 
-  const onValidateOutputFieldName = (index: number | undefined, nameToValidate: FieldName): boolean => {
+  const onValidateOutputFieldName = (index: number | undefined, nameToValidate: string): boolean => {
     return validateOutputFieldName(index, nameToValidate);
   };
 

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsContainer.tsx
@@ -26,7 +26,7 @@ import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { ArrowAltCircleLeftIcon } from "@patternfly/react-icons/dist/js/icons/arrow-alt-circle-left-icon";
 import { BoltIcon } from "@patternfly/react-icons/dist/js/icons/bolt-icon";
 import { PlusIcon } from "@patternfly/react-icons/dist/js/icons/plus-icon";
-import { FieldName, MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
 import { Actions } from "../../../reducers";
 import OutputFieldsTable from "./OutputFieldsTable";
 import OutputsBatchAdd from "./OutputsBatchAdd";
@@ -44,7 +44,7 @@ interface OutputsContainerProps {
   modelIndex: number;
   output?: Output;
   miningSchema?: MiningSchema;
-  validateOutputFieldName: (index: number | undefined, name: FieldName) => boolean;
+  validateOutputFieldName: (index: number | undefined, name: string) => boolean;
   deleteOutputField: (index: number) => void;
   commitOutputField: (index: number | undefined, outputField: OutputField) => void;
 }
@@ -94,7 +94,7 @@ export const OutputsContainer = (props: OutputsContainerProps) => {
     const numberOfOutputFields = output?.OutputField.length;
     if (numberOfOutputFields !== undefined) {
       const existingNames: string[] = output?.OutputField.map((of) => of.name.toString()) ?? [];
-      const newOutputFieldName: FieldName = findIncrementalName("New output", existingNames, 1) as FieldName;
+      const newOutputFieldName: string = findIncrementalName("New output", existingNames, 1);
       const newOutputField: OutputField = {
         name: newOutputFieldName,
         dataType: "string",

--- a/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsHandler.tsx
+++ b/packages/pmml-editor/src/editor/components/Outputs/organisms/OutputsHandler.tsx
@@ -21,7 +21,7 @@ import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/M
 import { Title, TitleSizes } from "@patternfly/react-core/dist/js/components/Title";
 import { CloseIcon } from "@patternfly/react-icons/dist/js/icons/close-icon";
 import { WarningTriangleIcon } from "@patternfly/react-icons/dist/js/icons/warning-triangle-icon";
-import { FieldName, MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { MiningSchema, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
 import { OutputsContainer } from "./OutputsContainer";
 import { Operation, useOperation } from "../../EditorScorecard";
 import { useValidationRegistry } from "../../../validation";
@@ -32,7 +32,7 @@ interface OutputsHandlerProps {
   modelIndex: number;
   output?: Output;
   miningSchema?: MiningSchema;
-  validateOutputFieldName: (index: number | undefined, name: FieldName) => boolean;
+  validateOutputFieldName: (index: number | undefined, name: string) => boolean;
   deleteOutputField: (index: number) => void;
   commitOutputField: (index: number | undefined, outputField: OutputField) => void;
 }

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryFieldReducer.ts
@@ -15,7 +15,7 @@
  */
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
-import { DataField, FieldName } from "@kie-tools/pmml-editor-marshaller";
+import { DataField } from "@kie-tools/pmml-editor-marshaller";
 import { Reducer } from "react";
 import {
   hasIntervals,
@@ -32,7 +32,7 @@ interface DataDictionaryFieldPayload {
     readonly modelIndex?: number;
     readonly dataDictionaryIndex: number;
     readonly dataField: DataField;
-    readonly originalName: FieldName;
+    readonly originalName: string;
   };
 }
 

--- a/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/DataDictionaryReducer.ts
@@ -15,7 +15,7 @@
  */
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
-import { DataDictionary, DataType, FieldName, OpType } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary, DataType, OpType } from "@kie-tools/pmml-editor-marshaller";
 import { Reducer } from "react";
 import { validateDataFields, ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
@@ -33,7 +33,7 @@ interface DataDictionaryPayload {
   };
   [Actions.AddBatchDataDictionaryFields]: {
     readonly modelIndex?: number;
-    readonly dataDictionaryFields: FieldName[];
+    readonly dataDictionaryFields: string[];
   };
   [Actions.ReorderDataDictionaryFields]: {
     readonly oldIndex: number;
@@ -52,7 +52,7 @@ export const DataDictionaryReducer: HistoryAwareValidatingReducer<DataDictionary
       case Actions.AddDataDictionaryField:
         historyService.batch(state, Builder().forDataDictionary().build(), (draft) => {
           draft.DataField.push({
-            name: action.payload.name as FieldName,
+            name: action.payload.name as string,
             dataType: action.payload.type,
             optype: action.payload.optype,
           });

--- a/packages/pmml-editor/src/editor/reducers/MiningSchemaFieldReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/MiningSchemaFieldReducer.ts
@@ -17,7 +17,6 @@ import { Reducer } from "react";
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
 import {
-  FieldName,
   InvalidValueTreatmentMethod,
   MiningField,
   MissingValueTreatmentMethod,
@@ -42,8 +41,8 @@ interface MiningSchemaFieldPayload {
   [Actions.UpdateMiningSchemaField]: {
     readonly modelIndex: number;
     readonly miningSchemaIndex: number;
-    readonly name: FieldName;
-    readonly originalName: FieldName | undefined;
+    readonly name: string;
+    readonly originalName: string | undefined;
     readonly usageType: UsageType | undefined;
     readonly optype: OpType | undefined;
     readonly importance: number | undefined;

--- a/packages/pmml-editor/src/editor/reducers/MiningSchemaReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/MiningSchemaReducer.ts
@@ -16,7 +16,7 @@
 import { Reducer } from "react";
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
-import { FieldName, MiningSchema } from "@kie-tools/pmml-editor-marshaller";
+import { MiningSchema } from "@kie-tools/pmml-editor-marshaller";
 import { ValidationRegistry } from "../validation";
 import { Builder } from "../paths";
 import { validateMiningFields } from "../validation/MiningSchema";
@@ -25,12 +25,12 @@ import { getMiningSchema } from "../PMMLModelHelper";
 interface MiningSchemaPayload {
   [Actions.AddMiningSchemaFields]: {
     readonly modelIndex: number;
-    readonly names: FieldName[];
+    readonly names: string[];
   };
   [Actions.DeleteMiningSchemaField]: {
     readonly modelIndex: number;
     readonly miningSchemaIndex: number;
-    readonly name?: FieldName;
+    readonly name?: string;
   };
 }
 

--- a/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/OutputReducer.ts
@@ -15,7 +15,7 @@
  */
 import { ActionMap, Actions, AllActions } from "./Actions";
 import { HistoryAwareValidatingReducer, HistoryService } from "../history";
-import { FieldName, Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { Output, OutputField } from "@kie-tools/pmml-editor-marshaller";
 import { Reducer } from "react";
 import { Builder } from "../paths";
 import { getCharacteristics, getMiningSchema, getOutputs } from "../PMMLModelHelper";
@@ -33,7 +33,7 @@ interface OutputPayload {
   };
   [Actions.AddBatchOutputs]: {
     readonly modelIndex: number;
-    readonly outputFields: FieldName[];
+    readonly outputFields: string[];
   };
 }
 

--- a/packages/pmml-editor/src/editor/reducers/ScorecardReducer.ts
+++ b/packages/pmml-editor/src/editor/reducers/ScorecardReducer.ts
@@ -19,7 +19,6 @@ import {
   BaselineMethod,
   CompoundPredicate,
   False,
-  FieldName,
   MiningFunction,
   Predicate,
   ReasonCodeAlgorithm,
@@ -381,8 +380,8 @@ export const ScorecardReducer: HistoryAwareValidatingReducer<Scorecard, AllActio
 const updatePredicateFieldName = (
   pathBuilder: PredicateBuilder,
   predicate: Predicate | undefined,
-  name: FieldName,
-  originalName: FieldName | undefined,
+  name: string,
+  originalName: string | undefined,
   service: HistoryService
 ) => {
   if (predicate === undefined) {

--- a/packages/pmml-editor/src/editor/validation/Attributes.ts
+++ b/packages/pmml-editor/src/editor/validation/Attributes.ts
@@ -18,7 +18,6 @@ import {
   Characteristic,
   CompoundPredicate,
   False,
-  FieldName,
   MiningField,
   Predicate,
   SimplePredicate,
@@ -120,7 +119,7 @@ export const validateAttributes = (
 const validatePredicate = (
   pathBuilder: PredicateBuilder,
   predicate: Predicate | undefined,
-  fieldNames: FieldName[],
+  fieldNames: string[],
   validationRegistry: ValidationRegistry
 ) => {
   if (predicate === undefined) {

--- a/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer.test.tsx
@@ -15,11 +15,10 @@
  */
 import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
-import { DataField, DataType, FieldName, MiningField } from "@kie-tools/pmml-editor-marshaller";
+import { DataField, MiningField } from "@kie-tools/pmml-editor-marshaller";
 import MiningSchemaContainer, {
   MiningSchemaContext,
 } from "../../../../../src/editor/components/MiningSchema/MiningSchemaContainer/MiningSchemaContainer";
-import { DDDataField } from "../../../../../src/editor/components/DataDictionary/DataDictionaryContainer/DataDictionaryContainer";
 
 const onAddField = jest.fn((name) => {});
 const onDeleteField = jest.fn((index) => {});
@@ -27,12 +26,12 @@ const onUpdateField = jest.fn((index, originalName, field) => {});
 
 const dataFields: DataField[] = [
   {
-    name: "field1" as FieldName,
+    name: "field1",
     optype: "categorical",
     dataType: "string",
   },
   {
-    name: "field2" as FieldName,
+    name: "field2",
     optype: "categorical",
     dataType: "string",
   },
@@ -47,10 +46,10 @@ beforeEach(() => {
 
   miningFields = [
     {
-      name: "field1" as FieldName,
+      name: "field1",
     },
     {
-      name: "field2" as FieldName,
+      name: "field2",
     },
   ];
 });

--- a/packages/pmml-editor/tests/editor/components/Outputs/organisms/OutputFieldsTable/OutputFieldsTable.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/Outputs/organisms/OutputFieldsTable/OutputFieldsTable.test.tsx
@@ -17,7 +17,7 @@ import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import { Operation, OperationContext } from "../../../../../../src/editor/components/EditorScorecard";
 import OutputFieldsTable from "../../../../../../src/editor/components/Outputs/organisms/OutputFieldsTable";
-import { FieldName, OutputField } from "@kie-tools/pmml-editor-marshaller";
+import { OutputField } from "@kie-tools/pmml-editor-marshaller";
 import { DataType } from "@kie-tools/pmml-editor-marshaller/src";
 
 const setSelectedOutputIndex = jest.fn((index) => {});
@@ -43,11 +43,11 @@ beforeEach(() => {
 
   outputs = [
     {
-      name: "output1" as FieldName,
+      name: "output1",
       dataType: "string" as DataType,
     },
     {
-      name: "output2" as FieldName,
+      name: "output2",
       dataType: "string" as DataType,
     },
   ];

--- a/packages/pmml-editor/tests/editor/reducers/DataDictionaryFieldReducer.test.ts
+++ b/packages/pmml-editor/tests/editor/reducers/DataDictionaryFieldReducer.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DataField, FieldName } from "@kie-tools/pmml-editor-marshaller";
+import { DataField } from "@kie-tools/pmml-editor-marshaller";
 import { Actions, AllActions, DataDictionaryFieldReducer } from "@kie-tools/pmml-editor/dist/editor/reducers";
 import { Reducer } from "react";
 import { HistoryService } from "@kie-tools/pmml-editor/dist/editor/history";
@@ -21,7 +21,7 @@ import { ValidationRegistry } from "@kie-tools/pmml-editor/dist/editor/validatio
 
 const historyService = new HistoryService([]);
 const validationRegistry = new ValidationRegistry();
-const dataFields: DataField[] = [{ name: "field1" as FieldName, dataType: "boolean", optype: "categorical" }];
+const dataFields: DataField[] = [{ name: "field1", dataType: "boolean", optype: "categorical" }];
 const pmml = { version: "1.0", DataDictionary: { DataField: dataFields }, Header: {} };
 const reducer: Reducer<DataField[], AllActions> = DataDictionaryFieldReducer(historyService, validationRegistry);
 
@@ -31,8 +31,8 @@ describe("DataDictionaryFieldReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         dataDictionaryIndex: 0,
-        dataField: { name: "updated" as FieldName, dataType: "string", optype: "ordinal" },
-        originalName: "field1" as FieldName,
+        dataField: { name: "updated", dataType: "string", optype: "ordinal" },
+        originalName: "field1",
       },
     });
     const updated = historyService.commit(pmml)?.DataDictionary.DataField as DataField[];
@@ -49,8 +49,8 @@ describe("DataDictionaryFieldReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         dataDictionaryIndex: -1,
-        dataField: { name: "updated" as FieldName, dataType: "boolean", optype: "categorical" },
-        originalName: "field1" as FieldName,
+        dataField: { name: "updated", dataType: "boolean", optype: "categorical" },
+        originalName: "field1",
       },
     });
     const updated = historyService.commit(pmml)?.DataDictionary.DataField as DataField[];
@@ -63,8 +63,8 @@ describe("DataDictionaryFieldReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         dataDictionaryIndex: 1,
-        dataField: { name: "updated" as FieldName, dataType: "boolean", optype: "categorical" },
-        originalName: "field1" as FieldName,
+        dataField: { name: "updated", dataType: "boolean", optype: "categorical" },
+        originalName: "field1",
       },
     });
     const updated = historyService.commit(pmml)?.DataDictionary.DataField as DataField[];

--- a/packages/pmml-editor/tests/editor/reducers/DataDictionaryReducer.test.ts
+++ b/packages/pmml-editor/tests/editor/reducers/DataDictionaryReducer.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DataDictionary, FieldName } from "@kie-tools/pmml-editor-marshaller";
+import { DataDictionary } from "@kie-tools/pmml-editor-marshaller";
 import { Actions, AllActions, DataDictionaryReducer } from "@kie-tools/pmml-editor/dist/editor/reducers";
 import { Reducer } from "react";
 import { HistoryService } from "@kie-tools/pmml-editor/dist/editor/history";
@@ -50,7 +50,7 @@ describe("DataDictionaryReducer::Valid actions", () => {
       {
         DataField: [
           {
-            name: "field1" as FieldName,
+            name: "field1",
             dataType: "string",
             optype: "categorical",
           },

--- a/packages/pmml-editor/tests/editor/reducers/DelegatingModelReducer.test.ts
+++ b/packages/pmml-editor/tests/editor/reducers/DelegatingModelReducer.test.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FieldName, MiningField, Model, PMML, Scorecard } from "@kie-tools/pmml-editor-marshaller";
+import { MiningField, Model, PMML, Scorecard } from "@kie-tools/pmml-editor-marshaller";
 import { Actions, AllActions } from "@kie-tools/pmml-editor/dist/editor/reducers";
 import { Reducer } from "react";
 import { HistoryService } from "@kie-tools/pmml-editor/dist/editor/history";
 import { DelegatingModelReducer } from "@kie-tools/pmml-editor/dist/editor/reducers/DelegatingModelReducer";
 
 const service = new HistoryService([]);
-const miningFields: MiningField[] = [{ name: "field1" as FieldName }];
+const miningFields: MiningField[] = [{ name: "field1" }];
 const models: Model[] = [
   new Scorecard({
     MiningSchema: { MiningField: miningFields },
@@ -35,7 +35,7 @@ const models: Model[] = [
 ];
 const pmml: PMML = {
   version: "1.0",
-  DataDictionary: { DataField: [{ name: "field1" as FieldName, dataType: "boolean", optype: "categorical" }] },
+  DataDictionary: { DataField: [{ name: "field1", dataType: "boolean", optype: "categorical" }] },
   Header: {},
   models: models,
 };
@@ -63,8 +63,8 @@ describe("DelegatingModelReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         dataDictionaryIndex: 0,
-        dataField: { name: "updated" as FieldName, dataType: "string", optype: "ordinal" },
-        originalName: "field1" as FieldName,
+        dataField: { name: "updated", dataType: "string", optype: "ordinal" },
+        originalName: "field1",
       },
     });
     service.commit(pmml);
@@ -82,8 +82,8 @@ describe("DelegatingModelReducer::Valid actions", () => {
       payload: {
         modelIndex: 1,
         miningSchemaIndex: 0,
-        name: "updated" as FieldName,
-        originalName: "field1" as FieldName,
+        name: "updated",
+        originalName: "field1",
         usageType: undefined,
         optype: undefined,
         importance: undefined,

--- a/packages/pmml-editor/tests/editor/reducers/MiningSchemaFieldReducer.test.ts
+++ b/packages/pmml-editor/tests/editor/reducers/MiningSchemaFieldReducer.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FieldName, MiningField, Model, PMML, Scorecard } from "@kie-tools/pmml-editor-marshaller";
+import { MiningField, Model, PMML, Scorecard } from "@kie-tools/pmml-editor-marshaller";
 import { Actions, AllActions } from "@kie-tools/pmml-editor/dist/editor/reducers";
 import { Reducer } from "react";
 import { HistoryService } from "@kie-tools/pmml-editor/dist/editor/history";
@@ -22,7 +22,7 @@ import { ValidationRegistry } from "@kie-tools/pmml-editor/dist/editor/validatio
 
 const historyService = new HistoryService([]);
 const validationRegistry = new ValidationRegistry();
-const miningFields: MiningField[] = [{ name: "field1" as FieldName }];
+const miningFields: MiningField[] = [{ name: "field1" }];
 const models: Model[] = [
   new Scorecard({
     MiningSchema: { MiningField: miningFields },
@@ -32,7 +32,7 @@ const models: Model[] = [
 ];
 const pmml: PMML = {
   version: "1.0",
-  DataDictionary: { DataField: [{ name: "field1" as FieldName, dataType: "boolean", optype: "categorical" }] },
+  DataDictionary: { DataField: [{ name: "field1", dataType: "boolean", optype: "categorical" }] },
   Header: {},
   models: models,
 };
@@ -45,8 +45,8 @@ describe("MiningSchemaFieldReducer::Valid actions", () => {
       payload: {
         modelIndex: 0,
         dataDictionaryIndex: 0,
-        dataField: { name: "updated" as FieldName, dataType: "string", optype: "ordinal" },
-        originalName: "field1" as FieldName,
+        dataField: { name: "updated", dataType: "string", optype: "ordinal" },
+        originalName: "field1",
       },
     });
     const updated = historyService.commit(pmml)?.models as Model[];
@@ -63,8 +63,8 @@ describe("MiningSchemaFieldReducer::Valid actions", () => {
       payload: {
         modelIndex: 0,
         miningSchemaIndex: 0,
-        name: "updated" as FieldName,
-        originalName: "field1" as FieldName,
+        name: "updated",
+        originalName: "field1",
         usageType: "active",
         optype: "ordinal",
         importance: 5,

--- a/packages/pmml-editor/tests/editor/reducers/ScorecardReducer.test.ts
+++ b/packages/pmml-editor/tests/editor/reducers/ScorecardReducer.test.ts
@@ -15,7 +15,6 @@
  */
 import {
   CompoundPredicate,
-  FieldName,
   Model,
   PMML,
   Predicate,
@@ -356,7 +355,7 @@ describe("ScorecardReducer::Valid actions", () => {
       type: Actions.AddMiningSchemaFields,
       payload: {
         modelIndex: 0,
-        names: ["miningSchemaField1" as FieldName],
+        names: ["miningSchemaField1"],
       },
     });
 
@@ -371,7 +370,7 @@ describe("ScorecardReducer::Valid actions", () => {
 
   test("Actions.DeleteMiningSchemaField", () => {
     const scorecard: Scorecard = {
-      MiningSchema: { MiningField: [{ name: "miningSchemaField" as FieldName }] },
+      MiningSchema: { MiningField: [{ name: "miningSchemaField" }] },
       Characteristics: {
         Characteristic: [],
       },
@@ -420,7 +419,7 @@ describe("ScorecardReducer::Valid actions", () => {
         attributeIndex: 0,
         reasonCode: "updatedAttributeReasonCode",
         partialScore: 2.0,
-        predicate: new SimplePredicate({ field: "field" as FieldName, operator: "equal", value: 100 }),
+        predicate: new SimplePredicate({ field: "field", operator: "equal", value: 100 }),
       },
     });
 
@@ -447,7 +446,7 @@ describe("ScorecardReducer::Valid actions", () => {
                 reasonCode: "attributeReasonCode",
                 partialScore: 1.0,
                 predicate: new SimplePredicate({
-                  field: "dataField" as FieldName,
+                  field: "dataField",
                   operator: "equal",
                   value: 100,
                 }),
@@ -460,7 +459,7 @@ describe("ScorecardReducer::Valid actions", () => {
     };
     const pmml: PMML = {
       version: "1.0",
-      DataDictionary: { DataField: [{ name: "dataField" as FieldName, dataType: "string", optype: "categorical" }] },
+      DataDictionary: { DataField: [{ name: "dataField", dataType: "string", optype: "categorical" }] },
       Header: {},
       models: [scorecard],
     };
@@ -469,8 +468,8 @@ describe("ScorecardReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         modelIndex: 0,
-        dataField: { name: "updatedDataField" as FieldName, dataType: "string", optype: "categorical" },
-        originalName: "dataField" as FieldName,
+        dataField: { name: "updatedDataField", dataType: "string", optype: "categorical" },
+        originalName: "dataField",
         dataDictionaryIndex: 0,
       },
     });
@@ -504,12 +503,12 @@ describe("ScorecardReducer::Valid actions", () => {
                 predicate: new CompoundPredicate({
                   predicates: [
                     new SimplePredicate({
-                      field: "dataField" as FieldName,
+                      field: "dataField",
                       operator: "greaterThan",
                       value: 100,
                     }),
                     new SimplePredicate({
-                      field: "dataField" as FieldName,
+                      field: "dataField",
                       operator: "lessOrEqual",
                       value: 200,
                     }),
@@ -525,7 +524,7 @@ describe("ScorecardReducer::Valid actions", () => {
     };
     const pmml: PMML = {
       version: "1.0",
-      DataDictionary: { DataField: [{ name: "dataField" as FieldName, dataType: "string", optype: "categorical" }] },
+      DataDictionary: { DataField: [{ name: "dataField", dataType: "string", optype: "categorical" }] },
       Header: {},
       models: [scorecard],
     };
@@ -534,8 +533,8 @@ describe("ScorecardReducer::Valid actions", () => {
       type: Actions.UpdateDataDictionaryField,
       payload: {
         modelIndex: 0,
-        dataField: { name: "updatedDataField" as FieldName, dataType: "string", optype: "categorical" },
-        originalName: "dataField" as FieldName,
+        dataField: { name: "updatedDataField", dataType: "string", optype: "categorical" },
+        originalName: "dataField",
         dataDictionaryIndex: 0,
       },
     });

--- a/packages/pmml-editor/tests/editor/validation/Attributes.test.ts
+++ b/packages/pmml-editor/tests/editor/validation/Attributes.test.ts
@@ -16,7 +16,7 @@
 
 import { ValidationEntry, ValidationRegistry } from "@kie-tools/pmml-editor/dist/editor/validation";
 import { validateAttribute, validateAttributes } from "@kie-tools/pmml-editor/dist/editor/validation/Attributes";
-import { CompoundPredicate, FieldName, SimplePredicate } from "@kie-tools/pmml-editor-marshaller";
+import { CompoundPredicate, SimplePredicate } from "@kie-tools/pmml-editor-marshaller";
 
 let registry: ValidationRegistry;
 beforeEach(() => {
@@ -44,8 +44,8 @@ describe("ValidateAttribute", () => {
       },
       false,
       2,
-      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
-      [{ name: "field1" as FieldName }],
+      { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
+      [{ name: "field1" }],
       registry
     );
 
@@ -67,8 +67,8 @@ describe("ValidateAttribute", () => {
       },
       false,
       2,
-      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
-      [{ name: "field1" as FieldName }],
+      { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
+      [{ name: "field1" }],
       registry
     );
 
@@ -87,9 +87,9 @@ describe("ValidateAttribute", () => {
       2,
       {
         reasonCode: "reasonCode",
-        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+        predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -107,9 +107,9 @@ describe("ValidateAttribute", () => {
       true,
       2,
       {
-        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+        predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -132,9 +132,9 @@ describe("ValidateAttribute", () => {
       2,
       {
         partialScore: 2.0,
-        predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+        predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -170,7 +170,7 @@ describe("ValidateAttribute", () => {
       },
       false,
       2,
-      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+      { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
       [],
       registry
     );
@@ -196,12 +196,12 @@ describe("ValidateAttribute", () => {
         predicate: new CompoundPredicate({
           predicates: [
             new SimplePredicate({
-              field: "field1" as FieldName,
+              field: "field1",
               operator: "greaterThan",
               value: 100,
             }),
             new SimplePredicate({
-              field: "field1" as FieldName,
+              field: "field1",
               operator: "lessOrEqual",
               value: 200,
             }),
@@ -234,8 +234,8 @@ describe("ValidateAttribute", () => {
       },
       false,
       2,
-      { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
-      [{ name: "field1" as FieldName }],
+      { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
+      [{ name: "field1" }],
       registry
     );
 
@@ -256,12 +256,12 @@ describe("ValidateAttribute", () => {
         predicate: new CompoundPredicate({
           predicates: [
             new SimplePredicate({
-              field: "field1" as FieldName,
+              field: "field1",
               operator: "greaterThan",
               value: 100,
             }),
             new SimplePredicate({
-              field: "field1" as FieldName,
+              field: "field1",
               operator: "lessOrEqual",
               value: 200,
             }),
@@ -269,7 +269,7 @@ describe("ValidateAttribute", () => {
           booleanOperator: "and",
         }),
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -286,12 +286,12 @@ describe("ValidateAttributes", () => {
       {
         Attribute: [
           {
-            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+            predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
           },
-          { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+          { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
         ],
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -307,12 +307,12 @@ describe("ValidateAttributes", () => {
         Attribute: [
           {
             partialScore: 1.0,
-            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+            predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
           },
-          { predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }) },
+          { predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }) },
         ],
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 
@@ -332,15 +332,15 @@ describe("ValidateAttributes", () => {
         Attribute: [
           {
             partialScore: 1.0,
-            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+            predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
           },
           {
             partialScore: 2.0,
-            predicate: new SimplePredicate({ field: "field1" as FieldName, operator: "equal", value: 100 }),
+            predicate: new SimplePredicate({ field: "field1", operator: "equal", value: 100 }),
           },
         ],
       },
-      [{ name: "field1" as FieldName }],
+      [{ name: "field1" }],
       registry
     );
 


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/125

Remove unnecessary `FieldName` class from the  `pmml-editor-marshaller`.