### PR TITLE
 kie-issues#44: DMN Editor: Autolayout is broken for decision services

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/graph/DMNSizeHandler.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/graph/DMNSizeHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.graph;
+
+import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
+import org.kie.workbench.common.dmn.api.property.dimensions.Height;
+import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.Width;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.SizeHandler;
+
+public class DMNSizeHandler implements SizeHandler {
+
+    @Override
+    public void setSize(final Node node,
+                        final double width,
+                        final double height) {
+        if (node.getContent() instanceof Definition) {
+            final Object innerDefinition = ((Definition) node.getContent()).getDefinition();
+            if (innerDefinition instanceof DMNViewDefinition) {
+                final RectangleDimensionsSet dimensionSet = ((DMNViewDefinition) innerDefinition).getDimensionsSet();
+                dimensionSet.setHeight(new Height(height));
+                dimensionSet.setWidth(new Width(width));
+            }
+        }
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessor.java
@@ -18,19 +18,41 @@ package org.kie.workbench.common.dmn.client.widgets.toolbar;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import org.kie.workbench.common.dmn.api.definition.model.DMNElementReference;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
+import org.kie.workbench.common.stunner.core.graph.impl.EdgeImpl;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.GraphProcessor;
-import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPosition;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPositionImpl;
+import org.kie.workbench.common.stunner.core.util.UUID;
+
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.SugiyamaLayoutService.DEFAULT_INNER_VERTICAL_PADDING;
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.SugiyamaLayoutService.DEFAULT_PARENT_NODE_HEIGHT;
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning.DEFAULT_VERTEX_HEIGHT;
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning.DEFAULT_VERTEX_WIDTH;
 
 @DMNEditor
 public class DMNGraphProcessor implements GraphProcessor {
 
+    public static final int DEFAULT_TOP_VERTICAL_PADDING = 40;
+    public static final int INPUT_NODE_VERTICAL_PADDING = DEFAULT_PARENT_NODE_HEIGHT / 2 + DEFAULT_INNER_VERTICAL_PADDING;
     private final HashMap<String, String> replacedNodes;
 
     public DMNGraphProcessor() {
@@ -40,27 +62,76 @@ public class DMNGraphProcessor implements GraphProcessor {
     @Override
     public Iterable<? extends Node> getNodes(final Graph<?, ?> graph) {
 
-        final List<Node> nodes = new ArrayList();
-        graph.nodes().forEach(nodes::add);
+        final List<Node> nodes = extractGraphNodes(graph);
 
-        for (final Node n : graph.nodes()) {
-            final Definition def = (Definition) n.getContent();
-            if (def.getDefinition() instanceof DecisionService) {
-                final List<Node> childNodes = getChildNodes(n);
-                nodes.removeAll(childNodes);
-                // Remove all nodes inside DS
-                // All edges that points to nodes inside DS now points to DS
-                for (final Node o : childNodes) {
-                    replacedNodes.put(o.getUUID(), n.getUUID());
-                }
-            }
-        }
+        final Map<String, DecisionService> decisionServiceNodes = getDecisionServicesNodes(graph);
+
+        decisionServiceNodes.forEach((nodeUuid, decisionService) -> replaceDecisionServiceInnerNodes(nodes,
+                                                                                                     nodeUuid,
+                                                                                                     decisionService));
 
         return nodes;
     }
 
-    protected List<Node> getChildNodes(final Node node) {
-        return GraphUtils.getChildNodes(node);
+    List<Node> extractGraphNodes(final Graph<?, ?> graph) {
+        final List<Node> nodes = new ArrayList();
+        graph.nodes().forEach(nodes::add);
+        return nodes;
+    }
+
+    void replaceDecisionServiceInnerNodes(final List<Node> nodes,
+                                          final String nodeUuid,
+                                          final DecisionService decisionService) {
+        final HashSet<String> innerIds = getInnerIds(decisionService);
+        final List<Node> removedNodes = new ArrayList<>();
+        nodes.stream().filter(this::hasContentDefinitionId)
+                .forEach(node -> {
+                    final String contentId = getContentDefinitionId(node);
+                    if (innerIds.contains(contentId)) {
+                        removedNodes.add(node);
+                        getReplacedNodes().put(node.getUUID(), nodeUuid);
+                    }
+                });
+
+        nodes.removeAll(removedNodes);
+    }
+
+    HashSet<String> getInnerIds(final DecisionService decisionService) {
+        final HashSet<String> innerIds = new HashSet<>();
+        innerIds.addAll(getDecisionIds(decisionService.getEncapsulatedDecision()));
+        innerIds.addAll(getDecisionIds(decisionService.getOutputDecision()));
+        return innerIds;
+    }
+
+    List<String> getDecisionIds(final List<DMNElementReference> decisions) {
+        return decisions.stream()
+                .map(e -> e.getHref().replace("#", ""))
+                .collect(Collectors.toList());
+    }
+
+    Map<String, DecisionService> getDecisionServicesNodes(final Graph<?, ?> graph) {
+        return StreamSupport.stream(graph.nodes().spliterator(), false)
+                .filter(n -> containsDecisionService(n))
+                .collect(Collectors.toMap(Element::getUUID,
+                                          n -> extractDecisionService(n)));
+    }
+
+    private static DecisionService extractDecisionService(final Node n) {
+        return (DecisionService) (((Definition) n.getContent()).getDefinition());
+    }
+
+    private static boolean containsDecisionService(final Node n) {
+        return n.getContent() instanceof Definition
+                && ((Definition) n.getContent()).getDefinition() instanceof DecisionService;
+    }
+
+    String getContentDefinitionId(final Node node) {
+        return ((HasContentDefinitionId) ((Definition) node.getContent()).getDefinition()).getContentDefinitionId();
+    }
+
+    boolean hasContentDefinitionId(final Node node) {
+        return node.getContent() instanceof Definition
+                && ((Definition) node.getContent()).getDefinition() instanceof HasContentDefinitionId;
     }
 
     @Override
@@ -71,5 +142,89 @@ public class DMNGraphProcessor implements GraphProcessor {
     @Override
     public String getReplaceNodeId(final String uuid) {
         return replacedNodes.get(uuid);
+    }
+
+    @Override
+    public Map<String, String> getReplacedNodes() {
+        return this.replacedNodes;
+    }
+
+    @Override
+    public void connect(final Node parentNode,
+                        final Node innerNode) {
+        final Edge<Child, Node> edge = createEdge(parentNode, innerNode);
+        innerNode.getInEdges().add(edge);
+        parentNode.getOutEdges().add(edge);
+    }
+
+    Edge<Child, Node> createEdge(final Node parentNode, final Node innerNode) {
+        final Edge<Child, Node> edge = new EdgeImpl<>(UUID.uuid());
+        edge.setContent(new Child());
+        edge.setSourceNode(parentNode);
+        edge.setTargetNode(innerNode);
+        return edge;
+    }
+
+    @Override
+    public VertexPosition getChildVertexPosition(final String parentId,
+                                                 final String innerNodeId,
+                                                 double horizontalPadding,
+                                                 final Graph<?, ?> graph) {
+
+        final Optional<Node> parentNode = getNodeFromGraph(parentId, graph);
+        final Node parent = parentNode.orElseThrow(() -> new UnsupportedOperationException(
+                "Unable to find parent '" + parentId + "' of the node '" + innerNodeId + "'"));
+
+        final double verticalPadding = getVerticalPadding(parent, innerNodeId);
+
+        final Point2D ulChild = new Point2D(horizontalPadding,
+                                            verticalPadding);
+        final Point2D brChild = new Point2D(ulChild.getX() + DEFAULT_VERTEX_WIDTH,
+                                            ulChild.getY() + DEFAULT_VERTEX_HEIGHT);
+        final VertexPosition position = new VertexPositionImpl(innerNodeId,
+                                                               ulChild,
+                                                               brChild);
+        return position;
+    }
+
+    double getVerticalPadding(final Node parent,
+                              final String innerNodeId) {
+
+        final Optional<Edge> targetEdge = getTargetEdgeToId(parent, innerNodeId);
+        if (!targetEdge.isPresent()) {
+            return 0; // There is no vertical padding
+        }
+
+        final Optional<DecisionService> decisionService = getDecisionService(parent);
+        final DecisionService ds = decisionService.get();
+        final Edge edge = targetEdge.get();
+        final Node targetNode = edge.getTargetNode();
+        final String realId = "#" + getContentDefinitionId(targetNode);
+
+        if (isOutput(ds, realId)) {
+            return DEFAULT_TOP_VERTICAL_PADDING;
+        }
+        return INPUT_NODE_VERTICAL_PADDING;
+    }
+
+    boolean isOutput(final DecisionService ds, final String realId) {
+        return ds.getOutputDecision().stream()
+                .anyMatch(output -> Objects.equals(output.getHref(), realId));
+    }
+
+    Optional<Edge> getTargetEdgeToId(final Node parent, final String innerNodeId) {
+        return parent.getOutEdges().stream()
+                .filter(e -> e instanceof Edge && Objects.equals(((Edge) e).getTargetNode().getUUID(), innerNodeId))
+                .findFirst();
+    }
+
+    private Optional<DecisionService> getDecisionService(final Node node) {
+        if (node.getContent() instanceof Definition) {
+            final Object innerDefinition = ((Definition) node.getContent()).getDefinition();
+            if (innerDefinition instanceof DecisionService) {
+                return Optional.of((DecisionService) innerDefinition);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -82,7 +83,7 @@ public class DMNGraphProcessor implements GraphProcessor {
     void replaceDecisionServiceInnerNodes(final List<Node> nodes,
                                           final String nodeUuid,
                                           final DecisionService decisionService) {
-        final HashSet<String> innerIds = getInnerIds(decisionService);
+        final Set<String> innerIds = getInnerIds(decisionService);
         final List<Node> removedNodes = new ArrayList<>();
         nodes.stream().filter(this::hasContentDefinitionId)
                 .forEach(node -> {
@@ -96,7 +97,7 @@ public class DMNGraphProcessor implements GraphProcessor {
         nodes.removeAll(removedNodes);
     }
 
-    HashSet<String> getInnerIds(final DecisionService decisionService) {
+    Set<String> getInnerIds(final DecisionService decisionService) {
         final HashSet<String> innerIds = new HashSet<>();
         innerIds.addAll(getDecisionIds(decisionService.getEncapsulatedDecision()));
         innerIds.addAll(getDecisionIds(decisionService.getOutputDecision()));
@@ -153,8 +154,14 @@ public class DMNGraphProcessor implements GraphProcessor {
     public void connect(final Node parentNode,
                         final Node innerNode) {
         final Edge<Child, Node> edge = createEdge(parentNode, innerNode);
+        removeParent(innerNode);
         innerNode.getInEdges().add(edge);
         parentNode.getOutEdges().add(edge);
+    }
+
+    private static void removeParent(final Node innerNode) {
+        innerNode.getInEdges().removeIf(innerEdge -> (innerEdge instanceof Edge)
+                && ((Edge) innerEdge).getContent() instanceof Child);
     }
 
     Edge<Child, Node> createEdge(final Node parentNode, final Node innerNode) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNSugiyamaLayoutService.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNSugiyamaLayoutService.java
@@ -20,7 +20,9 @@ import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
+import org.kie.workbench.common.dmn.client.graph.DMNSizeHandler;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.LayoutService;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.SizeHandler;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.SugiyamaLayoutService;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step01.CycleBreaker;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step02.VertexLayerer;
@@ -32,11 +34,12 @@ public class DMNSugiyamaLayoutService extends SugiyamaLayoutService implements L
 
     /**
      * Default constructor.
-     * @param cycleBreaker The strategy used to break cycles in cycle graphs.
-     * @param vertexLayerer The strategy used to choose the layer for each vertex.
-     * @param vertexOrdering The strategy used to order vertices inside each layer.
+     *
+     * @param cycleBreaker      The strategy used to break cycles in cycle graphs.
+     * @param vertexLayerer     The strategy used to choose the layer for each vertex.
+     * @param vertexOrdering    The strategy used to order vertices inside each layer.
      * @param vertexPositioning The strategy used to position vertices on screen (x,y coordinates).
-     * @param graphProcessor Applies some pre-process in the graph to extract the nodes to be used.
+     * @param graphProcessor    Applies some pre-process in the graph to extract the nodes to be used.
      */
     @Inject
     public DMNSugiyamaLayoutService(final CycleBreaker cycleBreaker,
@@ -45,5 +48,10 @@ public class DMNSugiyamaLayoutService extends SugiyamaLayoutService implements L
                                     final VertexPositioning vertexPositioning,
                                     final @Any DMNGraphProcessor graphProcessor) {
         super(cycleBreaker, vertexLayerer, vertexOrdering, vertexPositioning, graphProcessor);
+    }
+
+    @Override
+    public SizeHandler getSizeHandler() {
+        return new DMNSizeHandler();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/graph/DMNSizeHandlerTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/graph/DMNSizeHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.dmn.client.graph;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.DMNViewDefinition;
+import org.kie.workbench.common.dmn.api.property.dimensions.Height;
+import org.kie.workbench.common.dmn.api.property.dimensions.RectangleDimensionsSet;
+import org.kie.workbench.common.dmn.api.property.dimensions.Width;
+import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DMNSizeHandlerTest {
+
+    @Captor
+    private ArgumentCaptor<Height> heightArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<Width> widthArgumentCaptor;
+
+    @Test
+    public void testSetSize() {
+
+        final double width = 300;
+        final double height = 100;
+        final DMNSizeHandler sizeHandler = new DMNSizeHandler();
+        final RectangleDimensionsSet rectangle = mock(RectangleDimensionsSet.class);
+        final Node node = createNode(rectangle);
+
+        sizeHandler.setSize(node, width, height);
+
+        verify(rectangle).setWidth(widthArgumentCaptor.capture());
+        verify(rectangle).setHeight(heightArgumentCaptor.capture());
+
+        final Width capturedWidth = widthArgumentCaptor.getValue();
+        final Height capturedHeight = heightArgumentCaptor.getValue();
+
+        assertEquals(width, capturedWidth.getValue(), 0.01);
+        assertEquals(height, capturedHeight.getValue(), 0.01);
+    }
+
+    private Node createNode(final RectangleDimensionsSet rectangle) {
+        final Node node = mock(Node.class);
+        final Definition content = mock(Definition.class);
+        final DMNViewDefinition viewDefinition = mock(DMNViewDefinition.class);
+        when(node.getContent()).thenReturn(content);
+        when(content.getDefinition()).thenReturn(viewDefinition);
+        when(viewDefinition.getDimensionsSet()).thenReturn(rectangle);
+
+        return node;
+    }
+}

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessorTest.java
@@ -16,32 +16,58 @@
 
 package org.kie.workbench.common.dmn.client.widgets.toolbar;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.dmn.api.definition.model.DMNElementReference;
 import org.kie.workbench.common.dmn.api.definition.model.Decision;
 import org.kie.workbench.common.dmn.api.definition.model.DecisionService;
+import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.HasContentDefinitionId;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
+import org.kie.workbench.common.stunner.core.graph.content.relationship.Child;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPosition;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+import static org.kie.workbench.common.dmn.client.widgets.toolbar.DMNGraphProcessor.DEFAULT_TOP_VERTICAL_PADDING;
+import static org.kie.workbench.common.dmn.client.widgets.toolbar.DMNGraphProcessor.INPUT_NODE_VERTICAL_PADDING;
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning.DEFAULT_VERTEX_HEIGHT;
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning.DEFAULT_VERTEX_WIDTH;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DMNGraphProcessorTest {
 
+    private DMNGraphProcessor processor;
+
+    @Before
+    public void setup() {
+        this.processor = spy(new DMNGraphProcessor());
+    }
+
     @Test
     public void testGetNodes() {
-        final DMNGraphProcessor processor = new DMNGraphProcessor();
         final Graph graph = mock(Graph.class);
         final Decision decision1 = mock(Decision.class);
         final Decision decision2 = mock(Decision.class);
@@ -60,35 +86,366 @@ public class DMNGraphProcessorTest {
 
     @Test
     public void testGetNodesWithDecisionServices() {
-        final String childId1 = "id1";
-        final String childId2 = "id2";
-        final String dsId = "dsId";
-        final String decisionNodeId = "decision1Node";
-        final DMNGraphProcessor processor = spy(new DMNGraphProcessor());
-        final Graph graph = mock(Graph.class);
-        final Decision decision1 = mock(Decision.class);
-        final Node decisionNode = createNode(decision1, decisionNodeId);
-        final DecisionService ds = mock(DecisionService.class);
-        final Node dsNode = createNode(ds, dsId);
-        final Decision child1 = mock(Decision.class);
-        final Node ch1 = createNode(child1, childId1);
-        final Decision child2 = mock(Decision.class);
-        final Node ch2 = createNode(child2, childId2);
-        final List<Node> children = Arrays.asList(ch1, ch2);
-        doReturn(children).when(processor).getChildNodes(dsNode);
 
-        final List<Node> graphNodes = createGraphNodes(dsNode, decisionNode);
+        final String ds1Id = "ds1Id";
+        final String ds2Id = "ds2Id";
+        final Graph graph = mock(Graph.class);
+        final Decision randomDecision = mock(Decision.class);
+        final DecisionService ds1 = mock(DecisionService.class);
+        final DecisionService ds2 = mock(DecisionService.class);
+        final Decision ds1Child1 = mock(Decision.class);
+        final Decision ds1Child2 = mock(Decision.class);
+        final Decision ds2SingleChild = mock(Decision.class);
+        final Map<String, DecisionService> decisionServices = new HashMap() {{
+            put(ds1Id, ds1);
+            put(ds2Id, ds2);
+        }};
+
+        final Node ds1Node = createNode(ds1, ds1Id);
+        final Node ds2Node = createNode(ds2, ds2Id);
+        final Node ds1Child1Node = createNode(ds1Child1, "ds1Child1");
+        final Node ds1Child2Node = createNode(ds1Child2, "ds1Child2");
+        final Node ds2SingleChildNode = createNode(ds2SingleChild, "ds2SingleChild");
+        final Node randomDecisionNode = createNode(randomDecision, "randomDecision");
+
+        final List<Node> graphNodes = createGraphNodes(ds1Node,
+                                                       ds2Node,
+                                                       ds1Child1Node,
+                                                       ds1Child2Node,
+                                                       ds2SingleChildNode,
+                                                       randomDecisionNode);
+
+        doReturn(graphNodes).when(processor).extractGraphNodes(graph);
+        doReturn(decisionServices).when(processor).getDecisionServicesNodes(graph);
+
+        processor.getNodes(graph);
+
+        verify(processor).replaceDecisionServiceInnerNodes(graphNodes,
+                                                           ds1Id,
+                                                           ds1);
+
+        verify(processor).replaceDecisionServiceInnerNodes(graphNodes,
+                                                           ds2Id,
+                                                           ds2);
+    }
+
+    @Test
+    public void testExtractGraphNodes() {
+
+        final Graph graph = mock(Graph.class);
+        final Node node1 = mock(Node.class);
+        final Node node2 = mock(Node.class);
+        final Node node3 = mock(Node.class);
+        final List<Node> graphNodes = createGraphNodes(node1,
+                                                       node2,
+                                                       node3);
         when(graph.nodes()).thenReturn(graphNodes);
 
-        final List<Node> nodes = (List<Node>) processor.getNodes(graph);
+        final List<Node> extractedNodes = processor.extractGraphNodes(graph);
 
+        assertEquals(3, extractedNodes.size());
+        assertTrue(extractedNodes.contains(node1));
+        assertTrue(extractedNodes.contains(node2));
+        assertTrue(extractedNodes.contains(node3));
+    }
+
+    @Test
+    public void testReplaceDecisionServiceInnerNodes() {
+
+        final String child1Id = "childId1";
+        final String child2Id = "childId2";
+        final String nonChildId = "nonChildId";
+        final String nodeUuid = "decisionServiceNodeUuid";
+        final DecisionService decisionService = new DecisionService();
+        final Decision child1 = mock(Decision.class);
+        final Decision child2 = mock(Decision.class);
+        final Decision nonChild = mock(Decision.class);
+
+        final Node child1Node = createNode(child1, child1Id);
+        final Node child2Node = createNode(child2, child2Id);
+        final Node nonChildNode = createNode(nonChild, nonChildId);
+        final Node decisionServiceNode = createNode(decisionService, nodeUuid);
+
+        final List<Node> nodes = new ArrayList(Arrays.asList(decisionServiceNode,
+                                                             child1Node,
+                                                             nonChildNode,
+                                                             child2Node));
+
+        final HashSet<String> innerIds = new HashSet<>(Arrays.asList(child1Id,
+                                                                     child2Id));
+
+        doReturn(innerIds).when(processor).getInnerIds(decisionService);
+        doReturn(true).when(processor).hasContentDefinitionId(any());
+        doReturn(child1Id).when(processor).getContentDefinitionId(child1Node);
+        doReturn(child2Id).when(processor).getContentDefinitionId(child2Node);
+        doReturn(nonChildId).when(processor).getContentDefinitionId(nonChildNode);
+
+        processor.replaceDecisionServiceInnerNodes(nodes,
+                                                   nodeUuid,
+                                                   decisionService);
+
+        final Map<String, String> replacedNodes = processor.getReplacedNodes();
+
+        assertTrue(replacedNodes.containsKey(child1Id));
+        assertTrue(replacedNodes.containsKey(child2Id));
+        assertFalse(replacedNodes.containsKey(nonChildId));
         assertEquals(2, nodes.size());
-        assertTrue(nodes.contains(dsNode));
-        assertTrue(nodes.contains(decisionNode));
-        assertTrue(processor.isReplacedByAnotherNode(childId1));
-        assertEquals(dsId, processor.getReplaceNodeId(childId1));
-        assertTrue(processor.isReplacedByAnotherNode(childId2));
-        assertEquals(dsId, processor.getReplaceNodeId(childId2));
+        assertTrue(nodes.contains(decisionServiceNode));
+        assertTrue(nodes.contains(nonChildNode));
+    }
+
+    @Test
+    public void testGetInnerIds() {
+
+        final DecisionService decisionService = mock(DecisionService.class);
+        final List<DMNElementReference> encapsulatedDecisions = mock(List.class);
+        final List<DMNElementReference> outputDecisions = mock(List.class);
+        final String outputId = "outputId";
+        final String encapsulatedId = "encapsulatedId";
+        final List<String> outputDecisionsId = Collections.singletonList(outputId);
+        final List<String> encapsulatedDecisionsId = Collections.singletonList(encapsulatedId);
+
+        when(decisionService.getEncapsulatedDecision()).thenReturn(encapsulatedDecisions);
+        when(decisionService.getOutputDecision()).thenReturn(outputDecisions);
+
+        doReturn(outputDecisionsId).when(processor).getDecisionIds(outputDecisions);
+        doReturn(encapsulatedDecisionsId).when(processor).getDecisionIds(encapsulatedDecisions);
+
+        final HashSet<String> innerIds = processor.getInnerIds(decisionService);
+
+        assertEquals(2, innerIds.size());
+        assertTrue(innerIds.contains(outputId));
+        assertTrue(innerIds.contains(encapsulatedId));
+    }
+
+    @Test
+    public void testGetDecisionsIds() {
+
+        final String href1 = UUID.randomUUID().toString();
+        final String href2 = UUID.randomUUID().toString();
+        final String href3 = UUID.randomUUID().toString();
+        final DMNElementReference reference1 = new DMNElementReference();
+        final DMNElementReference reference2 = new DMNElementReference();
+        final DMNElementReference reference3 = new DMNElementReference();
+
+        reference1.setHref("#" + href1);
+        reference2.setHref("#" + href2);
+        reference3.setHref("#" + href3);
+
+        final List<String> decisionIds = processor.getDecisionIds(Arrays.asList(reference1,
+                                                                                reference2,
+                                                                                reference3));
+
+        assertEquals(3, decisionIds.size());
+        assertTrue(decisionIds.contains(href1));
+        assertTrue(decisionIds.contains(href2));
+        assertTrue(decisionIds.contains(href3));
+    }
+
+    @Test
+    public void testGetDecisionServicesNodes() {
+
+        final Decision decision = mock(Decision.class);
+        final DecisionService decisionService = mock(DecisionService.class);
+        final String id = "id";
+        final Node decisionNode = createNode(decision, "someId");
+        final Node decisionServiceNode = createNode(decisionService, id);
+        final Graph graph = mock(Graph.class);
+        final List<Node> graphNodes = createGraphNodes(decisionServiceNode, decisionNode);
+
+        when(graph.nodes()).thenReturn(graphNodes);
+
+        final Map<String, DecisionService> decisionServiceNodes = processor.getDecisionServicesNodes(graph);
+
+        assertEquals(1, decisionServiceNodes.size());
+        assertTrue(decisionServiceNodes.containsKey(id));
+        assertTrue(decisionServiceNodes.containsValue(decisionService));
+    }
+
+    @Test
+    public void testGetContentDefinitionId() {
+
+        final HasContentDefinitionId hasContentDefinitionId = mock(HasContentDefinitionId.class);
+        final String contentDefinitionId = "someContentId";
+        when(hasContentDefinitionId.getContentDefinitionId()).thenReturn(contentDefinitionId);
+
+        final Node node = createNode(hasContentDefinitionId, "thisIsTheNodeIdNotTheContent");
+
+        final String result = processor.getContentDefinitionId(node);
+
+        assertEquals(contentDefinitionId, result);
+    }
+
+    @Test
+    public void testHasContentDefinitionId() {
+        final HasContentDefinitionId hasContentDefinitionId = mock(HasContentDefinitionId.class);
+        final String contentDefinitionId = "someContentId";
+        when(hasContentDefinitionId.getContentDefinitionId()).thenReturn(contentDefinitionId);
+
+        final Node node = createNode(hasContentDefinitionId, "thisIsTheNodeIdNotTheContent");
+
+        assertTrue(processor.hasContentDefinitionId(node));
+    }
+
+    @Test
+    public void testHasContentDefinitionIdWhenDoesNot() {
+
+        final Node node = createNode(new Object(), "thisIsTheNodeIdNotTheContent");
+
+        assertFalse(processor.hasContentDefinitionId(node));
+    }
+
+    @Test
+    public void testConnect() {
+
+        final Node parentNode = mock(Node.class);
+        final Node innerNode = mock(Node.class);
+        final Edge edge = mock(Edge.class);
+
+        final List parentOutEdges = mock(List.class);
+        final List parentInEdges = mock(List.class);
+        final List innerOutEdges = mock(List.class);
+        final List innerInEdges = mock(List.class);
+
+        when(parentNode.getOutEdges()).thenReturn(parentOutEdges);
+        when(parentNode.getInEdges()).thenReturn(parentInEdges);
+        when(innerNode.getOutEdges()).thenReturn(innerOutEdges);
+        when(innerNode.getInEdges()).thenReturn(innerInEdges);
+
+        doReturn(edge).when(processor).createEdge(parentNode, innerNode);
+
+        processor.connect(parentNode, innerNode);
+
+        verify(parentOutEdges).add(edge);
+        verify(innerInEdges).add(edge);
+        verify(parentInEdges, never()).add(edge);
+        verify(innerOutEdges, never()).add(edge);
+    }
+
+    @Test
+    public void testGetChildVertexPosition() {
+
+        final String parentId = "parentId";
+        final String innerNodeId = "innerId";
+        final Double horizontalPadding = 123.0;
+        final Double verticalPadding = 444.0;
+        final Graph<?, ?> graph = mock(Graph.class);
+
+        final Node parentNode = mock(Node.class);
+        final Optional<Node> parentNodeOpt = Optional.of(parentNode);
+
+        doReturn(parentNodeOpt).when(processor).getNodeFromGraph(parentId, graph);
+        doReturn(verticalPadding).when(processor).getVerticalPadding(parentNode, innerNodeId);
+
+        final VertexPosition position = processor.getChildVertexPosition(parentId,
+                                                                         innerNodeId,
+                                                                         horizontalPadding,
+                                                                         graph);
+
+        assertEquals(innerNodeId, position.getId());
+        assertEquals(horizontalPadding, position.getUpperLeft().getX());
+        assertEquals(verticalPadding, position.getUpperLeft().getY());
+        assertEquals(horizontalPadding + DEFAULT_VERTEX_WIDTH, position.getBottomRight().getX());
+        assertEquals(verticalPadding + DEFAULT_VERTEX_HEIGHT, position.getBottomRight().getY());
+    }
+
+    @Test
+    public void testGetVerticalPadding_WhenThereIsNoTargetNode() {
+
+        final Node parentNode = mock(Node.class);
+        final String innerNodeId = "innerNodeId";
+
+        doReturn(Optional.empty()).when(processor).getTargetEdgeToId(parentNode, innerNodeId);
+
+        final double verticalPadding = processor.getVerticalPadding(parentNode, innerNodeId);
+
+        assertEquals(0, verticalPadding, 0.01);
+    }
+
+    @Test
+    public void testGetVerticalPadding_WhenIsOutputNode() {
+
+        final DecisionService decisionServiceOfParentNode = mock(DecisionService.class);
+        final Node parentNode = createNode(decisionServiceOfParentNode, "dsId");
+        final Edge edge = mock(Edge.class);
+        final HasContentDefinitionId contentOfTarget = mock(HasContentDefinitionId.class);
+        final String idOfTarget = "idOfTarget";
+        final String innerNodeId = "innerNodeId";
+        final Node targetNode = createNode(contentOfTarget, "randomId");
+
+        when(contentOfTarget.getContentDefinitionId()).thenReturn(idOfTarget);
+        when(edge.getTargetNode()).thenReturn(targetNode);
+
+        doReturn(Optional.of(edge)).when(processor).getTargetEdgeToId(parentNode, innerNodeId);
+        doReturn(true).when(processor).isOutput(decisionServiceOfParentNode, "#" + idOfTarget);
+
+        double verticalPadding = processor.getVerticalPadding(parentNode,
+                                                              innerNodeId);
+
+        assertEquals(DEFAULT_TOP_VERTICAL_PADDING, verticalPadding, 0.01);
+    }
+
+    @Test
+    public void testGetVerticalPadding_WhenIsInputNode() {
+
+        final DecisionService decisionServiceOfParentNode = mock(DecisionService.class);
+        final Node parentNode = createNode(decisionServiceOfParentNode, "dsId");
+        final Edge edge = mock(Edge.class);
+        final HasContentDefinitionId contentOfTarget = mock(HasContentDefinitionId.class);
+        final String idOfTarget = "idOfTarget";
+        final String innerNodeId = "innerNodeId";
+        final Node targetNode = createNode(contentOfTarget, "randomId");
+
+        when(contentOfTarget.getContentDefinitionId()).thenReturn(idOfTarget);
+        when(edge.getTargetNode()).thenReturn(targetNode);
+
+        doReturn(Optional.of(edge)).when(processor).getTargetEdgeToId(parentNode, innerNodeId);
+        doReturn(false).when(processor).isOutput(decisionServiceOfParentNode, "#" + idOfTarget);
+
+        double verticalPadding = processor.getVerticalPadding(parentNode,
+                                                              innerNodeId);
+
+        assertEquals(INPUT_NODE_VERTICAL_PADDING, verticalPadding, 0.01);
+    }
+
+    @Test
+    public void testIsOutput_WhenItIs() {
+
+        final DecisionService decisionService = new DecisionService();
+        final DMNElementReference reference = new DMNElementReference();
+        final String theId = "#theid";
+
+        reference.setHref(theId);
+
+        decisionService.getOutputDecision().add(reference);
+
+        assertTrue(processor.isOutput(decisionService, theId));
+    }
+
+    @Test
+    public void testIsOutput_WhenItIsNot() {
+
+        final DecisionService decisionService = new DecisionService();
+        final DMNElementReference reference = new DMNElementReference();
+        final String theId = "#theid";
+
+        reference.setHref(theId);
+
+        decisionService.getEncapsulatedDecision().add(reference);
+
+        assertFalse(processor.isOutput(decisionService, theId));
+    }
+
+    @Test
+    public void testCreateEdge() {
+
+        final Node parentNode = mock(Node.class);
+        final Node innerNode = mock(Node.class);
+
+        final Edge<Child, Node> edge = processor.createEdge(parentNode, innerNode);
+
+        assertEquals(parentNode, edge.getSourceNode());
+        assertEquals(innerNode, edge.getTargetNode());
     }
 
     private List<Node> createGraphNodes(final Node... nodes) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/widgets/toolbar/DMNGraphProcessorTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -211,7 +212,7 @@ public class DMNGraphProcessorTest {
         doReturn(outputDecisionsId).when(processor).getDecisionIds(outputDecisions);
         doReturn(encapsulatedDecisionsId).when(processor).getDecisionIds(encapsulatedDecisions);
 
-        final HashSet<String> innerIds = processor.getInnerIds(decisionService);
+        final Set<String> innerIds = processor.getInnerIds(decisionService);
 
         assertEquals(2, innerIds.size());
         assertTrue(innerIds.contains(outputId));
@@ -305,7 +306,14 @@ public class DMNGraphProcessorTest {
         final List parentOutEdges = mock(List.class);
         final List parentInEdges = mock(List.class);
         final List innerOutEdges = mock(List.class);
-        final List innerInEdges = mock(List.class);
+        final List innerInEdges = new ArrayList();
+        final Edge olderParentEdge = mock(Edge.class);
+        final Edge someOtherNonRelatedEdge = mock(Edge.class);
+        final Child child = mock(Child.class);
+        when(olderParentEdge.getContent()).thenReturn(child);
+
+        innerInEdges.add(olderParentEdge);
+        innerInEdges.add(someOtherNonRelatedEdge);
 
         when(parentNode.getOutEdges()).thenReturn(parentOutEdges);
         when(parentNode.getInEdges()).thenReturn(parentInEdges);
@@ -317,9 +325,12 @@ public class DMNGraphProcessorTest {
         processor.connect(parentNode, innerNode);
 
         verify(parentOutEdges).add(edge);
-        verify(innerInEdges).add(edge);
         verify(parentInEdges, never()).add(edge);
         verify(innerOutEdges, never()).add(edge);
+
+        assertFalse(innerInEdges.contains(olderParentEdge));
+        assertTrue(innerInEdges.contains(edge));
+        assertTrue(innerInEdges.contains(someOtherNonRelatedEdge));
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/main/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditor.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.ui.RequiresResize;
 import elemental2.dom.HTMLElement;
 import elemental2.promise.Promise;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.kie.workbench.common.dmn.api.qualifiers.DMNEditor;
 import org.kie.workbench.common.dmn.client.commands.general.NavigateToExpressionEditorCommand;
 import org.kie.workbench.common.dmn.client.common.KogitoChannelHelper;
 import org.kie.workbench.common.dmn.client.docks.navigator.DecisionNavigatorDock;
@@ -44,6 +45,7 @@ import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.session.DMNSession;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
+import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNLayoutHelper;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.GuidedTourBridgeInitializer;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerPresenter;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
@@ -57,7 +59,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.ConfirmationDialog;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
@@ -99,7 +100,7 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
     protected final DecisionNavigatorDock decisionNavigatorDock;
     protected final DiagramEditorPropertiesDock diagramPropertiesDock;
     protected final PreviewDiagramDock diagramPreviewAndExplorerDock;
-    protected final LayoutHelper layoutHelper;
+    protected final DMNLayoutHelper layoutHelper;
     protected final OpenDiagramLayoutExecutor openDiagramLayoutExecutor;
     protected final DataTypesPage dataTypesPage;
     protected final DMNEditorSearchIndex editorSearchIndex;
@@ -129,7 +130,7 @@ public abstract class AbstractDMNDiagramEditor extends MultiPageEditorContainerP
                                        final DecisionNavigatorDock decisionNavigatorDock,
                                        final DiagramEditorPropertiesDock diagramPropertiesDock,
                                        final PreviewDiagramDock diagramPreviewAndExplorerDock,
-                                       final LayoutHelper layoutHelper,
+                                       final @DMNEditor DMNLayoutHelper layoutHelper,
                                        final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                                        final DataTypesPage dataTypesPage,
                                        final KogitoClientDiagramService diagramServices,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-common/src/test/java/org/kie/workbench/common/dmn/webapp/kogito/common/client/editor/AbstractDMNDiagramEditorTest.java
@@ -37,6 +37,7 @@ import org.kie.workbench.common.dmn.client.editors.search.DMNSearchableElement;
 import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.resources.i18n.DMNEditorConstants;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
+import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNLayoutHelper;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.GuidedTourBridgeInitializer;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
@@ -46,7 +47,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.ConfirmationDialog;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.service.ClientRuntimeError;
@@ -122,7 +122,7 @@ public class AbstractDMNDiagramEditorTest {
     private PreviewDiagramDock diagramPreviewAndExplorerDock;
 
     @Mock
-    private LayoutHelper layoutHelper;
+    private DMNLayoutHelper layoutHelper;
 
     @Mock
     private OpenDiagramLayoutExecutor openDiagramLayoutExecutor;
@@ -462,7 +462,7 @@ public class AbstractDMNDiagramEditorTest {
                                                final DecisionNavigatorDock decisionNavigatorDock,
                                                final DiagramEditorPropertiesDock diagramPropertiesDock,
                                                final PreviewDiagramDock diagramPreviewAndExplorerDock,
-                                               final LayoutHelper layoutHelper,
+                                               final DMNLayoutHelper layoutHelper,
                                                final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                                                final DataTypesPage dataTypesPage,
                                                final KogitoClientDiagramService diagramServices,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/main/java/org/kie/workbench/common/dmn/showcase/client/editor/DMNDiagramEditor.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.dmn.client.editors.types.DataTypesPage;
 import org.kie.workbench.common.dmn.client.editors.types.listview.common.DataTypeEditModeToggleEvent;
 import org.kie.workbench.common.dmn.client.events.EditExpressionEvent;
 import org.kie.workbench.common.dmn.client.widgets.codecompletion.MonacoFEELInitializer;
+import org.kie.workbench.common.dmn.client.widgets.toolbar.DMNLayoutHelper;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.editor.AbstractDMNDiagramEditor;
 import org.kie.workbench.common.dmn.webapp.kogito.common.client.tour.GuidedTourBridgeInitializer;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
@@ -55,7 +56,6 @@ import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler
 import org.kie.workbench.common.stunner.core.client.canvas.ConfirmationDialog;
 import org.kie.workbench.common.stunner.core.client.canvas.util.CanvasFileExport;
 import org.kie.workbench.common.stunner.core.client.command.SessionCommandManager;
-import org.kie.workbench.common.stunner.core.client.components.layout.LayoutHelper;
 import org.kie.workbench.common.stunner.core.client.components.layout.OpenDiagramLayoutExecutor;
 import org.kie.workbench.common.stunner.core.client.i18n.ClientTranslationService;
 import org.kie.workbench.common.stunner.core.client.shape.Shape;
@@ -90,7 +90,7 @@ public class DMNDiagramEditor extends AbstractDMNDiagramEditor {
                             final DecisionNavigatorDock decisionNavigatorDock,
                             final DiagramEditorPropertiesDock diagramPropertiesDock,
                             final PreviewDiagramDock diagramPreviewAndExplorerDock,
-                            final LayoutHelper layoutHelper,
+                            final @DMNEditor DMNLayoutHelper layoutHelper,
                             final OpenDiagramLayoutExecutor openDiagramLayoutExecutor,
                             final DataTypesPage dataTypesPage,
                             final KogitoClientDiagramService diagramServices,

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
@@ -2,238 +2,238 @@
 <dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0082-feel-coercion" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_i9fboPUUEeesLuP4RHs4vA" name="0082-feel-coercion" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0082-feel-coercion">
    <dmn:description>FEEL type conformance of DT and BKM results</dmn:description>
    <dmn:extensionElements />
-   <dmn:itemDefinition id="_F3588A29-D4EF-41FD-8C88-5F1036E4A8BC" name="tNumberList" isCollection="true">
+   <dmn:itemDefinition id="_39EF120F-9B37-4682-9410-F41887CE29A2" name="tNumberList" isCollection="true">
       <dmn:typeRef>number</dmn:typeRef>
    </dmn:itemDefinition>
-   <dmn:itemDefinition id="_CA2E82D7-1AC8-4EA4-92A1-4086C946026F" name="tStringList" isCollection="true">
+   <dmn:itemDefinition id="_7DF5F629-0C97-42AC-A771-7282339D88A9" name="tStringList" isCollection="true">
       <dmn:typeRef>string</dmn:typeRef>
    </dmn:itemDefinition>
-   <dmn:itemDefinition id="_3DBD02D1-0A1A-4067-B4BF-7DEAB12D6606" name="tDS_001" isCollection="false">
-      <dmn:itemComponent id="_76867EB5-DB25-422A-A45E-03C0992801AF" name="decision_ds_001" isCollection="false">
+   <dmn:itemDefinition id="_932970A7-9FED-4AEC-A946-4C2E526BF3C0" name="tDS_001" isCollection="false">
+      <dmn:itemComponent id="_B32D4D95-1DA6-433A-93CD-223A01701A50" name="decision_ds_001" isCollection="false">
          <dmn:typeRef>string</dmn:typeRef>
       </dmn:itemComponent>
    </dmn:itemDefinition>
-   <dmn:itemDefinition id="_48ECFC75-A67D-4A49-A910-F6706F14A41B" name="tNameAndAge" isCollection="false">
-      <dmn:itemComponent id="_FAB2CC4C-59A0-4DC7-9D14-72F656BD12F9" name="name" isCollection="false">
+   <dmn:itemDefinition id="_20F663CF-FEC1-45EA-83AD-FF6FEA4B2031" name="tNameAndAge" isCollection="false">
+      <dmn:itemComponent id="_61C437FA-BEAE-4B85-955F-551E132A9E31" name="name" isCollection="false">
          <dmn:typeRef>string</dmn:typeRef>
       </dmn:itemComponent>
-      <dmn:itemComponent id="_E77DD21B-367A-43D4-8A16-0595BEF18FE9" name="age" isCollection="false">
+      <dmn:itemComponent id="_7BF8B1D0-D9E1-448A-B3CE-1CA1E490EEA5" name="age" isCollection="false">
          <dmn:typeRef>number</dmn:typeRef>
       </dmn:itemComponent>
    </dmn:itemDefinition>
    <dmn:decisionService id="_decisionService_001" name="decisionService_001">
       <dmn:extensionElements />
-      <dmn:variable id="_0166884C-1325-4D71-8E4D-B5D2A1D3F27F" name="decisionService_001" typeRef="tDS_001" />
+      <dmn:variable id="_089E4678-3B00-41C7-BE4F-A8796A51C3D3" name="decisionService_001" typeRef="tDS_001" />
       <dmn:outputDecision href="#_decision_ds_001" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_002" name="decisionService_002">
       <dmn:extensionElements />
-      <dmn:variable id="_8214FC84-209C-422E-8127-F525F78ED099" name="decisionService_002" />
+      <dmn:variable id="_54DAA01C-439F-459C-B089-13D0D173E64B" name="decisionService_002" />
       <dmn:outputDecision href="#_decision_ds_002" />
       <dmn:inputData href="#_decisionService_002_input_1" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_003" name="decisionService_003">
       <dmn:extensionElements />
-      <dmn:variable id="_CEE104CC-7DA1-41CF-AB71-C87548DDDBB9" name="decisionService_003" />
+      <dmn:variable id="_D1452FAD-E8FF-4281-A8E1-030BFDEBD9FC" name="decisionService_003" />
       <dmn:outputDecision href="#_decision_ds_003" />
       <dmn:inputData href="#_decisionService_003_input_1" />
    </dmn:decisionService>
    <dmn:decision id="_decision_001" name="decision_001">
       <dmn:extensionElements />
-      <dmn:variable id="_D7ABCC84-3B53-4A41-AC8B-73A949722ED5" name="decision_001" typeRef="string" />
-      <dmn:literalExpression id="_D277AC92-BA78-434A-9030-98F28587C10F">
+      <dmn:variable id="_D71C3224-4D04-41EA-A920-9F0532ED5D48" name="decision_001" typeRef="string" />
+      <dmn:literalExpression id="_B8F344CD-17EC-49A4-82EF-15FC52A0A17E">
          <dmn:text>1+1</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_003" name="decision_003">
       <dmn:extensionElements />
-      <dmn:variable id="_C7E96099-EF6E-4451-B62D-1BBB3232A41C" name="decision_003" typeRef="tNumberList" />
-      <dmn:literalExpression id="_715D160B-F6B6-434D-B0C5-32B865C232FC">
+      <dmn:variable id="_23633D78-A8DA-4341-82D1-6BA6E7E39379" name="decision_003" typeRef="tNumberList" />
+      <dmn:literalExpression id="_A6588F1A-73CB-4769-9DD4-68F00AD6DF2F">
          <dmn:text>[1,2,"foo"]</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_004" name="decision_004">
       <dmn:extensionElements />
-      <dmn:variable id="_17026328-ADB2-4316-BBA1-AC4116D35970" name="decision_004" typeRef="tNameAndAge" />
-      <dmn:literalExpression id="_9BE89A60-AECD-4FD8-AD43-E3AE71E8A5CB">
+      <dmn:variable id="_B890815E-179C-4C73-A35B-61C03666B2DB" name="decision_004" typeRef="tNameAndAge" />
+      <dmn:literalExpression id="_9094C6F0-3B1D-495B-8659-68B770EC4B8B">
          <dmn:text>{name: "foo", surname: "bar", age: 10}</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_005" name="decision_005">
       <dmn:extensionElements />
-      <dmn:variable id="_340AC03F-EE0B-4A32-9284-5604BCC577AB" name="decision_005" typeRef="tNameAndAge" />
-      <dmn:literalExpression id="_6FFBD558-AB35-485F-8045-6387C0DD8A42">
+      <dmn:variable id="_A378871A-2A7F-4EE8-9338-5386FE3E3EC2" name="decision_005" typeRef="tNameAndAge" />
+      <dmn:literalExpression id="_FF113522-29B5-4986-9C3B-B66A2EF015FB">
          <dmn:text>{name: "foo"}</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_006" name="decision_006">
       <dmn:extensionElements />
-      <dmn:variable id="_23E1F8A9-51FD-4C43-8075-056E40CD384F" name="decision_006" typeRef="tStringList" />
-      <dmn:literalExpression id="_ED551414-BBE9-4B20-9362-A81FFEE7DF19">
+      <dmn:variable id="_4805ED29-C56D-46A4-BB6F-99F7B225C828" name="decision_006" typeRef="tStringList" />
+      <dmn:literalExpression id="_3FE6DC6A-4B57-4A4F-AE87-3008A31E4024">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_006_a" name="decision_006_a">
       <dmn:extensionElements />
-      <dmn:variable id="_FBA2C16C-2C1F-41F6-A795-1701821DDF9B" name="decision_006_a" typeRef="tNumberList" />
-      <dmn:literalExpression id="_CBC0E494-26AC-4D1F-B34C-69FFAA39080A">
+      <dmn:variable id="_58E3A66C-991B-4D43-BB40-C755F5AE62E7" name="decision_006_a" typeRef="tNumberList" />
+      <dmn:literalExpression id="_DEBC29F2-7B45-4AD9-9BDB-AF813D2E85EC">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_007" name="decision_007">
       <dmn:extensionElements />
-      <dmn:variable id="_153DBBE7-9C1D-40C5-90C4-0443AC355F8E" name="decision_007" typeRef="string" />
-      <dmn:literalExpression id="_5D39D344-741C-484A-B3D8-80FC57102BD2">
+      <dmn:variable id="_58114907-1331-469F-BD54-DA1C644DA3E5" name="decision_007" typeRef="string" />
+      <dmn:literalExpression id="_93BA298A-D6CF-4073-83D7-E5DFD46C7249">
          <dmn:text>["foo"]</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_007_a" name="decision_007_a">
       <dmn:extensionElements />
-      <dmn:variable id="_AD4FB2DD-AD1E-4CFA-AEA4-3AA94EE5D074" name="decision_007_a" typeRef="string" />
-      <dmn:literalExpression id="_FCF4F8F8-84A1-4657-B08C-8B222A719D14">
+      <dmn:variable id="_19E09A88-B2B8-47FD-BBC3-DB9D303EA2DC" name="decision_007_a" typeRef="string" />
+      <dmn:literalExpression id="_F73B228D-FE83-42BB-8364-9EA2A0BF0266">
          <dmn:text>[1]</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_008" name="decision_008">
       <dmn:extensionElements />
-      <dmn:variable id="_8F5E8021-F4D3-40CC-8044-E1FDF48558B3" name="decision_008" typeRef="list" />
-      <dmn:literalExpression id="_98638ECF-2EBF-4606-ACFB-587001CFD3BA">
+      <dmn:variable id="_196A486E-7985-4383-8FD7-4F4E6FD64115" name="decision_008" typeRef="list" />
+      <dmn:literalExpression id="_10D122AA-E1BB-4EEB-B5BA-DE44F44EB565">
          <dmn:text>null</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:businessKnowledgeModel id="_bkm_001" name="bkm_001">
       <dmn:extensionElements />
-      <dmn:variable id="_0EA60753-2B27-4BF7-9829-1A334C103AE8" name="bkm_001" />
-      <dmn:encapsulatedLogic id="_2C43E9DD-1882-4CC3-B2E7-C9783841D1C2" kind="FEEL">
-         <dmn:formalParameter id="_72FBD076-BF52-4BD3-A059-A9BDC39BE0D5" name="nameAndAge" typeRef="tNameAndAge" />
-         <dmn:literalExpression id="_2EE79C8B-4C16-4550-970D-250A7566B5B5">
+      <dmn:variable id="_B89E188E-BCED-4A6F-B813-12BB5ADB959D" name="bkm_001" />
+      <dmn:encapsulatedLogic id="_1503CD38-C6F5-4BF4-82F2-2747EB26F43B" kind="FEEL">
+         <dmn:formalParameter id="_387B2B56-2031-4CCC-B068-AEDF5401EDB8" name="nameAndAge" typeRef="tNameAndAge" />
+         <dmn:literalExpression id="_C3FD39CF-CD00-47AD-87D5-887B342687BA">
             <dmn:text>nameAndAge != null</dmn:text>
          </dmn:literalExpression>
       </dmn:encapsulatedLogic>
    </dmn:businessKnowledgeModel>
    <dmn:decision id="_decision_bkm_001" name="decision_bkm_001">
       <dmn:extensionElements />
-      <dmn:variable id="_48629294-3EA8-4499-B7E0-A71AB91E3A96" name="decision_bkm_001" />
-      <dmn:knowledgeRequirement id="_68546B11-7C06-4A8B-95B0-4C124CADAA2C">
+      <dmn:variable id="_0728551F-7FB5-4CAF-BBDF-F192ECC20F09" name="decision_bkm_001" />
+      <dmn:knowledgeRequirement id="_A7CC1B9F-797F-423C-98EE-B9E14D4A4CB5">
          <dmn:requiredKnowledge href="#_bkm_001" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_93493631-022A-4C87-91DF-58F9A4F644AA">
+      <dmn:literalExpression id="_48D8BAD3-1812-45FD-89E3-EF6B7B8F3EC6">
          <dmn:text>bkm_001({name: "foo", surname: "bar", age: 10})</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_bkm_002" name="decision_bkm_002">
       <dmn:extensionElements />
-      <dmn:variable id="_358C7C6B-B85F-42FA-851D-92E67259EA22" name="decision_bkm_002" />
-      <dmn:knowledgeRequirement id="_F8436D5E-B368-4771-8F41-E631E4B3B0A0">
+      <dmn:variable id="_1E580BDF-1DC7-4783-8FC7-AFA227D87D80" name="decision_bkm_002" />
+      <dmn:knowledgeRequirement id="_5A8B3B8D-5E11-464B-B7BA-83B005DC48A9">
          <dmn:requiredKnowledge href="#_bkm_001" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_90C983F3-68EE-4B3B-9DE2-C21F0E93B955">
+      <dmn:literalExpression id="_A0A33844-1DC8-4719-9955-7DC551ED4F0C">
          <dmn:text>bkm_001({name: "foo"})</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:businessKnowledgeModel id="_bkm_002" name="bkm_002">
       <dmn:extensionElements />
-      <dmn:variable id="_C2C2EF9F-D911-49B2-8AA6-9B95FC98FCDC" name="bkm_002" typeRef="tNameAndAge" />
-      <dmn:encapsulatedLogic id="_6F57B3F5-311C-4BA9-B38E-F094B71A6D50" kind="FEEL">
-         <dmn:formalParameter id="_41E21842-DE69-49C2-9ACF-18C59015BF6A" name="nameAndAge" typeRef="tNameAndAge" />
-         <dmn:literalExpression id="_D6F7F274-441E-419F-9E14-43F2DB655967">
+      <dmn:variable id="_92BEEB15-10B9-4946-95E2-E83B06C57A6E" name="bkm_002" typeRef="tNameAndAge" />
+      <dmn:encapsulatedLogic id="_C1D1E52F-4260-4F15-88F6-9B8F9C56CBB7" kind="FEEL">
+         <dmn:formalParameter id="_9B3AC200-4615-4009-96D4-1C29DADC1B5E" name="nameAndAge" typeRef="tNameAndAge" />
+         <dmn:literalExpression id="_761A0FB1-C89F-4412-A2E1-829EC3C9909A">
             <dmn:text>nameAndAge != null</dmn:text>
          </dmn:literalExpression>
       </dmn:encapsulatedLogic>
    </dmn:businessKnowledgeModel>
    <dmn:decision id="_decision_bkm_003" name="decision_bkm_003">
       <dmn:extensionElements />
-      <dmn:variable id="_6E9C1944-BCBC-4495-861C-1474979FB25B" name="decision_bkm_003" />
-      <dmn:knowledgeRequirement id="_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4">
+      <dmn:variable id="_0DAFBE28-E7AF-4035-96F1-BC547F1033F2" name="decision_bkm_003" />
+      <dmn:knowledgeRequirement id="_43A1354A-4159-4877-8144-CC0E44C7334D">
          <dmn:requiredKnowledge href="#_bkm_002" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_D163B8D3-2B0D-488F-BB0A-551254CE4002">
+      <dmn:literalExpression id="_E297C226-2603-472F-A15C-9DD514F4727A">
          <dmn:text>bkm_002({name: "foo"})</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:businessKnowledgeModel id="_bkm_004" name="bkm_004">
       <dmn:extensionElements />
-      <dmn:variable id="_407F6BF8-E319-476A-B511-67F87CF7B3F0" name="bkm_004" typeRef="tNumberList" />
-      <dmn:encapsulatedLogic id="_CE285C61-7483-4FCB-AC28-D6B803B6A3E7" kind="FEEL">
-         <dmn:formalParameter id="_750C1E3B-C297-4069-A8DA-A5774230F762" name="arg" />
-         <dmn:literalExpression id="_49A0FBD4-6637-4B53-BB5F-43B5C42B2D3B">
+      <dmn:variable id="_AE488030-1703-41C9-AD83-4A8F9A862705" name="bkm_004" typeRef="tNumberList" />
+      <dmn:encapsulatedLogic id="_4B90C4F7-DC7C-4193-9C06-8A21B6ECC28C" kind="FEEL">
+         <dmn:formalParameter id="_A5FE68CF-C31B-4795-A1EF-E2613028536F" name="arg" />
+         <dmn:literalExpression id="_187715A8-B7A7-492C-9913-E9DFBC8B4AB3">
             <dmn:text>arg</dmn:text>
          </dmn:literalExpression>
       </dmn:encapsulatedLogic>
    </dmn:businessKnowledgeModel>
    <dmn:businessKnowledgeModel id="_bkm_005" name="bkm_005">
       <dmn:extensionElements />
-      <dmn:variable id="_F5AAE6D8-BF27-4F07-956D-113492457CE3" name="bkm_005" typeRef="number" />
-      <dmn:encapsulatedLogic id="_D56DE1E1-8FAF-4D65-900F-5AA5D3BE807B" kind="FEEL">
-         <dmn:formalParameter id="_5565A56B-508A-46E1-AC68-0DC380E97C32" name="arg" />
-         <dmn:literalExpression id="_8262564E-8138-42C4-8AF4-1D52CC9E9399">
+      <dmn:variable id="_AEF7257F-96F2-4FB1-A3F3-7968E19BEB55" name="bkm_005" typeRef="number" />
+      <dmn:encapsulatedLogic id="_753E67E9-FBC9-4BF2-9311-FF644F1EFA4A" kind="FEEL">
+         <dmn:formalParameter id="_E5F2000C-E449-45BF-91B7-8D454E72D744" name="arg" />
+         <dmn:literalExpression id="_BA405A2F-4AC9-43D2-B2ED-A4AC02C4D89E">
             <dmn:text>[arg]</dmn:text>
          </dmn:literalExpression>
       </dmn:encapsulatedLogic>
    </dmn:businessKnowledgeModel>
    <dmn:decision id="_decision_bkm_004" name="decision_bkm_004">
       <dmn:extensionElements />
-      <dmn:variable id="_4F3FC0CF-8EFC-4230-A2C6-631718D507E0" name="decision_bkm_004" />
-      <dmn:knowledgeRequirement id="_3EBBAB17-C04D-4603-9939-27AE25901615">
+      <dmn:variable id="_9DA94638-059F-4D30-98C3-F8F4B6BAE94F" name="decision_bkm_004" />
+      <dmn:knowledgeRequirement id="_4F2CC784-FFB6-4FD1-B93E-6AAC424C9B79">
          <dmn:requiredKnowledge href="#_bkm_004" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_A3C4745D-B25F-4757-99FB-7943DDC5905A">
+      <dmn:literalExpression id="_5545F783-9AB2-48C4-98F7-9E146F14D9D7">
          <dmn:text>bkm_004(10)</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_bkm_004_a" name="decision_bkm_004_a">
       <dmn:extensionElements />
-      <dmn:variable id="_FDA2CDE3-A962-4142-B0F2-E95DBCD81B74" name="decision_bkm_004_a" />
-      <dmn:knowledgeRequirement id="_81A20E77-6873-408E-B46A-D629C10CF82C">
+      <dmn:variable id="_775EC7DC-9C86-44FD-A1DE-B38FD01028A1" name="decision_bkm_004_a" />
+      <dmn:knowledgeRequirement id="_49D4F488-6BEC-4A08-85E3-1742095D83B7">
          <dmn:requiredKnowledge href="#_bkm_004" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_36D66913-F7E4-40E4-A9E7-27C030B02513">
+      <dmn:literalExpression id="_B23C271F-E0D5-4F98-8D12-ADB16028074F">
          <dmn:text>bkm_004("foo")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_bkm_004_b" name="decision_bkm_004_b">
       <dmn:extensionElements />
-      <dmn:variable id="_7FC7E2DB-77C4-41C8-943C-FCE46F1A1493" name="decision_bkm_004_b" />
-      <dmn:knowledgeRequirement id="_D12DAA2A-8672-4B57-B3E6-031A1B244062">
+      <dmn:variable id="_8131C789-7D16-46CF-8BEC-F12395E03C29" name="decision_bkm_004_b" />
+      <dmn:knowledgeRequirement id="_32E58051-EE14-4466-8000-3CF48DE75275">
          <dmn:requiredKnowledge href="#_bkm_004" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_C2DE3F17-2C89-42BA-AF99-D61369CB6EDB">
+      <dmn:literalExpression id="_F4BBC747-3820-4522-A243-05C7C3A1BDE2">
          <dmn:text>bkm_004(null)</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_bkm_005" name="decision_bkm_005">
       <dmn:extensionElements />
-      <dmn:variable id="_C5752C79-F487-473D-A3D0-98470A220411" name="decision_bkm_005" />
-      <dmn:knowledgeRequirement id="_63E07842-23E3-4A56-843F-29876C7356B2">
+      <dmn:variable id="_8BF6EBBB-06A8-4003-A357-3A45E6392E75" name="decision_bkm_005" />
+      <dmn:knowledgeRequirement id="_9D22D377-E6FF-4199-8708-9223CA82004A">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_DBE08836-6D08-4D6E-B798-EC62556D0A00">
+      <dmn:literalExpression id="_A794268C-6321-4C02-9046-B3CF3F9E1761">
          <dmn:text>bkm_005(10)</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_bkm_005_a" name="decision_bkm_005_a">
       <dmn:extensionElements />
-      <dmn:variable id="_773028C5-459D-4077-83F6-0CE5DC63E50D" name="decision_bkm_005_a" />
-      <dmn:knowledgeRequirement id="_9D46D5A3-EACE-4B85-811C-6E222F520AAF">
+      <dmn:variable id="_1F3DB9B7-40AF-4B67-AD26-57398CB3F8AE" name="decision_bkm_005_a" />
+      <dmn:knowledgeRequirement id="_6DD439E0-4534-45F4-99AF-28B2CFDFCF79">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_D4641F86-9DF5-4DB3-8790-47FE824C6765">
+      <dmn:literalExpression id="_676D5194-084F-4E9E-8178-D2F0958DB618">
          <dmn:text>bkm_005("foo")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_invoke_001" name="invoke_001">
       <dmn:extensionElements />
-      <dmn:variable id="_E9DF663F-8803-4CBE-895C-6F27D6134190" name="invoke_001" />
-      <dmn:knowledgeRequirement id="_9A9924C7-D617-478E-BC2F-9D35F32D172D">
+      <dmn:variable id="_461FAC3D-9F1E-4740-A61A-D8A82275D3E2" name="invoke_001" />
+      <dmn:knowledgeRequirement id="_EB6C87AD-D98C-49C1-8E8B-4FE00C0DFF41">
          <dmn:requiredKnowledge href="#_bkm_001" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_24F82CA3-99D1-4892-9DAF-3AFE78B9C506">
-         <dmn:literalExpression id="_A437701C-23FB-482D-828A-FE2AA0612431">
+      <dmn:invocation id="_4F4F9F81-AE47-4E69-AAFE-72A9D26F04E8">
+         <dmn:literalExpression id="_77FA8DB6-E1A5-4E52-8C0A-80C7473853D9">
             <dmn:text>bkm_001</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_78EBAC4F-8FE1-456B-BE83-E9E68FE2F5FA" name="nameAndAge" />
-            <dmn:literalExpression id="_C5FCD024-5645-4BEB-A7D2-CF5E872B83AE">
+            <dmn:parameter id="_09FC23F6-3934-4033-BAD0-73C03C2B59DC" name="nameAndAge" />
+            <dmn:literalExpression id="_0E5F9160-4DBE-4397-A9FA-8C7507FF43AF">
                <dmn:text>{name: "foo"}</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -241,17 +241,17 @@
    </dmn:decision>
    <dmn:decision id="_invoke_002" name="invoke_002">
       <dmn:extensionElements />
-      <dmn:variable id="_52E0A7E1-A77F-46F2-8E95-BE780ADD8F25" name="invoke_002" typeRef="string" />
-      <dmn:knowledgeRequirement id="_4FB36F34-549D-4FB3-B5ED-134685380F3F">
+      <dmn:variable id="_2E8A22D5-2D67-4FF7-8B59-EFA4EEE17719" name="invoke_002" typeRef="string" />
+      <dmn:knowledgeRequirement id="_957FD353-447F-49E8-B416-11983AE09415">
          <dmn:requiredKnowledge href="#_bkm_001" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_94363EF7-FC61-4609-BC58-DAEF64F59464" typeRef="string">
-         <dmn:literalExpression id="_59E4D032-7A9A-43ED-A113-DC249C4E9C3B">
+      <dmn:invocation id="_3315BB4E-E257-4B97-8C2A-DC9B47C12CD2" typeRef="string">
+         <dmn:literalExpression id="_CC7C3720-C7ED-4B81-8B08-5D5EA611AD79">
             <dmn:text>bkm_001</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_050DDD99-187A-4AA5-B1BE-2584EC039B77" name="nameAndAge" />
-            <dmn:literalExpression id="_89950E0F-92D8-44B4-B9A3-81C90046CF6A">
+            <dmn:parameter id="_25665A0A-59B7-4ED1-AC6D-8CECB25C405E" name="nameAndAge" />
+            <dmn:literalExpression id="_430A4AD7-222C-450F-B4E0-F5FA20A13AE3">
                <dmn:text>{name: "foo", age: 10}</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -259,17 +259,17 @@
    </dmn:decision>
    <dmn:decision id="_invoke_003" name="invoke_003">
       <dmn:extensionElements />
-      <dmn:variable id="_B50D5920-AC26-423B-A8A5-21FE4883F130" name="invoke_003" typeRef="tNumberList" />
-      <dmn:knowledgeRequirement id="_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B">
+      <dmn:variable id="_0F6E99E7-E4E3-41C2-BBA3-FF7E58442C6F" name="invoke_003" typeRef="tNumberList" />
+      <dmn:knowledgeRequirement id="_A35293A4-70A8-4920-ADEA-5A1E3D974B23">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_794E9811-2A0B-4062-ACE5-F4610120FEFC" typeRef="tNumberList">
-         <dmn:literalExpression id="_3B49CC6C-11A2-424D-8D6F-FDFF4B9C577F">
+      <dmn:invocation id="_E0C6A7DD-679D-4DE2-972C-C9A6C2652A2F" typeRef="tNumberList">
+         <dmn:literalExpression id="_26EF41EB-F88E-4080-AD2D-572BC3CB7968">
             <dmn:text>bkm_005</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_0FAB7A6C-C99E-47F2-BC38-411CA87BD3CF" name="arg" />
-            <dmn:literalExpression id="_A0AC6786-37B1-4324-BB29-A6279952653B">
+            <dmn:parameter id="_30113170-CC0C-4B7D-BA7F-0F19AA503B8E" name="arg" />
+            <dmn:literalExpression id="_D11EF99F-A66D-4877-87EB-5552761E22A8">
                <dmn:text>10</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -277,17 +277,17 @@
    </dmn:decision>
    <dmn:decision id="_invoke_004" name="invoke_004">
       <dmn:extensionElements />
-      <dmn:variable id="_679C4EF9-54C4-48DD-A077-6D0C03C8273E" name="invoke_004" typeRef="tNumberList" />
-      <dmn:knowledgeRequirement id="_EAA6FD5F-785C-4CA4-9930-51F53869B0E7">
+      <dmn:variable id="_9C5D721A-4A91-4046-B067-90FD0ED8C9CD" name="invoke_004" typeRef="tNumberList" />
+      <dmn:knowledgeRequirement id="_60640E63-C9C1-49FF-8114-382AC9B64093">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_C1B48C5B-E77A-4DBD-8FD9-B6A152FD6D4D" typeRef="tNumberList">
-         <dmn:literalExpression id="_44207F2A-A61A-4144-AD84-75514DB72719">
+      <dmn:invocation id="_539BDAE7-4CA2-4DA1-8250-F5D43CD480ED" typeRef="tNumberList">
+         <dmn:literalExpression id="_33779F99-76FB-4D2E-B71D-BB358B4994AF">
             <dmn:text>bkm_005</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_BD8D119A-ECA0-4587-B28F-9EE0CB3BC9C5" name="arg" />
-            <dmn:literalExpression id="_D1047E70-958B-469B-B53C-6958D514D4B5">
+            <dmn:parameter id="_DFDDAF6A-5A7B-4E52-8F27-6E07363B14C7" name="arg" />
+            <dmn:literalExpression id="_18F31BC3-5AC5-4F75-8AD8-70EC4DA4E98C">
                <dmn:text>"foo"</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -295,17 +295,17 @@
    </dmn:decision>
    <dmn:decision id="_invoke_005" name="invoke_005">
       <dmn:extensionElements />
-      <dmn:variable id="_A324D844-3B29-49CF-891D-20429A9ADAFE" name="invoke_005" typeRef="number" />
-      <dmn:knowledgeRequirement id="_D2DA1995-D862-47FA-B833-BDDB92B5C87C">
+      <dmn:variable id="_B5FC899D-9EFC-484A-B25B-76972197397F" name="invoke_005" typeRef="number" />
+      <dmn:knowledgeRequirement id="_238D7A02-A4B9-4A04-AB24-6486A9D073CD">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_E5F0B0F8-07EA-4B28-9EA9-BA74FDB7AF71" typeRef="number">
-         <dmn:literalExpression id="_32DFA51C-81B8-483A-9D5D-4477E1E1B68B">
+      <dmn:invocation id="_6E7EEB68-DA8B-440F-9A43-6B94D7DA0C3B" typeRef="number">
+         <dmn:literalExpression id="_17C0978E-3B3B-4330-8EDF-1D20EAD0D3DC">
             <dmn:text>bkm_005</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_68A837DC-4928-4269-8F18-E8886646FB46" name="arg" />
-            <dmn:literalExpression id="_EE998D50-9323-410E-A685-B2698BB25466">
+            <dmn:parameter id="_202C4E2F-0047-4231-B3B9-A89C2D126AB2" name="arg" />
+            <dmn:literalExpression id="_71DB9933-1FB1-40DB-AE45-FC1EB71E27F6">
                <dmn:text>[10]</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -313,17 +313,17 @@
    </dmn:decision>
    <dmn:decision id="_invoke_006" name="invoke_006">
       <dmn:extensionElements />
-      <dmn:variable id="_BA5717BF-8662-439A-8E3D-ED1AAF159014" name="invoke_006" typeRef="number" />
-      <dmn:knowledgeRequirement id="_5BB47D86-2531-4C80-A73F-97FCD8E81DBD">
+      <dmn:variable id="_239D499A-0F97-4034-AC70-7C5831DF11D1" name="invoke_006" typeRef="number" />
+      <dmn:knowledgeRequirement id="_766B7897-92A9-4461-9E12-82FC50641572">
          <dmn:requiredKnowledge href="#_bkm_005" />
       </dmn:knowledgeRequirement>
-      <dmn:invocation id="_88BA6B31-357B-406F-8830-AEC5328318D8" typeRef="number">
-         <dmn:literalExpression id="_7285443C-BE70-481D-8763-68879AA0E463">
+      <dmn:invocation id="_307DD29E-C0E4-4907-8DC4-00728453ED69" typeRef="number">
+         <dmn:literalExpression id="_7E5856FD-4035-4BE2-95F8-7808874AC35B">
             <dmn:text>bkm_005</dmn:text>
          </dmn:literalExpression>
          <dmn:binding>
-            <dmn:parameter id="_832B3B7E-EDC1-483B-8F40-F2E105ADD07A" name="arg" />
-            <dmn:literalExpression id="_CED2D692-6F4C-4FE1-9957-07BD77EE1B10">
+            <dmn:parameter id="_153E3C55-4538-4578-8BB5-A2B4698FFBD8" name="arg" />
+            <dmn:literalExpression id="_B4C897AD-DDBF-4BDF-BA60-47C1550AF1BF">
                <dmn:text>["foo"]</dmn:text>
             </dmn:literalExpression>
          </dmn:binding>
@@ -331,16 +331,16 @@
    </dmn:decision>
    <dmn:decision id="_fd_001" name="fd_001">
       <dmn:extensionElements />
-      <dmn:variable id="_F4514CDB-AE73-459C-B6E6-2FF16A3C8D3D" name="fd_001" />
-      <dmn:context id="_18175A34-C931-44EB-84E2-62C52E82D80C">
+      <dmn:variable id="_A31C23CA-DA5E-4B65-929A-D28C6557D1BC" name="fd_001" />
+      <dmn:context id="_022FDD0F-923F-4945-B804-B3726D690722">
          <dmn:contextEntry>
-            <dmn:variable id="_559EBB70-EA8A-4EAA-BE1A-4400142C6BF0" name="fn" />
-            <dmn:literalExpression id="_103F6774-9FF7-4617-85B6-42E65EEEF942">
+            <dmn:variable id="_7F668513-D430-498F-B75B-EDA783CEA78D" name="fn" />
+            <dmn:literalExpression id="_1EF0C640-65A5-4902-B907-45EB07C6F48D">
                <dmn:text>function(arg: number) arg</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:literalExpression id="_0A6F707E-E81F-45CF-B389-0CBFAD3C4798">
+            <dmn:literalExpression id="_815B703D-7E0A-42DE-9B7E-2C4DF9A7DDF1">
                <dmn:text>fn(10)</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
@@ -348,16 +348,16 @@
    </dmn:decision>
    <dmn:decision id="_fd_002" name="fd_002">
       <dmn:extensionElements />
-      <dmn:variable id="_3D67778F-F1D6-4A93-A613-D368B332F499" name="fd_002" />
-      <dmn:context id="_CC81CC7D-5D38-455A-ACC6-216D350B108B">
+      <dmn:variable id="_24AD4441-9544-47C1-A85F-251F7B1CD828" name="fd_002" />
+      <dmn:context id="_42A3A817-9A49-47AD-9BC8-35FA9F612F72">
          <dmn:contextEntry>
-            <dmn:variable id="_D249BF9A-6A37-4831-951D-4BF71C4576AE" name="fn" />
-            <dmn:literalExpression id="_87FDB835-A7E4-4253-B37B-6C1BC89B9325">
+            <dmn:variable id="_7567055A-2E9B-4139-B3ED-AF7880845431" name="fn" />
+            <dmn:literalExpression id="_44A33019-81C1-483D-9F72-DC9E7C09963D">
                <dmn:text>function(arg: number) arg</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:literalExpression id="_E26F349A-8846-4732-B8FA-8A96B5E8CFC3">
+            <dmn:literalExpression id="_4CE11D52-FA28-4B66-A196-4EA8BD5A4459">
                <dmn:text>fn("foo")</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
@@ -365,176 +365,176 @@
    </dmn:decision>
    <dmn:decision id="_literal_001" name="literal_001">
       <dmn:extensionElements />
-      <dmn:variable id="_67FA5B3F-8C8D-4E38-8C00-940E697E8B26" name="literal_001" typeRef="number" />
-      <dmn:literalExpression id="_D69AE0B4-551D-4662-9695-760D0B47D915" typeRef="number">
+      <dmn:variable id="_218FEAD4-CAE3-4BA1-A001-25AE5BA9CC56" name="literal_001" typeRef="number" />
+      <dmn:literalExpression id="_18743744-1F6B-4A6C-B0EF-A1A373102C69" typeRef="number">
          <dmn:text>5+5</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_literal_002" name="literal_002">
       <dmn:extensionElements />
-      <dmn:variable id="_D1D1B598-8122-4C81-8930-C3FD3933F25A" name="literal_002" typeRef="number" />
-      <dmn:literalExpression id="_989C6F4F-E08F-485F-90DE-501B91FAC6C4" typeRef="number">
+      <dmn:variable id="_7CCA835F-4888-4B0F-9626-0B0E9FE587FC" name="literal_002" typeRef="number" />
+      <dmn:literalExpression id="_753085ED-A52C-41EE-AB4E-B03743B63AF7" typeRef="number">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_literal_003" name="literal_003">
       <dmn:extensionElements />
-      <dmn:variable id="_10F74ECF-1520-4871-938B-103632F3BED9" name="literal_003" typeRef="tNumberList" />
-      <dmn:literalExpression id="_A649C13A-A589-4742-8D99-4A812C88417C" typeRef="tNumberList">
+      <dmn:variable id="_C8EC035B-8F13-4943-9B90-256E5BF9E8FF" name="literal_003" typeRef="tNumberList" />
+      <dmn:literalExpression id="_85613F31-13AE-4128-AAFB-D919FACED836" typeRef="tNumberList">
          <dmn:text>10</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_literal_004" name="literal_004">
       <dmn:extensionElements />
-      <dmn:variable id="_EB9D5083-95EC-4C55-83EA-5B47845206E0" name="literal_004" typeRef="tNumberList" />
-      <dmn:literalExpression id="_E8528192-0932-421D-8408-2041C6E78A92" typeRef="tNumberList">
+      <dmn:variable id="_CDB70DA5-F4E6-4F1F-B08D-E8B19599BFCE" name="literal_004" typeRef="tNumberList" />
+      <dmn:literalExpression id="_8988E079-B2A0-4690-8E4B-97BD9DC4F622" typeRef="tNumberList">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_literal_005" name="literal_005">
       <dmn:extensionElements />
-      <dmn:variable id="_146BF83D-1B30-426F-A811-6D6797F9F864" name="literal_005" typeRef="number" />
-      <dmn:literalExpression id="_D14CEA9B-BFA4-4808-BB77-52466481445C" typeRef="number">
+      <dmn:variable id="_3EAC31EB-EAAF-4BCF-BC1F-45BFFE2B81B2" name="literal_005" typeRef="number" />
+      <dmn:literalExpression id="_5E240B13-60A2-44CD-BD66-2E0CD6BEEFB1" typeRef="number">
          <dmn:text>[10]</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_literal_006" name="literal_006">
       <dmn:extensionElements />
-      <dmn:variable id="_ADB0E85F-9E4B-4289-99D2-B02FABF0D922" name="literal_006" typeRef="number" />
-      <dmn:literalExpression id="_3B76E8FC-BABD-469D-A6B2-37BA327365F5" typeRef="number">
+      <dmn:variable id="_45DA7C4F-1621-43E5-B7CE-77045E141578" name="literal_006" typeRef="number" />
+      <dmn:literalExpression id="_5D001188-9D69-499B-912E-652B0AB664B8" typeRef="number">
          <dmn:text>["foo"]</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_ds_001" name="decision_ds_001">
       <dmn:extensionElements />
-      <dmn:variable id="_4567FB14-4222-4B8E-8014-59D4C2B4CBE2" name="decision_ds_001" />
-      <dmn:literalExpression id="_E1843FD2-62FB-459E-8BFF-071E13A56285">
+      <dmn:variable id="_C87E1A39-FB00-43DC-BE27-9B880AFC0010" name="decision_ds_001" />
+      <dmn:literalExpression id="_ACE4063D-B823-48DB-88C9-65F5BE9DCD1C">
          <dmn:text>1000</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_ds_002" name="decision_ds_002">
       <dmn:extensionElements />
-      <dmn:variable id="_4F9076C5-6D19-4298-B997-11032201CAAA" name="decision_ds_002" />
-      <dmn:informationRequirement id="_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE">
+      <dmn:variable id="_747EF5E9-D89D-49D0-AF50-E691D3160752" name="decision_ds_002" />
+      <dmn:informationRequirement id="_1CA91B26-9D39-402B-B57F-069B48E2BB16">
          <dmn:requiredInput href="#_decisionService_002_input_1" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_52547BEB-3E85-4310-A899-3062C255FF25">
+      <dmn:literalExpression id="_394EFC4B-25F9-4BDF-8ED3-B8DA75951046">
          <dmn:text>decisionService_002_input_1</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_decisionService_002_input_1" name="decisionService_002_input_1">
       <dmn:extensionElements />
-      <dmn:variable id="_DDAFD901-AA26-4148-B00E-B417D284E9D2" name="decisionService_002_input_1" typeRef="string" />
+      <dmn:variable id="_19F56E6E-6ACC-4B33-8732-A1A82E0FFE89" name="decisionService_002_input_1" typeRef="string" />
    </dmn:inputData>
    <dmn:decision id="_ds_invoke_002_with_number" name="ds_invoke_002_with_number">
       <dmn:extensionElements />
-      <dmn:variable id="_78BFF27A-7CFD-4873-B1E3-90E99768A5FB" name="ds_invoke_002_with_number" />
-      <dmn:knowledgeRequirement id="_F2016F44-D6AC-409C-B0B1-6048B6CDF959">
+      <dmn:variable id="_774351F4-72D7-4720-A20D-ED0E7BC436F5" name="ds_invoke_002_with_number" />
+      <dmn:knowledgeRequirement id="_77BD5335-D370-4238-BB1F-1D2080FAD2E3">
          <dmn:requiredKnowledge href="#_decisionService_002" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_4F4BEF6A-9B31-44D1-91F5-CBEFC27BFCC8">
+      <dmn:literalExpression id="_13C35C82-C252-45F9-861D-A7F110F456B9">
          <dmn:text>decisionService_002(10)</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_ds_invoke_002_with_singleton_list" name="ds_invoke_002_with_singleton_list">
       <dmn:extensionElements />
-      <dmn:variable id="_6B738A72-155F-4CD6-B0BE-2CC25F49E0CC" name="ds_invoke_002_with_singleton_list" />
-      <dmn:knowledgeRequirement id="_2B360566-81F1-41BD-8D5D-B0F786692652">
+      <dmn:variable id="_1F0EC3C0-719E-4883-B53E-9C546C20F0EC" name="ds_invoke_002_with_singleton_list" />
+      <dmn:knowledgeRequirement id="_22231295-B6F8-451F-8AC7-63EF6B4F3627">
          <dmn:requiredKnowledge href="#_decisionService_002" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_FAB14015-5787-428A-9DD7-3BC0C96D6728">
+      <dmn:literalExpression id="_3FE7E23F-246D-4AC6-8734-ED4E8BC37944">
          <dmn:text>decisionService_002(["foo"])</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_ds_003" name="decision_ds_003">
       <dmn:extensionElements />
-      <dmn:variable id="_DF95559F-608C-4DC1-BEE0-3D9D29847E45" name="decision_ds_003" />
-      <dmn:informationRequirement id="_20E48A54-F6B8-4E2E-BD46-DD38D44FA213">
+      <dmn:variable id="_51834C5F-EAC1-4CB4-BE1A-F40D4E7A7F79" name="decision_ds_003" />
+      <dmn:informationRequirement id="_878CB78B-4677-4A7C-B02E-89DD5E7EE0BE">
          <dmn:requiredInput href="#_decisionService_003_input_1" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_F680776D-71FB-4007-A1C6-6ED68EA9EB3A">
+      <dmn:literalExpression id="_46B8C03D-38AD-4191-8C99-69AD13124362">
          <dmn:text>decisionService_003_input_1</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_decisionService_003_input_1" name="decisionService_003_input_1">
       <dmn:extensionElements />
-      <dmn:variable id="_8C96E193-4659-45AD-9D72-9EF3549031B2" name="decisionService_003_input_1" typeRef="tStringList" />
+      <dmn:variable id="_6220C50E-0BA1-4095-8D79-73F7707E834A" name="decisionService_003_input_1" typeRef="tStringList" />
    </dmn:inputData>
    <dmn:decision id="_ds_invoke_003_with_string" name="ds_invoke_003_with_string">
       <dmn:extensionElements />
-      <dmn:variable id="_C3853E26-E710-43A8-B9EB-3E56A5970806" name="ds_invoke_003_with_string" />
-      <dmn:knowledgeRequirement id="_00D499AC-31B0-4704-AA50-1C4D22931B38">
+      <dmn:variable id="_087D57B1-01D9-4D1D-96EA-AEAA964C7721" name="ds_invoke_003_with_string" />
+      <dmn:knowledgeRequirement id="_C06F37AE-FE02-4525-A758-3464496BBCD7">
          <dmn:requiredKnowledge href="#_decisionService_003" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_6F69867A-5997-491F-893B-09518234E37A">
+      <dmn:literalExpression id="_2B6EC9D3-941C-4352-B9A8-45E185E67BE4">
          <dmn:text>decisionService_003("foo")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmndi:DMNDI>
-      <dmndi:DMNDiagram id="_888A41F2-5523-47D3-8BC2-80614F963D7B" name="DRG">
+      <dmndi:DMNDiagram id="_2B8668E6-4737-4B87-8925-6CC5C8CCF356" name="DRG">
          <di:extension>
             <kie:ComponentsWidthsExtension>
-               <kie:ComponentWidths dmnElementRef="_D277AC92-BA78-434A-9030-98F28587C10F" />
-               <kie:ComponentWidths dmnElementRef="_715D160B-F6B6-434D-B0C5-32B865C232FC" />
-               <kie:ComponentWidths dmnElementRef="_9BE89A60-AECD-4FD8-AD43-E3AE71E8A5CB" />
-               <kie:ComponentWidths dmnElementRef="_6FFBD558-AB35-485F-8045-6387C0DD8A42" />
-               <kie:ComponentWidths dmnElementRef="_ED551414-BBE9-4B20-9362-A81FFEE7DF19" />
-               <kie:ComponentWidths dmnElementRef="_CBC0E494-26AC-4D1F-B34C-69FFAA39080A" />
-               <kie:ComponentWidths dmnElementRef="_5D39D344-741C-484A-B3D8-80FC57102BD2" />
-               <kie:ComponentWidths dmnElementRef="_FCF4F8F8-84A1-4657-B08C-8B222A719D14" />
-               <kie:ComponentWidths dmnElementRef="_98638ECF-2EBF-4606-ACFB-587001CFD3BA" />
-               <kie:ComponentWidths dmnElementRef="_2EE79C8B-4C16-4550-970D-250A7566B5B5" />
-               <kie:ComponentWidths dmnElementRef="_2C43E9DD-1882-4CC3-B2E7-C9783841D1C2" />
-               <kie:ComponentWidths dmnElementRef="_93493631-022A-4C87-91DF-58F9A4F644AA" />
-               <kie:ComponentWidths dmnElementRef="_90C983F3-68EE-4B3B-9DE2-C21F0E93B955" />
-               <kie:ComponentWidths dmnElementRef="_D6F7F274-441E-419F-9E14-43F2DB655967" />
-               <kie:ComponentWidths dmnElementRef="_6F57B3F5-311C-4BA9-B38E-F094B71A6D50" />
-               <kie:ComponentWidths dmnElementRef="_D163B8D3-2B0D-488F-BB0A-551254CE4002" />
-               <kie:ComponentWidths dmnElementRef="_49A0FBD4-6637-4B53-BB5F-43B5C42B2D3B" />
-               <kie:ComponentWidths dmnElementRef="_CE285C61-7483-4FCB-AC28-D6B803B6A3E7" />
-               <kie:ComponentWidths dmnElementRef="_8262564E-8138-42C4-8AF4-1D52CC9E9399" />
-               <kie:ComponentWidths dmnElementRef="_D56DE1E1-8FAF-4D65-900F-5AA5D3BE807B" />
-               <kie:ComponentWidths dmnElementRef="_A3C4745D-B25F-4757-99FB-7943DDC5905A" />
-               <kie:ComponentWidths dmnElementRef="_36D66913-F7E4-40E4-A9E7-27C030B02513" />
-               <kie:ComponentWidths dmnElementRef="_C2DE3F17-2C89-42BA-AF99-D61369CB6EDB" />
-               <kie:ComponentWidths dmnElementRef="_DBE08836-6D08-4D6E-B798-EC62556D0A00" />
-               <kie:ComponentWidths dmnElementRef="_D4641F86-9DF5-4DB3-8790-47FE824C6765" />
-               <kie:ComponentWidths dmnElementRef="_24F82CA3-99D1-4892-9DAF-3AFE78B9C506" />
-               <kie:ComponentWidths dmnElementRef="_A437701C-23FB-482D-828A-FE2AA0612431" />
-               <kie:ComponentWidths dmnElementRef="_C5FCD024-5645-4BEB-A7D2-CF5E872B83AE" />
-               <kie:ComponentWidths dmnElementRef="_94363EF7-FC61-4609-BC58-DAEF64F59464" />
-               <kie:ComponentWidths dmnElementRef="_59E4D032-7A9A-43ED-A113-DC249C4E9C3B" />
-               <kie:ComponentWidths dmnElementRef="_89950E0F-92D8-44B4-B9A3-81C90046CF6A" />
-               <kie:ComponentWidths dmnElementRef="_794E9811-2A0B-4062-ACE5-F4610120FEFC" />
-               <kie:ComponentWidths dmnElementRef="_3B49CC6C-11A2-424D-8D6F-FDFF4B9C577F" />
-               <kie:ComponentWidths dmnElementRef="_A0AC6786-37B1-4324-BB29-A6279952653B" />
-               <kie:ComponentWidths dmnElementRef="_C1B48C5B-E77A-4DBD-8FD9-B6A152FD6D4D" />
-               <kie:ComponentWidths dmnElementRef="_44207F2A-A61A-4144-AD84-75514DB72719" />
-               <kie:ComponentWidths dmnElementRef="_D1047E70-958B-469B-B53C-6958D514D4B5" />
-               <kie:ComponentWidths dmnElementRef="_E5F0B0F8-07EA-4B28-9EA9-BA74FDB7AF71" />
-               <kie:ComponentWidths dmnElementRef="_32DFA51C-81B8-483A-9D5D-4477E1E1B68B" />
-               <kie:ComponentWidths dmnElementRef="_EE998D50-9323-410E-A685-B2698BB25466" />
-               <kie:ComponentWidths dmnElementRef="_88BA6B31-357B-406F-8830-AEC5328318D8" />
-               <kie:ComponentWidths dmnElementRef="_7285443C-BE70-481D-8763-68879AA0E463" />
-               <kie:ComponentWidths dmnElementRef="_CED2D692-6F4C-4FE1-9957-07BD77EE1B10" />
-               <kie:ComponentWidths dmnElementRef="_18175A34-C931-44EB-84E2-62C52E82D80C" />
-               <kie:ComponentWidths dmnElementRef="_103F6774-9FF7-4617-85B6-42E65EEEF942" />
-               <kie:ComponentWidths dmnElementRef="_0A6F707E-E81F-45CF-B389-0CBFAD3C4798" />
-               <kie:ComponentWidths dmnElementRef="_CC81CC7D-5D38-455A-ACC6-216D350B108B" />
-               <kie:ComponentWidths dmnElementRef="_87FDB835-A7E4-4253-B37B-6C1BC89B9325" />
-               <kie:ComponentWidths dmnElementRef="_E26F349A-8846-4732-B8FA-8A96B5E8CFC3" />
-               <kie:ComponentWidths dmnElementRef="_D69AE0B4-551D-4662-9695-760D0B47D915" />
-               <kie:ComponentWidths dmnElementRef="_989C6F4F-E08F-485F-90DE-501B91FAC6C4" />
-               <kie:ComponentWidths dmnElementRef="_A649C13A-A589-4742-8D99-4A812C88417C" />
-               <kie:ComponentWidths dmnElementRef="_E8528192-0932-421D-8408-2041C6E78A92" />
-               <kie:ComponentWidths dmnElementRef="_D14CEA9B-BFA4-4808-BB77-52466481445C" />
-               <kie:ComponentWidths dmnElementRef="_3B76E8FC-BABD-469D-A6B2-37BA327365F5" />
-               <kie:ComponentWidths dmnElementRef="_E1843FD2-62FB-459E-8BFF-071E13A56285" />
-               <kie:ComponentWidths dmnElementRef="_52547BEB-3E85-4310-A899-3062C255FF25" />
-               <kie:ComponentWidths dmnElementRef="_4F4BEF6A-9B31-44D1-91F5-CBEFC27BFCC8" />
-               <kie:ComponentWidths dmnElementRef="_FAB14015-5787-428A-9DD7-3BC0C96D6728" />
-               <kie:ComponentWidths dmnElementRef="_F680776D-71FB-4007-A1C6-6ED68EA9EB3A" />
-               <kie:ComponentWidths dmnElementRef="_6F69867A-5997-491F-893B-09518234E37A" />
+               <kie:ComponentWidths dmnElementRef="_B8F344CD-17EC-49A4-82EF-15FC52A0A17E" />
+               <kie:ComponentWidths dmnElementRef="_A6588F1A-73CB-4769-9DD4-68F00AD6DF2F" />
+               <kie:ComponentWidths dmnElementRef="_9094C6F0-3B1D-495B-8659-68B770EC4B8B" />
+               <kie:ComponentWidths dmnElementRef="_FF113522-29B5-4986-9C3B-B66A2EF015FB" />
+               <kie:ComponentWidths dmnElementRef="_3FE6DC6A-4B57-4A4F-AE87-3008A31E4024" />
+               <kie:ComponentWidths dmnElementRef="_DEBC29F2-7B45-4AD9-9BDB-AF813D2E85EC" />
+               <kie:ComponentWidths dmnElementRef="_93BA298A-D6CF-4073-83D7-E5DFD46C7249" />
+               <kie:ComponentWidths dmnElementRef="_F73B228D-FE83-42BB-8364-9EA2A0BF0266" />
+               <kie:ComponentWidths dmnElementRef="_10D122AA-E1BB-4EEB-B5BA-DE44F44EB565" />
+               <kie:ComponentWidths dmnElementRef="_C3FD39CF-CD00-47AD-87D5-887B342687BA" />
+               <kie:ComponentWidths dmnElementRef="_1503CD38-C6F5-4BF4-82F2-2747EB26F43B" />
+               <kie:ComponentWidths dmnElementRef="_48D8BAD3-1812-45FD-89E3-EF6B7B8F3EC6" />
+               <kie:ComponentWidths dmnElementRef="_A0A33844-1DC8-4719-9955-7DC551ED4F0C" />
+               <kie:ComponentWidths dmnElementRef="_761A0FB1-C89F-4412-A2E1-829EC3C9909A" />
+               <kie:ComponentWidths dmnElementRef="_C1D1E52F-4260-4F15-88F6-9B8F9C56CBB7" />
+               <kie:ComponentWidths dmnElementRef="_E297C226-2603-472F-A15C-9DD514F4727A" />
+               <kie:ComponentWidths dmnElementRef="_187715A8-B7A7-492C-9913-E9DFBC8B4AB3" />
+               <kie:ComponentWidths dmnElementRef="_4B90C4F7-DC7C-4193-9C06-8A21B6ECC28C" />
+               <kie:ComponentWidths dmnElementRef="_BA405A2F-4AC9-43D2-B2ED-A4AC02C4D89E" />
+               <kie:ComponentWidths dmnElementRef="_753E67E9-FBC9-4BF2-9311-FF644F1EFA4A" />
+               <kie:ComponentWidths dmnElementRef="_5545F783-9AB2-48C4-98F7-9E146F14D9D7" />
+               <kie:ComponentWidths dmnElementRef="_B23C271F-E0D5-4F98-8D12-ADB16028074F" />
+               <kie:ComponentWidths dmnElementRef="_F4BBC747-3820-4522-A243-05C7C3A1BDE2" />
+               <kie:ComponentWidths dmnElementRef="_A794268C-6321-4C02-9046-B3CF3F9E1761" />
+               <kie:ComponentWidths dmnElementRef="_676D5194-084F-4E9E-8178-D2F0958DB618" />
+               <kie:ComponentWidths dmnElementRef="_4F4F9F81-AE47-4E69-AAFE-72A9D26F04E8" />
+               <kie:ComponentWidths dmnElementRef="_77FA8DB6-E1A5-4E52-8C0A-80C7473853D9" />
+               <kie:ComponentWidths dmnElementRef="_0E5F9160-4DBE-4397-A9FA-8C7507FF43AF" />
+               <kie:ComponentWidths dmnElementRef="_3315BB4E-E257-4B97-8C2A-DC9B47C12CD2" />
+               <kie:ComponentWidths dmnElementRef="_CC7C3720-C7ED-4B81-8B08-5D5EA611AD79" />
+               <kie:ComponentWidths dmnElementRef="_430A4AD7-222C-450F-B4E0-F5FA20A13AE3" />
+               <kie:ComponentWidths dmnElementRef="_E0C6A7DD-679D-4DE2-972C-C9A6C2652A2F" />
+               <kie:ComponentWidths dmnElementRef="_26EF41EB-F88E-4080-AD2D-572BC3CB7968" />
+               <kie:ComponentWidths dmnElementRef="_D11EF99F-A66D-4877-87EB-5552761E22A8" />
+               <kie:ComponentWidths dmnElementRef="_539BDAE7-4CA2-4DA1-8250-F5D43CD480ED" />
+               <kie:ComponentWidths dmnElementRef="_33779F99-76FB-4D2E-B71D-BB358B4994AF" />
+               <kie:ComponentWidths dmnElementRef="_18F31BC3-5AC5-4F75-8AD8-70EC4DA4E98C" />
+               <kie:ComponentWidths dmnElementRef="_6E7EEB68-DA8B-440F-9A43-6B94D7DA0C3B" />
+               <kie:ComponentWidths dmnElementRef="_17C0978E-3B3B-4330-8EDF-1D20EAD0D3DC" />
+               <kie:ComponentWidths dmnElementRef="_71DB9933-1FB1-40DB-AE45-FC1EB71E27F6" />
+               <kie:ComponentWidths dmnElementRef="_307DD29E-C0E4-4907-8DC4-00728453ED69" />
+               <kie:ComponentWidths dmnElementRef="_7E5856FD-4035-4BE2-95F8-7808874AC35B" />
+               <kie:ComponentWidths dmnElementRef="_B4C897AD-DDBF-4BDF-BA60-47C1550AF1BF" />
+               <kie:ComponentWidths dmnElementRef="_022FDD0F-923F-4945-B804-B3726D690722" />
+               <kie:ComponentWidths dmnElementRef="_1EF0C640-65A5-4902-B907-45EB07C6F48D" />
+               <kie:ComponentWidths dmnElementRef="_815B703D-7E0A-42DE-9B7E-2C4DF9A7DDF1" />
+               <kie:ComponentWidths dmnElementRef="_42A3A817-9A49-47AD-9BC8-35FA9F612F72" />
+               <kie:ComponentWidths dmnElementRef="_44A33019-81C1-483D-9F72-DC9E7C09963D" />
+               <kie:ComponentWidths dmnElementRef="_4CE11D52-FA28-4B66-A196-4EA8BD5A4459" />
+               <kie:ComponentWidths dmnElementRef="_18743744-1F6B-4A6C-B0EF-A1A373102C69" />
+               <kie:ComponentWidths dmnElementRef="_753085ED-A52C-41EE-AB4E-B03743B63AF7" />
+               <kie:ComponentWidths dmnElementRef="_85613F31-13AE-4128-AAFB-D919FACED836" />
+               <kie:ComponentWidths dmnElementRef="_8988E079-B2A0-4690-8E4B-97BD9DC4F622" />
+               <kie:ComponentWidths dmnElementRef="_5E240B13-60A2-44CD-BD66-2E0CD6BEEFB1" />
+               <kie:ComponentWidths dmnElementRef="_5D001188-9D69-499B-912E-652B0AB664B8" />
+               <kie:ComponentWidths dmnElementRef="_ACE4063D-B823-48DB-88C9-65F5BE9DCD1C" />
+               <kie:ComponentWidths dmnElementRef="_394EFC4B-25F9-4BDF-8ED3-B8DA75951046" />
+               <kie:ComponentWidths dmnElementRef="_13C35C82-C252-45F9-861D-A7F110F456B9" />
+               <kie:ComponentWidths dmnElementRef="_3FE7E23F-246D-4AC6-8734-ED4E8BC37944" />
+               <kie:ComponentWidths dmnElementRef="_46B8C03D-38AD-4191-8C99-69AD13124362" />
+               <kie:ComponentWidths dmnElementRef="_2B6EC9D3-941C-4352-B9A8-45E185E67BE4" />
             </kie:ComponentsWidthsExtension>
          </di:extension>
          <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
@@ -897,7 +897,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="70" y="90" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
@@ -906,7 +906,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="3308" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
@@ -942,7 +942,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="3503" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
@@ -963,79 +963,79 @@
             <dc:Bounds x="5670" y="50" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_68546B11-7C06-4A8B-95B0-4C124CADAA2C" dmnElementRef="_68546B11-7C06-4A8B-95B0-4C124CADAA2C">
+         <dmndi:DMNEdge id="dmnedge-drg-_A7CC1B9F-797F-423C-98EE-B9E14D4A4CB5" dmnElementRef="_A7CC1B9F-797F-423C-98EE-B9E14D4A4CB5">
             <di:waypoint x="2638" y="400" />
             <di:waypoint x="1870" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F8436D5E-B368-4771-8F41-E631E4B3B0A0" dmnElementRef="_F8436D5E-B368-4771-8F41-E631E4B3B0A0">
+         <dmndi:DMNEdge id="dmnedge-drg-_5A8B3B8D-5E11-464B-B7BA-83B005DC48A9" dmnElementRef="_5A8B3B8D-5E11-464B-B7BA-83B005DC48A9">
             <di:waypoint x="2638" y="400" />
             <di:waypoint x="2045" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4" dmnElementRef="_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4">
+         <dmndi:DMNEdge id="dmnedge-drg-_43A1354A-4159-4877-8144-CC0E44C7334D" dmnElementRef="_43A1354A-4159-4877-8144-CC0E44C7334D">
             <di:waypoint x="2813" y="400" />
             <di:waypoint x="2220" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_3EBBAB17-C04D-4603-9939-27AE25901615" dmnElementRef="_3EBBAB17-C04D-4603-9939-27AE25901615">
+         <dmndi:DMNEdge id="dmnedge-drg-_4F2CC784-FFB6-4FD1-B93E-6AAC424C9B79" dmnElementRef="_4F2CC784-FFB6-4FD1-B93E-6AAC424C9B79">
             <di:waypoint x="2988" y="400" />
             <di:waypoint x="2395" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_81A20E77-6873-408E-B46A-D629C10CF82C" dmnElementRef="_81A20E77-6873-408E-B46A-D629C10CF82C">
+         <dmndi:DMNEdge id="dmnedge-drg-_49D4F488-6BEC-4A08-85E3-1742095D83B7" dmnElementRef="_49D4F488-6BEC-4A08-85E3-1742095D83B7">
             <di:waypoint x="2988" y="400" />
             <di:waypoint x="2745" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_D12DAA2A-8672-4B57-B3E6-031A1B244062" dmnElementRef="_D12DAA2A-8672-4B57-B3E6-031A1B244062">
+         <dmndi:DMNEdge id="dmnedge-drg-_32E58051-EE14-4466-8000-3CF48DE75275" dmnElementRef="_32E58051-EE14-4466-8000-3CF48DE75275">
             <di:waypoint x="2988" y="400" />
             <di:waypoint x="3095" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_63E07842-23E3-4A56-843F-29876C7356B2" dmnElementRef="_63E07842-23E3-4A56-843F-29876C7356B2">
+         <dmndi:DMNEdge id="dmnedge-drg-_9D22D377-E6FF-4199-8708-9223CA82004A" dmnElementRef="_9D22D377-E6FF-4199-8708-9223CA82004A">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="3270" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_9D46D5A3-EACE-4B85-811C-6E222F520AAF" dmnElementRef="_9D46D5A3-EACE-4B85-811C-6E222F520AAF">
+         <dmndi:DMNEdge id="dmnedge-drg-_6DD439E0-4534-45F4-99AF-28B2CFDFCF79" dmnElementRef="_6DD439E0-4534-45F4-99AF-28B2CFDFCF79">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="3445" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_9A9924C7-D617-478E-BC2F-9D35F32D172D" dmnElementRef="_9A9924C7-D617-478E-BC2F-9D35F32D172D">
+         <dmndi:DMNEdge id="dmnedge-drg-_EB6C87AD-D98C-49C1-8E8B-4FE00C0DFF41" dmnElementRef="_EB6C87AD-D98C-49C1-8E8B-4FE00C0DFF41">
             <di:waypoint x="2638" y="400" />
             <di:waypoint x="2570" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_4FB36F34-549D-4FB3-B5ED-134685380F3F" dmnElementRef="_4FB36F34-549D-4FB3-B5ED-134685380F3F">
+         <dmndi:DMNEdge id="dmnedge-drg-_957FD353-447F-49E8-B416-11983AE09415" dmnElementRef="_957FD353-447F-49E8-B416-11983AE09415">
             <di:waypoint x="2638" y="400" />
             <di:waypoint x="2920" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B" dmnElementRef="_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B">
+         <dmndi:DMNEdge id="dmnedge-drg-_A35293A4-70A8-4920-ADEA-5A1E3D974B23" dmnElementRef="_A35293A4-70A8-4920-ADEA-5A1E3D974B23">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="3620" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_EAA6FD5F-785C-4CA4-9930-51F53869B0E7" dmnElementRef="_EAA6FD5F-785C-4CA4-9930-51F53869B0E7">
+         <dmndi:DMNEdge id="dmnedge-drg-_60640E63-C9C1-49FF-8114-382AC9B64093" dmnElementRef="_60640E63-C9C1-49FF-8114-382AC9B64093">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="3795" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_D2DA1995-D862-47FA-B833-BDDB92B5C87C" dmnElementRef="_D2DA1995-D862-47FA-B833-BDDB92B5C87C">
+         <dmndi:DMNEdge id="dmnedge-drg-_238D7A02-A4B9-4A04-AB24-6486A9D073CD" dmnElementRef="_238D7A02-A4B9-4A04-AB24-6486A9D073CD">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="3970" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_5BB47D86-2531-4C80-A73F-97FCD8E81DBD" dmnElementRef="_5BB47D86-2531-4C80-A73F-97FCD8E81DBD">
+         <dmndi:DMNEdge id="dmnedge-drg-_766B7897-92A9-4461-9E12-82FC50641572" dmnElementRef="_766B7897-92A9-4461-9E12-82FC50641572">
             <di:waypoint x="3163" y="400" />
             <di:waypoint x="4145" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE" dmnElementRef="_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE">
+         <dmndi:DMNEdge id="dmnedge-drg-_1CA91B26-9D39-402B-B57F-069B48E2BB16" dmnElementRef="_1CA91B26-9D39-402B-B57F-069B48E2BB16">
             <di:waypoint x="2988" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="3358" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F2016F44-D6AC-409C-B0B1-6048B6CDF959" dmnElementRef="_F2016F44-D6AC-409C-B0B1-6048B6CDF959">
+         <dmndi:DMNEdge id="dmnedge-drg-_77BD5335-D370-4238-BB1F-1D2080FAD2E3" dmnElementRef="_77BD5335-D370-4238-BB1F-1D2080FAD2E3">
             <di:waypoint x="3338" y="400" />
             <di:waypoint x="5020" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_2B360566-81F1-41BD-8D5D-B0F786692652" dmnElementRef="_2B360566-81F1-41BD-8D5D-B0F786692652">
+         <dmndi:DMNEdge id="dmnedge-drg-_22231295-B6F8-451F-8AC7-63EF6B4F3627" dmnElementRef="_22231295-B6F8-451F-8AC7-63EF6B4F3627">
             <di:waypoint x="3338" y="400" />
             <di:waypoint x="5370" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_20E48A54-F6B8-4E2E-BD46-DD38D44FA213" dmnElementRef="_20E48A54-F6B8-4E2E-BD46-DD38D44FA213">
+         <dmndi:DMNEdge id="dmnedge-drg-_878CB78B-4677-4A7C-B02E-89DD5E7EE0BE" dmnElementRef="_878CB78B-4677-4A7C-B02E-89DD5E7EE0BE">
             <di:waypoint x="3163" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="3553" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_00D499AC-31B0-4704-AA50-1C4D22931B38" dmnElementRef="_00D499AC-31B0-4704-AA50-1C4D22931B38">
+         <dmndi:DMNEdge id="dmnedge-drg-_C06F37AE-FE02-4525-A758-3464496BBCD7" dmnElementRef="_C06F37AE-FE02-4525-A758-3464496BBCD7">
             <di:waypoint x="3533" y="400" />
             <di:waypoint x="5720" y="75" />
          </dmndi:DMNEdge>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0082-feel-coercion.dmn
@@ -1,1039 +1,1044 @@
-<?xml version="1.0" ?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0082-feel-coercion" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_i9fboPUUEeesLuP4RHs4vA" name="0082-feel-coercion" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0082-feel-coercion">
-  <dmn:description>FEEL type conformance of DT and BKM results</dmn:description>
-  <dmn:extensionElements/>
-  <dmn:itemDefinition id="_9A05F869-BDDD-49C2-B30D-DDBF72D755C6" name="tNumberList" isCollection="true">
-    <dmn:typeRef>number</dmn:typeRef>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_64EF4AF0-FFB7-4A88-88B4-01216CF63680" name="tStringList" isCollection="true">
-    <dmn:typeRef>string</dmn:typeRef>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_40F06DA8-5B16-4F71-8103-F3570DAA96EA" name="tDS_001" isCollection="false">
-    <dmn:itemComponent id="_6E3CA6D6-2B73-4C61-90FE-D84D9C423D70" name="decision_ds_001" isCollection="false">
-      <dmn:typeRef>string</dmn:typeRef>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
-  <dmn:itemDefinition id="_6386BE4D-F8F7-4C68-88BA-626D43EB6AFE" name="tNameAndAge" isCollection="false">
-    <dmn:itemComponent id="_FC917A0C-1FAD-41FE-AD49-614CD044BC8F" name="name" isCollection="false">
-      <dmn:typeRef>string</dmn:typeRef>
-    </dmn:itemComponent>
-    <dmn:itemComponent id="_A87E5274-E598-4D76-B0CD-7866AF2F7046" name="age" isCollection="false">
+<?xml version="1.0" encoding="UTF-8"?>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0082-feel-coercion" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_i9fboPUUEeesLuP4RHs4vA" name="0082-feel-coercion" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0082-feel-coercion">
+   <dmn:description>FEEL type conformance of DT and BKM results</dmn:description>
+   <dmn:extensionElements />
+   <dmn:itemDefinition id="_F3588A29-D4EF-41FD-8C88-5F1036E4A8BC" name="tNumberList" isCollection="true">
       <dmn:typeRef>number</dmn:typeRef>
-    </dmn:itemComponent>
-  </dmn:itemDefinition>
-  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E746D611-FFC1-4DC4-977E-C6A531A4EB90" name="decisionService_001" typeRef="tDS_001"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9E7E8AE3-B156-4219-9F2A-4B4D28234787" name="decisionService_002"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_566FD956-AD78-411E-B9EA-54DD1DEF0295" name="decisionService_003"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_001" name="decision_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_DC539B91-2FB5-4BF9-ABE9-E44D73C49DBA" name="decision_001" typeRef="string"/>
-    <dmn:literalExpression id="_4D52EE06-25BB-474B-B030-1DDE122A8424">
-      <dmn:text>1+1</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003" name="decision_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_1464F046-5BC4-4858-A3C0-9C1579B43C4E" name="decision_003" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_EAE3D59E-734D-49E2-BD45-F57D9737DFB6">
-      <dmn:text>[1,2,"foo"]</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_004" name="decision_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_C6400D70-47CE-4900-9AC8-142E7E7FC9B9" name="decision_004" typeRef="tNameAndAge"/>
-    <dmn:literalExpression id="_83883E5A-E19E-469A-985D-4DC31AE1EB90">
-      <dmn:text>{name: "foo", surname: "bar", age: 10}</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_005" name="decision_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_32A67EB0-9FC3-4F1D-A3F9-E4AF4F6B3E9B" name="decision_005" typeRef="tNameAndAge"/>
-    <dmn:literalExpression id="_717B58E6-90C0-4AC9-91C1-65BBFC6C412F">
-      <dmn:text>{name: "foo"}</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006" name="decision_006">
-    <dmn:extensionElements/>
-    <dmn:variable id="_954ADCC2-CE01-4D65-AABC-AE28CE374790" name="decision_006" typeRef="tStringList"/>
-    <dmn:literalExpression id="_AFA2D2DA-C8DF-4816-BE44-45F149707D20">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_a" name="decision_006_a">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2E04A2C9-5DBE-4B88-9090-20C61D0D9F49" name="decision_006_a" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_3A7A53EB-38A3-488F-9246-2C7CABB9B33C">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007" name="decision_007">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B34C2A69-E356-4756-B6DD-A8FD5604BDAB" name="decision_007" typeRef="string"/>
-    <dmn:literalExpression id="_696F7BC3-9512-4A96-9BEF-C74B734A3F38">
-      <dmn:text>["foo"]</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_a" name="decision_007_a">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8F5E8E1A-9C75-453C-9D91-621573F98B68" name="decision_007_a" typeRef="string"/>
-    <dmn:literalExpression id="_8F2F4ECA-125B-4F60-8D9A-0A3E24A126B4">
-      <dmn:text>[1]</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008" name="decision_008">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5FA836E4-EA83-4057-8A55-A868230F4CF0" name="decision_008" typeRef="list"/>
-    <dmn:literalExpression id="_2C30E334-4F12-4C94-8A9A-F9356EC5E3AE">
-      <dmn:text>null</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_bkm_001" name="bkm_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_113E95AA-5A7A-4117-9B28-523AF453743D" name="bkm_001"/>
-    <dmn:encapsulatedLogic id="_7D8AAE90-5B7A-42FF-AAA7-F4BC07B5F823" kind="FEEL">
-      <dmn:formalParameter id="_3934FFC1-EF50-44DA-8202-306CFFF1E240" name="nameAndAge" typeRef="tNameAndAge"/>
-      <dmn:literalExpression id="_4727B860-2E96-4002-9FA3-A18D3717DABA">
-        <dmn:text>nameAndAge != null</dmn:text>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_CA2E82D7-1AC8-4EA4-92A1-4086C946026F" name="tStringList" isCollection="true">
+      <dmn:typeRef>string</dmn:typeRef>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_3DBD02D1-0A1A-4067-B4BF-7DEAB12D6606" name="tDS_001" isCollection="false">
+      <dmn:itemComponent id="_76867EB5-DB25-422A-A45E-03C0992801AF" name="decision_ds_001" isCollection="false">
+         <dmn:typeRef>string</dmn:typeRef>
+      </dmn:itemComponent>
+   </dmn:itemDefinition>
+   <dmn:itemDefinition id="_48ECFC75-A67D-4A49-A910-F6706F14A41B" name="tNameAndAge" isCollection="false">
+      <dmn:itemComponent id="_FAB2CC4C-59A0-4DC7-9D14-72F656BD12F9" name="name" isCollection="false">
+         <dmn:typeRef>string</dmn:typeRef>
+      </dmn:itemComponent>
+      <dmn:itemComponent id="_E77DD21B-367A-43D4-8A16-0595BEF18FE9" name="age" isCollection="false">
+         <dmn:typeRef>number</dmn:typeRef>
+      </dmn:itemComponent>
+   </dmn:itemDefinition>
+   <dmn:decisionService id="_decisionService_001" name="decisionService_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_0166884C-1325-4D71-8E4D-B5D2A1D3F27F" name="decisionService_001" typeRef="tDS_001" />
+      <dmn:outputDecision href="#_decision_ds_001" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_002" name="decisionService_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_8214FC84-209C-422E-8127-F525F78ED099" name="decisionService_002" />
+      <dmn:outputDecision href="#_decision_ds_002" />
+      <dmn:inputData href="#_decisionService_002_input_1" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_003" name="decisionService_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_CEE104CC-7DA1-41CF-AB71-C87548DDDBB9" name="decisionService_003" />
+      <dmn:outputDecision href="#_decision_ds_003" />
+      <dmn:inputData href="#_decisionService_003_input_1" />
+   </dmn:decisionService>
+   <dmn:decision id="_decision_001" name="decision_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_D7ABCC84-3B53-4A41-AC8B-73A949722ED5" name="decision_001" typeRef="string" />
+      <dmn:literalExpression id="_D277AC92-BA78-434A-9030-98F28587C10F">
+         <dmn:text>1+1</dmn:text>
       </dmn:literalExpression>
-    </dmn:encapsulatedLogic>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_decision_bkm_001" name="decision_bkm_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A6EFF4EA-5DF1-4075-A3DB-A8FD8B5D91F3" name="decision_bkm_001"/>
-    <dmn:knowledgeRequirement id="_7B3BE5CF-8218-47D2-B2CC-970E1FD58468">
-      <dmn:requiredKnowledge href="#_bkm_001"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_8613DB9D-217D-4AD6-9A00-A616688B5216">
-      <dmn:text>bkm_001({name: "foo", surname: "bar", age: 10})</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_bkm_002" name="decision_bkm_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_82089E0F-C919-4400-BDBE-228841C17547" name="decision_bkm_002"/>
-    <dmn:knowledgeRequirement id="_8063F8D3-6062-4478-92B1-CEDFEFC9575A">
-      <dmn:requiredKnowledge href="#_bkm_001"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_879392DB-597B-4F0E-9BBD-3DAE0A7A7AAF">
-      <dmn:text>bkm_001({name: "foo"})</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_bkm_002" name="bkm_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8ECF4F3B-7A2E-4352-9108-2E59B70D0CBB" name="bkm_002" typeRef="tNameAndAge"/>
-    <dmn:encapsulatedLogic id="_94CDAB0B-54DE-4C39-95FE-A9A3CF5B1966" kind="FEEL">
-      <dmn:formalParameter id="_901F02AA-7356-4A82-B3D9-0378CAF09176" name="nameAndAge" typeRef="tNameAndAge"/>
-      <dmn:literalExpression id="_2E8FBA80-3C4F-412B-9C37-B7EA5BAE3DF8">
-        <dmn:text>nameAndAge != null</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_003" name="decision_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_C7E96099-EF6E-4451-B62D-1BBB3232A41C" name="decision_003" typeRef="tNumberList" />
+      <dmn:literalExpression id="_715D160B-F6B6-434D-B0C5-32B865C232FC">
+         <dmn:text>[1,2,"foo"]</dmn:text>
       </dmn:literalExpression>
-    </dmn:encapsulatedLogic>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_decision_bkm_003" name="decision_bkm_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D8EEF06A-35AF-4179-ABE9-EBA3FDF59F0A" name="decision_bkm_003"/>
-    <dmn:knowledgeRequirement id="_5ACB2078-518E-4743-9575-4BD03EDDA126">
-      <dmn:requiredKnowledge href="#_bkm_002"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_F2AD0936-C3A0-47D5-9730-67D609F97606">
-      <dmn:text>bkm_002({name: "foo"})</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:businessKnowledgeModel id="_bkm_004" name="bkm_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_03A3846D-BD69-4B83-B97B-D2BCE9A31437" name="bkm_004" typeRef="tNumberList"/>
-    <dmn:encapsulatedLogic id="_56DFE8A9-5C73-48C3-BD04-6FE89702D91F" kind="FEEL">
-      <dmn:formalParameter id="_760ED606-3975-4B4D-8165-6E8FC9804871" name="arg"/>
-      <dmn:literalExpression id="_8D1633B7-76C4-479F-8CA2-4E19F6BFD163">
-        <dmn:text>arg</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_004" name="decision_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_17026328-ADB2-4316-BBA1-AC4116D35970" name="decision_004" typeRef="tNameAndAge" />
+      <dmn:literalExpression id="_9BE89A60-AECD-4FD8-AD43-E3AE71E8A5CB">
+         <dmn:text>{name: "foo", surname: "bar", age: 10}</dmn:text>
       </dmn:literalExpression>
-    </dmn:encapsulatedLogic>
-  </dmn:businessKnowledgeModel>
-  <dmn:businessKnowledgeModel id="_bkm_005" name="bkm_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_6BDB1ABD-981E-4B87-9D5F-6F2192D67D0C" name="bkm_005" typeRef="number"/>
-    <dmn:encapsulatedLogic id="_CCC20C6C-5EB5-4289-BDF2-887DAC80C3AD" kind="FEEL">
-      <dmn:formalParameter id="_A836A9D2-D829-4590-A9E2-8F5CFF31FF8B" name="arg"/>
-      <dmn:literalExpression id="_99C422DC-9A90-4572-8FFB-25FA604C41FB">
-        <dmn:text>[arg]</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_005" name="decision_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_340AC03F-EE0B-4A32-9284-5604BCC577AB" name="decision_005" typeRef="tNameAndAge" />
+      <dmn:literalExpression id="_6FFBD558-AB35-485F-8045-6387C0DD8A42">
+         <dmn:text>{name: "foo"}</dmn:text>
       </dmn:literalExpression>
-    </dmn:encapsulatedLogic>
-  </dmn:businessKnowledgeModel>
-  <dmn:decision id="_decision_bkm_004" name="decision_bkm_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_46EE1842-0C85-4EB9-9FEC-5230B6662AA7" name="decision_bkm_004"/>
-    <dmn:knowledgeRequirement id="_A0CCB912-9FA0-446A-9CBD-6706BA653DD2">
-      <dmn:requiredKnowledge href="#_bkm_004"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_CDF7850B-7D2A-4E56-A0E5-CE5F64F8764F">
-      <dmn:text>bkm_004(10)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_bkm_004_a" name="decision_bkm_004_a">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8AB8B8C7-C055-41FC-B508-0E263A0E6EE9" name="decision_bkm_004_a"/>
-    <dmn:knowledgeRequirement id="_32CEA84D-85B5-48A6-8BA3-D241F7A261FE">
-      <dmn:requiredKnowledge href="#_bkm_004"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_2AF29277-430E-4F4D-A5E5-9DCA00BD805A">
-      <dmn:text>bkm_004("foo")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_bkm_004_b" name="decision_bkm_004_b">
-    <dmn:extensionElements/>
-    <dmn:variable id="_20565219-71E1-418B-950B-BF515D083647" name="decision_bkm_004_b"/>
-    <dmn:knowledgeRequirement id="_AB09AF7F-53DA-433F-93CA-78E46482703F">
-      <dmn:requiredKnowledge href="#_bkm_004"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_4547B8C0-EC6B-4122-BE6F-27A6AC2F90AB">
-      <dmn:text>bkm_004(null)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_bkm_005" name="decision_bkm_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_354ED0C1-1336-44BE-A65E-048E3A18769E" name="decision_bkm_005"/>
-    <dmn:knowledgeRequirement id="_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_4985DB9C-1EAB-40FB-8F57-4FAFB8B339E7">
-      <dmn:text>bkm_005(10)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_bkm_005_a" name="decision_bkm_005_a">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E37780CE-6042-46A7-8A64-D838F7248BC5" name="decision_bkm_005_a"/>
-    <dmn:knowledgeRequirement id="_32616BE5-7354-455A-B94F-1E5F494BBD61">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_927F22D4-EBC0-4C83-B809-C4E57854AC94">
-      <dmn:text>bkm_005("foo")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_invoke_001" name="invoke_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_20D68AE5-9E60-4616-BDC8-60C903AD5346" name="invoke_001"/>
-    <dmn:knowledgeRequirement id="_844CC3F6-599F-4499-A803-C1886139969A">
-      <dmn:requiredKnowledge href="#_bkm_001"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_3FF9B459-238C-4F5B-9940-120899A2A557">
-      <dmn:literalExpression id="_400E2660-F788-4B34-8ECA-9EFA6320F0FA">
-        <dmn:text>bkm_001</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_006" name="decision_006">
+      <dmn:extensionElements />
+      <dmn:variable id="_23E1F8A9-51FD-4C43-8075-056E40CD384F" name="decision_006" typeRef="tStringList" />
+      <dmn:literalExpression id="_ED551414-BBE9-4B20-9362-A81FFEE7DF19">
+         <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_80DD4332-DBDA-43B9-8DBB-D20EF9E577F8" name="nameAndAge"/>
-        <dmn:literalExpression id="_D7A09AF7-F630-45CC-9D6F-8A9B22B32339">
-          <dmn:text>{name: "foo"}</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_invoke_002" name="invoke_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0F4B072E-9790-4F11-8C05-1442C6A9C123" name="invoke_002" typeRef="string"/>
-    <dmn:knowledgeRequirement id="_743FD00A-040C-4EF3-A16F-51F8E36EFE49">
-      <dmn:requiredKnowledge href="#_bkm_001"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_E11E9A94-D7CA-4F56-A551-20368C9A5E71" typeRef="string">
-      <dmn:literalExpression id="_E968333D-479F-4584-B273-F26560021DC0">
-        <dmn:text>bkm_001</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_a" name="decision_006_a">
+      <dmn:extensionElements />
+      <dmn:variable id="_FBA2C16C-2C1F-41F6-A795-1701821DDF9B" name="decision_006_a" typeRef="tNumberList" />
+      <dmn:literalExpression id="_CBC0E494-26AC-4D1F-B34C-69FFAA39080A">
+         <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_B2C745EC-78E6-4404-A86A-4FE9CDE1B2BB" name="nameAndAge"/>
-        <dmn:literalExpression id="_5811B4F0-9BA3-4083-93C0-C2C14441B585">
-          <dmn:text>{name: "foo", age: 10}</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_invoke_003" name="invoke_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D977DFF6-8C37-459D-A784-FFBB4781F66C" name="invoke_003" typeRef="tNumberList"/>
-    <dmn:knowledgeRequirement id="_004EB93A-E37A-4C38-BF48-CA4FED683432">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_2E781A59-36A3-49F7-8B0F-F1D0ADADE60E" typeRef="tNumberList">
-      <dmn:literalExpression id="_7FD82BC4-67FC-4033-B58F-98A19ED8B890">
-        <dmn:text>bkm_005</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_007" name="decision_007">
+      <dmn:extensionElements />
+      <dmn:variable id="_153DBBE7-9C1D-40C5-90C4-0443AC355F8E" name="decision_007" typeRef="string" />
+      <dmn:literalExpression id="_5D39D344-741C-484A-B3D8-80FC57102BD2">
+         <dmn:text>["foo"]</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_24CA7AC9-F47B-4051-9EC3-BB22E48B17E7" name="arg"/>
-        <dmn:literalExpression id="_FA66787D-DB73-46A6-A12F-4CCA1E27C1A5">
-          <dmn:text>10</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_invoke_004" name="invoke_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A79302B7-C7A2-4005-AB89-277E3D013819" name="invoke_004" typeRef="tNumberList"/>
-    <dmn:knowledgeRequirement id="_EBD496F0-9E21-47AD-A630-8C5E032B6749">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_9A884F00-26B9-4ADA-BB53-802C218DB96A" typeRef="tNumberList">
-      <dmn:literalExpression id="_EEE0851D-107F-444F-B0E0-98E1EA0C98CB">
-        <dmn:text>bkm_005</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_a" name="decision_007_a">
+      <dmn:extensionElements />
+      <dmn:variable id="_AD4FB2DD-AD1E-4CFA-AEA4-3AA94EE5D074" name="decision_007_a" typeRef="string" />
+      <dmn:literalExpression id="_FCF4F8F8-84A1-4657-B08C-8B222A719D14">
+         <dmn:text>[1]</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_C82D0D6B-1628-46AB-A93D-44FE1901DCFC" name="arg"/>
-        <dmn:literalExpression id="_9C1A5BA9-5B9B-4EA6-B970-6CB106CBDC49">
-          <dmn:text>"foo"</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_invoke_005" name="invoke_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_1B435357-01B7-41BC-8C67-DE15A60A6266" name="invoke_005" typeRef="number"/>
-    <dmn:knowledgeRequirement id="_ED2359BA-F57A-495B-8E75-C0913CD2BA05">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_6042D108-15EE-4041-AFBA-9A73892B0F36" typeRef="number">
-      <dmn:literalExpression id="_E66FBA75-5B4D-4D11-A00C-8DA09C36E687">
-        <dmn:text>bkm_005</dmn:text>
+   </dmn:decision>
+   <dmn:decision id="_decision_008" name="decision_008">
+      <dmn:extensionElements />
+      <dmn:variable id="_8F5E8021-F4D3-40CC-8044-E1FDF48558B3" name="decision_008" typeRef="list" />
+      <dmn:literalExpression id="_98638ECF-2EBF-4606-ACFB-587001CFD3BA">
+         <dmn:text>null</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_E5E80ACD-538E-47D4-9B63-A66618EF7E13" name="arg"/>
-        <dmn:literalExpression id="_754C9313-F07B-4EF6-8B51-F7E662374559">
-          <dmn:text>[10]</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_invoke_006" name="invoke_006">
-    <dmn:extensionElements/>
-    <dmn:variable id="_BE9E1631-9BBB-413A-A8BC-0EE7EC1C66FE" name="invoke_006" typeRef="number"/>
-    <dmn:knowledgeRequirement id="_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB">
-      <dmn:requiredKnowledge href="#_bkm_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:invocation id="_8CCB9AA5-2551-4CBE-A6D0-5258EA7D7B2A" typeRef="number">
-      <dmn:literalExpression id="_9F3CE04E-B813-4A4D-B795-00EF110CDB41">
-        <dmn:text>bkm_005</dmn:text>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_bkm_001" name="bkm_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_0EA60753-2B27-4BF7-9829-1A334C103AE8" name="bkm_001" />
+      <dmn:encapsulatedLogic id="_2C43E9DD-1882-4CC3-B2E7-C9783841D1C2" kind="FEEL">
+         <dmn:formalParameter id="_72FBD076-BF52-4BD3-A059-A9BDC39BE0D5" name="nameAndAge" typeRef="tNameAndAge" />
+         <dmn:literalExpression id="_2EE79C8B-4C16-4550-970D-250A7566B5B5">
+            <dmn:text>nameAndAge != null</dmn:text>
+         </dmn:literalExpression>
+      </dmn:encapsulatedLogic>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_decision_bkm_001" name="decision_bkm_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_48629294-3EA8-4499-B7E0-A71AB91E3A96" name="decision_bkm_001" />
+      <dmn:knowledgeRequirement id="_68546B11-7C06-4A8B-95B0-4C124CADAA2C">
+         <dmn:requiredKnowledge href="#_bkm_001" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_93493631-022A-4C87-91DF-58F9A4F644AA">
+         <dmn:text>bkm_001({name: "foo", surname: "bar", age: 10})</dmn:text>
       </dmn:literalExpression>
-      <dmn:binding>
-        <dmn:parameter id="_F0C43900-9AE8-4A01-9F3A-772D7535DD61" name="arg"/>
-        <dmn:literalExpression id="_AD152E30-FFBE-446F-93FA-ADB08AFE3C1D">
-          <dmn:text>["foo"]</dmn:text>
-        </dmn:literalExpression>
-      </dmn:binding>
-    </dmn:invocation>
-  </dmn:decision>
-  <dmn:decision id="_fd_001" name="fd_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D9D6E81C-7FEC-4DB5-BE18-13C8E3A570D6" name="fd_001"/>
-    <dmn:context id="_BFA99D23-4ED5-443E-A404-EB8E39ABC0B8">
-      <dmn:contextEntry>
-        <dmn:variable id="_2B21258E-3EE9-45C5-9C80-E4FD963E9ED2" name="fn"/>
-        <dmn:literalExpression id="_B16C4F7F-73AB-44B6-BC3A-18A2187567A0">
-          <dmn:text>function(arg: number) arg</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:literalExpression id="_11E452BA-7C70-4BDA-B33A-B69329828153">
-          <dmn:text>fn(10)</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_fd_002" name="fd_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_6FD58395-581E-4759-8078-E578E4587E17" name="fd_002"/>
-    <dmn:context id="_9F3B05D9-D013-4E9A-9007-89F24E2987A3">
-      <dmn:contextEntry>
-        <dmn:variable id="_F11FF135-35E0-4C3C-BFE5-5EE530EF5606" name="fn"/>
-        <dmn:literalExpression id="_9ECECABF-C811-4A7E-B161-7EFAE322E35E">
-          <dmn:text>function(arg: number) arg</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:literalExpression id="_05157905-263E-4A93-99B8-5C4010C0013E">
-          <dmn:text>fn("foo")</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_literal_001" name="literal_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_3A0C56EB-3F2F-4371-A093-C5E96F51D39A" name="literal_001" typeRef="number"/>
-    <dmn:literalExpression id="_AE433AB6-13C6-4842-91FC-433456F6E9E2" typeRef="number">
-      <dmn:text>5+5</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_literal_002" name="literal_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7C1280C8-F133-4912-B4D5-663CC9B667B5" name="literal_002" typeRef="number"/>
-    <dmn:literalExpression id="_405E4248-0F47-40E1-8C0D-C664D43DE004" typeRef="number">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_literal_003" name="literal_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5199C8EB-0115-4D5B-9BB7-E71F46C3F9EB" name="literal_003" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_00B05E56-2C80-4E18-BE2D-4FDDAA6C0462" typeRef="tNumberList">
-      <dmn:text>10</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_literal_004" name="literal_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2A866D70-8078-4659-9935-7D7AC06701E9" name="literal_004" typeRef="tNumberList"/>
-    <dmn:literalExpression id="_707987A6-7B84-4869-B510-283EC111D92F" typeRef="tNumberList">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_literal_005" name="literal_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A4ADEDAC-4DA4-4360-B182-FDC27031291F" name="literal_005" typeRef="number"/>
-    <dmn:literalExpression id="_F74B86CA-18B9-4121-B60C-33BC976AADAE" typeRef="number">
-      <dmn:text>[10]</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_literal_006" name="literal_006">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B5998FF9-FBD9-435B-B7F5-E4A5E0F1D94D" name="literal_006" typeRef="number"/>
-    <dmn:literalExpression id="_3D653879-9215-4EDE-BB8E-7384A9920FDC" typeRef="number">
-      <dmn:text>["foo"]</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_ds_001" name="decision_ds_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9BC85929-813B-4DEC-AD59-0F9B6BCC7F51" name="decision_ds_001"/>
-    <dmn:literalExpression id="_703534DA-03C6-45F6-9076-DCD70F05BC13">
-      <dmn:text>1000</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_ds_002" name="decision_ds_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_714A73AE-938B-4BA2-A5AB-E61F186A1457" name="decision_ds_002"/>
-    <dmn:informationRequirement id="_590A1A56-B5B1-435D-827C-03671BB0C575">
-      <dmn:requiredInput href="#_decisionService_002_input_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_67C2B891-A256-41CE-B8F4-7FE909555A20">
-      <dmn:text>decisionService_002_input_1</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_decisionService_002_input_1" name="decisionService_002_input_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B5CD8000-F3BE-4944-A993-9A8BA5398FF3" name="decisionService_002_input_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_ds_invoke_002_with_number" name="ds_invoke_002_with_number">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2F31B0E0-9B99-4F1C-938A-DA9FF9A081A0" name="ds_invoke_002_with_number"/>
-    <dmn:knowledgeRequirement id="_1E490D2C-A941-4F7B-BEB1-8409E4C63880">
-      <dmn:requiredKnowledge href="#_decisionService_002"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_3B9EBB55-5949-4838-A45C-2B652839265B">
-      <dmn:text>decisionService_002(10)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_ds_invoke_002_with_singleton_list" name="ds_invoke_002_with_singleton_list">
-    <dmn:extensionElements/>
-    <dmn:variable id="_46966129-92E3-4C82-80E5-AE962BA55EFD" name="ds_invoke_002_with_singleton_list"/>
-    <dmn:knowledgeRequirement id="_1A757F6C-CC80-45E0-B19A-A78E2E0D8382">
-      <dmn:requiredKnowledge href="#_decisionService_002"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_685C2316-FC3E-49F2-8E96-81D9FFA923A3">
-      <dmn:text>decisionService_002(["foo"])</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_ds_003" name="decision_ds_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F1DE46B2-60F5-4A79-A033-EBB80266648E" name="decision_ds_003"/>
-    <dmn:informationRequirement id="_7BD5372D-20EE-4D47-8AA9-B8E651010343">
-      <dmn:requiredInput href="#_decisionService_003_input_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_B27AE1EE-AD5E-4C5E-9070-D098018A557E">
-      <dmn:text>decisionService_003_input_1</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_decisionService_003_input_1" name="decisionService_003_input_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_6BC2A6B5-C668-49F5-910D-6FAAA99F434C" name="decisionService_003_input_1" typeRef="tStringList"/>
-  </dmn:inputData>
-  <dmn:decision id="_ds_invoke_003_with_string" name="ds_invoke_003_with_string">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5DFF8550-1321-4688-A375-FEA369016EFE" name="ds_invoke_003_with_string"/>
-    <dmn:knowledgeRequirement id="_3E92ADC3-4BAD-4D40-93F9-4591994078FB">
-      <dmn:requiredKnowledge href="#_decisionService_003"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_3EADD38C-A59B-4F10-BC98-EC980E1CA342">
-      <dmn:text>decisionService_003("foo")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_D8DB7496-FF51-43D8-B089-4F8A0E4BFDF7" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_4D52EE06-25BB-474B-B030-1DDE122A8424"/>
-          <kie:ComponentWidths dmnElementRef="_EAE3D59E-734D-49E2-BD45-F57D9737DFB6"/>
-          <kie:ComponentWidths dmnElementRef="_83883E5A-E19E-469A-985D-4DC31AE1EB90"/>
-          <kie:ComponentWidths dmnElementRef="_717B58E6-90C0-4AC9-91C1-65BBFC6C412F"/>
-          <kie:ComponentWidths dmnElementRef="_AFA2D2DA-C8DF-4816-BE44-45F149707D20"/>
-          <kie:ComponentWidths dmnElementRef="_3A7A53EB-38A3-488F-9246-2C7CABB9B33C"/>
-          <kie:ComponentWidths dmnElementRef="_696F7BC3-9512-4A96-9BEF-C74B734A3F38"/>
-          <kie:ComponentWidths dmnElementRef="_8F2F4ECA-125B-4F60-8D9A-0A3E24A126B4"/>
-          <kie:ComponentWidths dmnElementRef="_2C30E334-4F12-4C94-8A9A-F9356EC5E3AE"/>
-          <kie:ComponentWidths dmnElementRef="_4727B860-2E96-4002-9FA3-A18D3717DABA"/>
-          <kie:ComponentWidths dmnElementRef="_7D8AAE90-5B7A-42FF-AAA7-F4BC07B5F823"/>
-          <kie:ComponentWidths dmnElementRef="_8613DB9D-217D-4AD6-9A00-A616688B5216"/>
-          <kie:ComponentWidths dmnElementRef="_879392DB-597B-4F0E-9BBD-3DAE0A7A7AAF"/>
-          <kie:ComponentWidths dmnElementRef="_2E8FBA80-3C4F-412B-9C37-B7EA5BAE3DF8"/>
-          <kie:ComponentWidths dmnElementRef="_94CDAB0B-54DE-4C39-95FE-A9A3CF5B1966"/>
-          <kie:ComponentWidths dmnElementRef="_F2AD0936-C3A0-47D5-9730-67D609F97606"/>
-          <kie:ComponentWidths dmnElementRef="_8D1633B7-76C4-479F-8CA2-4E19F6BFD163"/>
-          <kie:ComponentWidths dmnElementRef="_56DFE8A9-5C73-48C3-BD04-6FE89702D91F"/>
-          <kie:ComponentWidths dmnElementRef="_99C422DC-9A90-4572-8FFB-25FA604C41FB"/>
-          <kie:ComponentWidths dmnElementRef="_CCC20C6C-5EB5-4289-BDF2-887DAC80C3AD"/>
-          <kie:ComponentWidths dmnElementRef="_CDF7850B-7D2A-4E56-A0E5-CE5F64F8764F"/>
-          <kie:ComponentWidths dmnElementRef="_2AF29277-430E-4F4D-A5E5-9DCA00BD805A"/>
-          <kie:ComponentWidths dmnElementRef="_4547B8C0-EC6B-4122-BE6F-27A6AC2F90AB"/>
-          <kie:ComponentWidths dmnElementRef="_4985DB9C-1EAB-40FB-8F57-4FAFB8B339E7"/>
-          <kie:ComponentWidths dmnElementRef="_927F22D4-EBC0-4C83-B809-C4E57854AC94"/>
-          <kie:ComponentWidths dmnElementRef="_3FF9B459-238C-4F5B-9940-120899A2A557"/>
-          <kie:ComponentWidths dmnElementRef="_400E2660-F788-4B34-8ECA-9EFA6320F0FA"/>
-          <kie:ComponentWidths dmnElementRef="_D7A09AF7-F630-45CC-9D6F-8A9B22B32339"/>
-          <kie:ComponentWidths dmnElementRef="_E11E9A94-D7CA-4F56-A551-20368C9A5E71"/>
-          <kie:ComponentWidths dmnElementRef="_E968333D-479F-4584-B273-F26560021DC0"/>
-          <kie:ComponentWidths dmnElementRef="_5811B4F0-9BA3-4083-93C0-C2C14441B585"/>
-          <kie:ComponentWidths dmnElementRef="_2E781A59-36A3-49F7-8B0F-F1D0ADADE60E"/>
-          <kie:ComponentWidths dmnElementRef="_7FD82BC4-67FC-4033-B58F-98A19ED8B890"/>
-          <kie:ComponentWidths dmnElementRef="_FA66787D-DB73-46A6-A12F-4CCA1E27C1A5"/>
-          <kie:ComponentWidths dmnElementRef="_9A884F00-26B9-4ADA-BB53-802C218DB96A"/>
-          <kie:ComponentWidths dmnElementRef="_EEE0851D-107F-444F-B0E0-98E1EA0C98CB"/>
-          <kie:ComponentWidths dmnElementRef="_9C1A5BA9-5B9B-4EA6-B970-6CB106CBDC49"/>
-          <kie:ComponentWidths dmnElementRef="_6042D108-15EE-4041-AFBA-9A73892B0F36"/>
-          <kie:ComponentWidths dmnElementRef="_E66FBA75-5B4D-4D11-A00C-8DA09C36E687"/>
-          <kie:ComponentWidths dmnElementRef="_754C9313-F07B-4EF6-8B51-F7E662374559"/>
-          <kie:ComponentWidths dmnElementRef="_8CCB9AA5-2551-4CBE-A6D0-5258EA7D7B2A"/>
-          <kie:ComponentWidths dmnElementRef="_9F3CE04E-B813-4A4D-B795-00EF110CDB41"/>
-          <kie:ComponentWidths dmnElementRef="_AD152E30-FFBE-446F-93FA-ADB08AFE3C1D"/>
-          <kie:ComponentWidths dmnElementRef="_BFA99D23-4ED5-443E-A404-EB8E39ABC0B8"/>
-          <kie:ComponentWidths dmnElementRef="_B16C4F7F-73AB-44B6-BC3A-18A2187567A0"/>
-          <kie:ComponentWidths dmnElementRef="_11E452BA-7C70-4BDA-B33A-B69329828153"/>
-          <kie:ComponentWidths dmnElementRef="_9F3B05D9-D013-4E9A-9007-89F24E2987A3"/>
-          <kie:ComponentWidths dmnElementRef="_9ECECABF-C811-4A7E-B161-7EFAE322E35E"/>
-          <kie:ComponentWidths dmnElementRef="_05157905-263E-4A93-99B8-5C4010C0013E"/>
-          <kie:ComponentWidths dmnElementRef="_AE433AB6-13C6-4842-91FC-433456F6E9E2"/>
-          <kie:ComponentWidths dmnElementRef="_405E4248-0F47-40E1-8C0D-C664D43DE004"/>
-          <kie:ComponentWidths dmnElementRef="_00B05E56-2C80-4E18-BE2D-4FDDAA6C0462"/>
-          <kie:ComponentWidths dmnElementRef="_707987A6-7B84-4869-B510-283EC111D92F"/>
-          <kie:ComponentWidths dmnElementRef="_F74B86CA-18B9-4121-B60C-33BC976AADAE"/>
-          <kie:ComponentWidths dmnElementRef="_3D653879-9215-4EDE-BB8E-7384A9920FDC"/>
-          <kie:ComponentWidths dmnElementRef="_703534DA-03C6-45F6-9076-DCD70F05BC13"/>
-          <kie:ComponentWidths dmnElementRef="_67C2B891-A256-41CE-B8F4-7FE909555A20"/>
-          <kie:ComponentWidths dmnElementRef="_3B9EBB55-5949-4838-A45C-2B652839265B"/>
-          <kie:ComponentWidths dmnElementRef="_685C2316-FC3E-49F2-8E96-81D9FFA923A3"/>
-          <kie:ComponentWidths dmnElementRef="_B27AE1EE-AD5E-4C5E-9070-D098018A557E"/>
-          <kie:ComponentWidths dmnElementRef="_3EADD38C-A59B-4F10-BC98-EC980E1CA342"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="50" y="150"/>
-          <di:waypoint x="150" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3375" y="325"/>
-          <di:waypoint x="3475" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3550" y="325"/>
-          <di:waypoint x="3650" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5300" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5475" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5650" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5825" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6000" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6175" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6350" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="6525" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_7B3BE5CF-8218-47D2-B2CC-970E1FD58468" dmnElementRef="_7B3BE5CF-8218-47D2-B2CC-970E1FD58468">
-        <di:waypoint x="2900" y="250"/>
-        <di:waypoint x="975" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8063F8D3-6062-4478-92B1-CEDFEFC9575A" dmnElementRef="_8063F8D3-6062-4478-92B1-CEDFEFC9575A">
-        <di:waypoint x="2900" y="250"/>
-        <di:waypoint x="1325" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_5ACB2078-518E-4743-9575-4BD03EDDA126" dmnElementRef="_5ACB2078-518E-4743-9575-4BD03EDDA126">
-        <di:waypoint x="2725" y="250"/>
-        <di:waypoint x="800" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_A0CCB912-9FA0-446A-9CBD-6706BA653DD2" dmnElementRef="_A0CCB912-9FA0-446A-9CBD-6706BA653DD2">
-        <di:waypoint x="3075" y="250"/>
-        <di:waypoint x="1500" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_32CEA84D-85B5-48A6-8BA3-D241F7A261FE" dmnElementRef="_32CEA84D-85B5-48A6-8BA3-D241F7A261FE">
-        <di:waypoint x="3075" y="250"/>
-        <di:waypoint x="1850" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_AB09AF7F-53DA-433F-93CA-78E46482703F" dmnElementRef="_AB09AF7F-53DA-433F-93CA-78E46482703F">
-        <di:waypoint x="3075" y="250"/>
-        <di:waypoint x="2200" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2" dmnElementRef="_3122BDD7-6DE6-46B8-B2C3-21F6597E02B2">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="3075" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_32616BE5-7354-455A-B94F-1E5F494BBD61" dmnElementRef="_32616BE5-7354-455A-B94F-1E5F494BBD61">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="3250" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_844CC3F6-599F-4499-A803-C1886139969A" dmnElementRef="_844CC3F6-599F-4499-A803-C1886139969A">
-        <di:waypoint x="2900" y="250"/>
-        <di:waypoint x="2025" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_743FD00A-040C-4EF3-A16F-51F8E36EFE49" dmnElementRef="_743FD00A-040C-4EF3-A16F-51F8E36EFE49">
-        <di:waypoint x="2900" y="250"/>
-        <di:waypoint x="2375" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_004EB93A-E37A-4C38-BF48-CA4FED683432" dmnElementRef="_004EB93A-E37A-4C38-BF48-CA4FED683432">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="3425" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_EBD496F0-9E21-47AD-A630-8C5E032B6749" dmnElementRef="_EBD496F0-9E21-47AD-A630-8C5E032B6749">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="3775" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_ED2359BA-F57A-495B-8E75-C0913CD2BA05" dmnElementRef="_ED2359BA-F57A-495B-8E75-C0913CD2BA05">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="3950" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB" dmnElementRef="_140D0C5A-B19C-4248-AB4C-51BF9CCDCADB">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="4125" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_590A1A56-B5B1-435D-827C-03671BB0C575" dmnElementRef="_590A1A56-B5B1-435D-827C-03671BB0C575">
-        <di:waypoint x="3775" y="250"/>
-        <di:waypoint x="4825" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1E490D2C-A941-4F7B-BEB1-8409E4C63880" dmnElementRef="_1E490D2C-A941-4F7B-BEB1-8409E4C63880">
-        <di:waypoint x="3425" y="250"/>
-        <di:waypoint x="4300" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1A757F6C-CC80-45E0-B19A-A78E2E0D8382" dmnElementRef="_1A757F6C-CC80-45E0-B19A-A78E2E0D8382">
-        <di:waypoint x="3425" y="250"/>
-        <di:waypoint x="4475" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7BD5372D-20EE-4D47-8AA9-B8E651010343" dmnElementRef="_7BD5372D-20EE-4D47-8AA9-B8E651010343">
-        <di:waypoint x="3950" y="250"/>
-        <di:waypoint x="5000" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3E92ADC3-4BAD-4D40-93F9-4591994078FB" dmnElementRef="_3E92ADC3-4BAD-4D40-93F9-4591994078FB">
-        <di:waypoint x="3600" y="250"/>
-        <di:waypoint x="4650" y="75"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+   </dmn:decision>
+   <dmn:decision id="_decision_bkm_002" name="decision_bkm_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_358C7C6B-B85F-42FA-851D-92E67259EA22" name="decision_bkm_002" />
+      <dmn:knowledgeRequirement id="_F8436D5E-B368-4771-8F41-E631E4B3B0A0">
+         <dmn:requiredKnowledge href="#_bkm_001" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_90C983F3-68EE-4B3B-9DE2-C21F0E93B955">
+         <dmn:text>bkm_001({name: "foo"})</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_bkm_002" name="bkm_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_C2C2EF9F-D911-49B2-8AA6-9B95FC98FCDC" name="bkm_002" typeRef="tNameAndAge" />
+      <dmn:encapsulatedLogic id="_6F57B3F5-311C-4BA9-B38E-F094B71A6D50" kind="FEEL">
+         <dmn:formalParameter id="_41E21842-DE69-49C2-9ACF-18C59015BF6A" name="nameAndAge" typeRef="tNameAndAge" />
+         <dmn:literalExpression id="_D6F7F274-441E-419F-9E14-43F2DB655967">
+            <dmn:text>nameAndAge != null</dmn:text>
+         </dmn:literalExpression>
+      </dmn:encapsulatedLogic>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_decision_bkm_003" name="decision_bkm_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_6E9C1944-BCBC-4495-861C-1474979FB25B" name="decision_bkm_003" />
+      <dmn:knowledgeRequirement id="_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4">
+         <dmn:requiredKnowledge href="#_bkm_002" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_D163B8D3-2B0D-488F-BB0A-551254CE4002">
+         <dmn:text>bkm_002({name: "foo"})</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:businessKnowledgeModel id="_bkm_004" name="bkm_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_407F6BF8-E319-476A-B511-67F87CF7B3F0" name="bkm_004" typeRef="tNumberList" />
+      <dmn:encapsulatedLogic id="_CE285C61-7483-4FCB-AC28-D6B803B6A3E7" kind="FEEL">
+         <dmn:formalParameter id="_750C1E3B-C297-4069-A8DA-A5774230F762" name="arg" />
+         <dmn:literalExpression id="_49A0FBD4-6637-4B53-BB5F-43B5C42B2D3B">
+            <dmn:text>arg</dmn:text>
+         </dmn:literalExpression>
+      </dmn:encapsulatedLogic>
+   </dmn:businessKnowledgeModel>
+   <dmn:businessKnowledgeModel id="_bkm_005" name="bkm_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_F5AAE6D8-BF27-4F07-956D-113492457CE3" name="bkm_005" typeRef="number" />
+      <dmn:encapsulatedLogic id="_D56DE1E1-8FAF-4D65-900F-5AA5D3BE807B" kind="FEEL">
+         <dmn:formalParameter id="_5565A56B-508A-46E1-AC68-0DC380E97C32" name="arg" />
+         <dmn:literalExpression id="_8262564E-8138-42C4-8AF4-1D52CC9E9399">
+            <dmn:text>[arg]</dmn:text>
+         </dmn:literalExpression>
+      </dmn:encapsulatedLogic>
+   </dmn:businessKnowledgeModel>
+   <dmn:decision id="_decision_bkm_004" name="decision_bkm_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_4F3FC0CF-8EFC-4230-A2C6-631718D507E0" name="decision_bkm_004" />
+      <dmn:knowledgeRequirement id="_3EBBAB17-C04D-4603-9939-27AE25901615">
+         <dmn:requiredKnowledge href="#_bkm_004" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_A3C4745D-B25F-4757-99FB-7943DDC5905A">
+         <dmn:text>bkm_004(10)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_bkm_004_a" name="decision_bkm_004_a">
+      <dmn:extensionElements />
+      <dmn:variable id="_FDA2CDE3-A962-4142-B0F2-E95DBCD81B74" name="decision_bkm_004_a" />
+      <dmn:knowledgeRequirement id="_81A20E77-6873-408E-B46A-D629C10CF82C">
+         <dmn:requiredKnowledge href="#_bkm_004" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_36D66913-F7E4-40E4-A9E7-27C030B02513">
+         <dmn:text>bkm_004("foo")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_bkm_004_b" name="decision_bkm_004_b">
+      <dmn:extensionElements />
+      <dmn:variable id="_7FC7E2DB-77C4-41C8-943C-FCE46F1A1493" name="decision_bkm_004_b" />
+      <dmn:knowledgeRequirement id="_D12DAA2A-8672-4B57-B3E6-031A1B244062">
+         <dmn:requiredKnowledge href="#_bkm_004" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_C2DE3F17-2C89-42BA-AF99-D61369CB6EDB">
+         <dmn:text>bkm_004(null)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_bkm_005" name="decision_bkm_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_C5752C79-F487-473D-A3D0-98470A220411" name="decision_bkm_005" />
+      <dmn:knowledgeRequirement id="_63E07842-23E3-4A56-843F-29876C7356B2">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_DBE08836-6D08-4D6E-B798-EC62556D0A00">
+         <dmn:text>bkm_005(10)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_bkm_005_a" name="decision_bkm_005_a">
+      <dmn:extensionElements />
+      <dmn:variable id="_773028C5-459D-4077-83F6-0CE5DC63E50D" name="decision_bkm_005_a" />
+      <dmn:knowledgeRequirement id="_9D46D5A3-EACE-4B85-811C-6E222F520AAF">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_D4641F86-9DF5-4DB3-8790-47FE824C6765">
+         <dmn:text>bkm_005("foo")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_invoke_001" name="invoke_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_E9DF663F-8803-4CBE-895C-6F27D6134190" name="invoke_001" />
+      <dmn:knowledgeRequirement id="_9A9924C7-D617-478E-BC2F-9D35F32D172D">
+         <dmn:requiredKnowledge href="#_bkm_001" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_24F82CA3-99D1-4892-9DAF-3AFE78B9C506">
+         <dmn:literalExpression id="_A437701C-23FB-482D-828A-FE2AA0612431">
+            <dmn:text>bkm_001</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_78EBAC4F-8FE1-456B-BE83-E9E68FE2F5FA" name="nameAndAge" />
+            <dmn:literalExpression id="_C5FCD024-5645-4BEB-A7D2-CF5E872B83AE">
+               <dmn:text>{name: "foo"}</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_invoke_002" name="invoke_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_52E0A7E1-A77F-46F2-8E95-BE780ADD8F25" name="invoke_002" typeRef="string" />
+      <dmn:knowledgeRequirement id="_4FB36F34-549D-4FB3-B5ED-134685380F3F">
+         <dmn:requiredKnowledge href="#_bkm_001" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_94363EF7-FC61-4609-BC58-DAEF64F59464" typeRef="string">
+         <dmn:literalExpression id="_59E4D032-7A9A-43ED-A113-DC249C4E9C3B">
+            <dmn:text>bkm_001</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_050DDD99-187A-4AA5-B1BE-2584EC039B77" name="nameAndAge" />
+            <dmn:literalExpression id="_89950E0F-92D8-44B4-B9A3-81C90046CF6A">
+               <dmn:text>{name: "foo", age: 10}</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_invoke_003" name="invoke_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_B50D5920-AC26-423B-A8A5-21FE4883F130" name="invoke_003" typeRef="tNumberList" />
+      <dmn:knowledgeRequirement id="_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_794E9811-2A0B-4062-ACE5-F4610120FEFC" typeRef="tNumberList">
+         <dmn:literalExpression id="_3B49CC6C-11A2-424D-8D6F-FDFF4B9C577F">
+            <dmn:text>bkm_005</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_0FAB7A6C-C99E-47F2-BC38-411CA87BD3CF" name="arg" />
+            <dmn:literalExpression id="_A0AC6786-37B1-4324-BB29-A6279952653B">
+               <dmn:text>10</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_invoke_004" name="invoke_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_679C4EF9-54C4-48DD-A077-6D0C03C8273E" name="invoke_004" typeRef="tNumberList" />
+      <dmn:knowledgeRequirement id="_EAA6FD5F-785C-4CA4-9930-51F53869B0E7">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_C1B48C5B-E77A-4DBD-8FD9-B6A152FD6D4D" typeRef="tNumberList">
+         <dmn:literalExpression id="_44207F2A-A61A-4144-AD84-75514DB72719">
+            <dmn:text>bkm_005</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_BD8D119A-ECA0-4587-B28F-9EE0CB3BC9C5" name="arg" />
+            <dmn:literalExpression id="_D1047E70-958B-469B-B53C-6958D514D4B5">
+               <dmn:text>"foo"</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_invoke_005" name="invoke_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_A324D844-3B29-49CF-891D-20429A9ADAFE" name="invoke_005" typeRef="number" />
+      <dmn:knowledgeRequirement id="_D2DA1995-D862-47FA-B833-BDDB92B5C87C">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_E5F0B0F8-07EA-4B28-9EA9-BA74FDB7AF71" typeRef="number">
+         <dmn:literalExpression id="_32DFA51C-81B8-483A-9D5D-4477E1E1B68B">
+            <dmn:text>bkm_005</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_68A837DC-4928-4269-8F18-E8886646FB46" name="arg" />
+            <dmn:literalExpression id="_EE998D50-9323-410E-A685-B2698BB25466">
+               <dmn:text>[10]</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_invoke_006" name="invoke_006">
+      <dmn:extensionElements />
+      <dmn:variable id="_BA5717BF-8662-439A-8E3D-ED1AAF159014" name="invoke_006" typeRef="number" />
+      <dmn:knowledgeRequirement id="_5BB47D86-2531-4C80-A73F-97FCD8E81DBD">
+         <dmn:requiredKnowledge href="#_bkm_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:invocation id="_88BA6B31-357B-406F-8830-AEC5328318D8" typeRef="number">
+         <dmn:literalExpression id="_7285443C-BE70-481D-8763-68879AA0E463">
+            <dmn:text>bkm_005</dmn:text>
+         </dmn:literalExpression>
+         <dmn:binding>
+            <dmn:parameter id="_832B3B7E-EDC1-483B-8F40-F2E105ADD07A" name="arg" />
+            <dmn:literalExpression id="_CED2D692-6F4C-4FE1-9957-07BD77EE1B10">
+               <dmn:text>["foo"]</dmn:text>
+            </dmn:literalExpression>
+         </dmn:binding>
+      </dmn:invocation>
+   </dmn:decision>
+   <dmn:decision id="_fd_001" name="fd_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_F4514CDB-AE73-459C-B6E6-2FF16A3C8D3D" name="fd_001" />
+      <dmn:context id="_18175A34-C931-44EB-84E2-62C52E82D80C">
+         <dmn:contextEntry>
+            <dmn:variable id="_559EBB70-EA8A-4EAA-BE1A-4400142C6BF0" name="fn" />
+            <dmn:literalExpression id="_103F6774-9FF7-4617-85B6-42E65EEEF942">
+               <dmn:text>function(arg: number) arg</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:literalExpression id="_0A6F707E-E81F-45CF-B389-0CBFAD3C4798">
+               <dmn:text>fn(10)</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_fd_002" name="fd_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_3D67778F-F1D6-4A93-A613-D368B332F499" name="fd_002" />
+      <dmn:context id="_CC81CC7D-5D38-455A-ACC6-216D350B108B">
+         <dmn:contextEntry>
+            <dmn:variable id="_D249BF9A-6A37-4831-951D-4BF71C4576AE" name="fn" />
+            <dmn:literalExpression id="_87FDB835-A7E4-4253-B37B-6C1BC89B9325">
+               <dmn:text>function(arg: number) arg</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:literalExpression id="_E26F349A-8846-4732-B8FA-8A96B5E8CFC3">
+               <dmn:text>fn("foo")</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_literal_001" name="literal_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_67FA5B3F-8C8D-4E38-8C00-940E697E8B26" name="literal_001" typeRef="number" />
+      <dmn:literalExpression id="_D69AE0B4-551D-4662-9695-760D0B47D915" typeRef="number">
+         <dmn:text>5+5</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_literal_002" name="literal_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_D1D1B598-8122-4C81-8930-C3FD3933F25A" name="literal_002" typeRef="number" />
+      <dmn:literalExpression id="_989C6F4F-E08F-485F-90DE-501B91FAC6C4" typeRef="number">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_literal_003" name="literal_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_10F74ECF-1520-4871-938B-103632F3BED9" name="literal_003" typeRef="tNumberList" />
+      <dmn:literalExpression id="_A649C13A-A589-4742-8D99-4A812C88417C" typeRef="tNumberList">
+         <dmn:text>10</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_literal_004" name="literal_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_EB9D5083-95EC-4C55-83EA-5B47845206E0" name="literal_004" typeRef="tNumberList" />
+      <dmn:literalExpression id="_E8528192-0932-421D-8408-2041C6E78A92" typeRef="tNumberList">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_literal_005" name="literal_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_146BF83D-1B30-426F-A811-6D6797F9F864" name="literal_005" typeRef="number" />
+      <dmn:literalExpression id="_D14CEA9B-BFA4-4808-BB77-52466481445C" typeRef="number">
+         <dmn:text>[10]</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_literal_006" name="literal_006">
+      <dmn:extensionElements />
+      <dmn:variable id="_ADB0E85F-9E4B-4289-99D2-B02FABF0D922" name="literal_006" typeRef="number" />
+      <dmn:literalExpression id="_3B76E8FC-BABD-469D-A6B2-37BA327365F5" typeRef="number">
+         <dmn:text>["foo"]</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_ds_001" name="decision_ds_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_4567FB14-4222-4B8E-8014-59D4C2B4CBE2" name="decision_ds_001" />
+      <dmn:literalExpression id="_E1843FD2-62FB-459E-8BFF-071E13A56285">
+         <dmn:text>1000</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_ds_002" name="decision_ds_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_4F9076C5-6D19-4298-B997-11032201CAAA" name="decision_ds_002" />
+      <dmn:informationRequirement id="_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE">
+         <dmn:requiredInput href="#_decisionService_002_input_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_52547BEB-3E85-4310-A899-3062C255FF25">
+         <dmn:text>decisionService_002_input_1</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_decisionService_002_input_1" name="decisionService_002_input_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_DDAFD901-AA26-4148-B00E-B417D284E9D2" name="decisionService_002_input_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_ds_invoke_002_with_number" name="ds_invoke_002_with_number">
+      <dmn:extensionElements />
+      <dmn:variable id="_78BFF27A-7CFD-4873-B1E3-90E99768A5FB" name="ds_invoke_002_with_number" />
+      <dmn:knowledgeRequirement id="_F2016F44-D6AC-409C-B0B1-6048B6CDF959">
+         <dmn:requiredKnowledge href="#_decisionService_002" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_4F4BEF6A-9B31-44D1-91F5-CBEFC27BFCC8">
+         <dmn:text>decisionService_002(10)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_ds_invoke_002_with_singleton_list" name="ds_invoke_002_with_singleton_list">
+      <dmn:extensionElements />
+      <dmn:variable id="_6B738A72-155F-4CD6-B0BE-2CC25F49E0CC" name="ds_invoke_002_with_singleton_list" />
+      <dmn:knowledgeRequirement id="_2B360566-81F1-41BD-8D5D-B0F786692652">
+         <dmn:requiredKnowledge href="#_decisionService_002" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_FAB14015-5787-428A-9DD7-3BC0C96D6728">
+         <dmn:text>decisionService_002(["foo"])</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_ds_003" name="decision_ds_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_DF95559F-608C-4DC1-BEE0-3D9D29847E45" name="decision_ds_003" />
+      <dmn:informationRequirement id="_20E48A54-F6B8-4E2E-BD46-DD38D44FA213">
+         <dmn:requiredInput href="#_decisionService_003_input_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_F680776D-71FB-4007-A1C6-6ED68EA9EB3A">
+         <dmn:text>decisionService_003_input_1</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_decisionService_003_input_1" name="decisionService_003_input_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_8C96E193-4659-45AD-9D72-9EF3549031B2" name="decisionService_003_input_1" typeRef="tStringList" />
+   </dmn:inputData>
+   <dmn:decision id="_ds_invoke_003_with_string" name="ds_invoke_003_with_string">
+      <dmn:extensionElements />
+      <dmn:variable id="_C3853E26-E710-43A8-B9EB-3E56A5970806" name="ds_invoke_003_with_string" />
+      <dmn:knowledgeRequirement id="_00D499AC-31B0-4704-AA50-1C4D22931B38">
+         <dmn:requiredKnowledge href="#_decisionService_003" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_6F69867A-5997-491F-893B-09518234E37A">
+         <dmn:text>decisionService_003("foo")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_888A41F2-5523-47D3-8BC2-80614F963D7B" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_D277AC92-BA78-434A-9030-98F28587C10F" />
+               <kie:ComponentWidths dmnElementRef="_715D160B-F6B6-434D-B0C5-32B865C232FC" />
+               <kie:ComponentWidths dmnElementRef="_9BE89A60-AECD-4FD8-AD43-E3AE71E8A5CB" />
+               <kie:ComponentWidths dmnElementRef="_6FFBD558-AB35-485F-8045-6387C0DD8A42" />
+               <kie:ComponentWidths dmnElementRef="_ED551414-BBE9-4B20-9362-A81FFEE7DF19" />
+               <kie:ComponentWidths dmnElementRef="_CBC0E494-26AC-4D1F-B34C-69FFAA39080A" />
+               <kie:ComponentWidths dmnElementRef="_5D39D344-741C-484A-B3D8-80FC57102BD2" />
+               <kie:ComponentWidths dmnElementRef="_FCF4F8F8-84A1-4657-B08C-8B222A719D14" />
+               <kie:ComponentWidths dmnElementRef="_98638ECF-2EBF-4606-ACFB-587001CFD3BA" />
+               <kie:ComponentWidths dmnElementRef="_2EE79C8B-4C16-4550-970D-250A7566B5B5" />
+               <kie:ComponentWidths dmnElementRef="_2C43E9DD-1882-4CC3-B2E7-C9783841D1C2" />
+               <kie:ComponentWidths dmnElementRef="_93493631-022A-4C87-91DF-58F9A4F644AA" />
+               <kie:ComponentWidths dmnElementRef="_90C983F3-68EE-4B3B-9DE2-C21F0E93B955" />
+               <kie:ComponentWidths dmnElementRef="_D6F7F274-441E-419F-9E14-43F2DB655967" />
+               <kie:ComponentWidths dmnElementRef="_6F57B3F5-311C-4BA9-B38E-F094B71A6D50" />
+               <kie:ComponentWidths dmnElementRef="_D163B8D3-2B0D-488F-BB0A-551254CE4002" />
+               <kie:ComponentWidths dmnElementRef="_49A0FBD4-6637-4B53-BB5F-43B5C42B2D3B" />
+               <kie:ComponentWidths dmnElementRef="_CE285C61-7483-4FCB-AC28-D6B803B6A3E7" />
+               <kie:ComponentWidths dmnElementRef="_8262564E-8138-42C4-8AF4-1D52CC9E9399" />
+               <kie:ComponentWidths dmnElementRef="_D56DE1E1-8FAF-4D65-900F-5AA5D3BE807B" />
+               <kie:ComponentWidths dmnElementRef="_A3C4745D-B25F-4757-99FB-7943DDC5905A" />
+               <kie:ComponentWidths dmnElementRef="_36D66913-F7E4-40E4-A9E7-27C030B02513" />
+               <kie:ComponentWidths dmnElementRef="_C2DE3F17-2C89-42BA-AF99-D61369CB6EDB" />
+               <kie:ComponentWidths dmnElementRef="_DBE08836-6D08-4D6E-B798-EC62556D0A00" />
+               <kie:ComponentWidths dmnElementRef="_D4641F86-9DF5-4DB3-8790-47FE824C6765" />
+               <kie:ComponentWidths dmnElementRef="_24F82CA3-99D1-4892-9DAF-3AFE78B9C506" />
+               <kie:ComponentWidths dmnElementRef="_A437701C-23FB-482D-828A-FE2AA0612431" />
+               <kie:ComponentWidths dmnElementRef="_C5FCD024-5645-4BEB-A7D2-CF5E872B83AE" />
+               <kie:ComponentWidths dmnElementRef="_94363EF7-FC61-4609-BC58-DAEF64F59464" />
+               <kie:ComponentWidths dmnElementRef="_59E4D032-7A9A-43ED-A113-DC249C4E9C3B" />
+               <kie:ComponentWidths dmnElementRef="_89950E0F-92D8-44B4-B9A3-81C90046CF6A" />
+               <kie:ComponentWidths dmnElementRef="_794E9811-2A0B-4062-ACE5-F4610120FEFC" />
+               <kie:ComponentWidths dmnElementRef="_3B49CC6C-11A2-424D-8D6F-FDFF4B9C577F" />
+               <kie:ComponentWidths dmnElementRef="_A0AC6786-37B1-4324-BB29-A6279952653B" />
+               <kie:ComponentWidths dmnElementRef="_C1B48C5B-E77A-4DBD-8FD9-B6A152FD6D4D" />
+               <kie:ComponentWidths dmnElementRef="_44207F2A-A61A-4144-AD84-75514DB72719" />
+               <kie:ComponentWidths dmnElementRef="_D1047E70-958B-469B-B53C-6958D514D4B5" />
+               <kie:ComponentWidths dmnElementRef="_E5F0B0F8-07EA-4B28-9EA9-BA74FDB7AF71" />
+               <kie:ComponentWidths dmnElementRef="_32DFA51C-81B8-483A-9D5D-4477E1E1B68B" />
+               <kie:ComponentWidths dmnElementRef="_EE998D50-9323-410E-A685-B2698BB25466" />
+               <kie:ComponentWidths dmnElementRef="_88BA6B31-357B-406F-8830-AEC5328318D8" />
+               <kie:ComponentWidths dmnElementRef="_7285443C-BE70-481D-8763-68879AA0E463" />
+               <kie:ComponentWidths dmnElementRef="_CED2D692-6F4C-4FE1-9957-07BD77EE1B10" />
+               <kie:ComponentWidths dmnElementRef="_18175A34-C931-44EB-84E2-62C52E82D80C" />
+               <kie:ComponentWidths dmnElementRef="_103F6774-9FF7-4617-85B6-42E65EEEF942" />
+               <kie:ComponentWidths dmnElementRef="_0A6F707E-E81F-45CF-B389-0CBFAD3C4798" />
+               <kie:ComponentWidths dmnElementRef="_CC81CC7D-5D38-455A-ACC6-216D350B108B" />
+               <kie:ComponentWidths dmnElementRef="_87FDB835-A7E4-4253-B37B-6C1BC89B9325" />
+               <kie:ComponentWidths dmnElementRef="_E26F349A-8846-4732-B8FA-8A96B5E8CFC3" />
+               <kie:ComponentWidths dmnElementRef="_D69AE0B4-551D-4662-9695-760D0B47D915" />
+               <kie:ComponentWidths dmnElementRef="_989C6F4F-E08F-485F-90DE-501B91FAC6C4" />
+               <kie:ComponentWidths dmnElementRef="_A649C13A-A589-4742-8D99-4A812C88417C" />
+               <kie:ComponentWidths dmnElementRef="_E8528192-0932-421D-8408-2041C6E78A92" />
+               <kie:ComponentWidths dmnElementRef="_D14CEA9B-BFA4-4808-BB77-52466481445C" />
+               <kie:ComponentWidths dmnElementRef="_3B76E8FC-BABD-469D-A6B2-37BA327365F5" />
+               <kie:ComponentWidths dmnElementRef="_E1843FD2-62FB-459E-8BFF-071E13A56285" />
+               <kie:ComponentWidths dmnElementRef="_52547BEB-3E85-4310-A899-3062C255FF25" />
+               <kie:ComponentWidths dmnElementRef="_4F4BEF6A-9B31-44D1-91F5-CBEFC27BFCC8" />
+               <kie:ComponentWidths dmnElementRef="_FAB14015-5787-428A-9DD7-3BC0C96D6728" />
+               <kie:ComponentWidths dmnElementRef="_F680776D-71FB-4007-A1C6-6ED68EA9EB3A" />
+               <kie:ComponentWidths dmnElementRef="_6F69867A-5997-491F-893B-09518234E37A" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="50" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="50" y="150" />
+               <di:waypoint x="190" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3288" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3288" y="475" />
+               <di:waypoint x="3428" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3483" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="3483" y="475" />
+               <di:waypoint x="3623" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="245" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="420" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004" dmnElementRef="_decision_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="595" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005" dmnElementRef="_decision_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="770" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006" dmnElementRef="_decision_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="945" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_a" dmnElementRef="_decision_006_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1120" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007" dmnElementRef="_decision_007" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1295" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_a" dmnElementRef="_decision_007_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1470" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008" dmnElementRef="_decision_008" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1645" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_001" dmnElementRef="_bkm_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2588" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_001" dmnElementRef="_decision_bkm_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1820" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_002" dmnElementRef="_decision_bkm_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1995" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_002" dmnElementRef="_bkm_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2763" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_003" dmnElementRef="_decision_bkm_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2170" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_004" dmnElementRef="_bkm_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2938" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_bkm_005" dmnElementRef="_bkm_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3113" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004" dmnElementRef="_decision_bkm_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2345" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_a" dmnElementRef="_decision_bkm_004_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2695" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_004_b" dmnElementRef="_decision_bkm_004_b" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3045" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005" dmnElementRef="_decision_bkm_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3220" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_bkm_005_a" dmnElementRef="_decision_bkm_005_a" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3395" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_001" dmnElementRef="_invoke_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2520" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_002" dmnElementRef="_invoke_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2870" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_003" dmnElementRef="_invoke_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3570" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_004" dmnElementRef="_invoke_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3745" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_005" dmnElementRef="_invoke_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3920" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_invoke_006" dmnElementRef="_invoke_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4095" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_fd_001" dmnElementRef="_fd_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4270" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_fd_002" dmnElementRef="_fd_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4445" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_001" dmnElementRef="_literal_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4620" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_002" dmnElementRef="_literal_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4795" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_003" dmnElementRef="_literal_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5145" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_004" dmnElementRef="_literal_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5495" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_005" dmnElementRef="_literal_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5845" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_literal_006" dmnElementRef="_literal_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="6020" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_001" dmnElementRef="_decision_ds_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_002" dmnElementRef="_decision_ds_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002_input_1" dmnElementRef="_decisionService_002_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2938" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_number" dmnElementRef="_ds_invoke_002_with_number" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="4970" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_002_with_singleton_list" dmnElementRef="_ds_invoke_002_with_singleton_list" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5320" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_ds_003" dmnElementRef="_decision_ds_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003_input_1" dmnElementRef="_decisionService_003_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="3113" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_ds_invoke_003_with_string" dmnElementRef="_ds_invoke_003_with_string" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="5670" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_68546B11-7C06-4A8B-95B0-4C124CADAA2C" dmnElementRef="_68546B11-7C06-4A8B-95B0-4C124CADAA2C">
+            <di:waypoint x="2638" y="400" />
+            <di:waypoint x="1870" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F8436D5E-B368-4771-8F41-E631E4B3B0A0" dmnElementRef="_F8436D5E-B368-4771-8F41-E631E4B3B0A0">
+            <di:waypoint x="2638" y="400" />
+            <di:waypoint x="2045" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4" dmnElementRef="_C2AF2D33-4F8F-4914-8F31-12E9CD3A9EF4">
+            <di:waypoint x="2813" y="400" />
+            <di:waypoint x="2220" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_3EBBAB17-C04D-4603-9939-27AE25901615" dmnElementRef="_3EBBAB17-C04D-4603-9939-27AE25901615">
+            <di:waypoint x="2988" y="400" />
+            <di:waypoint x="2395" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_81A20E77-6873-408E-B46A-D629C10CF82C" dmnElementRef="_81A20E77-6873-408E-B46A-D629C10CF82C">
+            <di:waypoint x="2988" y="400" />
+            <di:waypoint x="2745" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_D12DAA2A-8672-4B57-B3E6-031A1B244062" dmnElementRef="_D12DAA2A-8672-4B57-B3E6-031A1B244062">
+            <di:waypoint x="2988" y="400" />
+            <di:waypoint x="3095" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_63E07842-23E3-4A56-843F-29876C7356B2" dmnElementRef="_63E07842-23E3-4A56-843F-29876C7356B2">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="3270" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_9D46D5A3-EACE-4B85-811C-6E222F520AAF" dmnElementRef="_9D46D5A3-EACE-4B85-811C-6E222F520AAF">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="3445" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_9A9924C7-D617-478E-BC2F-9D35F32D172D" dmnElementRef="_9A9924C7-D617-478E-BC2F-9D35F32D172D">
+            <di:waypoint x="2638" y="400" />
+            <di:waypoint x="2570" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_4FB36F34-549D-4FB3-B5ED-134685380F3F" dmnElementRef="_4FB36F34-549D-4FB3-B5ED-134685380F3F">
+            <di:waypoint x="2638" y="400" />
+            <di:waypoint x="2920" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B" dmnElementRef="_F15B0F7D-C715-4CD9-BBC4-1FFDE6FE0E1B">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="3620" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_EAA6FD5F-785C-4CA4-9930-51F53869B0E7" dmnElementRef="_EAA6FD5F-785C-4CA4-9930-51F53869B0E7">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="3795" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_D2DA1995-D862-47FA-B833-BDDB92B5C87C" dmnElementRef="_D2DA1995-D862-47FA-B833-BDDB92B5C87C">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="3970" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_5BB47D86-2531-4C80-A73F-97FCD8E81DBD" dmnElementRef="_5BB47D86-2531-4C80-A73F-97FCD8E81DBD">
+            <di:waypoint x="3163" y="400" />
+            <di:waypoint x="4145" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE" dmnElementRef="_8DA828E3-CF2B-4AB8-85B9-17006F07C3EE">
+            <di:waypoint x="2988" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F2016F44-D6AC-409C-B0B1-6048B6CDF959" dmnElementRef="_F2016F44-D6AC-409C-B0B1-6048B6CDF959">
+            <di:waypoint x="3338" y="400" />
+            <di:waypoint x="5020" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_2B360566-81F1-41BD-8D5D-B0F786692652" dmnElementRef="_2B360566-81F1-41BD-8D5D-B0F786692652">
+            <di:waypoint x="3338" y="400" />
+            <di:waypoint x="5370" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_20E48A54-F6B8-4E2E-BD46-DD38D44FA213" dmnElementRef="_20E48A54-F6B8-4E2E-BD46-DD38D44FA213">
+            <di:waypoint x="3163" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_00D499AC-31B0-4704-AA50-1C4D22931B38" dmnElementRef="_00D499AC-31B0-4704-AA50-1C4D22931B38">
+            <di:waypoint x="3533" y="400" />
+            <di:waypoint x="5720" y="75" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
@@ -4,18 +4,18 @@
    <dmn:extensionElements />
    <dmn:decisionService id="_decisionService_001" name="decisionService_001">
       <dmn:extensionElements />
-      <dmn:variable id="_0F4D4997-C012-4D9A-8EA9-C6828585B324" name="decisionService_001" />
+      <dmn:variable id="_A440E5CE-D661-4773-839E-0BBEFBB577F0" name="decisionService_001" />
       <dmn:outputDecision href="#_decision_001" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_002" name="decisionService_002">
       <dmn:extensionElements />
-      <dmn:variable id="_0580A3E5-AA5E-440F-9C10-5CE175245B3E" name="decisionService_002" />
+      <dmn:variable id="_B184627C-C832-44AC-8C36-4B3F88009817" name="decisionService_002" />
       <dmn:outputDecision href="#_decision_002" />
       <dmn:inputDecision href="#_decision_002_input" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_003" name="decisionService_003">
       <dmn:extensionElements />
-      <dmn:variable id="_9CEC1BE6-3756-498A-B1D3-9AD92BC78F43" name="decisionService_003" />
+      <dmn:variable id="_4C88C773-3F34-48C3-B7E1-3967E8A05BD3" name="decisionService_003" />
       <dmn:outputDecision href="#_decision_003" />
       <dmn:inputDecision href="#_decision_003_input_1" />
       <dmn:inputDecision href="#_decision_003_input_2" />
@@ -23,47 +23,47 @@
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_004" name="decisionService_004">
       <dmn:extensionElements />
-      <dmn:variable id="_0756801E-C4FA-468B-93D5-79FD4336A8E0" name="decisionService_004" />
+      <dmn:variable id="_7E1C232A-F73C-498C-93F8-5D19142D46E4" name="decisionService_004" />
       <dmn:outputDecision href="#_decision_004_2" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_005" name="decisionService_005">
       <dmn:extensionElements />
-      <dmn:variable id="_E2BDFEE1-AE09-4415-A9BD-6FD699B25519" name="decisionService_005" />
+      <dmn:variable id="_B7BF6EAE-4910-4051-8E97-14404CA7D635" name="decisionService_005" />
       <dmn:outputDecision href="#_decision_005_2" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_006" name="decisionService_006">
       <dmn:extensionElements />
-      <dmn:variable id="_CDD8AEA2-20BC-4607-BE95-36C4264E2984" name="decisionService_006" />
+      <dmn:variable id="_76148D9A-C43F-4E7C-BEC8-D8E9C3283A52" name="decisionService_006" />
       <dmn:outputDecision href="#_decision_006_2" />
       <dmn:inputDecision href="#_decision_006_3" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_007" name="decisionService_007">
       <dmn:extensionElements />
-      <dmn:variable id="_67E1CFAB-5946-4AB6-B648-839E3783B6D6" name="decisionService_007" />
+      <dmn:variable id="_E77520D7-4F79-414A-A539-9471FEB5CB0C" name="decisionService_007" />
       <dmn:outputDecision href="#_decision_007_2" />
       <dmn:inputDecision href="#_decision_007_3" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_008" name="decisionService_008">
       <dmn:extensionElements />
-      <dmn:variable id="_32CB621E-3741-415D-ACE1-938808809B56" name="decisionService_008" />
+      <dmn:variable id="_CAF480AD-4117-4192-BF68-E3FFDCD83754" name="decisionService_008" />
       <dmn:outputDecision href="#_decision_008_2" />
       <dmn:inputDecision href="#_decision_008_3" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_009" name="decisionService_009">
       <dmn:extensionElements />
-      <dmn:variable id="_9C62847D-03A7-498C-A370-2392D2BFD52C" name="decisionService_009" />
+      <dmn:variable id="_4F2DC8CC-3887-47BD-BB13-2BB662F79011" name="decisionService_009" />
       <dmn:outputDecision href="#_decision_009_2" />
       <dmn:inputDecision href="#_decision_009_3" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_010" name="decisionService_010">
       <dmn:extensionElements />
-      <dmn:variable id="_00E2E6D6-A52D-4DBB-AB32-7F5AF6077354" name="decisionService_010" />
+      <dmn:variable id="_D568FF9B-F020-42ED-89F2-D91C8CE558AD" name="decisionService_010" />
       <dmn:outputDecision href="#_decision_010_2" />
       <dmn:inputDecision href="#_decision_010_3" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_011" name="decisionService_011">
       <dmn:extensionElements />
-      <dmn:variable id="_665096E1-8C7D-4432-9DD8-25526C360257" name="decisionService_011" />
+      <dmn:variable id="_70447F94-7418-4E02-8BF7-6CF692267A3F" name="decisionService_011" />
       <dmn:outputDecision href="#_decision_011_2" />
       <dmn:inputDecision href="#_decision_011_3" />
       <dmn:inputDecision href="#_decision_011_4" />
@@ -72,7 +72,7 @@
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_012" name="decisionService_012">
       <dmn:extensionElements />
-      <dmn:variable id="_71951D03-E9B3-41FE-A26A-D4EEE585E470" name="decisionService_012" />
+      <dmn:variable id="_22F14C0C-906B-48F8-B83F-ABBE83EAD646" name="decisionService_012" />
       <dmn:outputDecision href="#_decision_012_2" />
       <dmn:inputDecision href="#_decision_012_3" />
       <dmn:inputDecision href="#_decision_012_4" />
@@ -81,375 +81,375 @@
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_013" name="decisionService_013">
       <dmn:extensionElements />
-      <dmn:variable id="_11A13903-7A46-4BE7-87F6-9FAABE69B65C" name="decisionService_013" />
+      <dmn:variable id="_4763E785-F408-444A-99FE-BB4DB8EE087A" name="decisionService_013" />
       <dmn:outputDecision href="#_decision_013_2" />
       <dmn:inputDecision href="#_decision_013_3" />
       <dmn:inputData href="#_inputData_013_1" />
    </dmn:decisionService>
    <dmn:decisionService id="_decisionService_014" name="decisionService_014">
       <dmn:extensionElements />
-      <dmn:variable id="_D51768CC-5290-426C-81D9-4F298A9DD418" name="decisionService_014" />
+      <dmn:variable id="_A843D5E7-3441-4E8D-ACB6-99A697876BD5" name="decisionService_014" />
       <dmn:outputDecision href="#_decision_014_2" />
       <dmn:inputDecision href="#_decision_014_3" />
       <dmn:inputData href="#_inputData_014_1" />
    </dmn:decisionService>
    <dmn:decision id="_decision_001" name="decision_001">
       <dmn:extensionElements />
-      <dmn:variable id="_E32A53CB-178D-430F-8E0E-BCA6CF210196" name="decision_001" />
-      <dmn:literalExpression id="_A210860D-2130-487E-9BC1-18722D9B1B20">
+      <dmn:variable id="_53AFA50F-6E47-4C5D-9C7A-D81C19B4F53C" name="decision_001" />
+      <dmn:literalExpression id="_8F581FF2-48BA-4718-9126-9AF5519CA21E">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_002" name="decision_002">
       <dmn:extensionElements />
-      <dmn:variable id="_8F4E4A57-AC92-41C2-AB1A-18A0DD3ACA28" name="decision_002" />
-      <dmn:informationRequirement id="_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44">
+      <dmn:variable id="_AD800F98-4C7E-4443-A458-1D5AD39F8B10" name="decision_002" />
+      <dmn:informationRequirement id="_645D2FAB-9019-4349-BFCA-43B2512F55E3">
          <dmn:requiredDecision href="#_decision_002_input" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_E9D920F6-9CB3-4EC0-97B2-1C261AB49C8A">
+      <dmn:literalExpression id="_F8049040-4186-416D-9173-B33C466BDAF1">
          <dmn:text>"foo " + decision_002_input</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_002_input" name="decision_002_input">
       <dmn:extensionElements />
-      <dmn:variable id="_9674CFED-8768-4152-BFCE-C07A1A402E75" name="decision_002_input" />
-      <dmn:literalExpression id="_ADE0D019-4DE5-4A6C-B88D-9585254AB2D7">
+      <dmn:variable id="_F5D151A0-5395-406C-954A-5ED21873610A" name="decision_002_input" />
+      <dmn:literalExpression id="_A887FDC1-1188-428A-9745-51B2C34975C2">
          <dmn:text>"bar"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_003" name="decision_003">
       <dmn:extensionElements />
-      <dmn:variable id="_197DCD7C-3D3E-4563-8B58-7943A25E6792" name="decision_003" />
-      <dmn:informationRequirement id="_7DA42E36-7C59-43E7-B464-8FF4154CFF2D">
+      <dmn:variable id="_E2DFF666-E5BD-4FA0-BF32-6058DEAC94DA" name="decision_003" />
+      <dmn:informationRequirement id="_1E0A661A-309D-4174-B7B0-073127D5432F">
          <dmn:requiredDecision href="#_decision_003_input_1" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_963DCD28-9C59-4528-A2F9-CA386F67C61E">
+      <dmn:informationRequirement id="_A2AA8B52-CB56-4AC5-9BE5-8E250741F2D4">
          <dmn:requiredDecision href="#_decision_003_input_2" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_E698025C-02D1-49EE-8B36-684391A47AA0">
+      <dmn:informationRequirement id="_5079E9ED-C26A-49D2-8F94-DC6E2BC4BE99">
          <dmn:requiredInput href="#_inputData_003" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_75DBDAA9-5A3B-408E-A174-34B3BBDFC3F0">
+      <dmn:literalExpression id="_3B3D2E76-C1B3-438F-993E-8038BC2435BC">
          <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
       <dmn:extensionElements />
-      <dmn:variable id="_AB08C851-3EFA-4A68-8985-623DEC316ED0" name="decision_003_input_1" />
-      <dmn:literalExpression id="_EC72EBCC-C5F6-4911-9C63-97697E3D5B13">
+      <dmn:variable id="_EC9E517A-0093-4DDA-B47F-F640F8370251" name="decision_003_input_1" />
+      <dmn:literalExpression id="_96146F62-8857-4051-8CFD-B9EDBA84C000">
          <dmn:text>"d3_1"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
       <dmn:extensionElements />
-      <dmn:variable id="_6992C915-DF27-48F2-8F25-AFA93F280559" name="decision_003_input_2" />
-      <dmn:literalExpression id="_A1EB711A-2318-474C-BC5F-4C362893E19A">
+      <dmn:variable id="_5A7FF8C8-5D8B-437F-9FC3-843FE8FBF252" name="decision_003_input_2" />
+      <dmn:literalExpression id="_BCA658C0-4212-4F1A-829A-1B9038A30C02">
          <dmn:text>"d3_2"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_inputData_003" name="inputData_003">
       <dmn:extensionElements />
-      <dmn:variable id="_40185D70-248E-4BDA-A117-9C7AE90513B7" name="inputData_003" typeRef="string" />
+      <dmn:variable id="_418537BF-D5F9-4C6E-A413-C9B2D4EB0C46" name="inputData_003" typeRef="string" />
    </dmn:inputData>
    <dmn:decision id="_decision_004_1" name="decision_004_1">
       <dmn:extensionElements />
-      <dmn:variable id="_4AA94470-02F8-4BAF-A5AA-8BC757F3638B" name="decision_004_1" />
-      <dmn:knowledgeRequirement id="_E36A9C79-59C4-460C-8AD8-10C5C1D6B666">
+      <dmn:variable id="_C9E12190-1046-4256-AD34-609921F37863" name="decision_004_1" />
+      <dmn:knowledgeRequirement id="_5D665230-66F1-4EC7-AF2C-4FDC33F320AE">
          <dmn:requiredKnowledge href="#_decisionService_004" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_21D8FDAD-4B95-49FA-9044-6AD34EC8349B">
+      <dmn:literalExpression id="_1BBC7285-7B88-4A7A-BC51-927D27E699CC">
          <dmn:text>decisionService_004()</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_004_2" name="decision_004_2">
       <dmn:extensionElements />
-      <dmn:variable id="_8CB2E991-A010-481F-A4B4-B560789B3E28" name="decision_004_2" />
-      <dmn:literalExpression id="_9BFF49AB-BF22-4851-AA6F-0F2355B110EF">
+      <dmn:variable id="_3E4695C8-9CD6-43B3-9F5B-BFA4D9DEA6BA" name="decision_004_2" />
+      <dmn:literalExpression id="_92365AF1-62ED-4E15-8D96-FFA06F594B47">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_005_1" name="decision_005_1">
       <dmn:extensionElements />
-      <dmn:variable id="_8D7797BD-6AE9-477A-8085-DD44FA77513B" name="decision_005_1" />
-      <dmn:knowledgeRequirement id="_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C">
+      <dmn:variable id="_54D6FB26-A93F-49D6-B838-A837A4BF4178" name="decision_005_1" />
+      <dmn:knowledgeRequirement id="_E42A33FA-0F93-4ED4-A586-D4C744DF9611">
          <dmn:requiredKnowledge href="#_decisionService_005" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_FAEBF51B-5672-4FA6-8BEC-7A7B7CDCA6A5">
+      <dmn:literalExpression id="_27A79A2D-8B80-4EB2-81AE-0FBEC035F7AF">
          <dmn:text>decisionService_005("bar")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_005_2" name="decision_005_2">
       <dmn:extensionElements />
-      <dmn:variable id="_BF42529D-C61F-4E6E-AEB3-C712F5034043" name="decision_005_2" typeRef="string" />
-      <dmn:literalExpression id="_261154E6-C11E-4E67-84D2-2EFB9D8AFB66">
+      <dmn:variable id="_2B402A0F-7B60-418E-B683-860C69A34738" name="decision_005_2" typeRef="string" />
+      <dmn:literalExpression id="_6D19CC39-CCCF-4EAC-A08C-CABC8A3FC162">
          <dmn:text>"foo"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_006_1" name="decision_006_1">
       <dmn:extensionElements />
-      <dmn:variable id="_03D9BAAB-AB5C-4495-8474-59BC4A245D54" name="decision_006_1" />
-      <dmn:knowledgeRequirement id="_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC">
+      <dmn:variable id="_A976C358-3BD6-4180-837C-C43E4EF7CA30" name="decision_006_1" />
+      <dmn:knowledgeRequirement id="_161529A4-7B66-489B-BC8A-744B754FCC2C">
          <dmn:requiredKnowledge href="#_decisionService_006" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_00862001-F6CA-431B-8E71-048F0967DBA4">
+      <dmn:literalExpression id="_8CDF3DEC-62F8-46BB-8967-90FD7D53102A">
          <dmn:text>decisionService_006("bar")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_006_2" name="decision_006_2">
       <dmn:extensionElements />
-      <dmn:variable id="_99933CA7-C283-4DA8-9E0A-8E9A675954E8" name="decision_006_2" />
-      <dmn:informationRequirement id="_96A46E1F-4422-4BB3-8304-11943198A0C3">
+      <dmn:variable id="_A93B87B1-AEE1-4887-9471-58B18A1A0F1D" name="decision_006_2" />
+      <dmn:informationRequirement id="_5D38966A-549E-4BF5-8CF5-B5108D29F168">
          <dmn:requiredDecision href="#_decision_006_3" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_A5ECE8E9-E9E5-456F-9A07-4C400BA850E0">
+      <dmn:literalExpression id="_D2DDF0C5-9B85-41C2-8AA2-4BD5D544F520">
          <dmn:text>"foo " + decision_006_3</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_006_3" name="decision_006_3">
       <dmn:extensionElements />
-      <dmn:variable id="_41138FDA-34C8-4549-B423-5B5632BBA46B" name="decision_006_3" typeRef="string" />
-      <dmn:literalExpression id="_F637C497-F9AE-481C-BF6E-28E1A0CAD1B4">
+      <dmn:variable id="_01021CE0-D398-4FB5-A4BD-BBA357B9E83D" name="decision_006_3" typeRef="string" />
+      <dmn:literalExpression id="_0023FA21-A15D-441F-A23D-B0E768C50A79">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_007_1" name="decision_007_1">
       <dmn:extensionElements />
-      <dmn:variable id="_3AC481E4-CD1E-4F45-8BD5-7D1AC20F1EC2" name="decision_007_1" />
-      <dmn:knowledgeRequirement id="_304A86A8-CE2D-43C6-A03F-EDE9301220DC">
+      <dmn:variable id="_7AEB62AD-323E-4B2F-A293-8846F8A0DDD2" name="decision_007_1" />
+      <dmn:knowledgeRequirement id="_D216049C-03B7-45D5-8093-8A0BA3E79F8B">
          <dmn:requiredKnowledge href="#_decisionService_007" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_4ECC25D4-5970-46E6-83CD-F6FBAE44F8AC">
+      <dmn:literalExpression id="_43E34B34-4C99-43F9-B46A-A6BEB438DC84">
          <dmn:text>decisionService_007(123)</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_007_2" name="decision_007_2">
       <dmn:extensionElements />
-      <dmn:variable id="_E2A1416C-35FF-4547-AC2A-CD2B212162B8" name="decision_007_2" />
-      <dmn:informationRequirement id="_AC7F3583-C42A-49A1-9035-F8F030E5CD4E">
+      <dmn:variable id="_9B55D9DD-59A3-458E-8C92-1F3CB61F6048" name="decision_007_2" />
+      <dmn:informationRequirement id="_C3AEC7E7-45A4-4A87-9E81-1232A6B7934D">
          <dmn:requiredDecision href="#_decision_007_3" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_761D1D22-C5F3-4170-B92C-A1B3C37AB358">
+      <dmn:literalExpression id="_0FC3A89C-D850-4CA1-97C0-DF9328FDECC7">
          <dmn:text>decision_007_3 = null</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_007_3" name="decision_007_3">
       <dmn:extensionElements />
-      <dmn:variable id="_D18A7DA1-DF24-4499-8CA8-BD0DFCBCF877" name="decision_007_3" typeRef="string" />
-      <dmn:literalExpression id="_952C92A0-6D95-4F58-9DAD-A68122D63427">
+      <dmn:variable id="_C875B3C4-85E2-4680-ADCC-47A44957DC94" name="decision_007_3" typeRef="string" />
+      <dmn:literalExpression id="_4DF726FF-384D-4BEA-8C99-0188F0B43914">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_008_1" name="decision_008_1">
       <dmn:extensionElements />
-      <dmn:variable id="_35DF00EE-6EBF-4ABB-94C7-F10B41271B17" name="decision_008_1" />
-      <dmn:knowledgeRequirement id="_97716FE7-931B-4595-91AB-6B1C1D8FF808">
+      <dmn:variable id="_BA08A9CC-BF74-4D04-937A-18E9F0268C18" name="decision_008_1" />
+      <dmn:knowledgeRequirement id="_DE27FD9B-C945-44E3-A3C4-650E63CA6909">
          <dmn:requiredKnowledge href="#_decisionService_008" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_4C3B13B5-E62B-4E11-9064-065FDBCA6901">
+      <dmn:literalExpression id="_923691C8-8CFE-4878-ACDF-05B949F20D12">
          <dmn:text>decisionService_008()</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_008_2" name="decision_008_2">
       <dmn:extensionElements />
-      <dmn:variable id="_3BF3AE3E-10BA-43EB-AB7F-2BF5E0C6A404" name="decision_008_2" />
-      <dmn:informationRequirement id="_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E">
+      <dmn:variable id="_C0F0D25A-8556-4C5C-B09C-CE5CFA04CA1F" name="decision_008_2" />
+      <dmn:informationRequirement id="_36CD3861-3505-4B55-9DEE-A63DEBBD6E0A">
          <dmn:requiredDecision href="#_decision_008_3" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_35343B62-F4A4-41AD-A269-D9AF2894A125">
+      <dmn:literalExpression id="_76D70411-951A-4011-8CFF-A0FE0F1B20DE">
          <dmn:text>decision_008_3 = null</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_008_3" name="decision_008_3">
       <dmn:extensionElements />
-      <dmn:variable id="_3352A700-4D5C-4E6C-AFFA-F579786CC307" name="decision_008_3" typeRef="string" />
-      <dmn:literalExpression id="_E1DA5DBC-AB93-4645-8276-96C8168EEB0A">
+      <dmn:variable id="_AEC6AA41-6CC8-4B00-9672-34902BDD008D" name="decision_008_3" typeRef="string" />
+      <dmn:literalExpression id="_416B2B15-BDFD-4F48-B63C-3201F1C2AE86">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_009_1" name="decision_009_1">
       <dmn:extensionElements />
-      <dmn:variable id="_FE0E9380-11E1-44E4-8E90-11049700DAB5" name="decision_009_1" />
-      <dmn:knowledgeRequirement id="_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7">
+      <dmn:variable id="_89C4140F-65C1-46F4-A3F3-5992AA3D52E3" name="decision_009_1" />
+      <dmn:knowledgeRequirement id="_7D607060-2EF6-45F3-9BA8-5A9780B579E5">
          <dmn:requiredKnowledge href="#_decisionService_009" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_9898A8EC-B71A-462D-A157-B7ADDB6645BB">
+      <dmn:literalExpression id="_A662997D-A0BE-46AE-8F78-5F07C737054C">
          <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_009_2" name="decision_009_2">
       <dmn:extensionElements />
-      <dmn:variable id="_A4771183-69BD-4667-9FD4-9E98B93FF1EE" name="decision_009_2" />
-      <dmn:informationRequirement id="_B2971336-A88A-4C6A-953E-CCCD0312EC1F">
+      <dmn:variable id="_B150C256-74D5-4C3B-A1CD-4DA1D603C705" name="decision_009_2" />
+      <dmn:informationRequirement id="_196747BA-5799-4CFE-8CAE-79379D0157AF">
          <dmn:requiredDecision href="#_decision_009_3" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_83788BBF-B733-4D58-BB95-09956419CC21">
+      <dmn:literalExpression id="_B3C3FF9D-59F2-4F2D-B820-808805524A12">
          <dmn:text>"foo " + decision_009_3</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_009_3" name="decision_009_3">
       <dmn:extensionElements />
-      <dmn:variable id="_B7E5CE55-FC7A-4B8C-A251-1074D1FECE94" name="decision_009_3" typeRef="string" />
-      <dmn:literalExpression id="_BAE42AE7-A9E7-43B8-83F4-3F779B28D4AA">
+      <dmn:variable id="_6B228059-7002-4ED7-AE85-32C6592AC6C2" name="decision_009_3" typeRef="string" />
+      <dmn:literalExpression id="_7B896A5A-6ACD-4CB7-9DEC-1D192DEFFD43">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_010_1" name="decision_010_1">
       <dmn:extensionElements />
-      <dmn:variable id="_CEAD5BE0-8A9C-4CB5-89AA-22A78DAFD61C" name="decision_010_1" />
-      <dmn:knowledgeRequirement id="_17AF0346-C97C-4B25-9837-C415AB7AA63B">
+      <dmn:variable id="_F03EF4A8-D0C7-49E2-A775-F2F8458398D3" name="decision_010_1" />
+      <dmn:knowledgeRequirement id="_41B775BC-E3CB-4F28-B770-529295884251">
          <dmn:requiredKnowledge href="#_decisionService_010" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_59FF1D71-7155-4CC0-A3BB-92F6B555D926">
+      <dmn:literalExpression id="_E8CDFE8A-7206-4A75-954A-FBAFBEFAB405">
          <dmn:text>decisionService_010(foo: "bar")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_010_2" name="decision_010_2">
       <dmn:extensionElements />
-      <dmn:variable id="_3307C9EF-2318-4098-B5B2-67FFC9C8F9A3" name="decision_010_2" />
-      <dmn:informationRequirement id="_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE">
+      <dmn:variable id="_9F0C5645-310F-41A4-9CCE-D4A445731C8E" name="decision_010_2" />
+      <dmn:informationRequirement id="_A40B4759-5B6B-45C4-8B40-F0F5E06A0FAB">
          <dmn:requiredDecision href="#_decision_010_3" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_E128B822-3A08-4FEE-8023-597E9C73E878">
+      <dmn:literalExpression id="_564908B8-5111-40D0-A5C3-9D9D212557F7">
          <dmn:text>"foo " + decision_010_3</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_010_3" name="decision_010_3">
       <dmn:extensionElements />
-      <dmn:variable id="_7234872B-31AD-4A2B-956B-0610BB7E1619" name="decision_010_3" typeRef="string" />
-      <dmn:literalExpression id="_CB7CE518-63AF-4AAC-AAA2-6B324F272162">
+      <dmn:variable id="_7BD8A230-EC0B-44A0-8DE4-9911DC84F8EE" name="decision_010_3" typeRef="string" />
+      <dmn:literalExpression id="_661F576E-E427-4262-9583-B581C8449813">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_011_1" name="decision_011_1">
       <dmn:extensionElements />
-      <dmn:variable id="_EC7FB4AE-1E9D-47CF-A0E5-B51FCB1AD64A" name="decision_011_1" />
-      <dmn:knowledgeRequirement id="_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6">
+      <dmn:variable id="_EECE068E-6866-4F34-BAEF-A9C41C1F90D4" name="decision_011_1" />
+      <dmn:knowledgeRequirement id="_37B3C707-84E2-4E98-AC7A-34DCA80A496B">
          <dmn:requiredKnowledge href="#_decisionService_011" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_492162D7-2CF4-4993-BB63-2F05966BDF9E">
+      <dmn:literalExpression id="_39661235-6FC6-470B-834F-6E6DD1B763C6">
          <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_011_2" name="decision_011_2">
       <dmn:extensionElements />
-      <dmn:variable id="_2CE93DD0-AD96-41F9-B86F-1294E46DD4E4" name="decision_011_2" typeRef="string" />
-      <dmn:informationRequirement id="_4CAF49C0-975B-4181-8808-574C17DCC93C">
+      <dmn:variable id="_3BD63E9C-78E8-467B-B039-A2ABF0DF30DD" name="decision_011_2" typeRef="string" />
+      <dmn:informationRequirement id="_A9D9C47E-4994-4E9D-82F4-8549D051A578">
          <dmn:requiredDecision href="#_decision_011_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_35A85C57-98A2-4528-A486-DD8277F49691">
+      <dmn:informationRequirement id="_FC9F9FAC-0733-4977-855E-DF20F71066B5">
          <dmn:requiredDecision href="#_decision_011_4" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_B9E034A9-3D6F-4B47-A959-EA2E060E225A">
+      <dmn:informationRequirement id="_223E8516-AC0D-40F4-96CE-0427613BFB2C">
          <dmn:requiredInput href="#_inputData_011_1" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_FD16B1CD-03D5-487D-8E4F-3D910A8E8223">
+      <dmn:informationRequirement id="_58665D55-0E7F-4F13-98B9-BE06FC3C5334">
          <dmn:requiredInput href="#_inputData_011_2" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_D557026E-1B0F-4DE1-A978-D4CFDACB9318">
+      <dmn:literalExpression id="_CED7626B-E7FD-471A-BB4E-26133CFAA201">
          <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_011_3" name="decision_011_3">
       <dmn:extensionElements />
-      <dmn:variable id="_B708F561-F5DE-4703-B4CB-D1B2F363168C" name="decision_011_3" typeRef="string" />
-      <dmn:literalExpression id="_14EE46D0-4811-4A82-BE11-C5A29B308147">
+      <dmn:variable id="_D94B08D8-B3A6-45CD-93BC-AC69262E2CDB" name="decision_011_3" typeRef="string" />
+      <dmn:literalExpression id="_AA64774F-A554-40E1-9E39-6472D76D2E97">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_011_4" name="decision_011_4">
       <dmn:extensionElements />
-      <dmn:variable id="_E1C9670E-DDB1-4E11-85DD-900E192A8C7A" name="decision_011_4" typeRef="string" />
-      <dmn:literalExpression id="_87432A55-F890-45FE-A3B6-415981C121D3">
+      <dmn:variable id="_229356D3-969B-488E-BC41-5CAE47343390" name="decision_011_4" typeRef="string" />
+      <dmn:literalExpression id="_D81AC353-57EF-4D25-9487-4ACE335A20AE">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
       <dmn:extensionElements />
-      <dmn:variable id="_0BFD0ADB-A0F7-483E-8559-0240ECA8E13B" name="inputData_011_1" typeRef="string" />
+      <dmn:variable id="_DFF40F6F-8D39-403C-8DF1-46501DA9FCB9" name="inputData_011_1" typeRef="string" />
    </dmn:inputData>
    <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
       <dmn:extensionElements />
-      <dmn:variable id="_FCBDD6A8-3D01-42BD-A818-51B39C8A6DA0" name="inputData_011_2" typeRef="string" />
+      <dmn:variable id="_8B396255-0E03-42E9-833C-940C163C7B86" name="inputData_011_2" typeRef="string" />
    </dmn:inputData>
    <dmn:decision id="_decision_012_1" name="decision_012_1">
       <dmn:extensionElements />
-      <dmn:variable id="_37432F60-6E94-462E-9551-6A269E199520" name="decision_012_1" />
-      <dmn:knowledgeRequirement id="_0140EDEE-0271-427F-A448-EB53AA282574">
+      <dmn:variable id="_5E2C30C7-5EE4-4067-A499-BCDA46457CAB" name="decision_012_1" />
+      <dmn:knowledgeRequirement id="_F2EE638D-4B35-46D6-95A6-22D62858AF2C">
          <dmn:requiredKnowledge href="#_decisionService_012" />
       </dmn:knowledgeRequirement>
-      <dmn:literalExpression id="_AC3D82E3-E6FC-46F7-8CBB-3621150B7875">
+      <dmn:literalExpression id="_67C625D6-1534-4A64-8978-931A34438ECB">
          <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_012_2" name="decision_012_2">
       <dmn:extensionElements />
-      <dmn:variable id="_E798708A-DEA5-44D3-B257-BA60151282B9" name="decision_012_2" typeRef="string" />
-      <dmn:informationRequirement id="_1945BB17-3862-4540-9E42-06ED19ED54E0">
+      <dmn:variable id="_548CBC1E-A2FE-4D2C-86A9-B17460358EBD" name="decision_012_2" typeRef="string" />
+      <dmn:informationRequirement id="_65308170-4956-43FE-8183-5075BD982C8F">
          <dmn:requiredDecision href="#_decision_012_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_55319A16-B64D-4642-A094-95A62906E50E">
+      <dmn:informationRequirement id="_267E891E-FBF8-4A91-B5F2-B32417E298FB">
          <dmn:requiredDecision href="#_decision_012_4" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_16C43A17-1330-4ABD-8D3A-873D4DC2BD62">
+      <dmn:informationRequirement id="_3F16E24A-BDE7-47DC-9B57-08EA07949FAA">
          <dmn:requiredInput href="#_inputData_012_1" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_93143A33-7E05-4041-BFD9-5FCC9DAC225B">
+      <dmn:informationRequirement id="_4F8B0AEE-BE15-43EC-AF26-FECD461E996F">
          <dmn:requiredInput href="#_inputData_012_2" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_D0D85411-49CE-45E2-A21C-D97D37194EE7">
+      <dmn:literalExpression id="_D285B8DA-56F4-4677-BE71-AD2D916CE2CC">
          <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_012_3" name="decision_012_3">
       <dmn:extensionElements />
-      <dmn:variable id="_A4DC02AC-03B2-414A-A552-9E7DF5513071" name="decision_012_3" typeRef="string" />
-      <dmn:literalExpression id="_E867E58E-8FBC-4D24-A060-AA596D3AC99D">
+      <dmn:variable id="_CF6FFBD0-D928-41FF-8112-DA8C26038360" name="decision_012_3" typeRef="string" />
+      <dmn:literalExpression id="_49348BD2-E242-44CF-941B-B4B5E0019A71">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_012_4" name="decision_012_4">
       <dmn:extensionElements />
-      <dmn:variable id="_F51B63E8-C76E-4F72-920F-6DE0B93D94BF" name="decision_012_4" typeRef="string" />
-      <dmn:literalExpression id="_7B040662-8B42-4481-8491-BD0F1A48FA17">
+      <dmn:variable id="_A7AF581F-91CE-474B-BC54-D38B0B819A76" name="decision_012_4" typeRef="string" />
+      <dmn:literalExpression id="_B2A26C2F-1141-42D9-AFC8-EAD433D2FFE5">
          <dmn:text>"I never get invoked"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
       <dmn:extensionElements />
-      <dmn:variable id="_D6D10997-1C53-4467-8885-C8BB75F01065" name="inputData_012_1" typeRef="string" />
+      <dmn:variable id="_BCE8AD03-09A4-4A8D-96A2-A8FD679DBE31" name="inputData_012_1" typeRef="string" />
    </dmn:inputData>
    <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
       <dmn:extensionElements />
-      <dmn:variable id="_87717F80-C2A7-4365-989E-7C91FE9BFDA8" name="inputData_012_2" typeRef="string" />
+      <dmn:variable id="_6CF6FADA-7E46-4C0B-A57A-3E89E1CAB579" name="inputData_012_2" typeRef="string" />
    </dmn:inputData>
    <dmn:decision id="_decision_013_1" name="decision_013_1">
       <dmn:extensionElements />
-      <dmn:variable id="_21F2E3BA-A8FD-4FCB-BE95-1CE78128B4BF" name="decision_013_1" />
-      <dmn:informationRequirement id="_40DDA2C3-D3CF-469E-A25C-61E70338306F">
+      <dmn:variable id="_B2A3D910-8BA2-4CA7-8463-2F81ED31D424" name="decision_013_1" />
+      <dmn:informationRequirement id="_EBFA85AD-1BA8-49BB-B492-CCD770738DFF">
          <dmn:requiredDecision href="#_decision_013_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_83CB5E26-2D0D-450C-A6F9-B2129B05E58C">
+      <dmn:informationRequirement id="_2EB7E700-C770-4EC3-893A-CC0AA699B82F">
          <dmn:requiredInput href="#_inputData_013_1" />
       </dmn:informationRequirement>
-      <dmn:knowledgeRequirement id="_BDADE40A-949A-4D34-93F5-99F5143F385C">
+      <dmn:knowledgeRequirement id="_8BEB7F62-A559-43A9-89CE-8E4B1E62CD75">
          <dmn:requiredKnowledge href="#_decisionService_013" />
       </dmn:knowledgeRequirement>
-      <dmn:context id="_9F438869-C243-40A0-A518-FCA21726D21C">
+      <dmn:context id="_33B0BF98-23A7-430E-B3E2-E23D53423FBF">
          <dmn:contextEntry>
-            <dmn:variable id="_E0386032-0939-4B38-A658-68017709FF9F" name="decisionService_013" />
-            <dmn:literalExpression id="_E6B92D7C-47DC-4DF6-8AEB-3CAEB924CDC2">
+            <dmn:variable id="_BEA88379-B665-4501-8F2D-AA725378E202" name="decisionService_013" />
+            <dmn:literalExpression id="_C5FFFA95-4E53-4841-8435-262C76ED5404">
                <dmn:text>decisionService_013("A", "B")</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:variable id="_3CE8A8FA-3CCC-4E1D-B808-6226665DB0BB" name="inputData_013_1" />
-            <dmn:literalExpression id="_9C841399-D583-43CF-94F3-E4E3285E1285">
+            <dmn:variable id="_19FA6A14-C642-418D-A2F4-9FDF113F6E71" name="inputData_013_1" />
+            <dmn:literalExpression id="_CD8F25C3-6EA7-4EEE-89EE-EB1F99752005">
                <dmn:text>inputData_013_1</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:variable id="_89461005-9376-46ED-A92A-9730BCC59255" name="decision_013_3" />
-            <dmn:literalExpression id="_10F1B85E-D124-4B58-9717-2CB867219A4C">
+            <dmn:variable id="_6E375198-D54D-448B-8A5A-42081E14ECF2" name="decision_013_3" />
+            <dmn:literalExpression id="_EA165272-7352-4D6B-A40E-816203071C87">
                <dmn:text>decision_013_3</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
@@ -457,56 +457,56 @@
    </dmn:decision>
    <dmn:decision id="_decision_013_2" name="decision_013_2">
       <dmn:extensionElements />
-      <dmn:variable id="_84341D22-4C43-40CC-8155-8DAD1B67ECE5" name="decision_013_2" typeRef="string" />
-      <dmn:informationRequirement id="_93F96A2C-5E53-47F0-93F6-3A7F22918308">
+      <dmn:variable id="_3321B9BA-19EF-4D42-A971-EEFCC58A53A1" name="decision_013_2" typeRef="string" />
+      <dmn:informationRequirement id="_5D3FA33F-7E17-4C92-857F-B820125317AD">
          <dmn:requiredDecision href="#_decision_013_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D">
+      <dmn:informationRequirement id="_6A0E67E5-E920-495A-BCE8-26E25F38A106">
          <dmn:requiredInput href="#_inputData_013_1" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_642DF3FC-366D-477D-83E3-114F14D39CB5">
+      <dmn:literalExpression id="_D9A11D7C-3BD3-4ADC-81F1-CABCD6DD52CB">
          <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_013_3" name="decision_013_3">
       <dmn:extensionElements />
-      <dmn:variable id="_1B06159D-8EB0-4682-A531-EE3B6D3A9620" name="decision_013_3" typeRef="string" />
-      <dmn:literalExpression id="_5E04C292-6CD4-4F5B-B47E-B49A9E928864">
+      <dmn:variable id="_DFF34525-DD67-4798-A95F-AF42F0B04042" name="decision_013_3" typeRef="string" />
+      <dmn:literalExpression id="_00711E65-ECD2-4E02-817C-C50B426A05AC">
          <dmn:text>"D"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
       <dmn:extensionElements />
-      <dmn:variable id="_1907F35A-AE8F-4DFE-B13C-C58CB8A2C8DC" name="inputData_013_1" typeRef="string" />
+      <dmn:variable id="_F412DAB7-98F4-4D97-92C0-6F6D01A68237" name="inputData_013_1" typeRef="string" />
    </dmn:inputData>
    <dmn:decision id="_decision_014_1" name="decision_014_1">
       <dmn:extensionElements />
-      <dmn:variable id="_247A730B-582E-4F06-837F-75922EB3982D" name="decision_014_1" />
-      <dmn:informationRequirement id="_57EE2567-07AE-411C-B9F7-B3786FE673BF">
+      <dmn:variable id="_3CBF1881-24F0-4973-A641-DB2A5B0DB538" name="decision_014_1" />
+      <dmn:informationRequirement id="_A7FF4CA2-D58E-4C9F-88C1-45450E2B3C71">
          <dmn:requiredDecision href="#_decision_014_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_58C00258-283A-479B-BC80-3F1191809987">
+      <dmn:informationRequirement id="_D16BBDC7-A122-4219-9B3F-3CC3492DAF2D">
          <dmn:requiredInput href="#_inputData_014_1" />
       </dmn:informationRequirement>
-      <dmn:knowledgeRequirement id="_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C">
+      <dmn:knowledgeRequirement id="_27996495-43D3-48EE-84C2-A76987C3FB42">
          <dmn:requiredKnowledge href="#_decisionService_014" />
       </dmn:knowledgeRequirement>
-      <dmn:context id="_DA7E11C4-4FCD-46EF-B015-9C988B9BFAA4">
+      <dmn:context id="_DEA12286-93C8-40F1-BE7B-F93186F37772">
          <dmn:contextEntry>
-            <dmn:variable id="_7E25957E-609F-4B68-B8B5-AEA7487B9DAA" name="inputData_014_1" />
-            <dmn:literalExpression id="_266D0801-FB54-4E70-AB1C-4FE76A61D50E">
+            <dmn:variable id="_B66A50F7-54EE-483A-8227-98AA45A55BED" name="inputData_014_1" />
+            <dmn:literalExpression id="_60F6E3FE-07F4-4EB8-A9AA-BD0F7A7A491B">
                <dmn:text>inputData_014_1</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:variable id="_7C6F1234-25A9-4CDA-9FCC-DA4C533C0E82" name="decision_014_3" />
-            <dmn:literalExpression id="_1A2135C4-A8CF-400B-B144-47A346EF7726">
+            <dmn:variable id="_9E02DF72-D209-4BFA-A8FD-B017FCBCBFC0" name="decision_014_3" />
+            <dmn:literalExpression id="_2B28A750-0F55-45DE-9E6B-3AB86A7F29CC">
                <dmn:text>decision_014_3</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
          <dmn:contextEntry>
-            <dmn:variable id="_B764755D-3094-4319-9332-5961827DECB3" name="decisionService_014" />
-            <dmn:literalExpression id="_DA46D806-E856-4E9D-8FA6-BAAA13BC2664">
+            <dmn:variable id="_0776AC84-78FF-4C1E-BF3D-06092B2C3C0E" name="decisionService_014" />
+            <dmn:literalExpression id="_4CE0D225-D774-4DDC-9D68-9D5DC44F9947">
                <dmn:text>decisionService_014("A", "B")</dmn:text>
             </dmn:literalExpression>
          </dmn:contextEntry>
@@ -514,77 +514,77 @@
    </dmn:decision>
    <dmn:decision id="_decision_014_2" name="decision_014_2">
       <dmn:extensionElements />
-      <dmn:variable id="_BBFF2454-6DA5-4597-B1EC-4A87E6D75FFA" name="decision_014_2" typeRef="string" />
-      <dmn:informationRequirement id="_B1410847-C0EC-4503-B203-E63017D72DD6">
+      <dmn:variable id="_5CD2FC03-AB1A-4A6A-8A0D-130513C3675D" name="decision_014_2" typeRef="string" />
+      <dmn:informationRequirement id="_29FFDE0B-3970-41B1-8BE4-CB70E6F0C695">
          <dmn:requiredDecision href="#_decision_014_3" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9">
+      <dmn:informationRequirement id="_D5B2F7B0-5274-4C88-B6D7-36A65F832A24">
          <dmn:requiredInput href="#_inputData_014_1" />
       </dmn:informationRequirement>
-      <dmn:literalExpression id="_366B09CE-FF4D-44C9-BDB6-8A6617E90F9E">
+      <dmn:literalExpression id="_9E479DB3-A5EC-4E97-9AD8-66B78CC4B2C4">
          <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:decision id="_decision_014_3" name="decision_014_3">
       <dmn:extensionElements />
-      <dmn:variable id="_5D11D347-2CD9-44B0-ACFC-864BB44AC6C3" name="decision_014_3" typeRef="string" />
-      <dmn:literalExpression id="_A4DAC3CC-BA02-421E-A578-2592E3FD2DC5">
+      <dmn:variable id="_E716842A-DB0D-48A6-94CD-65A3A373F49B" name="decision_014_3" typeRef="string" />
+      <dmn:literalExpression id="_1706C5A8-25B7-4193-A0C3-2B6BAFFDB9F4">
          <dmn:text>"D"</dmn:text>
       </dmn:literalExpression>
    </dmn:decision>
    <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
       <dmn:extensionElements />
-      <dmn:variable id="_E73365F8-133B-4CE2-B52F-A8BD4E233DCF" name="inputData_014_1" typeRef="string" />
+      <dmn:variable id="_32F0DE16-FC6F-4326-9544-94C0D2F272BE" name="inputData_014_1" typeRef="string" />
    </dmn:inputData>
    <dmndi:DMNDI>
-      <dmndi:DMNDiagram id="_B94B2EE7-6863-424C-8664-C8E7319A93C7" name="DRG">
+      <dmndi:DMNDiagram id="_9DBE331E-8D52-46CC-B089-84E17D3DCA98" name="DRG">
          <di:extension>
             <kie:ComponentsWidthsExtension>
-               <kie:ComponentWidths dmnElementRef="_A210860D-2130-487E-9BC1-18722D9B1B20" />
-               <kie:ComponentWidths dmnElementRef="_E9D920F6-9CB3-4EC0-97B2-1C261AB49C8A" />
-               <kie:ComponentWidths dmnElementRef="_ADE0D019-4DE5-4A6C-B88D-9585254AB2D7" />
-               <kie:ComponentWidths dmnElementRef="_75DBDAA9-5A3B-408E-A174-34B3BBDFC3F0" />
-               <kie:ComponentWidths dmnElementRef="_EC72EBCC-C5F6-4911-9C63-97697E3D5B13" />
-               <kie:ComponentWidths dmnElementRef="_A1EB711A-2318-474C-BC5F-4C362893E19A" />
-               <kie:ComponentWidths dmnElementRef="_21D8FDAD-4B95-49FA-9044-6AD34EC8349B" />
-               <kie:ComponentWidths dmnElementRef="_9BFF49AB-BF22-4851-AA6F-0F2355B110EF" />
-               <kie:ComponentWidths dmnElementRef="_FAEBF51B-5672-4FA6-8BEC-7A7B7CDCA6A5" />
-               <kie:ComponentWidths dmnElementRef="_261154E6-C11E-4E67-84D2-2EFB9D8AFB66" />
-               <kie:ComponentWidths dmnElementRef="_00862001-F6CA-431B-8E71-048F0967DBA4" />
-               <kie:ComponentWidths dmnElementRef="_A5ECE8E9-E9E5-456F-9A07-4C400BA850E0" />
-               <kie:ComponentWidths dmnElementRef="_F637C497-F9AE-481C-BF6E-28E1A0CAD1B4" />
-               <kie:ComponentWidths dmnElementRef="_4ECC25D4-5970-46E6-83CD-F6FBAE44F8AC" />
-               <kie:ComponentWidths dmnElementRef="_761D1D22-C5F3-4170-B92C-A1B3C37AB358" />
-               <kie:ComponentWidths dmnElementRef="_952C92A0-6D95-4F58-9DAD-A68122D63427" />
-               <kie:ComponentWidths dmnElementRef="_4C3B13B5-E62B-4E11-9064-065FDBCA6901" />
-               <kie:ComponentWidths dmnElementRef="_35343B62-F4A4-41AD-A269-D9AF2894A125" />
-               <kie:ComponentWidths dmnElementRef="_E1DA5DBC-AB93-4645-8276-96C8168EEB0A" />
-               <kie:ComponentWidths dmnElementRef="_9898A8EC-B71A-462D-A157-B7ADDB6645BB" />
-               <kie:ComponentWidths dmnElementRef="_83788BBF-B733-4D58-BB95-09956419CC21" />
-               <kie:ComponentWidths dmnElementRef="_BAE42AE7-A9E7-43B8-83F4-3F779B28D4AA" />
-               <kie:ComponentWidths dmnElementRef="_59FF1D71-7155-4CC0-A3BB-92F6B555D926" />
-               <kie:ComponentWidths dmnElementRef="_E128B822-3A08-4FEE-8023-597E9C73E878" />
-               <kie:ComponentWidths dmnElementRef="_CB7CE518-63AF-4AAC-AAA2-6B324F272162" />
-               <kie:ComponentWidths dmnElementRef="_492162D7-2CF4-4993-BB63-2F05966BDF9E" />
-               <kie:ComponentWidths dmnElementRef="_D557026E-1B0F-4DE1-A978-D4CFDACB9318" />
-               <kie:ComponentWidths dmnElementRef="_14EE46D0-4811-4A82-BE11-C5A29B308147" />
-               <kie:ComponentWidths dmnElementRef="_87432A55-F890-45FE-A3B6-415981C121D3" />
-               <kie:ComponentWidths dmnElementRef="_AC3D82E3-E6FC-46F7-8CBB-3621150B7875" />
-               <kie:ComponentWidths dmnElementRef="_D0D85411-49CE-45E2-A21C-D97D37194EE7" />
-               <kie:ComponentWidths dmnElementRef="_E867E58E-8FBC-4D24-A060-AA596D3AC99D" />
-               <kie:ComponentWidths dmnElementRef="_7B040662-8B42-4481-8491-BD0F1A48FA17" />
-               <kie:ComponentWidths dmnElementRef="_9F438869-C243-40A0-A518-FCA21726D21C" />
-               <kie:ComponentWidths dmnElementRef="_E6B92D7C-47DC-4DF6-8AEB-3CAEB924CDC2" />
-               <kie:ComponentWidths dmnElementRef="_9C841399-D583-43CF-94F3-E4E3285E1285" />
-               <kie:ComponentWidths dmnElementRef="_10F1B85E-D124-4B58-9717-2CB867219A4C" />
-               <kie:ComponentWidths dmnElementRef="_642DF3FC-366D-477D-83E3-114F14D39CB5" />
-               <kie:ComponentWidths dmnElementRef="_5E04C292-6CD4-4F5B-B47E-B49A9E928864" />
-               <kie:ComponentWidths dmnElementRef="_DA7E11C4-4FCD-46EF-B015-9C988B9BFAA4" />
-               <kie:ComponentWidths dmnElementRef="_266D0801-FB54-4E70-AB1C-4FE76A61D50E" />
-               <kie:ComponentWidths dmnElementRef="_1A2135C4-A8CF-400B-B144-47A346EF7726" />
-               <kie:ComponentWidths dmnElementRef="_DA46D806-E856-4E9D-8FA6-BAAA13BC2664" />
-               <kie:ComponentWidths dmnElementRef="_366B09CE-FF4D-44C9-BDB6-8A6617E90F9E" />
-               <kie:ComponentWidths dmnElementRef="_A4DAC3CC-BA02-421E-A578-2592E3FD2DC5" />
+               <kie:ComponentWidths dmnElementRef="_8F581FF2-48BA-4718-9126-9AF5519CA21E" />
+               <kie:ComponentWidths dmnElementRef="_F8049040-4186-416D-9173-B33C466BDAF1" />
+               <kie:ComponentWidths dmnElementRef="_A887FDC1-1188-428A-9745-51B2C34975C2" />
+               <kie:ComponentWidths dmnElementRef="_3B3D2E76-C1B3-438F-993E-8038BC2435BC" />
+               <kie:ComponentWidths dmnElementRef="_96146F62-8857-4051-8CFD-B9EDBA84C000" />
+               <kie:ComponentWidths dmnElementRef="_BCA658C0-4212-4F1A-829A-1B9038A30C02" />
+               <kie:ComponentWidths dmnElementRef="_1BBC7285-7B88-4A7A-BC51-927D27E699CC" />
+               <kie:ComponentWidths dmnElementRef="_92365AF1-62ED-4E15-8D96-FFA06F594B47" />
+               <kie:ComponentWidths dmnElementRef="_27A79A2D-8B80-4EB2-81AE-0FBEC035F7AF" />
+               <kie:ComponentWidths dmnElementRef="_6D19CC39-CCCF-4EAC-A08C-CABC8A3FC162" />
+               <kie:ComponentWidths dmnElementRef="_8CDF3DEC-62F8-46BB-8967-90FD7D53102A" />
+               <kie:ComponentWidths dmnElementRef="_D2DDF0C5-9B85-41C2-8AA2-4BD5D544F520" />
+               <kie:ComponentWidths dmnElementRef="_0023FA21-A15D-441F-A23D-B0E768C50A79" />
+               <kie:ComponentWidths dmnElementRef="_43E34B34-4C99-43F9-B46A-A6BEB438DC84" />
+               <kie:ComponentWidths dmnElementRef="_0FC3A89C-D850-4CA1-97C0-DF9328FDECC7" />
+               <kie:ComponentWidths dmnElementRef="_4DF726FF-384D-4BEA-8C99-0188F0B43914" />
+               <kie:ComponentWidths dmnElementRef="_923691C8-8CFE-4878-ACDF-05B949F20D12" />
+               <kie:ComponentWidths dmnElementRef="_76D70411-951A-4011-8CFF-A0FE0F1B20DE" />
+               <kie:ComponentWidths dmnElementRef="_416B2B15-BDFD-4F48-B63C-3201F1C2AE86" />
+               <kie:ComponentWidths dmnElementRef="_A662997D-A0BE-46AE-8F78-5F07C737054C" />
+               <kie:ComponentWidths dmnElementRef="_B3C3FF9D-59F2-4F2D-B820-808805524A12" />
+               <kie:ComponentWidths dmnElementRef="_7B896A5A-6ACD-4CB7-9DEC-1D192DEFFD43" />
+               <kie:ComponentWidths dmnElementRef="_E8CDFE8A-7206-4A75-954A-FBAFBEFAB405" />
+               <kie:ComponentWidths dmnElementRef="_564908B8-5111-40D0-A5C3-9D9D212557F7" />
+               <kie:ComponentWidths dmnElementRef="_661F576E-E427-4262-9583-B581C8449813" />
+               <kie:ComponentWidths dmnElementRef="_39661235-6FC6-470B-834F-6E6DD1B763C6" />
+               <kie:ComponentWidths dmnElementRef="_CED7626B-E7FD-471A-BB4E-26133CFAA201" />
+               <kie:ComponentWidths dmnElementRef="_AA64774F-A554-40E1-9E39-6472D76D2E97" />
+               <kie:ComponentWidths dmnElementRef="_D81AC353-57EF-4D25-9487-4ACE335A20AE" />
+               <kie:ComponentWidths dmnElementRef="_67C625D6-1534-4A64-8978-931A34438ECB" />
+               <kie:ComponentWidths dmnElementRef="_D285B8DA-56F4-4677-BE71-AD2D916CE2CC" />
+               <kie:ComponentWidths dmnElementRef="_49348BD2-E242-44CF-941B-B4B5E0019A71" />
+               <kie:ComponentWidths dmnElementRef="_B2A26C2F-1141-42D9-AFC8-EAD433D2FFE5" />
+               <kie:ComponentWidths dmnElementRef="_33B0BF98-23A7-430E-B3E2-E23D53423FBF" />
+               <kie:ComponentWidths dmnElementRef="_C5FFFA95-4E53-4841-8435-262C76ED5404" />
+               <kie:ComponentWidths dmnElementRef="_CD8F25C3-6EA7-4EEE-89EE-EB1F99752005" />
+               <kie:ComponentWidths dmnElementRef="_EA165272-7352-4D6B-A40E-816203071C87" />
+               <kie:ComponentWidths dmnElementRef="_D9A11D7C-3BD3-4ADC-81F1-CABCD6DD52CB" />
+               <kie:ComponentWidths dmnElementRef="_00711E65-ECD2-4E02-817C-C50B426A05AC" />
+               <kie:ComponentWidths dmnElementRef="_DEA12286-93C8-40F1-BE7B-F93186F37772" />
+               <kie:ComponentWidths dmnElementRef="_60F6E3FE-07F4-4EB8-A9AA-BD0F7A7A491B" />
+               <kie:ComponentWidths dmnElementRef="_2B28A750-0F55-45DE-9E6B-3AB86A7F29CC" />
+               <kie:ComponentWidths dmnElementRef="_4CE0D225-D774-4DDC-9D68-9D5DC44F9947" />
+               <kie:ComponentWidths dmnElementRef="_9E479DB3-A5EC-4E97-9AD8-66B78CC4B2C4" />
+               <kie:ComponentWidths dmnElementRef="_1706C5A8-25B7-4193-A0C3-2B6BAFFDB9F4" />
             </kie:ComponentsWidthsExtension>
          </di:extension>
          <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
@@ -775,7 +775,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2473" y="90" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
@@ -784,7 +784,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="1228" y="90" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
@@ -802,7 +802,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="858" y="90" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
@@ -847,7 +847,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="245" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
@@ -865,7 +865,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="440" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
@@ -883,7 +883,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="635" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
@@ -910,7 +910,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="1355" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
@@ -937,7 +937,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="1725" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
@@ -964,7 +964,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2115" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
@@ -991,7 +991,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2310" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
@@ -1018,7 +1018,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2700" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
@@ -1072,7 +1072,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2895" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
@@ -1126,7 +1126,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="1920" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
@@ -1162,7 +1162,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dc:Bounds x="2505" y="415" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
@@ -1183,149 +1183,149 @@
             <dc:Bounds x="1450" y="700" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44" dmnElementRef="_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44">
+         <dmndi:DMNEdge id="dmnedge-drg-_645D2FAB-9019-4349-BFCA-43B2512F55E3" dmnElementRef="_645D2FAB-9019-4349-BFCA-43B2512F55E3">
             <di:waypoint x="1580" y="400" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="1278" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_7DA42E36-7C59-43E7-B464-8FF4154CFF2D" dmnElementRef="_7DA42E36-7C59-43E7-B464-8FF4154CFF2D">
+         <dmndi:DMNEdge id="dmnedge-drg-_1E0A661A-309D-4174-B7B0-073127D5432F" dmnElementRef="_1E0A661A-309D-4174-B7B0-073127D5432F">
             <di:waypoint x="860" y="400" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="908" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_963DCD28-9C59-4528-A2F9-CA386F67C61E" dmnElementRef="_963DCD28-9C59-4528-A2F9-CA386F67C61E">
+         <dmndi:DMNEdge id="dmnedge-drg-_A2AA8B52-CB56-4AC5-9BE5-8E250741F2D4" dmnElementRef="_A2AA8B52-CB56-4AC5-9BE5-8E250741F2D4">
             <di:waypoint x="1035" y="400" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="908" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_E698025C-02D1-49EE-8B36-684391A47AA0" dmnElementRef="_E698025C-02D1-49EE-8B36-684391A47AA0">
+         <dmndi:DMNEdge id="dmnedge-drg-_5079E9ED-C26A-49D2-8F94-DC6E2BC4BE99" dmnElementRef="_5079E9ED-C26A-49D2-8F94-DC6E2BC4BE99">
             <di:waypoint x="1210" y="400" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="908" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_E36A9C79-59C4-460C-8AD8-10C5C1D6B666" dmnElementRef="_E36A9C79-59C4-460C-8AD8-10C5C1D6B666">
+         <dmndi:DMNEdge id="dmnedge-drg-_5D665230-66F1-4EC7-AF2C-4FDC33F320AE" dmnElementRef="_5D665230-66F1-4EC7-AF2C-4FDC33F320AE">
             <di:waypoint x="275" y="400" />
             <di:waypoint x="363" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C" dmnElementRef="_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C">
+         <dmndi:DMNEdge id="dmnedge-drg-_E42A33FA-0F93-4ED4-A586-D4C744DF9611" dmnElementRef="_E42A33FA-0F93-4ED4-A586-D4C744DF9611">
             <di:waypoint x="470" y="400" />
             <di:waypoint x="538" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC" dmnElementRef="_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC">
+         <dmndi:DMNEdge id="dmnedge-drg-_161529A4-7B66-489B-BC8A-744B754FCC2C" dmnElementRef="_161529A4-7B66-489B-BC8A-744B754FCC2C">
             <di:waypoint x="665" y="400" />
             <di:waypoint x="713" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_96A46E1F-4422-4BB3-8304-11943198A0C3" dmnElementRef="_96A46E1F-4422-4BB3-8304-11943198A0C3">
+         <dmndi:DMNEdge id="dmnedge-drg-_5D38966A-549E-4BF5-8CF5-B5108D29F168" dmnElementRef="_5D38966A-549E-4BF5-8CF5-B5108D29F168">
             <di:waypoint x="100" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="685" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_304A86A8-CE2D-43C6-A03F-EDE9301220DC" dmnElementRef="_304A86A8-CE2D-43C6-A03F-EDE9301220DC">
+         <dmndi:DMNEdge id="dmnedge-drg-_D216049C-03B7-45D5-8093-8A0BA3E79F8B" dmnElementRef="_D216049C-03B7-45D5-8093-8A0BA3E79F8B">
             <di:waypoint x="1385" y="400" />
             <di:waypoint x="1083" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_AC7F3583-C42A-49A1-9035-F8F030E5CD4E" dmnElementRef="_AC7F3583-C42A-49A1-9035-F8F030E5CD4E">
+         <dmndi:DMNEdge id="dmnedge-drg-_C3AEC7E7-45A4-4A87-9E81-1232A6B7934D" dmnElementRef="_C3AEC7E7-45A4-4A87-9E81-1232A6B7934D">
             <di:waypoint x="275" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="1405" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_97716FE7-931B-4595-91AB-6B1C1D8FF808" dmnElementRef="_97716FE7-931B-4595-91AB-6B1C1D8FF808">
+         <dmndi:DMNEdge id="dmnedge-drg-_DE27FD9B-C945-44E3-A3C4-650E63CA6909" dmnElementRef="_DE27FD9B-C945-44E3-A3C4-650E63CA6909">
             <di:waypoint x="1755" y="400" />
             <di:waypoint x="1453" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E" dmnElementRef="_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E">
+         <dmndi:DMNEdge id="dmnedge-drg-_36CD3861-3505-4B55-9DEE-A63DEBBD6E0A" dmnElementRef="_36CD3861-3505-4B55-9DEE-A63DEBBD6E0A">
             <di:waypoint x="450" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="1775" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7" dmnElementRef="_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7">
+         <dmndi:DMNEdge id="dmnedge-drg-_7D607060-2EF6-45F3-9BA8-5A9780B579E5" dmnElementRef="_7D607060-2EF6-45F3-9BA8-5A9780B579E5">
             <di:waypoint x="2145" y="400" />
             <di:waypoint x="1803" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_B2971336-A88A-4C6A-953E-CCCD0312EC1F" dmnElementRef="_B2971336-A88A-4C6A-953E-CCCD0312EC1F">
+         <dmndi:DMNEdge id="dmnedge-drg-_196747BA-5799-4CFE-8CAE-79379D0157AF" dmnElementRef="_196747BA-5799-4CFE-8CAE-79379D0157AF">
             <di:waypoint x="975" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2165" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_17AF0346-C97C-4B25-9837-C415AB7AA63B" dmnElementRef="_17AF0346-C97C-4B25-9837-C415AB7AA63B">
+         <dmndi:DMNEdge id="dmnedge-drg-_41B775BC-E3CB-4F28-B770-529295884251" dmnElementRef="_41B775BC-E3CB-4F28-B770-529295884251">
             <di:waypoint x="2340" y="400" />
             <di:waypoint x="1978" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE" dmnElementRef="_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE">
+         <dmndi:DMNEdge id="dmnedge-drg-_A40B4759-5B6B-45C4-8B40-F0F5E06A0FAB" dmnElementRef="_A40B4759-5B6B-45C4-8B40-F0F5E06A0FAB">
             <di:waypoint x="1150" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2360" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6" dmnElementRef="_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6">
+         <dmndi:DMNEdge id="dmnedge-drg-_37B3C707-84E2-4E98-AC7A-34DCA80A496B" dmnElementRef="_37B3C707-84E2-4E98-AC7A-34DCA80A496B">
             <di:waypoint x="2730" y="400" />
             <di:waypoint x="2328" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_4CAF49C0-975B-4181-8808-574C17DCC93C" dmnElementRef="_4CAF49C0-975B-4181-8808-574C17DCC93C">
+         <dmndi:DMNEdge id="dmnedge-drg-_A9D9C47E-4994-4E9D-82F4-8549D051A578" dmnElementRef="_A9D9C47E-4994-4E9D-82F4-8549D051A578">
             <di:waypoint x="1675" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2750" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_35A85C57-98A2-4528-A486-DD8277F49691" dmnElementRef="_35A85C57-98A2-4528-A486-DD8277F49691">
+         <dmndi:DMNEdge id="dmnedge-drg-_FC9F9FAC-0733-4977-855E-DF20F71066B5" dmnElementRef="_FC9F9FAC-0733-4977-855E-DF20F71066B5">
             <di:waypoint x="1850" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2750" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_B9E034A9-3D6F-4B47-A959-EA2E060E225A" dmnElementRef="_B9E034A9-3D6F-4B47-A959-EA2E060E225A">
+         <dmndi:DMNEdge id="dmnedge-drg-_223E8516-AC0D-40F4-96CE-0427613BFB2C" dmnElementRef="_223E8516-AC0D-40F4-96CE-0427613BFB2C">
             <di:waypoint x="2025" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2750" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_FD16B1CD-03D5-487D-8E4F-3D910A8E8223" dmnElementRef="_FD16B1CD-03D5-487D-8E4F-3D910A8E8223">
+         <dmndi:DMNEdge id="dmnedge-drg-_58665D55-0E7F-4F13-98B9-BE06FC3C5334" dmnElementRef="_58665D55-0E7F-4F13-98B9-BE06FC3C5334">
             <di:waypoint x="2200" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2750" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_0140EDEE-0271-427F-A448-EB53AA282574" dmnElementRef="_0140EDEE-0271-427F-A448-EB53AA282574">
+         <dmndi:DMNEdge id="dmnedge-drg-_F2EE638D-4B35-46D6-95A6-22D62858AF2C" dmnElementRef="_F2EE638D-4B35-46D6-95A6-22D62858AF2C">
             <di:waypoint x="2925" y="400" />
             <di:waypoint x="2698" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_1945BB17-3862-4540-9E42-06ED19ED54E0" dmnElementRef="_1945BB17-3862-4540-9E42-06ED19ED54E0">
+         <dmndi:DMNEdge id="dmnedge-drg-_65308170-4956-43FE-8183-5075BD982C8F" dmnElementRef="_65308170-4956-43FE-8183-5075BD982C8F">
             <di:waypoint x="2375" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2945" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_55319A16-B64D-4642-A094-95A62906E50E" dmnElementRef="_55319A16-B64D-4642-A094-95A62906E50E">
+         <dmndi:DMNEdge id="dmnedge-drg-_267E891E-FBF8-4A91-B5F2-B32417E298FB" dmnElementRef="_267E891E-FBF8-4A91-B5F2-B32417E298FB">
             <di:waypoint x="2550" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2945" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_16C43A17-1330-4ABD-8D3A-873D4DC2BD62" dmnElementRef="_16C43A17-1330-4ABD-8D3A-873D4DC2BD62">
+         <dmndi:DMNEdge id="dmnedge-drg-_3F16E24A-BDE7-47DC-9B57-08EA07949FAA" dmnElementRef="_3F16E24A-BDE7-47DC-9B57-08EA07949FAA">
             <di:waypoint x="2725" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2945" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_93143A33-7E05-4041-BFD9-5FCC9DAC225B" dmnElementRef="_93143A33-7E05-4041-BFD9-5FCC9DAC225B">
+         <dmndi:DMNEdge id="dmnedge-drg-_4F8B0AEE-BE15-43EC-AF26-FECD461E996F" dmnElementRef="_4F8B0AEE-BE15-43EC-AF26-FECD461E996F">
             <di:waypoint x="2900" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2945" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_40DDA2C3-D3CF-469E-A25C-61E70338306F" dmnElementRef="_40DDA2C3-D3CF-469E-A25C-61E70338306F">
+         <dmndi:DMNEdge id="dmnedge-drg-_EBFA85AD-1BA8-49BB-B492-CCD770738DFF" dmnElementRef="_EBFA85AD-1BA8-49BB-B492-CCD770738DFF">
             <di:waypoint x="625" y="725" />
             <di:waypoint x="1628" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_83CB5E26-2D0D-450C-A6F9-B2129B05E58C" dmnElementRef="_83CB5E26-2D0D-450C-A6F9-B2129B05E58C">
+         <dmndi:DMNEdge id="dmnedge-drg-_2EB7E700-C770-4EC3-893A-CC0AA699B82F" dmnElementRef="_2EB7E700-C770-4EC3-893A-CC0AA699B82F">
             <di:waypoint x="800" y="725" />
             <di:waypoint x="1628" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_BDADE40A-949A-4D34-93F5-99F5143F385C" dmnElementRef="_BDADE40A-949A-4D34-93F5-99F5143F385C">
+         <dmndi:DMNEdge id="dmnedge-drg-_8BEB7F62-A559-43A9-89CE-8E4B1E62CD75" dmnElementRef="_8BEB7F62-A559-43A9-89CE-8E4B1E62CD75">
             <di:waypoint x="1950" y="400" />
             <di:waypoint x="1628" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_93F96A2C-5E53-47F0-93F6-3A7F22918308" dmnElementRef="_93F96A2C-5E53-47F0-93F6-3A7F22918308">
+         <dmndi:DMNEdge id="dmnedge-drg-_5D3FA33F-7E17-4C92-857F-B820125317AD" dmnElementRef="_5D3FA33F-7E17-4C92-857F-B820125317AD">
             <di:waypoint x="625" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="1970" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D" dmnElementRef="_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D">
+         <dmndi:DMNEdge id="dmnedge-drg-_6A0E67E5-E920-495A-BCE8-26E25F38A106" dmnElementRef="_6A0E67E5-E920-495A-BCE8-26E25F38A106">
             <di:waypoint x="800" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="1970" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_57EE2567-07AE-411C-B9F7-B3786FE673BF" dmnElementRef="_57EE2567-07AE-411C-B9F7-B3786FE673BF">
+         <dmndi:DMNEdge id="dmnedge-drg-_A7FF4CA2-D58E-4C9F-88C1-45450E2B3C71" dmnElementRef="_A7FF4CA2-D58E-4C9F-88C1-45450E2B3C71">
             <di:waypoint x="1325" y="725" />
             <di:waypoint x="2153" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_58C00258-283A-479B-BC80-3F1191809987" dmnElementRef="_58C00258-283A-479B-BC80-3F1191809987">
+         <dmndi:DMNEdge id="dmnedge-drg-_D16BBDC7-A122-4219-9B3F-3CC3492DAF2D" dmnElementRef="_D16BBDC7-A122-4219-9B3F-3CC3492DAF2D">
             <di:waypoint x="1500" y="725" />
             <di:waypoint x="2153" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C" dmnElementRef="_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C">
+         <dmndi:DMNEdge id="dmnedge-drg-_27996495-43D3-48EE-84C2-A76987C3FB42" dmnElementRef="_27996495-43D3-48EE-84C2-A76987C3FB42">
             <di:waypoint x="2535" y="400" />
             <di:waypoint x="2153" y="75" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_B1410847-C0EC-4503-B203-E63017D72DD6" dmnElementRef="_B1410847-C0EC-4503-B203-E63017D72DD6">
+         <dmndi:DMNEdge id="dmnedge-drg-_29FFDE0B-3970-41B1-8BE4-CB70E6F0C695" dmnElementRef="_29FFDE0B-3970-41B1-8BE4-CB70E6F0C695">
             <di:waypoint x="1325" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2555" y="440" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9" dmnElementRef="_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9">
+         <dmndi:DMNEdge id="dmnedge-drg-_D5B2F7B0-5274-4C88-B6D7-36A65F832A24" dmnElementRef="_D5B2F7B0-5274-4C88-B6D7-36A65F832A24">
             <di:waypoint x="1500" y="725" />
-            <di:waypoint x="70" y="65" />
+            <di:waypoint x="2555" y="440" />
          </dmndi:DMNEdge>
       </dmndi:DMNDiagram>
    </dmndi:DMNDI>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0085-decision-services.dmn
@@ -1,1297 +1,1332 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
-  <dmn:description>Decision Services</dmn:description>
-  <dmn:extensionElements/>
-  <dmn:decisionService id="_decisionService_001" name="decisionService_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_EC7DF9E4-FAB6-4AB9-8908-B481F22F2A25" name="decisionService_001"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_002" name="decisionService_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_45D50755-F64C-4954-8F89-BAC223CD21AE" name="decisionService_002"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_003" name="decisionService_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D76FBC5A-689D-4DE9-A588-EED2961E07D7" name="decisionService_003"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_004" name="decisionService_004">
-    <dmn:extensionElements/>
-    <dmn:variable id="_26675CA3-B2FB-4792-8C63-D4629EFCC9BD" name="decisionService_004"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_005" name="decisionService_005">
-    <dmn:extensionElements/>
-    <dmn:variable id="_EEDEA4B5-2AF4-4CAD-BCD6-DC92EAA0B217" name="decisionService_005"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_006" name="decisionService_006">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D1260077-9C4D-490D-9BF6-AD6A96E30F5E" name="decisionService_006"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_007" name="decisionService_007">
-    <dmn:extensionElements/>
-    <dmn:variable id="_AAB776B9-E2E8-49A9-9B5C-90E0A988AC50" name="decisionService_007"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_008" name="decisionService_008">
-    <dmn:extensionElements/>
-    <dmn:variable id="_1BF5587E-CA76-4C9C-9D5B-5BF34A11BA75" name="decisionService_008"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_009" name="decisionService_009">
-    <dmn:extensionElements/>
-    <dmn:variable id="_4E417097-1FDC-41D5-8137-1F9B49053F01" name="decisionService_009"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_010" name="decisionService_010">
-    <dmn:extensionElements/>
-    <dmn:variable id="_28F892E8-DB27-4822-9A56-41C1AF2755B0" name="decisionService_010"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_011" name="decisionService_011">
-    <dmn:extensionElements/>
-    <dmn:variable id="_008A6C56-36DD-4326-9920-3744ED20E368" name="decisionService_011"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_012" name="decisionService_012">
-    <dmn:extensionElements/>
-    <dmn:variable id="_8049FFF3-FAB0-4A4D-8E7C-66F64F0B76A5" name="decisionService_012"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_013" name="decisionService_013">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9F79D1EB-7DD4-49E6-93A8-2B24236243D5" name="decisionService_013"/>
-  </dmn:decisionService>
-  <dmn:decisionService id="_decisionService_014" name="decisionService_014">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7394ED1B-F341-438D-B53A-FBFA706A284A" name="decisionService_014"/>
-  </dmn:decisionService>
-  <dmn:decision id="_decision_001" name="decision_001">
-    <dmn:extensionElements/>
-    <dmn:variable id="_34B6642F-E948-449D-8B16-90CEFD6FB336" name="decision_001"/>
-    <dmn:literalExpression id="_7FDBBB36-ED6D-4F0A-BF43-E3FDDA44A21B">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_002" name="decision_002">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7ED51E29-0507-492E-8077-74173AADD2F7" name="decision_002"/>
-    <dmn:informationRequirement id="_48327838-A3B3-4A1C-9018-C16961353832">
-      <dmn:requiredDecision href="#_decision_002_input"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_52594767-C42D-46EA-890A-61A738508E67">
-      <dmn:text>"foo " + decision_002_input</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_002_input" name="decision_002_input">
-    <dmn:extensionElements/>
-    <dmn:variable id="_4FE88921-82D7-42A7-BDC7-00A6AC02073B" name="decision_002_input"/>
-    <dmn:literalExpression id="_415FC122-078D-47F2-880B-0155697E9662">
-      <dmn:text>"bar"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003" name="decision_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B2B0F8D7-E607-4981-87E2-9722C56C7EA7" name="decision_003"/>
-    <dmn:informationRequirement id="_E2B96527-3A45-4FC3-A433-9F445073D21E">
-      <dmn:requiredDecision href="#_decision_003_input_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_C88D4810-6090-4C42-9B8B-765318419D94">
-      <dmn:requiredDecision href="#_decision_003_input_2"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_3BBF348F-7D76-43C5-9C3C-AB3954D2A001">
-      <dmn:requiredInput href="#_inputData_003"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_EE66BAA2-F15A-4FA9-890D-F2DB1FF31420">
-      <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_71129976-4968-4E86-B8CE-06EB52249428" name="decision_003_input_1"/>
-    <dmn:literalExpression id="_B877AFC4-2D88-4FEE-8C14-661585A02AF1">
-      <dmn:text>"d3_1"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5172A883-61AD-4819-959A-FDD742B7F6A3" name="decision_003_input_2"/>
-    <dmn:literalExpression id="_62CD8FBD-56E0-474C-8B1F-92AB5DCC2DD0">
-      <dmn:text>"d3_2"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_003" name="inputData_003">
-    <dmn:extensionElements/>
-    <dmn:variable id="_351D0B2E-25A3-4897-822D-4E2A2A1E7238" name="inputData_003" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_decision_004_1" name="decision_004_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9778E0D6-1B39-4A59-A0C8-A4B45E3F9E82" name="decision_004_1"/>
-    <dmn:knowledgeRequirement id="_2EB3293E-2DE4-419E-AFC7-E83C107EF972">
-      <dmn:requiredKnowledge href="#_decisionService_004"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_7E3F51E4-8251-4968-867B-81ACF16390EA">
-      <dmn:text>decisionService_004()</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_004_2" name="decision_004_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F532D145-45A0-410F-986E-DF0B1E1E715E" name="decision_004_2"/>
-    <dmn:literalExpression id="_34705EDE-A378-4850-9A60-3E6335EE87B4">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_005_1" name="decision_005_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_87B1F551-2627-4831-BA0D-7E3E452EF096" name="decision_005_1"/>
-    <dmn:knowledgeRequirement id="_7C238A40-CE07-47A4-BD73-392645E9A07F">
-      <dmn:requiredKnowledge href="#_decisionService_005"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_17CB5BBE-A597-44A4-B937-F89D66C6C4E7">
-      <dmn:text>decisionService_005("bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_005_2" name="decision_005_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_BE78BE6F-22DC-451F-813E-36AD69DE6BAE" name="decision_005_2" typeRef="string"/>
-    <dmn:literalExpression id="_CE8547A9-8F64-4C28-8C05-62CFB6447ADC">
-      <dmn:text>"foo"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_1" name="decision_006_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2C1ABCE7-1BE8-4C7E-AA76-FB2AF0847C83" name="decision_006_1"/>
-    <dmn:knowledgeRequirement id="_FCE2091B-D88C-4EEA-9EB2-AECB8D644296">
-      <dmn:requiredKnowledge href="#_decisionService_006"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_2022C849-014F-4C56-A6D1-13E24115F3F4">
-      <dmn:text>decisionService_006("bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_2" name="decision_006_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E4D5F821-5E35-495B-AAD7-CF978290B1F8" name="decision_006_2"/>
-    <dmn:informationRequirement id="_3C60FB2C-767A-45E2-9630-367077116AAD">
-      <dmn:requiredDecision href="#_decision_006_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_49024C4A-881C-4055-A38C-BB0B42C488E4">
-      <dmn:text>"foo " + decision_006_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_006_3" name="decision_006_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_AB2C2537-C61C-4F87-BEF3-7105EC61463F" name="decision_006_3" typeRef="string"/>
-    <dmn:literalExpression id="_E37B2275-C9EE-4D59-8E54-360F59267175">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_1" name="decision_007_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2DB62567-35CF-4729-AF61-2A77F331C021" name="decision_007_1"/>
-    <dmn:knowledgeRequirement id="_E2CCF4CC-61F7-4625-A47C-C02433674CB0">
-      <dmn:requiredKnowledge href="#_decisionService_007"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_DCDE434B-052F-4677-BB14-99F67EE8E6ED">
-      <dmn:text>decisionService_007(123)</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_2" name="decision_007_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_DA133DA9-BDF4-4A6D-A570-8FF5C237E2B3" name="decision_007_2"/>
-    <dmn:informationRequirement id="_8B06E8E0-C65D-4F2D-A31E-853E4DD86583">
-      <dmn:requiredDecision href="#_decision_007_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_0E3B6F2D-07BA-40F0-A49A-264F48EEA552">
-      <dmn:text>decision_007_3 = null</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_007_3" name="decision_007_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_4D172687-E4BB-47E2-8A8C-BCF1713E43E1" name="decision_007_3" typeRef="string"/>
-    <dmn:literalExpression id="_47C41417-D43F-4310-BEC6-55B6EA938319">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008_1" name="decision_008_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_63DB3FDC-EF4B-483E-9DBB-2995E6997B3B" name="decision_008_1"/>
-    <dmn:knowledgeRequirement id="_59730883-C5AD-4838-A828-E36ED83F0A28">
-      <dmn:requiredKnowledge href="#_decisionService_008"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_5B598507-528B-42F8-9BA1-238D3B478D69">
-      <dmn:text>decisionService_008()</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008_2" name="decision_008_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D83C9F6B-3418-4567-8943-80674601F2B6" name="decision_008_2"/>
-    <dmn:informationRequirement id="_8EA2F696-D099-4DD5-A67C-164D148824EB">
-      <dmn:requiredDecision href="#_decision_008_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_EEE16197-1AC0-4F91-A8F5-A933FC3A1F97">
-      <dmn:text>decision_008_3 = null</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_008_3" name="decision_008_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_62C75E8A-76DE-4C47-87BE-D9D546B81628" name="decision_008_3" typeRef="string"/>
-    <dmn:literalExpression id="_A1BFE2B0-89B0-480C-B016-767CF7597B58">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_009_1" name="decision_009_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_2BEDD4D7-351D-49B3-B536-C075D84FBF0C" name="decision_009_1"/>
-    <dmn:knowledgeRequirement id="_E212024F-4A31-4516-A465-85A3181542B3">
-      <dmn:requiredKnowledge href="#_decisionService_009"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_C25163F7-1ADA-443B-B2AD-DE2C14FEE0DE">
-      <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_009_2" name="decision_009_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B3BD7DB9-A6B3-4D55-B373-6EBDA9960D1A" name="decision_009_2"/>
-    <dmn:informationRequirement id="_298E4FA3-A9DB-4B02-B878-C53CFE708DF1">
-      <dmn:requiredDecision href="#_decision_009_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_656354B5-471C-416B-ABFE-FDFBF3BC0302">
-      <dmn:text>"foo " + decision_009_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_009_3" name="decision_009_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A851A690-975A-4653-B74A-67977F4E2AC7" name="decision_009_3" typeRef="string"/>
-    <dmn:literalExpression id="_092AF037-3183-41A0-8398-1A0B3B9CE80F">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_010_1" name="decision_010_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7BC2E34C-C6F6-43D5-B778-70058F0D2D03" name="decision_010_1"/>
-    <dmn:knowledgeRequirement id="_1F343A9F-34AA-41DD-8134-8E23D7AB804E">
-      <dmn:requiredKnowledge href="#_decisionService_010"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_5F2ED633-51F5-4391-9480-3684F7C972EA">
-      <dmn:text>decisionService_010(foo: "bar")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_010_2" name="decision_010_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9C9E53A7-F01F-460A-9759-E7F49800C5B6" name="decision_010_2"/>
-    <dmn:informationRequirement id="_24FDD129-04BF-499F-8233-231FA35AF051">
-      <dmn:requiredDecision href="#_decision_010_3"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_8E17B04B-FEB5-45B4-9F51-9B51F6E7BF32">
-      <dmn:text>"foo " + decision_010_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_010_3" name="decision_010_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B04E68D6-C173-4758-BBDA-67BBD020B831" name="decision_010_3" typeRef="string"/>
-    <dmn:literalExpression id="_FBF9E0B8-D74B-4742-BEEE-8C5E558B4907">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_1" name="decision_011_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_C2D8C7AC-B7BF-4A87-9729-354083F8C1F3" name="decision_011_1"/>
-    <dmn:knowledgeRequirement id="_C16DA847-D4B4-4736-8E1C-6DD808688E92">
-      <dmn:requiredKnowledge href="#_decisionService_011"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_9BB7616E-A222-4E16-A2E4-52F6EC320CCE">
-      <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_2" name="decision_011_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_C98E507E-3D43-43D0-B8A2-0F6B905DDAFF" name="decision_011_2" typeRef="string"/>
-    <dmn:informationRequirement id="_E5B24964-1B33-4DE5-9C63-82A62E974DEC">
-      <dmn:requiredDecision href="#_decision_011_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07">
-      <dmn:requiredDecision href="#_decision_011_4"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3">
-      <dmn:requiredInput href="#_inputData_011_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8B485F45-A12F-44FB-A72A-8F090678BDDD">
-      <dmn:requiredInput href="#_inputData_011_2"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_C6227EEB-10CA-4B69-A07E-079F4C530E24">
-      <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_3" name="decision_011_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_765E446F-B923-4E13-901D-C5709A8FDE33" name="decision_011_3" typeRef="string"/>
-    <dmn:literalExpression id="_B7F329B9-482A-4E16-9C9A-1C1F939258D0">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_011_4" name="decision_011_4">
-    <dmn:extensionElements/>
-    <dmn:variable id="_E74E506F-B3FF-4421-871F-AEDF4A1B0D06" name="decision_011_4" typeRef="string"/>
-    <dmn:literalExpression id="_5AE4C508-A1EE-4C28-AF41-3B68DF65FCCF">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_82576A5C-B7FA-4383-9DFA-1EA499812378" name="inputData_011_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_29C656F0-5768-4D4E-8364-BAAFA4D6899A" name="inputData_011_2" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_decision_012_1" name="decision_012_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_F1556702-0C14-4044-B035-7AE7FC8F0EC1" name="decision_012_1"/>
-    <dmn:knowledgeRequirement id="_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA">
-      <dmn:requiredKnowledge href="#_decisionService_012"/>
-    </dmn:knowledgeRequirement>
-    <dmn:literalExpression id="_621750B7-8033-45E0-90BF-7D00248CC251">
-      <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_2" name="decision_012_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_17B1F637-B472-4291-944A-3C4DAA4D46A4" name="decision_012_2" typeRef="string"/>
-    <dmn:informationRequirement id="_F8800C29-3B28-4AE5-B2A2-0457F994F839">
-      <dmn:requiredDecision href="#_decision_012_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_386E4803-5F5F-4194-A8B5-F3534DFC7AD9">
-      <dmn:requiredDecision href="#_decision_012_4"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_D07DA03D-C33A-4807-8711-968E4853E0F1">
-      <dmn:requiredInput href="#_inputData_012_1"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_32E47634-89BF-4AF3-A6B7-61AE25AB151B">
-      <dmn:requiredInput href="#_inputData_012_2"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_68420CC3-DDF8-45C2-B850-B431E9F03DB9">
-      <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_3" name="decision_012_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_3E7745CA-4B3F-4A27-A886-D8957D27C097" name="decision_012_3" typeRef="string"/>
-    <dmn:literalExpression id="_9753439E-01DE-4951-BB5A-3F2130C17B25">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_012_4" name="decision_012_4">
-    <dmn:extensionElements/>
-    <dmn:variable id="_1E8F5F3D-B562-4308-B3D8-5C1F148DA008" name="decision_012_4" typeRef="string"/>
-    <dmn:literalExpression id="_ACC927D0-6731-497E-94EB-001EE1031DCB">
-      <dmn:text>"I never get invoked"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_0AF9125C-D653-48F6-B8DF-618894CEF61D" name="inputData_012_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D188E9FA-3675-4A4F-98E8-051066D1B665" name="inputData_012_2" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_decision_013_1" name="decision_013_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_48F74264-DBA9-45C5-A185-920B2C70D2EB" name="decision_013_1"/>
-    <dmn:informationRequirement id="_C66633F4-6718-491C-9D40-8AFF21CE4CD5">
-      <dmn:requiredDecision href="#_decision_013_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_1893C895-D655-4607-81A5-363DE8DBD597">
-      <dmn:requiredInput href="#_inputData_013_1"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_D73018C3-F4DF-4B8A-946B-70692A2464DD">
-      <dmn:requiredKnowledge href="#_decisionService_013"/>
-    </dmn:knowledgeRequirement>
-    <dmn:context id="_BA9A5C7B-A043-4488-8087-1E0FD818394F">
-      <dmn:contextEntry>
-        <dmn:variable id="_8CFAD888-C64A-4386-B8A2-91DE5D79F1A9" name="decisionService_013"/>
-        <dmn:literalExpression id="_E35A33F0-5648-4150-AAA5-A65BBF324B47">
-          <dmn:text>decisionService_013("A", "B")</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_C0D9D68A-56A7-436A-BAFE-609FA7781DEF" name="inputData_013_1"/>
-        <dmn:literalExpression id="_55B320EF-7562-4608-A06D-11A550BF1F96">
-          <dmn:text>inputData_013_1</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_F2E4A4DA-4A5F-4F2E-9A99-0DC190416B26" name="decision_013_3"/>
-        <dmn:literalExpression id="_8834D5F9-21FC-4106-B292-1BCEDD58220F">
-          <dmn:text>decision_013_3</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_decision_013_2" name="decision_013_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A83F6FDD-1FE9-4BA4-A51F-2B8859A4A2F7" name="decision_013_2" typeRef="string"/>
-    <dmn:informationRequirement id="_A9B18C1C-2D92-4A64-A936-3051A852D66F">
-      <dmn:requiredDecision href="#_decision_013_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_A975CC18-C9EC-48A1-8691-26DDC2A81F45">
-      <dmn:requiredInput href="#_inputData_013_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_8D028CA6-9754-492E-822B-F159B5E2F438">
-      <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_013_3" name="decision_013_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_BA181F99-EFD7-4458-BB1C-DC37A05FE91B" name="decision_013_3" typeRef="string"/>
-    <dmn:literalExpression id="_0C1B1B54-3234-4D8E-A5D5-F3EC937414BC">
-      <dmn:text>"D"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D612C6F8-F9F7-4A17-A321-F61E929220C5" name="inputData_013_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:decision id="_decision_014_1" name="decision_014_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_B6FD71AF-516F-4D19-BFB1-668F076D9E62" name="decision_014_1"/>
-    <dmn:informationRequirement id="_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F">
-      <dmn:requiredDecision href="#_decision_014_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550">
-      <dmn:requiredInput href="#_inputData_014_1"/>
-    </dmn:informationRequirement>
-    <dmn:knowledgeRequirement id="_00254681-64B2-4809-95A3-1B7AFAC4D1ED">
-      <dmn:requiredKnowledge href="#_decisionService_014"/>
-    </dmn:knowledgeRequirement>
-    <dmn:context id="_92D2CB90-6C26-46BE-AA2A-21B95DCAB74E">
-      <dmn:contextEntry>
-        <dmn:variable id="_DEC673FD-913A-4232-8795-D4A795EBF4C3" name="inputData_014_1"/>
-        <dmn:literalExpression id="_79A9451C-7E30-4562-AADE-023010A48E47">
-          <dmn:text>inputData_014_1</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_0E14B7C6-1110-4DE4-8034-F62EACFA0E8E" name="decision_014_3"/>
-        <dmn:literalExpression id="_67C34FE6-31AC-4810-9577-EA694ADE2127">
-          <dmn:text>decision_014_3</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-      <dmn:contextEntry>
-        <dmn:variable id="_89FED9AF-5258-4F8A-943C-20966F9C881D" name="decisionService_014"/>
-        <dmn:literalExpression id="_A8E8FE1E-EBB4-473E-A5E0-408565FD28BF">
-          <dmn:text>decisionService_014("A", "B")</dmn:text>
-        </dmn:literalExpression>
-      </dmn:contextEntry>
-    </dmn:context>
-  </dmn:decision>
-  <dmn:decision id="_decision_014_2" name="decision_014_2">
-    <dmn:extensionElements/>
-    <dmn:variable id="_10DA8AB0-E1B9-44A8-9473-8979F6D66624" name="decision_014_2" typeRef="string"/>
-    <dmn:informationRequirement id="_80959823-0175-4165-8060-DFAAB74A1123">
-      <dmn:requiredDecision href="#_decision_014_3"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_40616155-0E1B-4A83-A65A-2DB14DD7B65D">
-      <dmn:requiredInput href="#_inputData_014_1"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_87F856EE-0726-4DB7-92CC-D16F5B1A5A29">
-      <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_decision_014_3" name="decision_014_3">
-    <dmn:extensionElements/>
-    <dmn:variable id="_D4EFBAF0-72B8-466A-B39A-E25CB0A04135" name="decision_014_3" typeRef="string"/>
-    <dmn:literalExpression id="_DD6BD7E1-A422-42EF-B2F2-942DC0B1A92F">
-      <dmn:text>"D"</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
-    <dmn:extensionElements/>
-    <dmn:variable id="_13B39E4F-DFE1-4516-A007-8C64985881A2" name="inputData_014_1" typeRef="string"/>
-  </dmn:inputData>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_3681B41E-85D2-4111-9061-E4F7A725F207" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_7FDBBB36-ED6D-4F0A-BF43-E3FDDA44A21B"/>
-          <kie:ComponentWidths dmnElementRef="_52594767-C42D-46EA-890A-61A738508E67"/>
-          <kie:ComponentWidths dmnElementRef="_415FC122-078D-47F2-880B-0155697E9662"/>
-          <kie:ComponentWidths dmnElementRef="_EE66BAA2-F15A-4FA9-890D-F2DB1FF31420"/>
-          <kie:ComponentWidths dmnElementRef="_B877AFC4-2D88-4FEE-8C14-661585A02AF1"/>
-          <kie:ComponentWidths dmnElementRef="_62CD8FBD-56E0-474C-8B1F-92AB5DCC2DD0"/>
-          <kie:ComponentWidths dmnElementRef="_7E3F51E4-8251-4968-867B-81ACF16390EA"/>
-          <kie:ComponentWidths dmnElementRef="_34705EDE-A378-4850-9A60-3E6335EE87B4"/>
-          <kie:ComponentWidths dmnElementRef="_17CB5BBE-A597-44A4-B937-F89D66C6C4E7"/>
-          <kie:ComponentWidths dmnElementRef="_CE8547A9-8F64-4C28-8C05-62CFB6447ADC"/>
-          <kie:ComponentWidths dmnElementRef="_2022C849-014F-4C56-A6D1-13E24115F3F4"/>
-          <kie:ComponentWidths dmnElementRef="_49024C4A-881C-4055-A38C-BB0B42C488E4"/>
-          <kie:ComponentWidths dmnElementRef="_E37B2275-C9EE-4D59-8E54-360F59267175"/>
-          <kie:ComponentWidths dmnElementRef="_DCDE434B-052F-4677-BB14-99F67EE8E6ED"/>
-          <kie:ComponentWidths dmnElementRef="_0E3B6F2D-07BA-40F0-A49A-264F48EEA552"/>
-          <kie:ComponentWidths dmnElementRef="_47C41417-D43F-4310-BEC6-55B6EA938319"/>
-          <kie:ComponentWidths dmnElementRef="_5B598507-528B-42F8-9BA1-238D3B478D69"/>
-          <kie:ComponentWidths dmnElementRef="_EEE16197-1AC0-4F91-A8F5-A933FC3A1F97"/>
-          <kie:ComponentWidths dmnElementRef="_A1BFE2B0-89B0-480C-B016-767CF7597B58"/>
-          <kie:ComponentWidths dmnElementRef="_C25163F7-1ADA-443B-B2AD-DE2C14FEE0DE"/>
-          <kie:ComponentWidths dmnElementRef="_656354B5-471C-416B-ABFE-FDFBF3BC0302"/>
-          <kie:ComponentWidths dmnElementRef="_092AF037-3183-41A0-8398-1A0B3B9CE80F"/>
-          <kie:ComponentWidths dmnElementRef="_5F2ED633-51F5-4391-9480-3684F7C972EA"/>
-          <kie:ComponentWidths dmnElementRef="_8E17B04B-FEB5-45B4-9F51-9B51F6E7BF32"/>
-          <kie:ComponentWidths dmnElementRef="_FBF9E0B8-D74B-4742-BEEE-8C5E558B4907"/>
-          <kie:ComponentWidths dmnElementRef="_9BB7616E-A222-4E16-A2E4-52F6EC320CCE"/>
-          <kie:ComponentWidths dmnElementRef="_C6227EEB-10CA-4B69-A07E-079F4C530E24"/>
-          <kie:ComponentWidths dmnElementRef="_B7F329B9-482A-4E16-9C9A-1C1F939258D0"/>
-          <kie:ComponentWidths dmnElementRef="_5AE4C508-A1EE-4C28-AF41-3B68DF65FCCF"/>
-          <kie:ComponentWidths dmnElementRef="_621750B7-8033-45E0-90BF-7D00248CC251"/>
-          <kie:ComponentWidths dmnElementRef="_68420CC3-DDF8-45C2-B850-B431E9F03DB9"/>
-          <kie:ComponentWidths dmnElementRef="_9753439E-01DE-4951-BB5A-3F2130C17B25"/>
-          <kie:ComponentWidths dmnElementRef="_ACC927D0-6731-497E-94EB-001EE1031DCB"/>
-          <kie:ComponentWidths dmnElementRef="_BA9A5C7B-A043-4488-8087-1E0FD818394F"/>
-          <kie:ComponentWidths dmnElementRef="_E35A33F0-5648-4150-AAA5-A65BBF324B47"/>
-          <kie:ComponentWidths dmnElementRef="_55B320EF-7562-4608-A06D-11A550BF1F96"/>
-          <kie:ComponentWidths dmnElementRef="_8834D5F9-21FC-4106-B292-1BCEDD58220F"/>
-          <kie:ComponentWidths dmnElementRef="_8D028CA6-9754-492E-822B-F159B5E2F438"/>
-          <kie:ComponentWidths dmnElementRef="_0C1B1B54-3234-4D8E-A5D5-F3EC937414BC"/>
-          <kie:ComponentWidths dmnElementRef="_92D2CB90-6C26-46BE-AA2A-21B95DCAB74E"/>
-          <kie:ComponentWidths dmnElementRef="_79A9451C-7E30-4562-AADE-023010A48E47"/>
-          <kie:ComponentWidths dmnElementRef="_67C34FE6-31AC-4810-9577-EA694ADE2127"/>
-          <kie:ComponentWidths dmnElementRef="_A8E8FE1E-EBB4-473E-A5E0-408565FD28BF"/>
-          <kie:ComponentWidths dmnElementRef="_87F856EE-0726-4DB7-92CC-D16F5B1A5A29"/>
-          <kie:ComponentWidths dmnElementRef="_DD6BD7E1-A422-42EF-B2F2-942DC0B1A92F"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3725" y="150"/>
-          <di:waypoint x="3825" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4075" y="150"/>
-          <di:waypoint x="4175" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4425" y="150"/>
-          <di:waypoint x="4525" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="575" y="325"/>
-          <di:waypoint x="675" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="750" y="325"/>
-          <di:waypoint x="850" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="925" y="325"/>
-          <di:waypoint x="1025" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="1800" y="325"/>
-          <di:waypoint x="1900" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="2150" y="325"/>
-          <di:waypoint x="2250" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3025" y="325"/>
-          <di:waypoint x="3125" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3200" y="325"/>
-          <di:waypoint x="3300" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4075" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4075" y="325"/>
-          <di:waypoint x="4175" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4950" y="325"/>
-          <di:waypoint x="5050" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="3375" y="325"/>
-          <di:waypoint x="3475" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="4250" y="325"/>
-          <di:waypoint x="4350" y="325"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="575" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4950" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="750" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="925" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3200" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4425" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5125" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1975" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4250" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5300" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2150" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="5475" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1100" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1275" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1450" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1625" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3550" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="1800" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2500" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2850" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2325" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="2675" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3725" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3900" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3025" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="3375" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4600" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="4775" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_48327838-A3B3-4A1C-9018-C16961353832" dmnElementRef="_48327838-A3B3-4A1C-9018-C16961353832">
-        <di:waypoint x="2025" y="250"/>
-        <di:waypoint x="1500" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E2B96527-3A45-4FC3-A433-9F445073D21E" dmnElementRef="_E2B96527-3A45-4FC3-A433-9F445073D21E">
-        <di:waypoint x="100" y="250"/>
-        <di:waypoint x="450" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_C88D4810-6090-4C42-9B8B-765318419D94" dmnElementRef="_C88D4810-6090-4C42-9B8B-765318419D94">
-        <di:waypoint x="275" y="250"/>
-        <di:waypoint x="450" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3BBF348F-7D76-43C5-9C3C-AB3954D2A001" dmnElementRef="_3BBF348F-7D76-43C5-9C3C-AB3954D2A001">
-        <di:waypoint x="450" y="250"/>
-        <di:waypoint x="450" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2EB3293E-2DE4-419E-AFC7-E83C107EF972" dmnElementRef="_2EB3293E-2DE4-419E-AFC7-E83C107EF972">
-        <di:waypoint x="625" y="250"/>
-        <di:waypoint x="625" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_7C238A40-CE07-47A4-BD73-392645E9A07F" dmnElementRef="_7C238A40-CE07-47A4-BD73-392645E9A07F">
-        <di:waypoint x="800" y="250"/>
-        <di:waypoint x="800" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_FCE2091B-D88C-4EEA-9EB2-AECB8D644296" dmnElementRef="_FCE2091B-D88C-4EEA-9EB2-AECB8D644296">
-        <di:waypoint x="975" y="250"/>
-        <di:waypoint x="975" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_3C60FB2C-767A-45E2-9630-367077116AAD" dmnElementRef="_3C60FB2C-767A-45E2-9630-367077116AAD">
-        <di:waypoint x="3600" y="250"/>
-        <di:waypoint x="2550" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E2CCF4CC-61F7-4625-A47C-C02433674CB0" dmnElementRef="_E2CCF4CC-61F7-4625-A47C-C02433674CB0">
-        <di:waypoint x="1850" y="250"/>
-        <di:waypoint x="1325" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8B06E8E0-C65D-4F2D-A31E-853E4DD86583" dmnElementRef="_8B06E8E0-C65D-4F2D-A31E-853E4DD86583">
-        <di:waypoint x="4475" y="250"/>
-        <di:waypoint x="3250" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_59730883-C5AD-4838-A828-E36ED83F0A28" dmnElementRef="_59730883-C5AD-4838-A828-E36ED83F0A28">
-        <di:waypoint x="2200" y="250"/>
-        <di:waypoint x="1675" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8EA2F696-D099-4DD5-A67C-164D148824EB" dmnElementRef="_8EA2F696-D099-4DD5-A67C-164D148824EB">
-        <di:waypoint x="5175" y="250"/>
-        <di:waypoint x="3950" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E212024F-4A31-4516-A465-85A3181542B3" dmnElementRef="_E212024F-4A31-4516-A465-85A3181542B3">
-        <di:waypoint x="3075" y="250"/>
-        <di:waypoint x="2025" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_298E4FA3-A9DB-4B02-B878-C53CFE708DF1" dmnElementRef="_298E4FA3-A9DB-4B02-B878-C53CFE708DF1">
-        <di:waypoint x="5350" y="250"/>
-        <di:waypoint x="4300" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1F343A9F-34AA-41DD-8134-8E23D7AB804E" dmnElementRef="_1F343A9F-34AA-41DD-8134-8E23D7AB804E">
-        <di:waypoint x="3250" y="250"/>
-        <di:waypoint x="2200" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_24FDD129-04BF-499F-8233-231FA35AF051" dmnElementRef="_24FDD129-04BF-499F-8233-231FA35AF051">
-        <di:waypoint x="5525" y="250"/>
-        <di:waypoint x="4825" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_C16DA847-D4B4-4736-8E1C-6DD808688E92" dmnElementRef="_C16DA847-D4B4-4736-8E1C-6DD808688E92">
-        <di:waypoint x="4125" y="250"/>
-        <di:waypoint x="2900" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E5B24964-1B33-4DE5-9C63-82A62E974DEC" dmnElementRef="_E5B24964-1B33-4DE5-9C63-82A62E974DEC">
-        <di:waypoint x="1150" y="250"/>
-        <di:waypoint x="1150" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07" dmnElementRef="_47A3FBD0-C5A3-46E9-9A73-A6E7A0543D07">
-        <di:waypoint x="1325" y="250"/>
-        <di:waypoint x="1150" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3" dmnElementRef="_03DCDE71-DBB0-4818-BBF3-4C4DDEA391A3">
-        <di:waypoint x="1500" y="250"/>
-        <di:waypoint x="1150" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8B485F45-A12F-44FB-A72A-8F090678BDDD" dmnElementRef="_8B485F45-A12F-44FB-A72A-8F090678BDDD">
-        <di:waypoint x="1675" y="250"/>
-        <di:waypoint x="1150" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA" dmnElementRef="_0DCF7C01-2BEE-42E6-9A6E-75BD06D3DAAA">
-        <di:waypoint x="5000" y="250"/>
-        <di:waypoint x="3600" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_F8800C29-3B28-4AE5-B2A2-0457F994F839" dmnElementRef="_F8800C29-3B28-4AE5-B2A2-0457F994F839">
-        <di:waypoint x="2375" y="250"/>
-        <di:waypoint x="1850" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_386E4803-5F5F-4194-A8B5-F3534DFC7AD9" dmnElementRef="_386E4803-5F5F-4194-A8B5-F3534DFC7AD9">
-        <di:waypoint x="2550" y="250"/>
-        <di:waypoint x="1850" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_D07DA03D-C33A-4807-8711-968E4853E0F1" dmnElementRef="_D07DA03D-C33A-4807-8711-968E4853E0F1">
-        <di:waypoint x="2725" y="250"/>
-        <di:waypoint x="1850" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_32E47634-89BF-4AF3-A6B7-61AE25AB151B" dmnElementRef="_32E47634-89BF-4AF3-A6B7-61AE25AB151B">
-        <di:waypoint x="2900" y="250"/>
-        <di:waypoint x="1850" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_C66633F4-6718-491C-9D40-8AFF21CE4CD5" dmnElementRef="_C66633F4-6718-491C-9D40-8AFF21CE4CD5">
-        <di:waypoint x="3775" y="250"/>
-        <di:waypoint x="2375" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_1893C895-D655-4607-81A5-363DE8DBD597" dmnElementRef="_1893C895-D655-4607-81A5-363DE8DBD597">
-        <di:waypoint x="3950" y="250"/>
-        <di:waypoint x="2375" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_D73018C3-F4DF-4B8A-946B-70692A2464DD" dmnElementRef="_D73018C3-F4DF-4B8A-946B-70692A2464DD">
-        <di:waypoint x="3425" y="250"/>
-        <di:waypoint x="2375" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_A9B18C1C-2D92-4A64-A936-3051A852D66F" dmnElementRef="_A9B18C1C-2D92-4A64-A936-3051A852D66F">
-        <di:waypoint x="3775" y="250"/>
-        <di:waypoint x="2725" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_A975CC18-C9EC-48A1-8691-26DDC2A81F45" dmnElementRef="_A975CC18-C9EC-48A1-8691-26DDC2A81F45">
-        <di:waypoint x="3950" y="250"/>
-        <di:waypoint x="2725" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F" dmnElementRef="_2DA5A6A8-5369-4982-AFCA-468C4D0D1B3F">
-        <di:waypoint x="4650" y="250"/>
-        <di:waypoint x="3075" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550" dmnElementRef="_87DCC3D8-7AE5-4B9A-83DF-8C5BA2F6B550">
-        <di:waypoint x="4825" y="250"/>
-        <di:waypoint x="3075" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_00254681-64B2-4809-95A3-1B7AFAC4D1ED" dmnElementRef="_00254681-64B2-4809-95A3-1B7AFAC4D1ED">
-        <di:waypoint x="4300" y="250"/>
-        <di:waypoint x="3075" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_80959823-0175-4165-8060-DFAAB74A1123" dmnElementRef="_80959823-0175-4165-8060-DFAAB74A1123">
-        <di:waypoint x="4650" y="250"/>
-        <di:waypoint x="3425" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_40616155-0E1B-4A83-A65A-2DB14DD7B65D" dmnElementRef="_40616155-0E1B-4A83-A65A-2DB14DD7B65D">
-        <di:waypoint x="4825" y="250"/>
-        <di:waypoint x="3425" y="75"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="http://www.montera.com.au/spec/DMN/0085-decision-services" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="_i9fboPUUEeesLuP4RHs4vA" name="0085-decision-services" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="http://www.montera.com.au/spec/DMN/0085-decision-services">
+   <dmn:description>Decision Services</dmn:description>
+   <dmn:extensionElements />
+   <dmn:decisionService id="_decisionService_001" name="decisionService_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_0F4D4997-C012-4D9A-8EA9-C6828585B324" name="decisionService_001" />
+      <dmn:outputDecision href="#_decision_001" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_002" name="decisionService_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_0580A3E5-AA5E-440F-9C10-5CE175245B3E" name="decisionService_002" />
+      <dmn:outputDecision href="#_decision_002" />
+      <dmn:inputDecision href="#_decision_002_input" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_003" name="decisionService_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_9CEC1BE6-3756-498A-B1D3-9AD92BC78F43" name="decisionService_003" />
+      <dmn:outputDecision href="#_decision_003" />
+      <dmn:inputDecision href="#_decision_003_input_1" />
+      <dmn:inputDecision href="#_decision_003_input_2" />
+      <dmn:inputData href="#_inputData_003" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_004" name="decisionService_004">
+      <dmn:extensionElements />
+      <dmn:variable id="_0756801E-C4FA-468B-93D5-79FD4336A8E0" name="decisionService_004" />
+      <dmn:outputDecision href="#_decision_004_2" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_005" name="decisionService_005">
+      <dmn:extensionElements />
+      <dmn:variable id="_E2BDFEE1-AE09-4415-A9BD-6FD699B25519" name="decisionService_005" />
+      <dmn:outputDecision href="#_decision_005_2" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_006" name="decisionService_006">
+      <dmn:extensionElements />
+      <dmn:variable id="_CDD8AEA2-20BC-4607-BE95-36C4264E2984" name="decisionService_006" />
+      <dmn:outputDecision href="#_decision_006_2" />
+      <dmn:inputDecision href="#_decision_006_3" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_007" name="decisionService_007">
+      <dmn:extensionElements />
+      <dmn:variable id="_67E1CFAB-5946-4AB6-B648-839E3783B6D6" name="decisionService_007" />
+      <dmn:outputDecision href="#_decision_007_2" />
+      <dmn:inputDecision href="#_decision_007_3" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_008" name="decisionService_008">
+      <dmn:extensionElements />
+      <dmn:variable id="_32CB621E-3741-415D-ACE1-938808809B56" name="decisionService_008" />
+      <dmn:outputDecision href="#_decision_008_2" />
+      <dmn:inputDecision href="#_decision_008_3" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_009" name="decisionService_009">
+      <dmn:extensionElements />
+      <dmn:variable id="_9C62847D-03A7-498C-A370-2392D2BFD52C" name="decisionService_009" />
+      <dmn:outputDecision href="#_decision_009_2" />
+      <dmn:inputDecision href="#_decision_009_3" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_010" name="decisionService_010">
+      <dmn:extensionElements />
+      <dmn:variable id="_00E2E6D6-A52D-4DBB-AB32-7F5AF6077354" name="decisionService_010" />
+      <dmn:outputDecision href="#_decision_010_2" />
+      <dmn:inputDecision href="#_decision_010_3" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_011" name="decisionService_011">
+      <dmn:extensionElements />
+      <dmn:variable id="_665096E1-8C7D-4432-9DD8-25526C360257" name="decisionService_011" />
+      <dmn:outputDecision href="#_decision_011_2" />
+      <dmn:inputDecision href="#_decision_011_3" />
+      <dmn:inputDecision href="#_decision_011_4" />
+      <dmn:inputData href="#_inputData_011_1" />
+      <dmn:inputData href="#_inputData_011_2" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_012" name="decisionService_012">
+      <dmn:extensionElements />
+      <dmn:variable id="_71951D03-E9B3-41FE-A26A-D4EEE585E470" name="decisionService_012" />
+      <dmn:outputDecision href="#_decision_012_2" />
+      <dmn:inputDecision href="#_decision_012_3" />
+      <dmn:inputDecision href="#_decision_012_4" />
+      <dmn:inputData href="#_inputData_012_1" />
+      <dmn:inputData href="#_inputData_012_2" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_013" name="decisionService_013">
+      <dmn:extensionElements />
+      <dmn:variable id="_11A13903-7A46-4BE7-87F6-9FAABE69B65C" name="decisionService_013" />
+      <dmn:outputDecision href="#_decision_013_2" />
+      <dmn:inputDecision href="#_decision_013_3" />
+      <dmn:inputData href="#_inputData_013_1" />
+   </dmn:decisionService>
+   <dmn:decisionService id="_decisionService_014" name="decisionService_014">
+      <dmn:extensionElements />
+      <dmn:variable id="_D51768CC-5290-426C-81D9-4F298A9DD418" name="decisionService_014" />
+      <dmn:outputDecision href="#_decision_014_2" />
+      <dmn:inputDecision href="#_decision_014_3" />
+      <dmn:inputData href="#_inputData_014_1" />
+   </dmn:decisionService>
+   <dmn:decision id="_decision_001" name="decision_001">
+      <dmn:extensionElements />
+      <dmn:variable id="_E32A53CB-178D-430F-8E0E-BCA6CF210196" name="decision_001" />
+      <dmn:literalExpression id="_A210860D-2130-487E-9BC1-18722D9B1B20">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_002" name="decision_002">
+      <dmn:extensionElements />
+      <dmn:variable id="_8F4E4A57-AC92-41C2-AB1A-18A0DD3ACA28" name="decision_002" />
+      <dmn:informationRequirement id="_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44">
+         <dmn:requiredDecision href="#_decision_002_input" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_E9D920F6-9CB3-4EC0-97B2-1C261AB49C8A">
+         <dmn:text>"foo " + decision_002_input</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_002_input" name="decision_002_input">
+      <dmn:extensionElements />
+      <dmn:variable id="_9674CFED-8768-4152-BFCE-C07A1A402E75" name="decision_002_input" />
+      <dmn:literalExpression id="_ADE0D019-4DE5-4A6C-B88D-9585254AB2D7">
+         <dmn:text>"bar"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003" name="decision_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_197DCD7C-3D3E-4563-8B58-7943A25E6792" name="decision_003" />
+      <dmn:informationRequirement id="_7DA42E36-7C59-43E7-B464-8FF4154CFF2D">
+         <dmn:requiredDecision href="#_decision_003_input_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_963DCD28-9C59-4528-A2F9-CA386F67C61E">
+         <dmn:requiredDecision href="#_decision_003_input_2" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_E698025C-02D1-49EE-8B36-684391A47AA0">
+         <dmn:requiredInput href="#_inputData_003" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_75DBDAA9-5A3B-408E-A174-34B3BBDFC3F0">
+         <dmn:text>"A " + decision_003_input_1 + " " + decision_003_input_2 + " " + inputData_003</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003_input_1" name="decision_003_input_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_AB08C851-3EFA-4A68-8985-623DEC316ED0" name="decision_003_input_1" />
+      <dmn:literalExpression id="_EC72EBCC-C5F6-4911-9C63-97697E3D5B13">
+         <dmn:text>"d3_1"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_003_input_2" name="decision_003_input_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_6992C915-DF27-48F2-8F25-AFA93F280559" name="decision_003_input_2" />
+      <dmn:literalExpression id="_A1EB711A-2318-474C-BC5F-4C362893E19A">
+         <dmn:text>"d3_2"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_003" name="inputData_003">
+      <dmn:extensionElements />
+      <dmn:variable id="_40185D70-248E-4BDA-A117-9C7AE90513B7" name="inputData_003" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_004_1" name="decision_004_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_4AA94470-02F8-4BAF-A5AA-8BC757F3638B" name="decision_004_1" />
+      <dmn:knowledgeRequirement id="_E36A9C79-59C4-460C-8AD8-10C5C1D6B666">
+         <dmn:requiredKnowledge href="#_decisionService_004" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_21D8FDAD-4B95-49FA-9044-6AD34EC8349B">
+         <dmn:text>decisionService_004()</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_004_2" name="decision_004_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_8CB2E991-A010-481F-A4B4-B560789B3E28" name="decision_004_2" />
+      <dmn:literalExpression id="_9BFF49AB-BF22-4851-AA6F-0F2355B110EF">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_005_1" name="decision_005_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_8D7797BD-6AE9-477A-8085-DD44FA77513B" name="decision_005_1" />
+      <dmn:knowledgeRequirement id="_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C">
+         <dmn:requiredKnowledge href="#_decisionService_005" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_FAEBF51B-5672-4FA6-8BEC-7A7B7CDCA6A5">
+         <dmn:text>decisionService_005("bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_005_2" name="decision_005_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_BF42529D-C61F-4E6E-AEB3-C712F5034043" name="decision_005_2" typeRef="string" />
+      <dmn:literalExpression id="_261154E6-C11E-4E67-84D2-2EFB9D8AFB66">
+         <dmn:text>"foo"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_1" name="decision_006_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_03D9BAAB-AB5C-4495-8474-59BC4A245D54" name="decision_006_1" />
+      <dmn:knowledgeRequirement id="_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC">
+         <dmn:requiredKnowledge href="#_decisionService_006" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_00862001-F6CA-431B-8E71-048F0967DBA4">
+         <dmn:text>decisionService_006("bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_2" name="decision_006_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_99933CA7-C283-4DA8-9E0A-8E9A675954E8" name="decision_006_2" />
+      <dmn:informationRequirement id="_96A46E1F-4422-4BB3-8304-11943198A0C3">
+         <dmn:requiredDecision href="#_decision_006_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_A5ECE8E9-E9E5-456F-9A07-4C400BA850E0">
+         <dmn:text>"foo " + decision_006_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_006_3" name="decision_006_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_41138FDA-34C8-4549-B423-5B5632BBA46B" name="decision_006_3" typeRef="string" />
+      <dmn:literalExpression id="_F637C497-F9AE-481C-BF6E-28E1A0CAD1B4">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_1" name="decision_007_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_3AC481E4-CD1E-4F45-8BD5-7D1AC20F1EC2" name="decision_007_1" />
+      <dmn:knowledgeRequirement id="_304A86A8-CE2D-43C6-A03F-EDE9301220DC">
+         <dmn:requiredKnowledge href="#_decisionService_007" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_4ECC25D4-5970-46E6-83CD-F6FBAE44F8AC">
+         <dmn:text>decisionService_007(123)</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_2" name="decision_007_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_E2A1416C-35FF-4547-AC2A-CD2B212162B8" name="decision_007_2" />
+      <dmn:informationRequirement id="_AC7F3583-C42A-49A1-9035-F8F030E5CD4E">
+         <dmn:requiredDecision href="#_decision_007_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_761D1D22-C5F3-4170-B92C-A1B3C37AB358">
+         <dmn:text>decision_007_3 = null</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_007_3" name="decision_007_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_D18A7DA1-DF24-4499-8CA8-BD0DFCBCF877" name="decision_007_3" typeRef="string" />
+      <dmn:literalExpression id="_952C92A0-6D95-4F58-9DAD-A68122D63427">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_1" name="decision_008_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_35DF00EE-6EBF-4ABB-94C7-F10B41271B17" name="decision_008_1" />
+      <dmn:knowledgeRequirement id="_97716FE7-931B-4595-91AB-6B1C1D8FF808">
+         <dmn:requiredKnowledge href="#_decisionService_008" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_4C3B13B5-E62B-4E11-9064-065FDBCA6901">
+         <dmn:text>decisionService_008()</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_2" name="decision_008_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_3BF3AE3E-10BA-43EB-AB7F-2BF5E0C6A404" name="decision_008_2" />
+      <dmn:informationRequirement id="_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E">
+         <dmn:requiredDecision href="#_decision_008_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_35343B62-F4A4-41AD-A269-D9AF2894A125">
+         <dmn:text>decision_008_3 = null</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_008_3" name="decision_008_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_3352A700-4D5C-4E6C-AFFA-F579786CC307" name="decision_008_3" typeRef="string" />
+      <dmn:literalExpression id="_E1DA5DBC-AB93-4645-8276-96C8168EEB0A">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_1" name="decision_009_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_FE0E9380-11E1-44E4-8E90-11049700DAB5" name="decision_009_1" />
+      <dmn:knowledgeRequirement id="_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7">
+         <dmn:requiredKnowledge href="#_decisionService_009" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_9898A8EC-B71A-462D-A157-B7ADDB6645BB">
+         <dmn:text>decisionService_009(decision_009_3: "bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_2" name="decision_009_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_A4771183-69BD-4667-9FD4-9E98B93FF1EE" name="decision_009_2" />
+      <dmn:informationRequirement id="_B2971336-A88A-4C6A-953E-CCCD0312EC1F">
+         <dmn:requiredDecision href="#_decision_009_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_83788BBF-B733-4D58-BB95-09956419CC21">
+         <dmn:text>"foo " + decision_009_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_009_3" name="decision_009_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_B7E5CE55-FC7A-4B8C-A251-1074D1FECE94" name="decision_009_3" typeRef="string" />
+      <dmn:literalExpression id="_BAE42AE7-A9E7-43B8-83F4-3F779B28D4AA">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_1" name="decision_010_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_CEAD5BE0-8A9C-4CB5-89AA-22A78DAFD61C" name="decision_010_1" />
+      <dmn:knowledgeRequirement id="_17AF0346-C97C-4B25-9837-C415AB7AA63B">
+         <dmn:requiredKnowledge href="#_decisionService_010" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_59FF1D71-7155-4CC0-A3BB-92F6B555D926">
+         <dmn:text>decisionService_010(foo: "bar")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_2" name="decision_010_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_3307C9EF-2318-4098-B5B2-67FFC9C8F9A3" name="decision_010_2" />
+      <dmn:informationRequirement id="_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE">
+         <dmn:requiredDecision href="#_decision_010_3" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_E128B822-3A08-4FEE-8023-597E9C73E878">
+         <dmn:text>"foo " + decision_010_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_010_3" name="decision_010_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_7234872B-31AD-4A2B-956B-0610BB7E1619" name="decision_010_3" typeRef="string" />
+      <dmn:literalExpression id="_CB7CE518-63AF-4AAC-AAA2-6B324F272162">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_1" name="decision_011_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_EC7FB4AE-1E9D-47CF-A0E5-B51FCB1AD64A" name="decision_011_1" />
+      <dmn:knowledgeRequirement id="_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6">
+         <dmn:requiredKnowledge href="#_decisionService_011" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_492162D7-2CF4-4993-BB63-2F05966BDF9E">
+         <dmn:text>decisionService_011("A", "B", "C", "D")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_2" name="decision_011_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_2CE93DD0-AD96-41F9-B86F-1294E46DD4E4" name="decision_011_2" typeRef="string" />
+      <dmn:informationRequirement id="_4CAF49C0-975B-4181-8808-574C17DCC93C">
+         <dmn:requiredDecision href="#_decision_011_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_35A85C57-98A2-4528-A486-DD8277F49691">
+         <dmn:requiredDecision href="#_decision_011_4" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_B9E034A9-3D6F-4B47-A959-EA2E060E225A">
+         <dmn:requiredInput href="#_inputData_011_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_FD16B1CD-03D5-487D-8E4F-3D910A8E8223">
+         <dmn:requiredInput href="#_inputData_011_2" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_D557026E-1B0F-4DE1-A978-D4CFDACB9318">
+         <dmn:text>inputData_011_1 + " " + inputData_011_2 + " " + decision_011_3 + " " + decision_011_4</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_3" name="decision_011_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_B708F561-F5DE-4703-B4CB-D1B2F363168C" name="decision_011_3" typeRef="string" />
+      <dmn:literalExpression id="_14EE46D0-4811-4A82-BE11-C5A29B308147">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_011_4" name="decision_011_4">
+      <dmn:extensionElements />
+      <dmn:variable id="_E1C9670E-DDB1-4E11-85DD-900E192A8C7A" name="decision_011_4" typeRef="string" />
+      <dmn:literalExpression id="_87432A55-F890-45FE-A3B6-415981C121D3">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_011_1" name="inputData_011_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_0BFD0ADB-A0F7-483E-8559-0240ECA8E13B" name="inputData_011_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_inputData_011_2" name="inputData_011_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_FCBDD6A8-3D01-42BD-A818-51B39C8A6DA0" name="inputData_011_2" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_012_1" name="decision_012_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_37432F60-6E94-462E-9551-6A269E199520" name="decision_012_1" />
+      <dmn:knowledgeRequirement id="_0140EDEE-0271-427F-A448-EB53AA282574">
+         <dmn:requiredKnowledge href="#_decisionService_012" />
+      </dmn:knowledgeRequirement>
+      <dmn:literalExpression id="_AC3D82E3-E6FC-46F7-8CBB-3621150B7875">
+         <dmn:text>decisionService_012(decision_012_3: "C", inputData_012_1: "A", decision_012_4: "D", inputData_012_2: "B")</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_2" name="decision_012_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_E798708A-DEA5-44D3-B257-BA60151282B9" name="decision_012_2" typeRef="string" />
+      <dmn:informationRequirement id="_1945BB17-3862-4540-9E42-06ED19ED54E0">
+         <dmn:requiredDecision href="#_decision_012_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_55319A16-B64D-4642-A094-95A62906E50E">
+         <dmn:requiredDecision href="#_decision_012_4" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_16C43A17-1330-4ABD-8D3A-873D4DC2BD62">
+         <dmn:requiredInput href="#_inputData_012_1" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_93143A33-7E05-4041-BFD9-5FCC9DAC225B">
+         <dmn:requiredInput href="#_inputData_012_2" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_D0D85411-49CE-45E2-A21C-D97D37194EE7">
+         <dmn:text>inputData_012_1 + " " + inputData_012_2 + " " + decision_012_3 + " " + decision_012_4</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_3" name="decision_012_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_A4DC02AC-03B2-414A-A552-9E7DF5513071" name="decision_012_3" typeRef="string" />
+      <dmn:literalExpression id="_E867E58E-8FBC-4D24-A060-AA596D3AC99D">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_012_4" name="decision_012_4">
+      <dmn:extensionElements />
+      <dmn:variable id="_F51B63E8-C76E-4F72-920F-6DE0B93D94BF" name="decision_012_4" typeRef="string" />
+      <dmn:literalExpression id="_7B040662-8B42-4481-8491-BD0F1A48FA17">
+         <dmn:text>"I never get invoked"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_012_1" name="inputData_012_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_D6D10997-1C53-4467-8885-C8BB75F01065" name="inputData_012_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_inputData_012_2" name="inputData_012_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_87717F80-C2A7-4365-989E-7C91FE9BFDA8" name="inputData_012_2" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_013_1" name="decision_013_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_21F2E3BA-A8FD-4FCB-BE95-1CE78128B4BF" name="decision_013_1" />
+      <dmn:informationRequirement id="_40DDA2C3-D3CF-469E-A25C-61E70338306F">
+         <dmn:requiredDecision href="#_decision_013_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_83CB5E26-2D0D-450C-A6F9-B2129B05E58C">
+         <dmn:requiredInput href="#_inputData_013_1" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_BDADE40A-949A-4D34-93F5-99F5143F385C">
+         <dmn:requiredKnowledge href="#_decisionService_013" />
+      </dmn:knowledgeRequirement>
+      <dmn:context id="_9F438869-C243-40A0-A518-FCA21726D21C">
+         <dmn:contextEntry>
+            <dmn:variable id="_E0386032-0939-4B38-A658-68017709FF9F" name="decisionService_013" />
+            <dmn:literalExpression id="_E6B92D7C-47DC-4DF6-8AEB-3CAEB924CDC2">
+               <dmn:text>decisionService_013("A", "B")</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_3CE8A8FA-3CCC-4E1D-B808-6226665DB0BB" name="inputData_013_1" />
+            <dmn:literalExpression id="_9C841399-D583-43CF-94F3-E4E3285E1285">
+               <dmn:text>inputData_013_1</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_89461005-9376-46ED-A92A-9730BCC59255" name="decision_013_3" />
+            <dmn:literalExpression id="_10F1B85E-D124-4B58-9717-2CB867219A4C">
+               <dmn:text>decision_013_3</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_decision_013_2" name="decision_013_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_84341D22-4C43-40CC-8155-8DAD1B67ECE5" name="decision_013_2" typeRef="string" />
+      <dmn:informationRequirement id="_93F96A2C-5E53-47F0-93F6-3A7F22918308">
+         <dmn:requiredDecision href="#_decision_013_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D">
+         <dmn:requiredInput href="#_inputData_013_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_642DF3FC-366D-477D-83E3-114F14D39CB5">
+         <dmn:text>inputData_013_1 + " " + decision_013_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_013_3" name="decision_013_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_1B06159D-8EB0-4682-A531-EE3B6D3A9620" name="decision_013_3" typeRef="string" />
+      <dmn:literalExpression id="_5E04C292-6CD4-4F5B-B47E-B49A9E928864">
+         <dmn:text>"D"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_013_1" name="inputData_013_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_1907F35A-AE8F-4DFE-B13C-C58CB8A2C8DC" name="inputData_013_1" typeRef="string" />
+   </dmn:inputData>
+   <dmn:decision id="_decision_014_1" name="decision_014_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_247A730B-582E-4F06-837F-75922EB3982D" name="decision_014_1" />
+      <dmn:informationRequirement id="_57EE2567-07AE-411C-B9F7-B3786FE673BF">
+         <dmn:requiredDecision href="#_decision_014_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_58C00258-283A-479B-BC80-3F1191809987">
+         <dmn:requiredInput href="#_inputData_014_1" />
+      </dmn:informationRequirement>
+      <dmn:knowledgeRequirement id="_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C">
+         <dmn:requiredKnowledge href="#_decisionService_014" />
+      </dmn:knowledgeRequirement>
+      <dmn:context id="_DA7E11C4-4FCD-46EF-B015-9C988B9BFAA4">
+         <dmn:contextEntry>
+            <dmn:variable id="_7E25957E-609F-4B68-B8B5-AEA7487B9DAA" name="inputData_014_1" />
+            <dmn:literalExpression id="_266D0801-FB54-4E70-AB1C-4FE76A61D50E">
+               <dmn:text>inputData_014_1</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_7C6F1234-25A9-4CDA-9FCC-DA4C533C0E82" name="decision_014_3" />
+            <dmn:literalExpression id="_1A2135C4-A8CF-400B-B144-47A346EF7726">
+               <dmn:text>decision_014_3</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+         <dmn:contextEntry>
+            <dmn:variable id="_B764755D-3094-4319-9332-5961827DECB3" name="decisionService_014" />
+            <dmn:literalExpression id="_DA46D806-E856-4E9D-8FA6-BAAA13BC2664">
+               <dmn:text>decisionService_014("A", "B")</dmn:text>
+            </dmn:literalExpression>
+         </dmn:contextEntry>
+      </dmn:context>
+   </dmn:decision>
+   <dmn:decision id="_decision_014_2" name="decision_014_2">
+      <dmn:extensionElements />
+      <dmn:variable id="_BBFF2454-6DA5-4597-B1EC-4A87E6D75FFA" name="decision_014_2" typeRef="string" />
+      <dmn:informationRequirement id="_B1410847-C0EC-4503-B203-E63017D72DD6">
+         <dmn:requiredDecision href="#_decision_014_3" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9">
+         <dmn:requiredInput href="#_inputData_014_1" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_366B09CE-FF4D-44C9-BDB6-8A6617E90F9E">
+         <dmn:text>inputData_014_1 + " " + decision_014_3</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_decision_014_3" name="decision_014_3">
+      <dmn:extensionElements />
+      <dmn:variable id="_5D11D347-2CD9-44B0-ACFC-864BB44AC6C3" name="decision_014_3" typeRef="string" />
+      <dmn:literalExpression id="_A4DAC3CC-BA02-421E-A578-2592E3FD2DC5">
+         <dmn:text>"D"</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:inputData id="_inputData_014_1" name="inputData_014_1">
+      <dmn:extensionElements />
+      <dmn:variable id="_E73365F8-133B-4CE2-B52F-A8BD4E233DCF" name="inputData_014_1" typeRef="string" />
+   </dmn:inputData>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_B94B2EE7-6863-424C-8664-C8E7319A93C7" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_A210860D-2130-487E-9BC1-18722D9B1B20" />
+               <kie:ComponentWidths dmnElementRef="_E9D920F6-9CB3-4EC0-97B2-1C261AB49C8A" />
+               <kie:ComponentWidths dmnElementRef="_ADE0D019-4DE5-4A6C-B88D-9585254AB2D7" />
+               <kie:ComponentWidths dmnElementRef="_75DBDAA9-5A3B-408E-A174-34B3BBDFC3F0" />
+               <kie:ComponentWidths dmnElementRef="_EC72EBCC-C5F6-4911-9C63-97697E3D5B13" />
+               <kie:ComponentWidths dmnElementRef="_A1EB711A-2318-474C-BC5F-4C362893E19A" />
+               <kie:ComponentWidths dmnElementRef="_21D8FDAD-4B95-49FA-9044-6AD34EC8349B" />
+               <kie:ComponentWidths dmnElementRef="_9BFF49AB-BF22-4851-AA6F-0F2355B110EF" />
+               <kie:ComponentWidths dmnElementRef="_FAEBF51B-5672-4FA6-8BEC-7A7B7CDCA6A5" />
+               <kie:ComponentWidths dmnElementRef="_261154E6-C11E-4E67-84D2-2EFB9D8AFB66" />
+               <kie:ComponentWidths dmnElementRef="_00862001-F6CA-431B-8E71-048F0967DBA4" />
+               <kie:ComponentWidths dmnElementRef="_A5ECE8E9-E9E5-456F-9A07-4C400BA850E0" />
+               <kie:ComponentWidths dmnElementRef="_F637C497-F9AE-481C-BF6E-28E1A0CAD1B4" />
+               <kie:ComponentWidths dmnElementRef="_4ECC25D4-5970-46E6-83CD-F6FBAE44F8AC" />
+               <kie:ComponentWidths dmnElementRef="_761D1D22-C5F3-4170-B92C-A1B3C37AB358" />
+               <kie:ComponentWidths dmnElementRef="_952C92A0-6D95-4F58-9DAD-A68122D63427" />
+               <kie:ComponentWidths dmnElementRef="_4C3B13B5-E62B-4E11-9064-065FDBCA6901" />
+               <kie:ComponentWidths dmnElementRef="_35343B62-F4A4-41AD-A269-D9AF2894A125" />
+               <kie:ComponentWidths dmnElementRef="_E1DA5DBC-AB93-4645-8276-96C8168EEB0A" />
+               <kie:ComponentWidths dmnElementRef="_9898A8EC-B71A-462D-A157-B7ADDB6645BB" />
+               <kie:ComponentWidths dmnElementRef="_83788BBF-B733-4D58-BB95-09956419CC21" />
+               <kie:ComponentWidths dmnElementRef="_BAE42AE7-A9E7-43B8-83F4-3F779B28D4AA" />
+               <kie:ComponentWidths dmnElementRef="_59FF1D71-7155-4CC0-A3BB-92F6B555D926" />
+               <kie:ComponentWidths dmnElementRef="_E128B822-3A08-4FEE-8023-597E9C73E878" />
+               <kie:ComponentWidths dmnElementRef="_CB7CE518-63AF-4AAC-AAA2-6B324F272162" />
+               <kie:ComponentWidths dmnElementRef="_492162D7-2CF4-4993-BB63-2F05966BDF9E" />
+               <kie:ComponentWidths dmnElementRef="_D557026E-1B0F-4DE1-A978-D4CFDACB9318" />
+               <kie:ComponentWidths dmnElementRef="_14EE46D0-4811-4A82-BE11-C5A29B308147" />
+               <kie:ComponentWidths dmnElementRef="_87432A55-F890-45FE-A3B6-415981C121D3" />
+               <kie:ComponentWidths dmnElementRef="_AC3D82E3-E6FC-46F7-8CBB-3621150B7875" />
+               <kie:ComponentWidths dmnElementRef="_D0D85411-49CE-45E2-A21C-D97D37194EE7" />
+               <kie:ComponentWidths dmnElementRef="_E867E58E-8FBC-4D24-A060-AA596D3AC99D" />
+               <kie:ComponentWidths dmnElementRef="_7B040662-8B42-4481-8491-BD0F1A48FA17" />
+               <kie:ComponentWidths dmnElementRef="_9F438869-C243-40A0-A518-FCA21726D21C" />
+               <kie:ComponentWidths dmnElementRef="_E6B92D7C-47DC-4DF6-8AEB-3CAEB924CDC2" />
+               <kie:ComponentWidths dmnElementRef="_9C841399-D583-43CF-94F3-E4E3285E1285" />
+               <kie:ComponentWidths dmnElementRef="_10F1B85E-D124-4B58-9717-2CB867219A4C" />
+               <kie:ComponentWidths dmnElementRef="_642DF3FC-366D-477D-83E3-114F14D39CB5" />
+               <kie:ComponentWidths dmnElementRef="_5E04C292-6CD4-4F5B-B47E-B49A9E928864" />
+               <kie:ComponentWidths dmnElementRef="_DA7E11C4-4FCD-46EF-B015-9C988B9BFAA4" />
+               <kie:ComponentWidths dmnElementRef="_266D0801-FB54-4E70-AB1C-4FE76A61D50E" />
+               <kie:ComponentWidths dmnElementRef="_1A2135C4-A8CF-400B-B144-47A346EF7726" />
+               <kie:ComponentWidths dmnElementRef="_DA46D806-E856-4E9D-8FA6-BAAA13BC2664" />
+               <kie:ComponentWidths dmnElementRef="_366B09CE-FF4D-44C9-BDB6-8A6617E90F9E" />
+               <kie:ComponentWidths dmnElementRef="_A4DAC3CC-BA02-421E-A578-2592E3FD2DC5" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_001" dmnElementRef="_decisionService_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2453" y="50" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2453" y="150" />
+               <di:waypoint x="2593" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_002" dmnElementRef="_decisionService_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1208" y="50" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1208" y="150" />
+               <di:waypoint x="1348" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_003" dmnElementRef="_decisionService_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="838" y="50" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="838" y="150" />
+               <di:waypoint x="978" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_004" dmnElementRef="_decisionService_004" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="225" y="475" />
+               <di:waypoint x="365" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_005" dmnElementRef="_decisionService_005" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="420" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="420" y="475" />
+               <di:waypoint x="560" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_006" dmnElementRef="_decisionService_006" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="615" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="615" y="475" />
+               <di:waypoint x="755" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_007" dmnElementRef="_decisionService_007" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1335" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1335" y="475" />
+               <di:waypoint x="1475" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_008" dmnElementRef="_decisionService_008" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1705" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1705" y="475" />
+               <di:waypoint x="1845" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_009" dmnElementRef="_decisionService_009" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2095" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2095" y="475" />
+               <di:waypoint x="2235" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_010" dmnElementRef="_decisionService_010" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2290" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2290" y="475" />
+               <di:waypoint x="2430" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_011" dmnElementRef="_decisionService_011" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2680" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2680" y="475" />
+               <di:waypoint x="2820" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_012" dmnElementRef="_decisionService_012" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2875" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2875" y="475" />
+               <di:waypoint x="3015" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_013" dmnElementRef="_decisionService_013" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1900" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="1900" y="475" />
+               <di:waypoint x="2040" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decisionService_014" dmnElementRef="_decisionService_014" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2485" y="375" width="140" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="2485" y="475" />
+               <di:waypoint x="2625" y="475" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_001" dmnElementRef="_decision_001" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_002" dmnElementRef="_decision_002" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_002_input" dmnElementRef="_decision_002_input" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1530" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003" dmnElementRef="_decision_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_1" dmnElementRef="_decision_003_input_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="810" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_003_input_2" dmnElementRef="_decision_003_input_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="985" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_003" dmnElementRef="_inputData_003" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1160" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004_1" dmnElementRef="_decision_004_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="313" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_004_2" dmnElementRef="_decision_004_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005_1" dmnElementRef="_decision_005_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="488" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_005_2" dmnElementRef="_decision_005_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_1" dmnElementRef="_decision_006_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="663" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_2" dmnElementRef="_decision_006_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_006_3" dmnElementRef="_decision_006_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_1" dmnElementRef="_decision_007_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1033" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_2" dmnElementRef="_decision_007_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_007_3" dmnElementRef="_decision_007_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_1" dmnElementRef="_decision_008_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1403" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_2" dmnElementRef="_decision_008_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_008_3" dmnElementRef="_decision_008_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="400" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_1" dmnElementRef="_decision_009_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1753" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_2" dmnElementRef="_decision_009_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_009_3" dmnElementRef="_decision_009_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="925" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_1" dmnElementRef="_decision_010_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1928" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_2" dmnElementRef="_decision_010_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_010_3" dmnElementRef="_decision_010_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1100" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_1" dmnElementRef="_decision_011_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2278" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_2" dmnElementRef="_decision_011_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_3" dmnElementRef="_decision_011_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1625" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_011_4" dmnElementRef="_decision_011_4" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1800" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_1" dmnElementRef="_inputData_011_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1975" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_011_2" dmnElementRef="_inputData_011_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2150" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_1" dmnElementRef="_decision_012_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2648" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_2" dmnElementRef="_decision_012_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_3" dmnElementRef="_decision_012_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2325" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_012_4" dmnElementRef="_decision_012_4" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2500" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_1" dmnElementRef="_inputData_012_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2675" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_012_2" dmnElementRef="_inputData_012_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2850" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_1" dmnElementRef="_decision_013_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1578" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_2" dmnElementRef="_decision_013_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_013_3" dmnElementRef="_decision_013_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="575" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_013_1" dmnElementRef="_inputData_013_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="750" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_1" dmnElementRef="_decision_014_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="2103" y="50" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_2" dmnElementRef="_decision_014_2" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_decision_014_3" dmnElementRef="_decision_014_3" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1275" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_inputData_014_1" dmnElementRef="_inputData_014_1" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="1450" y="700" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44" dmnElementRef="_7A6C63B6-84B1-4D16-B0D9-26548EBBEA44">
+            <di:waypoint x="1580" y="400" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_7DA42E36-7C59-43E7-B464-8FF4154CFF2D" dmnElementRef="_7DA42E36-7C59-43E7-B464-8FF4154CFF2D">
+            <di:waypoint x="860" y="400" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_963DCD28-9C59-4528-A2F9-CA386F67C61E" dmnElementRef="_963DCD28-9C59-4528-A2F9-CA386F67C61E">
+            <di:waypoint x="1035" y="400" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_E698025C-02D1-49EE-8B36-684391A47AA0" dmnElementRef="_E698025C-02D1-49EE-8B36-684391A47AA0">
+            <di:waypoint x="1210" y="400" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_E36A9C79-59C4-460C-8AD8-10C5C1D6B666" dmnElementRef="_E36A9C79-59C4-460C-8AD8-10C5C1D6B666">
+            <di:waypoint x="275" y="400" />
+            <di:waypoint x="363" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C" dmnElementRef="_B71F7E0C-35A2-477A-BBF9-D9D402A78F7C">
+            <di:waypoint x="470" y="400" />
+            <di:waypoint x="538" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC" dmnElementRef="_348BCA06-43A4-45B5-A1B8-4ADCD5F409CC">
+            <di:waypoint x="665" y="400" />
+            <di:waypoint x="713" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_96A46E1F-4422-4BB3-8304-11943198A0C3" dmnElementRef="_96A46E1F-4422-4BB3-8304-11943198A0C3">
+            <di:waypoint x="100" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_304A86A8-CE2D-43C6-A03F-EDE9301220DC" dmnElementRef="_304A86A8-CE2D-43C6-A03F-EDE9301220DC">
+            <di:waypoint x="1385" y="400" />
+            <di:waypoint x="1083" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_AC7F3583-C42A-49A1-9035-F8F030E5CD4E" dmnElementRef="_AC7F3583-C42A-49A1-9035-F8F030E5CD4E">
+            <di:waypoint x="275" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_97716FE7-931B-4595-91AB-6B1C1D8FF808" dmnElementRef="_97716FE7-931B-4595-91AB-6B1C1D8FF808">
+            <di:waypoint x="1755" y="400" />
+            <di:waypoint x="1453" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E" dmnElementRef="_F1888DE7-6EB9-414E-AA0F-D3E84A6B0B7E">
+            <di:waypoint x="450" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7" dmnElementRef="_F616AC6B-CCCD-4D5F-B400-6C0B40DCECC7">
+            <di:waypoint x="2145" y="400" />
+            <di:waypoint x="1803" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_B2971336-A88A-4C6A-953E-CCCD0312EC1F" dmnElementRef="_B2971336-A88A-4C6A-953E-CCCD0312EC1F">
+            <di:waypoint x="975" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_17AF0346-C97C-4B25-9837-C415AB7AA63B" dmnElementRef="_17AF0346-C97C-4B25-9837-C415AB7AA63B">
+            <di:waypoint x="2340" y="400" />
+            <di:waypoint x="1978" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE" dmnElementRef="_63A8B3B4-D8A0-4541-A602-5A43A1C4A3AE">
+            <di:waypoint x="1150" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6" dmnElementRef="_F49B6B8C-6174-495C-AFC3-BE4CFE689EC6">
+            <di:waypoint x="2730" y="400" />
+            <di:waypoint x="2328" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_4CAF49C0-975B-4181-8808-574C17DCC93C" dmnElementRef="_4CAF49C0-975B-4181-8808-574C17DCC93C">
+            <di:waypoint x="1675" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_35A85C57-98A2-4528-A486-DD8277F49691" dmnElementRef="_35A85C57-98A2-4528-A486-DD8277F49691">
+            <di:waypoint x="1850" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_B9E034A9-3D6F-4B47-A959-EA2E060E225A" dmnElementRef="_B9E034A9-3D6F-4B47-A959-EA2E060E225A">
+            <di:waypoint x="2025" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_FD16B1CD-03D5-487D-8E4F-3D910A8E8223" dmnElementRef="_FD16B1CD-03D5-487D-8E4F-3D910A8E8223">
+            <di:waypoint x="2200" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_0140EDEE-0271-427F-A448-EB53AA282574" dmnElementRef="_0140EDEE-0271-427F-A448-EB53AA282574">
+            <di:waypoint x="2925" y="400" />
+            <di:waypoint x="2698" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_1945BB17-3862-4540-9E42-06ED19ED54E0" dmnElementRef="_1945BB17-3862-4540-9E42-06ED19ED54E0">
+            <di:waypoint x="2375" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_55319A16-B64D-4642-A094-95A62906E50E" dmnElementRef="_55319A16-B64D-4642-A094-95A62906E50E">
+            <di:waypoint x="2550" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_16C43A17-1330-4ABD-8D3A-873D4DC2BD62" dmnElementRef="_16C43A17-1330-4ABD-8D3A-873D4DC2BD62">
+            <di:waypoint x="2725" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_93143A33-7E05-4041-BFD9-5FCC9DAC225B" dmnElementRef="_93143A33-7E05-4041-BFD9-5FCC9DAC225B">
+            <di:waypoint x="2900" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_40DDA2C3-D3CF-469E-A25C-61E70338306F" dmnElementRef="_40DDA2C3-D3CF-469E-A25C-61E70338306F">
+            <di:waypoint x="625" y="725" />
+            <di:waypoint x="1628" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_83CB5E26-2D0D-450C-A6F9-B2129B05E58C" dmnElementRef="_83CB5E26-2D0D-450C-A6F9-B2129B05E58C">
+            <di:waypoint x="800" y="725" />
+            <di:waypoint x="1628" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_BDADE40A-949A-4D34-93F5-99F5143F385C" dmnElementRef="_BDADE40A-949A-4D34-93F5-99F5143F385C">
+            <di:waypoint x="1950" y="400" />
+            <di:waypoint x="1628" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_93F96A2C-5E53-47F0-93F6-3A7F22918308" dmnElementRef="_93F96A2C-5E53-47F0-93F6-3A7F22918308">
+            <di:waypoint x="625" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D" dmnElementRef="_5B508172-FBD9-4B8B-8B45-0F6ABB4FAC9D">
+            <di:waypoint x="800" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_57EE2567-07AE-411C-B9F7-B3786FE673BF" dmnElementRef="_57EE2567-07AE-411C-B9F7-B3786FE673BF">
+            <di:waypoint x="1325" y="725" />
+            <di:waypoint x="2153" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_58C00258-283A-479B-BC80-3F1191809987" dmnElementRef="_58C00258-283A-479B-BC80-3F1191809987">
+            <di:waypoint x="1500" y="725" />
+            <di:waypoint x="2153" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C" dmnElementRef="_3EAAEE81-9D20-4DF8-BAD3-53EA76CBB86C">
+            <di:waypoint x="2535" y="400" />
+            <di:waypoint x="2153" y="75" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_B1410847-C0EC-4503-B203-E63017D72DD6" dmnElementRef="_B1410847-C0EC-4503-B203-E63017D72DD6">
+            <di:waypoint x="1325" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9" dmnElementRef="_6AE5BA65-3C31-41C9-AEBB-CA98628B86D9">
+            <di:waypoint x="1500" y="725" />
+            <di:waypoint x="70" y="65" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
@@ -11,7 +11,7 @@
       <dmn:extensionElements />
       <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS" />
       <dmn:outputDecision href="#_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" />
-      <dmn:outputDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
+      <dmn:encapsulatedDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
       <dmn:inputDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
       <dmn:inputData href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
       <dmn:inputData href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
@@ -19,7 +19,7 @@
    <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
       <dmn:extensionElements />
       <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string" />
-      <dmn:informationRequirement id="_65AFCEF3-A401-465C-A931-F9D0F7635B6B">
+      <dmn:informationRequirement id="_3FF439EB-04D0-4918-B312-4AFFC5045E9C">
          <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
       </dmn:informationRequirement>
       <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
@@ -101,16 +101,16 @@
    <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
       <dmn:extensionElements />
       <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string" />
-      <dmn:informationRequirement id="_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB">
+      <dmn:informationRequirement id="_864E25F2-EDC9-40CD-AFF0-BC61B50ECEA1">
          <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_5EE41E2B-BB4C-4936-9966-92C8105DB64F">
+      <dmn:informationRequirement id="_8EB1449C-4E5D-4212-BD79-BDA06263D873">
          <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_FC235654-A5D3-4C27-AB0C-80A069ADC42E">
+      <dmn:informationRequirement id="_9ECC2B09-AD6D-49A7-B303-234749DA7659">
          <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
       </dmn:informationRequirement>
-      <dmn:informationRequirement id="_E2109D65-2489-4FD7-965D-9FA87C9ACB04">
+      <dmn:informationRequirement id="_12B36823-1325-477C-900B-A70637D066AF">
          <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
       </dmn:informationRequirement>
       <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
@@ -120,10 +120,10 @@
    <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
       <dmn:extensionElements />
       <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation" />
-      <dmn:informationRequirement id="_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F">
+      <dmn:informationRequirement id="_84EE4906-57A9-47BF-A3E3-D5354C9D0873">
          <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
       </dmn:informationRequirement>
-      <dmn:authorityRequirement id="_CBB7711E-2A3E-4905-A90F-313F85BC90F8">
+      <dmn:authorityRequirement id="_A8042A93-CAA8-4830-AE1C-DEC349B9F164">
          <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" />
       </dmn:authorityRequirement>
    </dmn:decision>
@@ -140,7 +140,7 @@
       <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade" />
    </dmn:inputData>
    <dmndi:DMNDI>
-      <dmndi:DMNDiagram id="_EA293523-15DC-41AD-88D9-C9E8A81F53A9" name="DRG">
+      <dmndi:DMNDiagram id="_80C2F67E-C88C-4FB5-9DC5-DDCB39055D3D" name="DRG">
          <di:extension>
             <kie:ComponentsWidthsExtension>
                <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" />
@@ -166,7 +166,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="20" y="120" width="100" height="50" />
+            <dc:Bounds x="157" y="170" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
@@ -175,7 +175,7 @@
                <dmndi:StrokeColor red="0" green="0" blue="0" />
                <dmndi:FontColor red="0" green="0" blue="0" />
             </dmndi:DMNStyle>
-            <dc:Bounds x="140" y="40" width="100" height="50" />
+            <dc:Bounds x="277" y="90" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
          <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
@@ -214,31 +214,31 @@
             <dc:Bounds x="225" y="375" width="100" height="50" />
             <dmndi:DMNLabel />
          </dmndi:DMNShape>
-         <dmndi:DMNEdge id="dmnedge-drg-_65AFCEF3-A401-465C-A931-F9D0F7635B6B" dmnElementRef="_65AFCEF3-A401-465C-A931-F9D0F7635B6B">
+         <dmndi:DMNEdge id="dmnedge-drg-_3FF439EB-04D0-4918-B312-4AFFC5045E9C" dmnElementRef="_3FF439EB-04D0-4918-B312-4AFFC5045E9C">
             <di:waypoint x="275" y="400" />
-            <di:waypoint x="70" y="145" />
+            <di:waypoint x="207" y="195" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB" dmnElementRef="_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB">
-            <di:waypoint x="70" y="145" />
-            <di:waypoint x="190" y="65" />
+         <dmndi:DMNEdge id="dmnedge-drg-_864E25F2-EDC9-40CD-AFF0-BC61B50ECEA1" dmnElementRef="_864E25F2-EDC9-40CD-AFF0-BC61B50ECEA1">
+            <di:waypoint x="207" y="195" />
+            <di:waypoint x="327" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_5EE41E2B-BB4C-4936-9966-92C8105DB64F" dmnElementRef="_5EE41E2B-BB4C-4936-9966-92C8105DB64F">
+         <dmndi:DMNEdge id="dmnedge-drg-_8EB1449C-4E5D-4212-BD79-BDA06263D873" dmnElementRef="_8EB1449C-4E5D-4212-BD79-BDA06263D873">
             <di:waypoint x="275" y="575" />
-            <di:waypoint x="190" y="65" />
+            <di:waypoint x="327" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_FC235654-A5D3-4C27-AB0C-80A069ADC42E" dmnElementRef="_FC235654-A5D3-4C27-AB0C-80A069ADC42E">
+         <dmndi:DMNEdge id="dmnedge-drg-_9ECC2B09-AD6D-49A7-B303-234749DA7659" dmnElementRef="_9ECC2B09-AD6D-49A7-B303-234749DA7659">
             <di:waypoint x="275" y="400" />
-            <di:waypoint x="190" y="65" />
+            <di:waypoint x="327" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_E2109D65-2489-4FD7-965D-9FA87C9ACB04" dmnElementRef="_E2109D65-2489-4FD7-965D-9FA87C9ACB04">
+         <dmndi:DMNEdge id="dmnedge-drg-_12B36823-1325-477C-900B-A70637D066AF" dmnElementRef="_12B36823-1325-477C-900B-A70637D066AF">
             <di:waypoint x="100" y="400" />
-            <di:waypoint x="190" y="65" />
+            <di:waypoint x="327" y="115" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F" dmnElementRef="_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F">
+         <dmndi:DMNEdge id="dmnedge-drg-_84EE4906-57A9-47BF-A3E3-D5354C9D0873" dmnElementRef="_84EE4906-57A9-47BF-A3E3-D5354C9D0873">
             <di:waypoint x="275" y="575" />
             <di:waypoint x="100" y="400" />
          </dmndi:DMNEdge>
-         <dmndi:DMNEdge id="dmnedge-drg-_CBB7711E-2A3E-4905-A90F-313F85BC90F8" dmnElementRef="_CBB7711E-2A3E-4905-A90F-313F85BC90F8">
+         <dmndi:DMNEdge id="dmnedge-drg-_A8042A93-CAA8-4830-AE1C-DEC349B9F164" dmnElementRef="_A8042A93-CAA8-4830-AE1C-DEC349B9F164">
             <di:waypoint x="100" y="575" />
             <di:waypoint x="100" y="400" />
          </dmndi:DMNEdge>

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/src/test/resources/org/kie/workbench/common/dmn/showcase/client/backward/compatibility/dmn13-expected/0088-no-decision-logic.dmn
@@ -1,242 +1,247 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
-  <dmn:extensionElements/>
-  <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
-    <dmn:typeRef>string</dmn:typeRef>
-    <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
-      <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
-    </dmn:allowedValues>
-  </dmn:itemDefinition>
-  <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
-    <dmn:extensionElements/>
-    <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS"/>
-  </dmn:decisionService>
-  <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string"/>
-    <dmn:informationRequirement id="_84729018-9BDD-4607-B235-1806B18C89BB">
-      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
-    </dmn:informationRequirement>
-    <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
-      <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
-        <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
-          <dmn:text>Grade</dmn:text>
-        </dmn:inputExpression>
-      </dmn:input>
-      <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8"/>
-      <dmn:annotation name=""/>
-      <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
-        <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
-          <dmn:text>"A"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
-          <dmn:text>"Graduated with merit"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
-        <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
-          <dmn:text>"B"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
-          <dmn:text>"Graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
-        <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
-          <dmn:text>"C"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
-          <dmn:text>"Graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
-        <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
-          <dmn:text>"D"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
-        <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
-          <dmn:text>"E"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-      <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
-        <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
-          <dmn:text>"F"</dmn:text>
-        </dmn:inputEntry>
-        <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
-          <dmn:text>"Not graduated"</dmn:text>
-        </dmn:outputEntry>
-        <dmn:annotationEntry>
-          <dmn:text></dmn:text>
-        </dmn:annotationEntry>
-      </dmn:rule>
-    </dmn:decisionTable>
-  </dmn:decision>
-  <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
-    <dmn:extensionElements/>
-    <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string"/>
-    <dmn:informationRequirement id="_92B8883D-CEFA-4379-90F9-3C0F42E0569F">
-      <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76">
-      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_E7DA2900-46F8-4DC1-BCF7-2E928619926A">
-      <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C"/>
-    </dmn:informationRequirement>
-    <dmn:informationRequirement id="_92B4D37C-3DCB-4BD2-A4E8-28465566C79E">
-      <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64"/>
-    </dmn:informationRequirement>
-    <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
-      <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
-    </dmn:literalExpression>
-  </dmn:decision>
-  <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
-    <dmn:extensionElements/>
-    <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation"/>
-    <dmn:informationRequirement id="_E7C0F865-D014-4005-B313-6FA55BD4203C">
-      <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794"/>
-    </dmn:informationRequirement>
-    <dmn:authorityRequirement id="_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249">
-      <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32"/>
-    </dmn:authorityRequirement>
-  </dmn:decision>
-  <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
-    <dmn:extensionElements/>
-    <dmn:type></dmn:type>
-  </dmn:knowledgeSource>
-  <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
-    <dmn:extensionElements/>
-    <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string"/>
-  </dmn:inputData>
-  <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
-    <dmn:extensionElements/>
-    <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade"/>
-  </dmn:inputData>
-  <dmndi:DMNDI>
-    <dmndi:DMNDiagram id="_329FD8A1-95D6-4199-AB25-F5FCFEB4E6C5" name="DRG">
-      <di:extension>
-        <kie:ComponentsWidthsExtension>
-          <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02"/>
-          <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7"/>
-        </kie:ComponentsWidthsExtension>
-      </di:extension>
-      <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="313" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-        <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="313" y="150"/>
-          <di:waypoint x="413" y="150"/>
-        </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="313" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="50" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="138" y="225" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="50" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="225" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
-        <dmndi:DMNStyle>
-          <dmndi:FillColor red="255" green="255" blue="255"/>
-          <dmndi:StrokeColor red="0" green="0" blue="0"/>
-          <dmndi:FontColor red="0" green="0" blue="0"/>
-        </dmndi:DMNStyle>
-        <dc:Bounds x="400" y="400" width="100" height="50"/>
-        <dmndi:DMNLabel/>
-      </dmndi:DMNShape>
-      <dmndi:DMNEdge id="dmnedge-drg-_84729018-9BDD-4607-B235-1806B18C89BB" dmnElementRef="_84729018-9BDD-4607-B235-1806B18C89BB">
-        <di:waypoint x="450" y="425"/>
-        <di:waypoint x="363" y="250"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_92B8883D-CEFA-4379-90F9-3C0F42E0569F" dmnElementRef="_92B8883D-CEFA-4379-90F9-3C0F42E0569F">
-        <di:waypoint x="363" y="250"/>
-        <di:waypoint x="188" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76" dmnElementRef="_8DF42B20-5ECD-4A58-BF5B-5BF8765A5A76">
-        <di:waypoint x="275" y="425"/>
-        <di:waypoint x="188" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E7DA2900-46F8-4DC1-BCF7-2E928619926A" dmnElementRef="_E7DA2900-46F8-4DC1-BCF7-2E928619926A">
-        <di:waypoint x="450" y="425"/>
-        <di:waypoint x="188" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_92B4D37C-3DCB-4BD2-A4E8-28465566C79E" dmnElementRef="_92B4D37C-3DCB-4BD2-A4E8-28465566C79E">
-        <di:waypoint x="188" y="250"/>
-        <di:waypoint x="188" y="75"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_E7C0F865-D014-4005-B313-6FA55BD4203C" dmnElementRef="_E7C0F865-D014-4005-B313-6FA55BD4203C">
-        <di:waypoint x="275" y="425"/>
-        <di:waypoint x="188" y="250"/>
-      </dmndi:DMNEdge>
-      <dmndi:DMNEdge id="dmnedge-drg-_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249" dmnElementRef="_C0A26CA4-7328-4DB0-B626-BEB3D9BF2249">
-        <di:waypoint x="100" y="425"/>
-        <di:waypoint x="188" y="250"/>
-      </dmndi:DMNEdge>
-    </dmndi:DMNDiagram>
-  </dmndi:DMNDI>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" id="_BA898F11-9F63-4A74-AF32-235D82663253" name="x1" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EBF07892-D449-49E8-B77A-08CDAAB2E820">
+   <dmn:extensionElements />
+   <dmn:itemDefinition id="_1A35CDE5-592B-4C7D-A302-15043E11830C" name="tGrade" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="enumeration" id="_E9560012-0F49-44D2-96D8-BA655980F315">
+         <dmn:text>"A", "B", "C", "D", "E", "F"</dmn:text>
+      </dmn:allowedValues>
+   </dmn:itemDefinition>
+   <dmn:decisionService id="_7A9C80F8-4A44-4080-9031-F28EA411A35C" name="Evaluation DS">
+      <dmn:extensionElements />
+      <dmn:variable id="_7D7F3394-69B4-46A6-BFED-4F71AFF6ABB3" name="Evaluation DS" />
+      <dmn:outputDecision href="#_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" />
+      <dmn:outputDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
+      <dmn:inputDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
+      <dmn:inputData href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
+      <dmn:inputData href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
+   </dmn:decisionService>
+   <dmn:decision id="_2770588B-EF63-490A-BA13-B21D4EB1926D" name="Graduation DT">
+      <dmn:extensionElements />
+      <dmn:variable id="_A41CE5F4-5B2F-490B-90A3-9E5F53ED5B01" name="Graduation DT" typeRef="string" />
+      <dmn:informationRequirement id="_65AFCEF3-A401-465C-A931-F9D0F7635B6B">
+         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
+      </dmn:informationRequirement>
+      <dmn:decisionTable id="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+         <dmn:input id="_AF31943B-2A05-4F02-839A-4F1B6C5DC073">
+            <dmn:inputExpression id="_BB692782-9108-449A-9D15-27D06007E04E">
+               <dmn:text>Grade</dmn:text>
+            </dmn:inputExpression>
+         </dmn:input>
+         <dmn:output id="_5F1FEDAD-C742-445A-B194-47B0112573B8" />
+         <dmn:annotation name="" />
+         <dmn:rule id="_967C2799-CC1E-45C5-9F6B-BF3C2F5BCF36">
+            <dmn:inputEntry id="_47B77F78-DE9F-4CF3-A78D-AD274A951078">
+               <dmn:text>"A"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_BF4EB2E1-51E3-4087-A9B4-5FB39F646CCB">
+               <dmn:text>"Graduated with merit"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_CC4BEE1B-2A3D-4EE7-8C97-4382E8213EA0">
+            <dmn:inputEntry id="_1DA3FD5D-E479-4153-881A-4A087C9B7F9F">
+               <dmn:text>"B"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_2B336B1E-F6FC-4742-9C43-77D1A21746FC">
+               <dmn:text>"Graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_95BBC24F-F50C-4D0E-A5B5-D07E328680C9">
+            <dmn:inputEntry id="_459FB1AA-8588-4C7B-AD2E-70A670569BD2">
+               <dmn:text>"C"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_92D429DE-3FD9-4E9F-864B-F9147B040121">
+               <dmn:text>"Graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_161963E2-94C8-4391-A8BF-DEC458BEB62C">
+            <dmn:inputEntry id="_076CA1F7-DC4A-4D33-BAF9-3E3D0A4A3462">
+               <dmn:text>"D"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_E14D7E3E-DA88-409E-8506-10A7EE1AC18D">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_A3513F68-6132-4535-95E0-739ACE67F456">
+            <dmn:inputEntry id="_F0479B26-22F1-4983-81A9-B53F7D8BCF41">
+               <dmn:text>"E"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_04CFBB41-21E0-456F-B9E5-AB8070DA84C8">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+         <dmn:rule id="_D9577634-8F7B-462D-BBAB-210F5FD586DC">
+            <dmn:inputEntry id="_79112C49-AD12-42B1-B056-8210E5AABF9A">
+               <dmn:text>"F"</dmn:text>
+            </dmn:inputEntry>
+            <dmn:outputEntry id="_7C07ED74-5578-4906-B542-D294C426B2B9">
+               <dmn:text>"Not graduated"</dmn:text>
+            </dmn:outputEntry>
+            <dmn:annotationEntry>
+               <dmn:text />
+            </dmn:annotationEntry>
+         </dmn:rule>
+      </dmn:decisionTable>
+   </dmn:decision>
+   <dmn:decision id="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" name="Graduation result">
+      <dmn:extensionElements />
+      <dmn:variable id="_5F80DA91-A764-42C4-A526-3CADCD34E856" name="Graduation result" typeRef="string" />
+      <dmn:informationRequirement id="_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB">
+         <dmn:requiredDecision href="#_2770588B-EF63-490A-BA13-B21D4EB1926D" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_5EE41E2B-BB4C-4936-9966-92C8105DB64F">
+         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_FC235654-A5D3-4C27-AB0C-80A069ADC42E">
+         <dmn:requiredInput href="#_8B025B2F-6110-4A25-9F8B-2E76DB81298C" />
+      </dmn:informationRequirement>
+      <dmn:informationRequirement id="_E2109D65-2489-4FD7-965D-9FA87C9ACB04">
+         <dmn:requiredDecision href="#_0C226138-201A-4073-8ED4-F28FA2A1BC64" />
+      </dmn:informationRequirement>
+      <dmn:literalExpression id="_7C49F288-73F5-41AB-97D8-C569099B2CC7">
+         <dmn:text>Student's name + " is " + Graduation DT + " with grade: " + Grade + " and evaluation: " + Teacher's Evaluation</dmn:text>
+      </dmn:literalExpression>
+   </dmn:decision>
+   <dmn:decision id="_0C226138-201A-4073-8ED4-F28FA2A1BC64" name="Teacher's Evaluation">
+      <dmn:extensionElements />
+      <dmn:variable id="_A2732FC7-2D94-4EFE-9A70-5A5D5F0EDCA3" name="Teacher's Evaluation" />
+      <dmn:informationRequirement id="_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F">
+         <dmn:requiredInput href="#_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" />
+      </dmn:informationRequirement>
+      <dmn:authorityRequirement id="_CBB7711E-2A3E-4905-A90F-313F85BC90F8">
+         <dmn:requiredAuthority href="#_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" />
+      </dmn:authorityRequirement>
+   </dmn:decision>
+   <dmn:knowledgeSource id="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" name="Teacher's knowledge" locationURI="">
+      <dmn:extensionElements />
+      <dmn:type />
+   </dmn:knowledgeSource>
+   <dmn:inputData id="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" name="Student's name">
+      <dmn:extensionElements />
+      <dmn:variable id="_9114ABD1-CD57-4E59-B6C7-FE7CD5AB1EFD" name="Student's name" typeRef="string" />
+   </dmn:inputData>
+   <dmn:inputData id="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" name="Grade">
+      <dmn:extensionElements />
+      <dmn:variable id="_22CC6AB7-BBB7-4F30-AFB3-FA67486F2DBA" name="Grade" typeRef="tGrade" />
+   </dmn:inputData>
+   <dmndi:DMNDI>
+      <dmndi:DMNDiagram id="_EA293523-15DC-41AD-88D9-C9E8A81F53A9" name="DRG">
+         <di:extension>
+            <kie:ComponentsWidthsExtension>
+               <kie:ComponentWidths dmnElementRef="_CD3DB28A-1220-41E4-B1E5-F4DA448FEC02" />
+               <kie:ComponentWidths dmnElementRef="_7C49F288-73F5-41AB-97D8-C569099B2CC7" />
+            </kie:ComponentsWidthsExtension>
+         </di:extension>
+         <dmndi:DMNShape id="dmnshape-drg-_7A9C80F8-4A44-4080-9031-F28EA411A35C" dmnElementRef="_7A9C80F8-4A44-4080-9031-F28EA411A35C" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="137" y="50" width="260" height="200" />
+            <dmndi:DMNLabel />
+            <dmndi:DMNDecisionServiceDividerLine>
+               <di:waypoint x="137" y="150" />
+               <di:waypoint x="397" y="150" />
+            </dmndi:DMNDecisionServiceDividerLine>
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_2770588B-EF63-490A-BA13-B21D4EB1926D" dmnElementRef="_2770588B-EF63-490A-BA13-B21D4EB1926D" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="20" y="120" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" dmnElementRef="_874E905E-290A-4B2F-ADB9-EDB3CA24CA67" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="140" y="40" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_0C226138-201A-4073-8ED4-F28FA2A1BC64" dmnElementRef="_0C226138-201A-4073-8ED4-F28FA2A1BC64" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" dmnElementRef="_2284D6C3-0DAD-4AF0-A758-C40D5A2A0A32" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="50" y="550" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" dmnElementRef="_40D8FD5A-BF1A-41FA-BFBE-41B5BBD81794" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="550" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNShape id="dmnshape-drg-_8B025B2F-6110-4A25-9F8B-2E76DB81298C" dmnElementRef="_8B025B2F-6110-4A25-9F8B-2E76DB81298C" isCollapsed="false">
+            <dmndi:DMNStyle>
+               <dmndi:FillColor red="255" green="255" blue="255" />
+               <dmndi:StrokeColor red="0" green="0" blue="0" />
+               <dmndi:FontColor red="0" green="0" blue="0" />
+            </dmndi:DMNStyle>
+            <dc:Bounds x="225" y="375" width="100" height="50" />
+            <dmndi:DMNLabel />
+         </dmndi:DMNShape>
+         <dmndi:DMNEdge id="dmnedge-drg-_65AFCEF3-A401-465C-A931-F9D0F7635B6B" dmnElementRef="_65AFCEF3-A401-465C-A931-F9D0F7635B6B">
+            <di:waypoint x="275" y="400" />
+            <di:waypoint x="70" y="145" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB" dmnElementRef="_A4CFDC6B-B8E0-4BC2-9359-509E5EEFDCDB">
+            <di:waypoint x="70" y="145" />
+            <di:waypoint x="190" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_5EE41E2B-BB4C-4936-9966-92C8105DB64F" dmnElementRef="_5EE41E2B-BB4C-4936-9966-92C8105DB64F">
+            <di:waypoint x="275" y="575" />
+            <di:waypoint x="190" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_FC235654-A5D3-4C27-AB0C-80A069ADC42E" dmnElementRef="_FC235654-A5D3-4C27-AB0C-80A069ADC42E">
+            <di:waypoint x="275" y="400" />
+            <di:waypoint x="190" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_E2109D65-2489-4FD7-965D-9FA87C9ACB04" dmnElementRef="_E2109D65-2489-4FD7-965D-9FA87C9ACB04">
+            <di:waypoint x="100" y="400" />
+            <di:waypoint x="190" y="65" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F" dmnElementRef="_DD0F9845-AC8A-403F-88BD-3E3A7E0AE43F">
+            <di:waypoint x="275" y="575" />
+            <di:waypoint x="100" y="400" />
+         </dmndi:DMNEdge>
+         <dmndi:DMNEdge id="dmnedge-drg-_CBB7711E-2A3E-4905-A90F-313F85BC90F8" dmnElementRef="_CBB7711E-2A3E-4905-A90F-313F85BC90F8">
+            <di:waypoint x="100" y="575" />
+            <di:waypoint x="100" y="400" />
+         </dmndi:DMNEdge>
+      </dmndi:DMNDiagram>
+   </dmndi:DMNDI>
 </dmn:definitions>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/GraphProcessor.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/GraphProcessor.java
@@ -16,8 +16,13 @@
 
 package org.kie.workbench.common.stunner.core.graph.processing.layout;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.kie.workbench.common.stunner.core.graph.content.view.Point2D;
 
 /**
  * Defines methods to perform helper actions in the graph to process the automatic layout.
@@ -26,6 +31,7 @@ public interface GraphProcessor {
 
     /**
      * Extract the nodes from the graph to be used for automatic layout.
+     *
      * @param graph The graph to perform automatic layout.
      * @return The nodes to be considered to automatic layout.
      */
@@ -34,6 +40,7 @@ public interface GraphProcessor {
     /**
      * Checks if some existing node in the graph is replaced for another one to perform automatic layout.
      * For example, a node inside another node.
+     *
      * @param uuid The uuid of the node.
      * @return True if the node is replaced by another one, false if it is not.
      */
@@ -43,10 +50,80 @@ public interface GraphProcessor {
 
     /**
      * Gets the UUID of the node to be considered instead for some specific node.
+     *
      * @param uuid The UUID of the specific node.
      * @return The new UUID to be considered to perform automatic layout, if `isReplacedByAnotherNode(uuiid)` is false, it returns `uuid`.
      */
     default String getReplaceNodeId(final String uuid) {
         return uuid;
+    }
+
+    /**
+     * Gets the replaced nodes collection, if there is any.
+     * A node is replaced by another node if it is inside another node like a Decision inside a DecisionService.
+     * In that case the node considered for layout is the parent node (DecisionService) and not the inner node (Decision).
+     *
+     * @return The collection of nodes replaced by another node.
+     */
+    default Map<String, String> getReplacedNodes() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Connects an inner node with its parent node. This is used in diagrams like DMN for example when a node should
+     * be positioned inside another node like a Decision node inside a DecisionService.
+     *
+     * @param parentNode The parent node.
+     * @param innerNode  The inner (child) node.
+     */
+    default void connect(final Node parentNode, final Node innerNode) {
+        // Does nothing because the graph (diagram) does not have inner nodes.
+    }
+
+    /**
+     * Gets the position of an inner node inside a parent node.
+     *
+     * @param parentId          The ID of the parent node.
+     * @param innerNodeId       The ID of the inner node.
+     * @param horizontalPadding The horizontal padding for the inner node.
+     * @param graph             The source graph of the nodes.
+     * @return The VertexPosition of the inner node.
+     */
+    default VertexPosition getChildVertexPosition(final String parentId,
+                                                  final String innerNodeId,
+                                                  final double horizontalPadding,
+                                                  final Graph<?, ?> graph) {
+        return new VertexPosition() {
+            @Override
+            public String getId() {
+                return null;
+            }
+
+            @Override
+            public Point2D getUpperLeft() {
+                return null;
+            }
+
+            @Override
+            public Point2D getBottomRight() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Get a node from a graph.
+     * @param uuid The uuid of the node.
+     * @param graph The graph.
+     * @return The node of the graph.
+     */
+    default Optional<Node> getNodeFromGraph(final String uuid,
+                                            final Graph<?, ?> graph) {
+        for (final Node n : graph.nodes()) {
+            if (n.getUUID() == uuid) {
+                return Optional.of(n);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/LayoutService.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/LayoutService.java
@@ -25,10 +25,17 @@ public interface LayoutService {
 
     /**
      * Creates a layout for the graph.
+     *
      * @param graph The graph.
      * @return The layout for the graph.
      */
     Layout createLayout(final Graph<?, ?> graph);
 
     boolean hasLayoutInformation(final Graph<?, ?> graph);
+
+    default SizeHandler getSizeHandler() {
+        return (node, width, height) -> {
+            // Do nothing if there is no specialized SizeHandler
+        };
+    }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/SizeHandler.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/SizeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.kie.workbench.common.stunner.core.graph.processing.layout;
 
-import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.Node;
 
-public interface LayoutExecutor {
+public interface SizeHandler {
 
-    void applyLayout(final Layout layout,
-                     final Graph graph,
-                     final SizeHandler sizeHandler);
+    void setSize(final Node node, final double width, final double height);
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/step04/VertexPositioning.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/step04/VertexPositioning.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04;
 
+import org.kie.workbench.common.stunner.core.graph.Graph;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.GraphProcessor;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.ReorderedGraph;
 
 public interface VertexPositioning {
@@ -23,6 +25,8 @@ public interface VertexPositioning {
     int DEFAULT_VERTEX_WIDTH = 100;
     int DEFAULT_VERTEX_HEIGHT = 50;
 
-    void calculateVerticesPositions(ReorderedGraph graph,
-                                    LayerArrangement arrangement);
+    void calculateVerticesPositions(final ReorderedGraph graph,
+                                    final LayerArrangement arrangement,
+                                    final GraphProcessor graphProcessor,
+                                    final Graph<?,?> stunnerGraph);
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/LayoutHelper.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/LayoutHelper.java
@@ -49,7 +49,7 @@ public class LayoutHelper {
         final Graph<?, Node> graph = diagram.getGraph();
         if (graph != null && (overrideCurrentLayout || !this.layoutService.hasLayoutInformation(graph))) {
             final Layout layout = this.layoutService.createLayout(graph);
-            layoutExecutor.applyLayout(layout, graph);
+            layoutExecutor.applyLayout(layout, graph, layoutService.getSizeHandler());
 
             for (final Node node : graph.nodes()) {
                 if (CanvasLayoutUtils.isCanvasRoot(diagram, node)) {
@@ -65,7 +65,4 @@ public class LayoutHelper {
         return layoutService.hasLayoutInformation(diagram.getGraph());
     }
 
-    public LayoutService getLayoutService() {
-        return this.layoutService;
-    }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/OpenDiagramLayoutExecutor.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/OpenDiagramLayoutExecutor.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.content.HasBounds;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.Layout;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.LayoutExecutor;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.SizeHandler;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPosition;
 
 /**
@@ -36,11 +37,11 @@ public final class OpenDiagramLayoutExecutor implements LayoutExecutor {
 
     @Override
     public void applyLayout(final Layout layout,
-                            final Graph graph) {
+                            final Graph graph,
+                            final SizeHandler sizeHandler) {
         if (layout.getNodePositions().size() == 0) {
             return;
         }
-
         final HashMap<String, Node> indexByUuid = new HashMap<>();
         for (final Object n : graph.nodes()) {
 
@@ -53,14 +54,29 @@ public final class OpenDiagramLayoutExecutor implements LayoutExecutor {
         for (final VertexPosition position : layout.getNodePositions()) {
 
             final Node indexed = indexByUuid.get(position.getId());
+
             if (indexed.getContent() instanceof HasBounds) {
-                ((HasBounds) indexed.getContent()).setBounds(Bounds.create(
-                        position.getUpperLeft().getX(),
-                        position.getUpperLeft().getY(),
-                        position.getBottomRight().getX(),
-                        position.getBottomRight().getY()
-                ));
+                setPosition(position, indexed);
+                setSize(sizeHandler, position, indexed);
             }
         }
+    }
+
+    void setSize(final SizeHandler sizeHandler,
+                 final VertexPosition position,
+                 final Node indexed) {
+        final double width = position.getBottomRight().getX() - position.getUpperLeft().getX();
+        final double height = position.getBottomRight().getY() - position.getUpperLeft().getY();
+
+        sizeHandler.setSize(indexed, width, height);
+    }
+
+    void setPosition(final VertexPosition position, final Node indexed) {
+        ((HasBounds) indexed.getContent()).setBounds(Bounds.create(
+                position.getUpperLeft().getX(),
+                position.getUpperLeft().getY(),
+                position.getBottomRight().getX(),
+                position.getBottomRight().getY()
+        ));
     }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/UndoableLayoutExecutor.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/components/layout/UndoableLayoutExecutor.java
@@ -25,6 +25,7 @@ import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.Layout;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.LayoutExecutor;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.SizeHandler;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPosition;
 
 /**
@@ -43,7 +44,7 @@ public class UndoableLayoutExecutor implements LayoutExecutor {
 
     @SuppressWarnings("Duplicates")
     @Override
-    public void applyLayout(final Layout layout, final Graph graph) {
+    public void applyLayout(final Layout layout, final Graph graph, final SizeHandler sizeHandler) {
         if (layout.getNodePositions().size() == 0) {
             return;
         }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/layout/LayoutHelperTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/layout/LayoutHelperTest.java
@@ -131,7 +131,7 @@ public class LayoutHelperTest {
         final LayoutHelper helper = new LayoutHelper(layoutService);
         helper.applyLayout(diagram, layoutExecutor, false);
 
-        verify(layoutExecutor, never()).applyLayout(any(), any());
+        verify(layoutExecutor, never()).applyLayout(any(), any(), any());
     }
 
     @Test
@@ -140,7 +140,7 @@ public class LayoutHelperTest {
         final LayoutHelper helper = new LayoutHelper(layoutService);
         helper.applyLayout(diagram, layoutExecutor, true);
 
-        verify(layoutExecutor).applyLayout(any(), any());
+        verify(layoutExecutor).applyLayout(any(), any(), any());
     }
 
     private static void isCloseToZero(final Bound bound) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/layout/UndoableLayoutExecutorTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/components/layout/UndoableLayoutExecutorTest.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasCommandManager
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.Layout;
+import org.kie.workbench.common.stunner.core.graph.processing.layout.SizeHandler;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.VertexPosition;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -64,6 +65,9 @@ public class UndoableLayoutExecutorTest {
     @Mock
     private Node node;
 
+    @Mock
+    private SizeHandler sizeHandler;
+
     private UndoableLayoutExecutor executor;
 
     @Before
@@ -84,7 +88,7 @@ public class UndoableLayoutExecutorTest {
 
     @Test
     public void testApplyLayout() {
-        executor.applyLayout(layout, graph);
+        executor.applyLayout(layout, graph, sizeHandler);
 
         verify(executor).createCommand(layout, graph);
         verify(commandManager).execute(any(), any());

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/LayeredGraph.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/LayeredGraph.java
@@ -102,8 +102,7 @@ public class LayeredGraph implements ReorderedGraph {
 
     @Override
     public int getVertexWidth(final String vertexId) {
-        final int width = verticesWidth.getOrDefault(vertexId, DEFAULT_VERTEX_WIDTH);
-        return width;
+        return verticesWidth.getOrDefault(vertexId, DEFAULT_VERTEX_WIDTH);
     }
 
     @Override

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutService.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutService.java
@@ -255,30 +255,14 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
 
                 if (parentPosition.isPresent()) {
 
-                    // tem q ver se é output ou input
-                    // Isso teria que processar fora daqui
-                    // No GraphProcessor é o ideal. Lá já tem
                     final Optional<Node> parentNode = graphProcessor.getNodeFromGraph(parentId, graph);
                     parentNode.ifPresent(parent -> graphProcessor.connect(parent, childNode.get()));
-                    // graphProcessor.get
                     final double padding = parentNodesWidth.getOrDefault(parentId, 0.0)
                             + DEFAULT_INNER_HORIZONTAL_PADDING;
                     final VertexPosition position = graphProcessor.getChildVertexPosition(parentId,
                                                                                           childId,
                                                                                           padding,
                                                                                           graph);
-
-//                    final Point2D parentBottomRight = parentPosition.get().getBottomRight();
-//
-//                    final Point2D ulChild = new Point2D(x,
-//                                                        DEFAULT_PARENT_NODE_HEIGHT / 2 + DEFAULT_INNER_VERTICAL_PADDING);
-//                    final Point2D brChild = new Point2D(ulChild.getX() + DEFAULT_VERTEX_WIDTH,
-//                                                        ulChild.getY() + DEFAULT_VERTEX_HEIGHT);
-//
-//                    final VertexPosition position = new VertexPositionImpl(childId,
-//                                                                           ulChild,
-//                                                                           brChild);
-
                     layout.getNodePositions().add(position);
 
                     parentNodesWidth.put(parentId, position.getUpperLeft().getX() + DEFAULT_VERTEX_WIDTH);

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutService.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutService.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
@@ -41,6 +43,8 @@ import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.st
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.LayerArrangement;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning;
 
+import static org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.VertexPositioning.DEFAULT_VERTEX_WIDTH;
+
 /**
  * Implementation of the Sugiyama automatic layout method.
  * This method is developed by Kozo Sugiyama, and draws the graph in a layered way.
@@ -56,6 +60,10 @@ import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.st
 @Default
 public class SugiyamaLayoutService extends AbstractLayoutService {
 
+    public static final int DEFAULT_INNER_HORIZONTAL_PADDING = 20;
+    public static final int DEFAULT_INNER_VERTICAL_PADDING = 20;
+    public static final int DEFAULT_PARENT_NODE_HEIGHT = 200;
+
     private final CycleBreaker cycleBreaker;
     private final VertexLayerer vertexLayerer;
     private final VertexOrdering vertexOrdering;
@@ -65,11 +73,12 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
 
     /**
      * Default constructor.
-     * @param cycleBreaker The strategy used to break cycles in cycle graphs.
-     * @param vertexLayerer The strategy used to choose the layer for each vertex.
-     * @param vertexOrdering The strategy used to order vertices inside each layer.
+     *
+     * @param cycleBreaker      The strategy used to break cycles in cycle graphs.
+     * @param vertexLayerer     The strategy used to choose the layer for each vertex.
+     * @param vertexOrdering    The strategy used to order vertices inside each layer.
      * @param vertexPositioning The strategy used to position vertices on screen (x,y coordinates).
-     * @param graphProcessor Applies some pre-process in the graph to extract the nodes to be used.
+     * @param graphProcessor    Applies some pre-process in the graph to extract the nodes to be used.
      */
     @Inject
     public SugiyamaLayoutService(final CycleBreaker cycleBreaker,
@@ -87,6 +96,7 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
     /**
      * Performs the automatic layout in graph using Sugiyama method,
      * putting vertices in layers in order to reduce edges crossing.
+     *
      * @param graph The graph.
      * @return The Layout for the vertices.
      * @see Layout
@@ -102,10 +112,12 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
         this.vertexLayerer.createLayers(layeredGraph);
         this.vertexOrdering.orderVertices(layeredGraph);
         this.vertexPositioning.calculateVerticesPositions(layeredGraph,
-                                                          DEFAULT_LAYER_ARRANGEMENT);
+                                                          DEFAULT_LAYER_ARRANGEMENT,
+                                                          graphProcessor,
+                                                          graph);
 
         final List<GraphLayer> orderedLayers = layeredGraph.getLayers();
-        return buildLayout(indexByUuid, orderedLayers);
+        return buildLayout(indexByUuid, orderedLayers, graph);
     }
 
     HashMap<String, Node> createIndex(final Iterable<? extends Node> nodes) {
@@ -178,7 +190,8 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
     }
 
     Layout buildLayout(final HashMap<String, Node> indexByUuid,
-                       final List<GraphLayer> layers) {
+                       final List<GraphLayer> layers,
+                       final Graph<?, ?> graph) {
 
         final Layout layout = new Layout();
 
@@ -194,7 +207,7 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
                 final Bound lowerRight = currentBounds.getLowerRight();
                 final int x2;
                 if (isCloseToZero(lowerRight.getX())) {
-                    x2 = x + VertexPositioning.DEFAULT_VERTEX_WIDTH;
+                    x2 = x + DEFAULT_VERTEX_WIDTH;
                 } else {
                     x2 = (int) (x + lowerRight.getX());
                 }
@@ -214,6 +227,95 @@ public class SugiyamaLayoutService extends AbstractLayoutService {
             }
         }
 
+        positionReplacedNodes(graph, layout);
+
         return layout;
+    }
+
+    private void positionReplacedNodes(final Graph<?, ?> graph,
+                                       final Layout layout) {
+
+        final Map<String, String> replacedNodes = graphProcessor.getReplacedNodes();
+        final Map<String, Double> parentNodesWidth = new HashMap<>();
+
+        for (final Map.Entry<String, String> entry : replacedNodes.entrySet()) {
+            final String childId = entry.getKey();
+            final String parentId = entry.getValue();
+            final Optional<Node> childNode = graphProcessor.getNodeFromGraph(childId, graph);
+
+            // We only set position for inner nodes that doesn't have a position yet
+            // because if the inner node has position, it moves with its parent.
+            if (childNode.isPresent()
+                    && !hasPositionSet(childNode.get())) {
+
+                final Optional<VertexPosition> parentPosition = layout.getNodePositions()
+                        .stream()
+                        .filter(p -> p.getId() == parentId)
+                        .findFirst();
+
+                if (parentPosition.isPresent()) {
+
+                    // tem q ver se é output ou input
+                    // Isso teria que processar fora daqui
+                    // No GraphProcessor é o ideal. Lá já tem
+                    final Optional<Node> parentNode = graphProcessor.getNodeFromGraph(parentId, graph);
+                    parentNode.ifPresent(parent -> graphProcessor.connect(parent, childNode.get()));
+                    // graphProcessor.get
+                    final double padding = parentNodesWidth.getOrDefault(parentId, 0.0)
+                            + DEFAULT_INNER_HORIZONTAL_PADDING;
+                    final VertexPosition position = graphProcessor.getChildVertexPosition(parentId,
+                                                                                          childId,
+                                                                                          padding,
+                                                                                          graph);
+
+//                    final Point2D parentBottomRight = parentPosition.get().getBottomRight();
+//
+//                    final Point2D ulChild = new Point2D(x,
+//                                                        DEFAULT_PARENT_NODE_HEIGHT / 2 + DEFAULT_INNER_VERTICAL_PADDING);
+//                    final Point2D brChild = new Point2D(ulChild.getX() + DEFAULT_VERTEX_WIDTH,
+//                                                        ulChild.getY() + DEFAULT_VERTEX_HEIGHT);
+//
+//                    final VertexPosition position = new VertexPositionImpl(childId,
+//                                                                           ulChild,
+//                                                                           brChild);
+
+                    layout.getNodePositions().add(position);
+
+                    parentNodesWidth.put(parentId, position.getUpperLeft().getX() + DEFAULT_VERTEX_WIDTH);
+                }
+            }
+        }
+
+        parentNodesWidth.forEach((parentId, width) -> {
+            final Optional<VertexPosition> parentPosition = layout.getNodePositions()
+                    .stream()
+                    .filter(p -> p.getId() == parentId)
+                    .findFirst();
+
+            parentPosition.ifPresent(position -> {
+                final Point2D upperLeft = position.getUpperLeft();
+                position.getBottomRight().setX(upperLeft.getX() + width + DEFAULT_INNER_HORIZONTAL_PADDING);
+                position.getBottomRight().setY(upperLeft.getY() + DEFAULT_PARENT_NODE_HEIGHT);
+            });
+        });
+    }
+
+    boolean hasPositionSet(final Node node) {
+        if (node.getContent() instanceof HasBounds) {
+            final Bounds bounds = ((HasBounds) node.getContent()).getBounds();
+            if (bounds.hasUpperLeft()
+                    && (isXSet(bounds.getUpperLeft()) || isYSet(bounds.getUpperLeft()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean isXSet(final Bound bound) {
+        return bound.hasX() && !isCloseToZero(bound.getX());
+    }
+
+    boolean isYSet(final Bound bound) {
+        return bound.hasY() && !isCloseToZero(bound.getY());
     }
 }

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/layout/IntegrationTests.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/layout/IntegrationTests.java
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.LayeredGraph;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step01.ReverseEdgesCycleBreaker;
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step02.LongestPathVertexLayerer;
@@ -30,11 +31,15 @@ import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.st
 import org.kie.workbench.common.stunner.core.graph.processing.layout.sugiyama.step04.LayerArrangement;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.mock;
+
 @RunWith(MockitoJUnitRunner.class)
 public class IntegrationTests {
 
     @Test
     public void testRealCase1() {
+        final GraphProcessor graphProcessor = mock(GraphProcessor.class);
+        final Graph<?, ?> stunnerGraph = mock(Graph.class);
         final LayeredGraph graph = new LayeredGraph(Graphs.REAL_CASE_1);
 
         final ReverseEdgesCycleBreaker s01 = new ReverseEdgesCycleBreaker();
@@ -55,7 +60,9 @@ public class IntegrationTests {
 
         final DefaultVertexPositioning defaultVertexPositioning = new DefaultVertexPositioning();
         defaultVertexPositioning.calculateVerticesPositions(graph,
-                                                            LayerArrangement.TopDown);
+                                                            LayerArrangement.TopDown,
+                                                            graphProcessor,
+                                                            stunnerGraph);
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutServiceTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/processing/layout/sugiyama/SugiyamaLayoutServiceTest.java
@@ -105,8 +105,10 @@ public class SugiyamaLayoutServiceTest {
         inOrder.verify(vertexLayerer).createLayers(layeredGraph);
         inOrder.verify(vertexOrdering).orderVertices(layeredGraph);
         inOrder.verify(vertexPositioning).calculateVerticesPositions(layeredGraph,
-                                                                     DEFAULT_LAYER_ARRANGEMENT);
-        verify(layoutService).buildLayout(indexByUuid, layers);
+                                                                     DEFAULT_LAYER_ARRANGEMENT,
+                                                                     graphProcessor,
+                                                                     graph);
+        verify(layoutService).buildLayout(indexByUuid, layers, graph);
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/44

**What this PR does?**
When user opens a DMN diagram that does not have layout information (the DMNDI node), the automatic layout is performed using a heuristic to calculate a good position for the nodes.

Nodes inside DecisionServices should move with its parent and are ignored by the algorithm that considers only the position of the DecisionService. 

Now after the auto layout is performed the nodes inside the DecisionService are repositioned to be visible inside the DecisionService (to follow the position of the DecisionService).

**Test**
To test this PR, open a DMN diagram that does not have layout information (the DMNDI node) and have a DecisionService.

1. If the Decision inside DecisionService are encapsulatedDecision, it should be the bottom part (bellow the divider) of the DecisionService
2. If it is outputDecision, it should be in the top part (above the divider)

