### PR TITLE
KOGITO-8793: BoudingBox values of states with tooltip boxes are wrong

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/BottomDepiction.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/BottomDepiction.java
@@ -31,7 +31,7 @@ public class BottomDepiction extends Group {
     private final HandlerRegistration mouseClickHandler;
 
     public BottomDepiction(String icon) {
-        setLocation(new Point2D(STATE_SHAPE_WIDTH / 2 - 8, STATE_SHAPE_HEIGHT - 18));
+        setLocation(new Point2D(STATE_SHAPE_WIDTH / 2 - 8, STATE_SHAPE_HEIGHT - 20));
         Rectangle border = new Rectangle(20, 20)
                 .setFillColor("white")
                 .setFillAlpha(0.001)

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/CornerIcon.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/CornerIcon.java
@@ -28,6 +28,7 @@ public class CornerIcon extends Group {
     private final HandlerRegistration mouseEnterHandler;
     private final HandlerRegistration mouseExitHandler;
     private final HandlerRegistration mouseClickHandler;
+    PrimitiveTextTooltip tooltipElement;
     private final String tooltipText;
 
     private final Rectangle border = new Rectangle(20, 20)
@@ -45,14 +46,6 @@ public class CornerIcon extends Group {
         add(border);
         this.tooltipText = tooltip;
 
-        PrimitiveTextTooltip tooltipElement = PrimitiveTextTooltip.Builder.build(tooltipText);
-        tooltipElement.withText(t -> {
-            t.setText(tooltipText);
-            t.setFontSize(12);
-        });
-        add(tooltipElement.asPrimitive());
-        tooltipElement.forComputedBoundingBox(border::getBoundingBox);
-
         MultiPath clockIcon = new MultiPath(icon)
                 .setScale(2)
                 .setStrokeWidth(0)
@@ -63,11 +56,14 @@ public class CornerIcon extends Group {
         mouseEnterHandler = border.addNodeMouseEnterHandler(event -> {
             this.getParent().moveToTop();
             this.moveToTop();
-            tooltipElement.show();
+            createToolTip();
             clockIcon.setFillColor("#4F5255");
         });
         mouseExitHandler = border.addNodeMouseExitHandler(event -> {
             tooltipElement.hide();
+            remove(tooltipElement.asPrimitive());
+            tooltipElement.destroy();
+            tooltipElement = null;
             clockIcon.setFillColor("#CCC");
             border.getLayer().batch();
         });
@@ -76,9 +72,24 @@ public class CornerIcon extends Group {
         );
     }
 
+    private void createToolTip() {
+        tooltipElement = PrimitiveTextTooltip.Builder.build(tooltipText);
+        tooltipElement.withText(t -> {
+            t.setText(tooltipText);
+            t.setFontSize(12);
+        });
+        add(tooltipElement.asPrimitive());
+        tooltipElement.forComputedBoundingBox(border::getBoundingBox);
+        tooltipElement.show();
+    }
+
     @Override
     public void destroy() {
         super.destroy();
+        if (tooltipElement != null) {
+            tooltipElement.destroy();
+            tooltipElement = null;
+        }
         mouseEnterHandler.removeHandler();
         mouseExitHandler.removeHandler();
         mouseClickHandler.removeHandler();

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/selenium/SWEditorSeleniumIT.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/selenium/SWEditorSeleniumIT.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.stunner.sw.client.selenium;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Rule;
@@ -435,6 +436,22 @@ public class SWEditorSeleniumIT extends SWEditorSeleniumBase {
         assertThat(points.get(11)).isEqualTo(988.3333333333334D); // Y
         assertThat(points.get(12)).isEqualTo(1083.834862385321D); // X
         assertThat(points.get(13)).isEqualTo(1085L); // Y
+    }
+
+    @Test
+    public void testStateDimension() throws Exception {
+        String resource = "LoanBroker.sw.json";
+        final String expected = loadResource(resource);
+        setContent(expected);
+        waitCanvasPanel();
+
+        List<String> nodeIds = jsHelper.getNodeIds();
+
+        List<Long> dimension = new ArrayList<>();
+        dimension.add(new Long(250));
+        dimension.add(new Long(90));
+
+        assertThat(jsHelper.getDimension(nodeIds.get(1))).isEqualTo(dimension);
     }
 
     private void testExample(String exampleName) throws Exception {

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-diagram-navigation.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-diagram-navigation.test.ts
@@ -43,8 +43,7 @@ describe("Serverless workflow editor - Diagram navigation tests", () => {
     await testHelper.closeAllNotifications();
   });
 
-  // The following test is skipped because there is a bug in Canvas API: https://issues.redhat.com/browse/KOGITO-8793
-  it.skip("Select states", async function () {
+  it("Select states", async function () {
     this.timeout(30000);
 
     const WORKFLOW_NAME = "applicant-request-decision.sw.json";


### PR DESCRIPTION
Hello @LuboTerifaj, @handreyrc,

there is a fix, now tooltip is created on mouse hover and removed on mouse out, so BoundingBox not expanding by the tooltip until it is not created.

Thank you!