### PR TITLE
KOGITO-8765 Include index.css in the final bundle

### DIFF
--- a/packages/dashbuilder-component-victory-charts/webpack.config.js
+++ b/packages/dashbuilder-component-victory-charts/webpack.config.js
@@ -19,6 +19,7 @@ const patternflyBase = require("@kie-tools-core/patternfly-base");
 const { merge } = require("webpack-merge");
 const common = require("@kie-tools-core/webpack-base/webpack.common.config");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = async (env) => {
   return merge(common(env), {
@@ -29,6 +30,9 @@ module.exports = async (env) => {
       new HtmlWebpackPlugin({
         template: "./static/index.html",
         minify: false,
+      }),
+      new CopyPlugin({
+        patterns: [{ from: path.resolve(__dirname, "./static/index.css"), to: "." }],
       }),
     ],
 


### PR DESCRIPTION
Index.css was not included in the final bundle so while using the victory-charts component in dashbuilder even in dark mode the chart was rendered in light mode. This issue has been resolved now.


![Screenshot from 2023-03-02 16-16-14](https://user-images.githubusercontent.com/82813768/222636143-beae5bae-2038-4b3c-ab59-2ec13665358f.png)

