### PR TITLE
KOGITO-8953: Skip basic operation tests for VS Code SWF extension

### DIFF
--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-basic-operations.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-basic-operations.test.ts
@@ -21,7 +21,7 @@ import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 import VSCodeTestHelper from "./helpers/VSCodeTestHelper";
 
-describe("Serverless workflow editor - Basic operations tests", () => {
+describe.skip("Serverless workflow editor - Basic operations tests", () => {
   const TEST_PROJECT_FOLDER: string = path.resolve("it-tests-tmp", "resources", "basic-operations");
 
   let testHelper: VSCodeTestHelper;

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-basic-operations.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-basic-operations.test.ts
@@ -21,6 +21,7 @@ import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 import VSCodeTestHelper from "./helpers/VSCodeTestHelper";
 
+// The following test is failing in github CI. See https://issues.redhat.com/browse/KOGITO-8952.
 describe.skip("Serverless workflow editor - Basic operations tests", () => {
   const TEST_PROJECT_FOLDER: string = path.resolve("it-tests-tmp", "resources", "basic-operations");
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-8953

**Description**
We had a failure to the test: Serverless workflow editor - Basic operations tests.
Please skip these tests to unblock the CI

Jira issue to unskip the tests: https://issues.redhat.com/browse/KOGITO-8952
