### PR TITLE
KOGITO-8730: Show code lenses on VS Code web

### DIFF
--- a/packages/vscode-extension-dashbuilder-editor/src/browser/extension.ts
+++ b/packages/vscode-extension-dashbuilder-editor/src/browser/extension.ts
@@ -23,6 +23,8 @@ import * as vscode from "vscode";
 import { DashbuilderVsCodeExtensionConfiguration } from "../extension/configuration";
 import { setupDashboardEditorControls } from "../extension/setupDashboardEditorControls";
 import { DashbuilderViewerChannelApiProducer } from "../api/DashbuilderViewerChannelApiProducer";
+import { setupBuiltInVsCodeEditorDashbuilderContributions } from "../extension/builtInVsCodeEditorDashbuilderContributions";
+import { VsCodeDashbuilderLanguageService } from "../extension/languageService/VsCodeDashbuilderLanguageService";
 
 const componentServerUrl = "https://start.kubesmarts.org/dashbuilder-client/dashbuilder/component";
 
@@ -56,6 +58,16 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   const configuration = new DashbuilderVsCodeExtensionConfiguration();
+
+  const vsCodeDashbuilderLanguageService = new VsCodeDashbuilderLanguageService();
+
+  setupBuiltInVsCodeEditorDashbuilderContributions({
+    context,
+    vsCodeDashbuilderLanguageService,
+    configuration,
+    kieEditorsStore,
+  });
+
   await setupDashboardEditorControls({
     context,
     configuration,

--- a/packages/vscode-extension-dashbuilder-editor/src/extension/builtInVsCodeEditorDashbuilderContributions.ts
+++ b/packages/vscode-extension-dashbuilder-editor/src/extension/builtInVsCodeEditorDashbuilderContributions.ts
@@ -109,7 +109,7 @@ export function setupBuiltInVsCodeEditorDashbuilderContributions(args: {
 
   args.context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
-      { scheme: "file", pattern: "**/*.dash.{yaml,yml,json}" },
+      { pattern: "**/*.dash.{yaml,yml,json}" },
       {
         provideCodeLenses: async (document: vscode.TextDocument, token: vscode.CancellationToken) => {
           const lsCodeLenses = await args.vsCodeDashbuilderLanguageService.getLs(document).getCodeLenses({
@@ -141,7 +141,7 @@ export function setupBuiltInVsCodeEditorDashbuilderContributions(args: {
 
   args.context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
-      { scheme: "file", pattern: "**/*.dash.{yaml,yml,json}" },
+      { pattern: "**/*.dash.{yaml,yml,json}" },
       {
         provideCompletionItems: async (
           document: vscode.TextDocument,

--- a/packages/vscode-extension-serverless-workflow-editor/src/extension/builtInVsCodeEditorSwfContributions.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/src/extension/builtInVsCodeEditorSwfContributions.ts
@@ -147,7 +147,7 @@ export function setupBuiltInVsCodeEditorSwfContributions(args: {
 
   args.context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
-      { scheme: "file", pattern: "**/*.sw.{json,yaml,yml}" },
+      { pattern: "**/*.sw.{json,yaml,yml}" },
       {
         provideCodeLenses: async (document: vscode.TextDocument, token: vscode.CancellationToken) => {
           const lsCodeLenses = await args.vsCodeSwfLanguageService.getLs(document).getCodeLenses({
@@ -179,7 +179,7 @@ export function setupBuiltInVsCodeEditorSwfContributions(args: {
 
   args.context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
-      { scheme: "file", pattern: "**/*.sw.{json,yaml,yml}" },
+      { pattern: "**/*.sw.{json,yaml,yml}" },
       {
         provideCompletionItems: async (
           document: vscode.TextDocument,


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8730

`scheme: "file"` selector does not apply on VS Code web.

Serverless Workflow Editor (web and desktop) after this change:
 
<img width="1920" alt="Screenshot 2023-02-24 at 14 18 07" src="https://user-images.githubusercontent.com/638737/221255631-1e20041a-ea2e-4483-b686-b003005cd6da.png">
