### PR TITLE
kie-issues#85: fix SearchInput focus and FileListItem display regressions

### DIFF
--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -61,7 +61,9 @@ export function FileListItem(props: {
 }) {
   const [keepGitStatusActionsDisplayed, setKeepGitStatusActionsDisplayed] = React.useState(false);
   const fileDirPath = props.file.relativeDirPath.split("/").join(" > ");
-
+  const fileName = [FileListItemDisplayMode.enabled, FileListItemDisplayMode.deleted].includes(props.displayMode)
+    ? props.file.nameWithoutExtension
+    : props.file.name;
   return (
     <>
       <Flex
@@ -83,13 +85,10 @@ export function FileListItem(props: {
           <Tooltip
             distance={5}
             position={"top-start"}
-            content={
-              props.file.nameWithoutExtension +
-              (props.displayMode === FileListItemDisplayMode.deleted ? " (Deleted)" : "")
-            }
+            content={fileName + (props.displayMode === FileListItemDisplayMode.deleted ? " (Deleted)" : "")}
           >
             <TextContent>
-              <Text component={TextVariants.p}>{props.file.nameWithoutExtension}</Text>
+              <Text component={TextVariants.p}>{fileName}</Text>
             </TextContent>
           </Tooltip>
         </FlexItem>


### PR DESCRIPTION
Problem was duplicate usage of a single ref object in two places (I though that the fact that containing component was a Memo value would be enough). 

Switching to callback and conditional assignment of the ref object into a specific occurrence of the SearchInput does resolve. Together with that I renamed `isScrollUsingRefEnabled` state property to `isModelsMenuActive` and reusing for 2 purposes now:
* scroll enabled only when isModelsMenuActive===true
* search ref object is assigned conditionally based on isModelsMenuActive value. (true -> search in models, false -> search in other files).