### PR TITLE
kie-issues#139: BPMN Editor breaking if `bpmn2` file lacks `id`

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/BaseRootProcessConverter.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/processes/BaseRootProcessConverter.java
@@ -66,7 +66,7 @@ public abstract class BaseRootProcessConverter<D extends BPMNDiagram<S, P, F, C>
     public Result<BpmnNode> convertProcess() {
 
         Process process = delegate.definitionResolver.getProcess();
-        String definitionsId = delegate.definitionResolver.getDefinitions().getId();
+        String definitionsId = delegate.definitionResolver.getDefinitionsId();
         BpmnNode processRoot = convertProcessNode(definitionsId, process);
 
         Result<Map<String, BpmnNode>> nodesResult = delegate.convertChildNodes(processRoot,

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientMarshalling.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/service/BPMNClientMarshalling.java
@@ -122,7 +122,7 @@ public class BPMNClientMarshalling {
                                                                              definitionsHandler.isJbpm(),
                                                                              mode);
 
-        metadata.setCanvasRootUUID(definitionResolver.getDefinitions().getId());
+        metadata.setCanvasRootUUID(definitionResolver.getDefinitionsId());
         metadata.setTitle(definitionResolver.getProcess().getName());
 
         final BaseConverterFactory converterFactory = new org.kie.workbench.common.stunner.bpmn.client.marshall.converters.tostunner.ConverterFactory(definitionResolver, typedFactoryManager);
@@ -131,13 +131,13 @@ public class BPMNClientMarshalling {
         final BpmnNode diagramRoot = result.value();
         dataTypeCache.initCache(diagramRoot);
 
-        // the root node contains all of the information
+        // the root node contains all the information
         // needed to build the entire graph (including parent/child relationships)
         // thus, we can now walk the graph to issue all the commands
         // to draw it on our canvas
         final Diagram<Graph<DefinitionSet, Node>, Metadata> diagram =
                 typedFactoryManager.newDiagram(
-                        definitionResolver.getDefinitions().getId(),
+                        definitionResolver.getDefinitionsId(),
                         getDefinitionSetClass(),
                         metadata);
         final Graph<DefinitionSet, Node> graph = diagram.getGraph();

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/DefinitionResolverTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/DefinitionResolverTest.java
@@ -44,6 +44,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -149,5 +150,18 @@ public class DefinitionResolverTest {
         setUp();
 
         assertEquals(parameter, definitionResolver.resolveSimulationParameters(elementRef).get());
+    }
+
+    @Test
+    public void testGetDefinitionsId() {
+        assertNotNull(definitionResolver.getDefinitionsId());
+
+        String definitionId = "12345";
+
+        when(definitions.getId()).thenReturn(definitionId);
+
+        definitionResolver = new DefinitionResolver(definitions, Collections.emptyList());
+
+        assertEquals(definitionId, definitionResolver.getDefinitionsId());
     }
 }


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/139

