### PR TITLE
KOGITO-8721: Improve Dashbuilder Fetch response error message

### DIFF
--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -162,12 +162,32 @@ public class ExternalDataSetClientProvider {
                 if (response.status == HttpResponseCodes.SC_OK) {
                     return register(def, callback, responseText, mimeType);
                 } else {
-                    return notAbleToRetrieveDataSet(def, callback);
+                    // return notAbleToRetrieveDataSet(def, callback);
+                    var exception = buildExceptionForResponse(responseText, response);
+                   return notAbleToRetrieveDataSet(def, callback, exception);
                 }
 
             }, error -> notAbleToRetrieveDataSet(def, callback));
-        }).catch_(e -> notAbleToRetrieveDataSet(def, callback));
+        }).catch_(e -> notAbleToRetrieveDataSet(def, callback,
+                new RuntimeException("Request not started, make sure that CORS is enabled. message: " + e)
+        ));
     }
+
+    
+
+    private Throwable buildExceptionForResponse(String responseText, Response response) {
+        var sb = new StringBuffer("The dataset URL is unreachable with status ");
+        sb.append(response.status);
+        sb.append(" - ");
+        sb.append(response.statusText);
+
+        if (responseText != null && !responseText.trim().isEmpty()) {
+            sb.append("\n");
+            sb.append("Response Text: ");
+            sb.append(responseText);
+        }
+        return new RuntimeException(sb.toString());
+   }
 
     private IThenable<Object> register(ExternalDataSetDef def,
                                        final DataSetReadyCallback callback,

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -162,7 +162,6 @@ public class ExternalDataSetClientProvider {
                 if (response.status == HttpResponseCodes.SC_OK) {
                     return register(def, callback, responseText, mimeType);
                 } else {
-                    // return notAbleToRetrieveDataSet(def, callback);
                     var exception = buildExceptionForResponse(responseText, response);
                    return notAbleToRetrieveDataSet(def, callback, exception);
                 }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -168,7 +168,7 @@ public class ExternalDataSetClientProvider {
 
             }, error -> notAbleToRetrieveDataSet(def, callback));
         }).catch_(e -> notAbleToRetrieveDataSet(def, callback,
-                new RuntimeException("Request not started, make sure that CORS is enabled. message: " + e)
+                new RuntimeException("Request not started, make sure that CORS is enabled. Message: " + e)
         ));
     }
 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/RuntimeDataSetClientServices.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/RuntimeDataSetClientServices.java
@@ -151,7 +151,7 @@ public class RuntimeDataSetClientServices implements DataSetClientServices {
 
                     @Override
                     public boolean onError(ClientRuntimeError error) {
-                        if (loader.isEditor()) {
+                        if (loader.isEditor() || loader.isClient() ) {
                             listener.onError(error);
                         } else {
                             DomGlobal.console.debug("Error retrieving dataset from client, trying from backend");


### PR DESCRIPTION
User friendly message is displayed when a dataset is missing or it's URL is not reachable and if there is any CORS error, A message is displayed which is relevant to it.

![Screenshot from 2023-02-27 15-03-03](https://user-images.githubusercontent.com/82813768/221527644-5335e7dd-8384-4603-a364-2c5be4d50320.png)
![Screenshot from 2023-02-27 15-01-58](https://user-images.githubusercontent.com/82813768/221527651-13ebcb8b-0a0b-45e9-b6b0-bc1a211fce3a.png)
