### PR TITLE
[0.26.1] KOGITO-8946: Missing structureref type for service task in VSCode BPMN editor 

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/basic-process.bpmn2
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/src/test/resources/org/kie/workbench/common/stunner/kogito/client/selenium/basic-process.bpmn2
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions id="__bLkUEGGEDmYo5bKfV8ACA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi">
+  <bpmn2:itemDefinition id="_E486B83F-1225-436D-94D5-C6817A74884C_InMessageType"/>
+  <bpmn2:itemDefinition id="_E486B83F-1225-436D-94D5-C6817A74884C_OutMessageType"/>
+  <bpmn2:message id="_E486B83F-1225-436D-94D5-C6817A74884C_InMessage" itemRef="_E486B83F-1225-436D-94D5-C6817A74884C_InMessageType"/>
+  <bpmn2:message id="_E486B83F-1225-436D-94D5-C6817A74884C_OutMessage" itemRef="_E486B83F-1225-436D-94D5-C6817A74884C_OutMessageType"/>
   <bpmn2:interface id="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceInterface" name="" implementationRef="">
-    <bpmn2:operation id="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceOperation" name="" implementationRef=""/>
+    <bpmn2:operation id="_E486B83F-1225-436D-94D5-C6817A74884C_ServiceOperation" name="" implementationRef="">
+      <bpmn2:inMessageRef>_E486B83F-1225-436D-94D5-C6817A74884C_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_E486B83F-1225-436D-94D5-C6817A74884C_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
   </bpmn2:interface>
   <bpmn2:collaboration id="_08979A00-BDE5-4176-8FB2-52E500C65209" name="Default Collaboration">
       <bpmn2:participant id="_B1EC8F09-91C0-4F32-85CC-1AB4EF037D5F" name="Pool Participant" processRef="AddUserBasicService" />

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/main/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriter.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import org.eclipse.bpmn2.DataObject;
 import org.eclipse.bpmn2.Interface;
+import org.eclipse.bpmn2.ItemDefinition;
+import org.eclipse.bpmn2.Message;
 import org.eclipse.bpmn2.Operation;
 import org.eclipse.bpmn2.ServiceTask;
 import org.kie.workbench.common.stunner.bpmn.client.marshall.converters.customproperties.CustomAttribute;
@@ -54,8 +56,29 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         //2 Interface
         String serviceInterface = value.getServiceInterface();
 
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        //in message
+        final Message inMessage;
+        ItemDefinition itemDefinitionInMsg = bpmn2.createItemDefinition();
+        itemDefinitionInMsg.setId(task.getId() + "_InMessageType");
+        itemDefinitionInMsg.setStructureRef(value.getInMessageStructure());
+        addItemDefinition(itemDefinitionInMsg);
+
+        inMessage = bpmn2.createMessage();
+        inMessage.setId(task.getId() + "_InMessage");
+        inMessage.setItemRef(itemDefinitionInMsg);
+        addRootElement(inMessage);
+
+        //out message
+        final Message outMessage;
+        ItemDefinition itemDefinitionOutMsg = bpmn2.createItemDefinition();
+        itemDefinitionOutMsg.setId(task.getId() + "_OutMessageType");
+        itemDefinitionOutMsg.setStructureRef(value.getOutMessagetructure());
+        addItemDefinition(itemDefinitionOutMsg);
+
+        outMessage = bpmn2.createMessage();
+        outMessage.setId(task.getId() + "_OutMessage");
+        outMessage.setItemRef(itemDefinitionOutMsg);
+        addRootElement(outMessage);
 
         //custom attribute
         CustomAttribute.serviceInterface.of(task).set(serviceInterface);
@@ -77,6 +100,8 @@ public class GenericServiceTaskPropertyWriter extends MultipleInstanceActivityPr
         iface.getOperations().add(operation);
         task.setOperationRef(operation);
         addInterfaceDefinition(iface);
+        operation.setInMessageRef(inMessage);
+        operation.setOutMessageRef(outMessage);
     }
 
     public void setAdHocAutostart(boolean autoStart) {

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/fromstunner/properties/GenericServiceTaskPropertyWriterTest.java
@@ -71,8 +71,8 @@ public class GenericServiceTaskPropertyWriterTest {
         assertEquals("serviceOperation", CustomAttribute.serviceOperation.of(serviceTask).get());
         assertEquals("serviceInterface", CustomAttribute.serviceInterface.of(serviceTask).get());
         assertEquals("serviceOperation", serviceTask.getOperationRef().getName());
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        assertEquals("inMessageStructure", serviceTask.getOperationRef().getInMessageRef().getItemRef().getStructureRef());
+        assertEquals("outMessagetructure", serviceTask.getOperationRef().getOutMessageRef().getItemRef().getStructureRef());
     }
 
     @Test

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/src/test/java/org/kie/workbench/common/stunner/bpmn/client/marshall/converters/tostunner/properties/GenericServiceTaskPropertyReaderTest.java
@@ -85,8 +85,8 @@ public class GenericServiceTaskPropertyReaderTest {
         assertEquals("Java", task.getServiceImplementation());
         assertEquals("serviceOperation", task.getServiceOperation());
         assertEquals("serviceInterface", task.getServiceInterface());
-        //https://issues.jboss.org/browse/KOGITO-418
-        // In/Out Messages should not be written now
+        assertEquals("inMessageStructure", task.getInMessageStructure());
+        assertEquals("outMessageStructure", task.getOutMessagetructure());
         assertEquals(SLA_DUE_DATE_CDATA, reader.getSLADueDate());
         assertEquals(false, reader.isAsync());
         assertEquals(true, reader.isAdHocAutostart());


### PR DESCRIPTION
Hello @LuboTerifaj, @romartin,

there is rebase of https://github.com/kiegroup/kie-tools/pull/1542 for [RHPAM-4604](https://issues.redhat.com/browse/RHPAM-4604) on branch `0.26.1-prerelease`.

Thank you!