### PR TITLE
KOGITO-8197: SWF Editor - States example export is broken

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/main/java/org/kie/workbench/common/stunner/sw/marshall/TransitionMarshalling.java
@@ -105,12 +105,7 @@ public interface TransitionMarshalling {
                     Node targetNode = edge.getTargetNode();
                     if (null != targetNode) {
                         State sourceState = getElementDefinition(sourceNode);
-
-                        if (sourceState.getTransition() instanceof String) {
-                            sourceState.setTransition(getStateNodeName(targetNode));
-                        } else {
-                            ((StateTransition) sourceState.getTransition()).setNextState(getStateNodeName(targetNode));
-                        }
+                        sourceState.setCompensatedBy(getStateNodeName(targetNode));
                     }
                 }
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/webapp/test.html
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/webapp/test.html
@@ -40,7 +40,7 @@
           .then(function (process) {
             var d = document.createElement("a");
             d.setAttribute("href", "data:text/xml;charset=utf-8," + encodeURIComponent(process));
-            d.setAttribute("download", "process.sw");
+            d.setAttribute("download", "process.sw.json");
             d.style.display = "none";
 
             document.body.appendChild(d);


### PR DESCRIPTION
Hello @romartin, @LuboTerifaj,

there is the fix for the issue. Issue was in Compensation Transition Unmarshaller.

After my changes I took the source file and the generated one and executed `diff` command on it. As result now there are some parameters in different order, but otherwise they are now identical.

Thank you!