### PR TITLE
[0.26.1] Bump tycho version to `2.7.5`

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.5.0</tycho.version>
+    <tycho.version>2.7.5</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>


### PR DESCRIPTION
Fixes this error:
```
[ERROR] Internal error: java.lang.IllegalArgumentException: bundleLocation not found: /Users/kgaevski/.m2/repository/org/eclipse/orbit/bundles/com.google.gson
│ org.apache.maven.InternalErrorException: Internal error: java.lang.IllegalArgumentException: bundleLocation not found: /Users/kgaevski/.m2/repository/org/ecli
│     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
│     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
│     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
│     at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
│     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
│     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
│     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
│     at java.lang.reflect.Method.invoke (Method.java:566)
│     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
│     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
│     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
│     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
│ Caused by: java.lang.IllegalArgumentException: bundleLocation not found: /Users/kgaevski/.m2/repository/org/eclipse/orbit/bundles/com.google.gson/2.8.8-SNAPSH
│     at org.eclipse.tycho.core.osgitools.EquinoxResolver.loadManifest (EquinoxResolver.java:497)
```

We do not see this error on `main` because it was fixed on https://github.com/kiegroup/kie-tools/pull/1421.