### PR TITLE
NO-ISSUE: Reverting logs introduced by #1538

### DIFF
--- a/packages/stunner-editors/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
+++ b/packages/stunner-editors/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/BindableProxyLoaderGenerator.java
@@ -74,16 +74,9 @@ public class BindableProxyLoaderGenerator extends AbstractAsyncGenerator {
     final MethodBlockBuilder<?> loadProxies = classBuilder.publicMethod(void.class, "loadBindableProxies");
 
     final Set<MetaClass> allBindableTypes = DataBindingUtil.getAllBindableTypes(context);
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("ERRAI ISSUE - ALL BINDABLE TYPES BEFORE 'addCacheRelevantClasses'" + allBindableTypes);
     addCacheRelevantClasses(allBindableTypes);
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("ERRAI ISSUE - ALL BINDABLE TYPES AFTER 'addCacheRelevantClasses'" + allBindableTypes);
 
     for (final MetaClass bindable : allBindableTypes) {
-      // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-      log.warn("ERRAI ISSUE - PROCESSED CLASS in FOR " + bindable.getFullyQualifiedName());
-
       if (bindable.isFinal()) {
         throw new RuntimeException("@Bindable type cannot be final: " + bindable.getFullyQualifiedName());
       }

--- a/packages/stunner-editors/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/DataBindingUtil.java
+++ b/packages/stunner-editors/errai-data-binding/src/main/java/org/jboss/errai/databinding/rebind/DataBindingUtil.java
@@ -378,45 +378,12 @@ public class DataBindingUtil {
    *         annotated and configured in ErraiApp.properties).
    */
   public static Set<MetaClass> getAllBindableTypes(final GeneratorContext context) {
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    Set<String> translatablePackages = RebindUtils.findTranslatablePackages(context);
-    log.warn("**********");
-    log.warn("translatablePackages");
-    translatablePackages.forEach(log::warn);
-
     final Collection<MetaClass> annotatedBindableTypes = ClassScanner.getTypesAnnotatedWith(Bindable.class,
-            translatablePackages,
-            context);
-
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("**********");
-    log.warn("annotatedBindableTypes");
-    annotatedBindableTypes.forEach(metaClass -> log.warn(metaClass.getFullyQualifiedName()));
+        RebindUtils.findTranslatablePackages(context), context);
 
     final Set<MetaClass> bindableTypes = new HashSet<>(annotatedBindableTypes);
-    Set<MetaClass> configuredBindableTypes1 = DataBindingUtil.getConfiguredBindableTypes();
-
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("**********");
-    log.warn("configuredBindableTypes1");
-    configuredBindableTypes1.forEach(metaClass -> log.warn(metaClass.getFullyQualifiedName()));
-
-    bindableTypes.addAll(configuredBindableTypes1);
-
-    Set<MetaClass> configuredNonBindableTypes1 = DataBindingUtil.getConfiguredNonBindableTypes();
-
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("**********");
-    log.warn("configuredNonBindableTypes1");
-    configuredNonBindableTypes1.forEach(metaClass -> log.warn(metaClass.getFullyQualifiedName()));
-
-    bindableTypes.removeAll(configuredNonBindableTypes1);
-
-    // TEMPORARY LOG FOR TRACING ERRAI CACHE ISSUE
-    log.warn("**********");
-    log.warn("bindableTypes");
-    bindableTypes.forEach(metaClass -> log.warn(metaClass.getFullyQualifiedName()));
-
+    bindableTypes.addAll(DataBindingUtil.getConfiguredBindableTypes());
+    bindableTypes.removeAll(DataBindingUtil.getConfiguredNonBindableTypes());
     return bindableTypes;
   }
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -625,7 +625,7 @@
           <runTarget>test.html</runTarget>
           <hostedWebapp>src/main/webapp</hostedWebapp>
           <gwtSdkFirstInClasspath>false</gwtSdkFirstInClasspath>
-          <logLevel>TRACE</logLevel>
+          <logLevel>WARN</logLevel>
           <generateJsInteropExports>true</generateJsInteropExports>
 
           <compileSourcesArtifacts>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -556,7 +556,7 @@
           <module>org.kie.workbench.common.stunner.kogito.KogitoBPMNEditor</module>
           <localWorkers>8</localWorkers>
           <noServer>false</noServer>
-          <logLevel>TRACE</logLevel>
+          <logLevel>WARN</logLevel>
           <disableCastChecking>true</disableCastChecking>
           <optimizationLevel>9</optimizationLevel>
           <draftCompile>false</draftCompile>


### PR DESCRIPTION
Partially reverting https://github.com/kiegroup/kie-tools/pull/1538, more precisely removing the logs we introduced to better analyze the errai-cache, in case it occurs again.

I suggest merging it in 7- 10 days OR before the next planned release.