### PR TITLE
KOGITO-8731: Make filter enabled by default when a "filter" is added to the YAML

### DIFF
--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerSettings.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerSettings.java
@@ -379,7 +379,7 @@ public class DisplayerSettings {
     }
 
     public boolean isFilterEnabled() {
-        return parseBoolean(settings.get(getSettingPath(DisplayerAttributeDef.FILTER_ENABLED)));
+        return parseBoolean(settings.get(getSettingPath(DisplayerAttributeDef.FILTER_ENABLED))) || isFilterListeningEnabled() || isFilterNotificationEnabled();
     }
 
     public void setFilterEnabled(boolean filterEnabled) {


### PR DESCRIPTION
The filter attribute once added in YAML then it's not necessary to add the parameter enabled: 'true' ;  the dashbuilder will enale it itself.

![Screenshot from 2023-03-01 11-08-02](https://user-images.githubusercontent.com/82813768/222054362-38e3a96e-8026-4fb8-8a39-26b9292c22b3.png)
