### PR TITLE
kie-issues#126: Drill-down menus not working on KIE Sandbox after PatternFly upgrade (kie-issues#108)

### DIFF
--- a/packages/online-editor/src/editor/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/FileSwitcher.tsx
@@ -194,21 +194,25 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
     setActiveMenu(`dd${props.workspace.descriptor.workspaceId}`);
   }, [isFilesDropdownOpen, props.workspace.descriptor.workspaceId]);
 
-  const drillIn = useCallback((fromMenuId, toMenuId, pathId) => {
+  const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
     setDrilldownPath((prev) => [...prev, pathId]);
     setActiveMenu(toMenuId);
   }, []);
 
-  const drillOut = useCallback((toMenuId) => {
+  const drillOut = useCallback((_event, toMenuId) => {
     setMenuDrilledIn((prev) => prev.slice(0, prev.length - 1));
     setDrilldownPath((prev) => prev.slice(0, prev.length - 1));
     setActiveMenu(toMenuId);
   }, []);
 
   const setHeight = useCallback((menuId: string, height: number) => {
-    // do not try to simplify this ternary's condition as some heights are 0, resulting in an infinite loop.
-    setMenuHeights((prev) => (prev[menuId] === height ? prev : { ...prev, [menuId]: height }));
+    setMenuHeights((prev) => {
+      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+        return { ...prev, [menuId]: height };
+      }
+      return prev;
+    });
   }, []);
 
   const workspacesMenuItems = useMemo(() => {
@@ -360,7 +364,7 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
                 menuHeight={activeMenu === ROOT_MENU_ID ? undefined : `${menuHeights[activeMenu]}px`}
                 style={{ overflow: "hidden" }}
               >
-                <MenuList>
+                <MenuList style={{ padding: 0 }}>
                   <MenuItem
                     itemId={props.workspace.descriptor.workspaceId}
                     direction={"down"}
@@ -707,7 +711,7 @@ export function FilesMenuItems(props: {
                 <>
                   <Divider component={"li"} />
                   <MenuGroup>
-                    <MenuList>
+                    <MenuList style={{ padding: 0 }}>
                       <MenuItem
                         onClick={(e) => {
                           e.stopPropagation();

--- a/packages/online-editor/src/editor/FileSwitcher.tsx
+++ b/packages/online-editor/src/editor/FileSwitcher.tsx
@@ -208,7 +208,7 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
 
   const setHeight = useCallback((menuId: string, height: number) => {
     setMenuHeights((prev) => {
-      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+      if (prev[menuId] === undefined || (menuId !== ROOT_MENU_ID && prev[menuId] !== height)) {
         return { ...prev, [menuId]: height };
       }
       return prev;

--- a/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
@@ -61,21 +61,25 @@ export function NewFileDropdownMenu(props: {
   const [menuHeights, setMenuHeights] = useState<{ [key: string]: number }>({});
   const [activeMenu, setActiveMenu] = useState("addFileRootMenu");
 
-  const drillIn = useCallback((fromMenuId, toMenuId, pathId) => {
+  const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
     setDrilldownPath((prev) => [...prev, pathId]);
     setActiveMenu(toMenuId);
   }, []);
 
-  const drillOut = useCallback((toMenuId) => {
+  const drillOut = useCallback((_event, toMenuId) => {
     setMenuDrilledIn((prev) => prev.slice(0, prev.length - 1));
     setDrilldownPath((prev) => prev.slice(0, prev.length - 1));
     setActiveMenu(toMenuId);
   }, []);
 
   const setHeight = useCallback((menuId: string, height: number) => {
-    // do not try to simplify this ternary's condition as some heights are 0, resulting in an infinite loop.
-    setMenuHeights((prev) => (prev[menuId] !== undefined ? prev : { ...prev, [menuId]: height }));
+    setMenuHeights((prev) => {
+      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+        return { ...prev, [menuId]: height };
+      }
+      return prev;
+    });
   }, []);
 
   const workspaces = useWorkspaces();
@@ -248,7 +252,7 @@ export function NewFileDropdownMenu(props: {
       tabIndex={1}
       style={{ boxShadow: "none", minWidth: "400px" }}
       id="addFileRootMenu"
-      containsDrilldown={true}
+      containsDrilldown
       onDrillIn={drillIn}
       onDrillOut={drillOut}
       activeMenu={activeMenu}
@@ -257,7 +261,7 @@ export function NewFileDropdownMenu(props: {
       drilledInMenus={menuDrilledIn}
     >
       <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
-        <MenuList>
+        <MenuList style={{ padding: 0 }}>
           <MenuItem
             itemId={"newBpmnItemId"}
             onClick={() => addEmptyFile("bpmn")}
@@ -267,28 +271,24 @@ export function NewFileDropdownMenu(props: {
               <FileLabel style={{ marginBottom: "4px" }} extension={"bpmn"} />
             </b>
           </MenuItem>
-          <MenuGroup label={" "}>
-            <MenuItem
-              itemId={"newDmnItemId"}
-              onClick={() => addEmptyFile("dmn")}
-              description="DMN files are used to generate decision models"
-            >
-              <b>
-                <FileLabel style={{ marginBottom: "4px" }} extension={"dmn"} />
-              </b>
-            </MenuItem>
-          </MenuGroup>
-          <MenuGroup label={" "}>
-            <MenuItem
-              itemId={"newPmmlItemId"}
-              onClick={() => addEmptyFile("pmml")}
-              description="PMML files are used to generate scorecards"
-            >
-              <b>
-                <FileLabel style={{ marginBottom: "4px" }} extension={"pmml"} />
-              </b>
-            </MenuItem>
-          </MenuGroup>
+          <MenuItem
+            itemId={"newDmnItemId"}
+            onClick={() => addEmptyFile("dmn")}
+            description="DMN files are used to generate decision models"
+          >
+            <b>
+              <FileLabel style={{ marginBottom: "4px" }} extension={"dmn"} />
+            </b>
+          </MenuItem>
+          <MenuItem
+            itemId={"newPmmlItemId"}
+            onClick={() => addEmptyFile("pmml")}
+            description="PMML files are used to generate scorecards"
+          >
+            <b>
+              <FileLabel style={{ marginBottom: "4px" }} extension={"pmml"} />
+            </b>
+          </MenuItem>
           <Divider />
           <MenuItem
             description={"Try sample models"}

--- a/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
@@ -49,6 +49,8 @@ import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/work
 import { useGlobalAlert } from "../alerts";
 import { useBitbucketClient } from "../bitbucket/Hooks";
 
+const ROOT_MENU_ID = "addFileRootMenu";
+
 export function NewFileDropdownMenu(props: {
   destinationDirPath: string;
   workspaceDescriptor: WorkspaceDescriptor;
@@ -59,7 +61,7 @@ export function NewFileDropdownMenu(props: {
   const [menuDrilledIn, setMenuDrilledIn] = useState<string[]>([]);
   const [drilldownPath, setDrilldownPath] = useState<string[]>([]);
   const [menuHeights, setMenuHeights] = useState<{ [key: string]: number }>({});
-  const [activeMenu, setActiveMenu] = useState("addFileRootMenu");
+  const [activeMenu, setActiveMenu] = useState(ROOT_MENU_ID);
 
   const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
@@ -75,7 +77,7 @@ export function NewFileDropdownMenu(props: {
 
   const setHeight = useCallback((menuId: string, height: number) => {
     setMenuHeights((prev) => {
-      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+      if (prev[menuId] === undefined || (menuId !== ROOT_MENU_ID && prev[menuId] !== height)) {
         return { ...prev, [menuId]: height };
       }
       return prev;
@@ -251,7 +253,7 @@ export function NewFileDropdownMenu(props: {
     <Menu
       tabIndex={1}
       style={{ boxShadow: "none", minWidth: "400px" }}
-      id="addFileRootMenu"
+      id={ROOT_MENU_ID}
       containsDrilldown={true}
       onDrillIn={drillIn}
       onDrillOut={drillOut}

--- a/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/online-editor/src/editor/NewFileDropdownMenu.tsx
@@ -252,7 +252,7 @@ export function NewFileDropdownMenu(props: {
       tabIndex={1}
       style={{ boxShadow: "none", minWidth: "400px" }}
       id="addFileRootMenu"
-      containsDrilldown
+      containsDrilldown={true}
       onDrillIn={drillIn}
       onDrillOut={drillOut}
       activeMenu={activeMenu}

--- a/packages/online-editor/static/resources/style.css
+++ b/packages/online-editor/static/resources/style.css
@@ -662,3 +662,7 @@ section.kie-tools--settings-tab {
 .kie-sandbox--file-switcher .pf-c-dropdown__menu {
   min-width: 0;
 }
+
+.pf-c-menu__item-description {
+  word-break: normal !important;
+}

--- a/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
@@ -181,21 +181,25 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
     setActiveMenu(`dd${props.workspace.descriptor.workspaceId}`);
   }, [isFilesDropdownOpen, props.workspace.descriptor.workspaceId]);
 
-  const drillIn = useCallback((fromMenuId, toMenuId, pathId) => {
+  const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
     setDrilldownPath((prev) => [...prev, pathId]);
     setActiveMenu(toMenuId);
   }, []);
 
-  const drillOut = useCallback((toMenuId) => {
+  const drillOut = useCallback((_event, toMenuId) => {
     setMenuDrilledIn((prev) => prev.slice(0, prev.length - 1));
     setDrilldownPath((prev) => prev.slice(0, prev.length - 1));
     setActiveMenu(toMenuId);
   }, []);
 
   const setHeight = useCallback((menuId: string, height: number) => {
-    // do not try to simplify this ternary's condition as some heights are 0, resulting in an infinite loop.
-    setMenuHeights((prev) => (prev[menuId] === height ? prev : { ...prev, [menuId]: height }));
+    setMenuHeights((prev) => {
+      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+        return { ...prev, [menuId]: height };
+      }
+      return prev;
+    });
   }, []);
 
   const workspacesMenuItems = useMemo(() => {
@@ -342,7 +346,7 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
                 menuHeight={activeMenu === ROOT_MENU_ID ? undefined : `${menuHeights[activeMenu]}px`}
                 style={{ overflow: "hidden" }}
               >
-                <MenuList>
+                <MenuList style={{ padding: 0 }}>
                   <MenuItem
                     itemId={props.workspace.descriptor.workspaceId}
                     description={"Current"}
@@ -637,7 +641,7 @@ export function FilesMenuItems(props: {
                 <>
                   <Divider component={"li"} />
                   <MenuGroup>
-                    <MenuList>
+                    <MenuList style={{ padding: 0 }}>
                       <MenuItem
                         onClick={(e) => {
                           e.stopPropagation();

--- a/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
@@ -195,7 +195,7 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
 
   const setHeight = useCallback((menuId: string, height: number) => {
     setMenuHeights((prev) => {
-      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+      if (prev[menuId] === undefined || (menuId !== ROOT_MENU_ID && prev[menuId] !== height)) {
         return { ...prev, [menuId]: height };
       }
       return prev;

--- a/packages/serverless-logic-web-tools/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/NewFileDropdownMenu.tsx
@@ -39,6 +39,8 @@ import { decoder } from "@kie-tools-core/workspaces-git-fs/dist/encoderdecoder/E
 import { extractExtension } from "@kie-tools-core/workspaces-git-fs/dist/relativePath/WorkspaceFileRelativePathParser";
 import { UrlType } from "../workspace/hooks/ImportableUrlHooks";
 
+const ROOT_MENU_ID = "addFileRootMenu";
+
 export function NewFileDropdownMenu(props: {
   alerts: AlertsController | undefined;
   destinationDirPath: string;
@@ -50,7 +52,7 @@ export function NewFileDropdownMenu(props: {
   const [menuDrilledIn, setMenuDrilledIn] = useState<string[]>([]);
   const [drilldownPath, setDrilldownPath] = useState<string[]>([]);
   const [menuHeights, setMenuHeights] = useState<{ [key: string]: number }>({});
-  const [activeMenu, setActiveMenu] = useState("addFileRootMenu");
+  const [activeMenu, setActiveMenu] = useState(ROOT_MENU_ID);
 
   const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
@@ -66,7 +68,7 @@ export function NewFileDropdownMenu(props: {
 
   const setHeight = useCallback((menuId: string, height: number) => {
     setMenuHeights((prev) => {
-      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+      if (prev[menuId] === undefined || (menuId !== ROOT_MENU_ID && prev[menuId] !== height)) {
         return { ...prev, [menuId]: height };
       }
       return prev;
@@ -208,7 +210,7 @@ export function NewFileDropdownMenu(props: {
   return (
     <Menu
       style={{ boxShadow: "none", minWidth: "400px" }}
-      id="addFileRootMenu"
+      id={ROOT_MENU_ID}
       containsDrilldown={true}
       onDrillIn={drillIn}
       onDrillOut={drillOut}

--- a/packages/serverless-logic-web-tools/src/editor/NewFileDropdownMenu.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/NewFileDropdownMenu.tsx
@@ -52,21 +52,25 @@ export function NewFileDropdownMenu(props: {
   const [menuHeights, setMenuHeights] = useState<{ [key: string]: number }>({});
   const [activeMenu, setActiveMenu] = useState("addFileRootMenu");
 
-  const drillIn = useCallback((fromMenuId, toMenuId, pathId) => {
+  const drillIn = useCallback((_event, fromMenuId, toMenuId, pathId) => {
     setMenuDrilledIn((prev) => [...prev, fromMenuId]);
     setDrilldownPath((prev) => [...prev, pathId]);
     setActiveMenu(toMenuId);
   }, []);
 
-  const drillOut = useCallback((toMenuId) => {
+  const drillOut = useCallback((_event, toMenuId) => {
     setMenuDrilledIn((prev) => prev.slice(0, prev.length - 1));
     setDrilldownPath((prev) => prev.slice(0, prev.length - 1));
     setActiveMenu(toMenuId);
   }, []);
 
   const setHeight = useCallback((menuId: string, height: number) => {
-    // do not try to simplify this ternary's condition as some heights are 0, resulting in an infinite loop.
-    setMenuHeights((prev) => (prev[menuId] !== undefined ? prev : { ...prev, [menuId]: height }));
+    setMenuHeights((prev) => {
+      if (prev[menuId] === undefined || (menuId !== "addFileRootMenu" && prev[menuId] !== height)) {
+        return { ...prev, [menuId]: height };
+      }
+      return prev;
+    });
   }, []);
 
   const workspaces = useWorkspaces();
@@ -214,7 +218,7 @@ export function NewFileDropdownMenu(props: {
       drilledInMenus={menuDrilledIn}
     >
       <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
-        <MenuList>
+        <MenuList style={{ padding: 0 }}>
           <MenuItem
             itemId={"newSwfItemId"}
             onClick={() => addEmptyFile(FileTypes.SW_JSON)}

--- a/packages/serverless-logic-web-tools/static/resources/style.css
+++ b/packages/serverless-logic-web-tools/static/resources/style.css
@@ -652,3 +652,7 @@ section.kie-tools--settings-tab {
 .pf-c-masthead__main::before {
   display: none;
 }
+
+.pf-c-menu__item-description {
+  word-break: normal !important;
+}


### PR DESCRIPTION
- Fixes [kie-issues#126](https://github.com/kiegroup/kie-issues/issues/126)
- Remove sword breaking from menu item descriptions