### PR TITLE
KOGITO-8729: Out of memory error while building dashbuilder-component-swf-editor in development

### DIFF
--- a/packages/serverless-workflow-standalone-editor/package.json
+++ b/packages/serverless-workflow-standalone-editor/package.json
@@ -16,9 +16,9 @@
     "dist/swf"
   ],
   "scripts": {
-    "build:dev": "rimraf dist && webpack --env dev --config webpack.editor-resources.config.js && webpack --env dev --config webpack.build-resources.config.js && pnpm build:preprocessor && webpack --env dev --config webpack.package-resources.config.js",
+    "build:dev": "rimraf dist && webpack --config webpack.editor-resources.config.js && webpack --config webpack.build-resources.config.js && pnpm build:preprocessor && webpack --config webpack.package-resources.config.js",
     "build:preprocessor": "node dist/preprocessor/preprocessor.js",
-    "build:prod": "pnpm lint && pnpm test && rimraf dist && webpack --env dev --config webpack.editor-resources.config.js && webpack --config webpack.build-resources.config.js && pnpm build:preprocessor && webpack --config webpack.package-resources.config.js",
+    "build:prod": "pnpm lint && pnpm test && rimraf dist && webpack --config webpack.editor-resources.config.js && webpack --config webpack.build-resources.config.js && pnpm build:preprocessor && webpack --config webpack.package-resources.config.js",
     "build:productization": "pnpm build:prod",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",


### PR DESCRIPTION
To reproduce the error, run these commands without this change:
```
export NODE_OPTIONS="--max-old-space-size=2000"
pnpm bootstrap && pnpm -F @kie-tools/dashbuilder-component-swf-editor... build:dev
```
After the change, the build should be successful.