### PR TITLE
kie-issues#157:  Connection to Shared Worker is lost when KIE Sandbox tab is frozen by chrome

### DIFF
--- a/packages/online-editor/build/defaultEnvJson.ts
+++ b/packages/online-editor/build/defaultEnvJson.ts
@@ -24,6 +24,7 @@ import { AuthProviderGroup, AuthProviderType } from "../src/authProviders/AuthPr
 const buildEnv: any = env; // build-env is not typed
 
 export const defaultEnvJson: EnvJson = {
+  KIE_SANDBOX_VERSION: buildEnv.root.version,
   KIE_SANDBOX_GIT_CORS_PROXY_URL: buildEnv.onlineEditor.gitCorsProxyUrl,
   KIE_SANDBOX_EXTENDED_SERVICES_URL: buildEnv.onlineEditor.extendedServicesUrl,
   KIE_SANDBOX_REQUIRE_CUSTOM_COMMIT_MESSAGE: buildEnv.onlineEditor.requireCustomCommitMessage,

--- a/packages/online-editor/src/env/EnvJson.ts
+++ b/packages/online-editor/src/env/EnvJson.ts
@@ -18,6 +18,7 @@ import { AuthProvider } from "../authProviders/AuthProvidersApi";
 import { AcceleratorConfig } from "../accelerators/AcceleratorsApi";
 
 export interface EnvJson {
+  KIE_SANDBOX_VERSION: string;
   KIE_SANDBOX_EXTENDED_SERVICES_URL: string;
   KIE_SANDBOX_GIT_CORS_PROXY_URL: string;
   KIE_SANDBOX_REQUIRE_CUSTOM_COMMIT_MESSAGE: boolean;

--- a/packages/online-editor/src/workspace/components/WorkspacesContextProviderWithCustomCommitMessagesModal.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspacesContextProviderWithCustomCommitMessagesModal.tsx
@@ -44,6 +44,7 @@ export const WorkspacesContextProviderWithCustomCommitMessagesModal: FunctionCom
           workspacesSharedWorkerScriptUrl={"workspace/worker/sharedWorker.js"}
           shouldRequireCommitMessage={env.KIE_SANDBOX_REQUIRE_CUSTOM_COMMIT_MESSAGE}
           onCommitMessageRequest={onCommitMessageRequest}
+          workerNamePrefix={`kie-sandbox-${env.KIE_SANDBOX_VERSION}`}
         >
           {props.children}
         </WorkspacesContextProvider>

--- a/packages/online-editor/src/workspace/worker/sharedWorker.ts
+++ b/packages/online-editor/src/workspace/worker/sharedWorker.ts
@@ -36,6 +36,7 @@ const workspaceServices = createWorkspaceServices({ gitCorsProxyUrl: gitCorsProx
 // shared worker connection
 
 declare let onconnect: any;
+
 // eslint-disable-next-line prefer-const
 onconnect = async (e: MessageEvent) => {
   console.log("Connected to Workspaces Shared Worker");

--- a/packages/serverless-logic-web-tools/src/App.tsx
+++ b/packages/serverless-logic-web-tools/src/App.tsx
@@ -38,7 +38,11 @@ export const App = () => (
       [SettingsContextProvider, {}],
       [
         WorkspacesContextProvider,
-        { workspacesSharedWorkerScriptUrl: "workspace/worker/sharedWorker.js", shouldRequireCommitMessage: false },
+        {
+          workspacesSharedWorkerScriptUrl: "workspace/worker/sharedWorker.js",
+          shouldRequireCommitMessage: false,
+          workerNamePrexi: `serverless-logic-web-tools-${process.env.WEBPACK_REPLACE__version}`,
+        },
       ],
       [OpenShiftContextProvider, {}],
       [VirtualServiceRegistryContextProvider, {}],

--- a/packages/serverless-logic-web-tools/src/App.tsx
+++ b/packages/serverless-logic-web-tools/src/App.tsx
@@ -41,7 +41,7 @@ export const App = () => (
         {
           workspacesSharedWorkerScriptUrl: "workspace/worker/sharedWorker.js",
           shouldRequireCommitMessage: false,
-          workerNamePrexi: `serverless-logic-web-tools-${process.env.WEBPACK_REPLACE__version}`,
+          workerNamePrefix: `serverless-logic-web-tools-${process.env.WEBPACK_REPLACE__version}`,
         },
       ],
       [OpenShiftContextProvider, {}],

--- a/packages/workspaces-git-fs/src/context/WorkspacesContextProvider.tsx
+++ b/packages/workspaces-git-fs/src/context/WorkspacesContextProvider.tsx
@@ -55,6 +55,10 @@ export function WorkspacesContextProvider(props: Props) {
     });
   }, [props.workerNamePrefix, props.workspacesSharedWorkerScriptUrl]);
 
+  // Listen to the `resume` event from the Page Lifecycle API (https://developer.chrome.com/blog/page-lifecycle-api/).
+  // This event indicates that the Chrome tab was in a frozen state and is now in one of the active/passive/hidden states.
+  // Updating the WorkspacesSharedWorker is necessary because its connection will be lost after some time while the tab is frozen.
+  // This happens because the Shared Worker ping function will timeout without an answer and close the connection.
   useEffect(() => {
     window.addEventListener("resume", updateWorkspaceSharedWorker, { capture: true });
 

--- a/packages/workspaces-git-fs/src/worker/WorkspacesSharedWorker.ts
+++ b/packages/workspaces-git-fs/src/worker/WorkspacesSharedWorker.ts
@@ -52,6 +52,10 @@ export class WorkspacesSharedWorker {
     return callback(this.workspacesWorkerBus);
   }
 
+  public closeWorkerPort() {
+    this.workspacesWorker?.port.close();
+  }
+
   private createWorker() {
     this.workspacesWorker = new SharedWorker(this.args.workerScriptUrl, this.args.workerName);
     this.workspacesWorker.port.start();


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/157
Closes https://github.com/kiegroup/kie-issues/issues/82

Fixes the connection to the Shared Worker whenever the browser freezes and the resumes a tab.
This happens because while frozen the `ping` function from the Shared Worker will timeout and eventually close the connection.

This PR adds an event listener to the `resume` event and recreates the Shared Worker connection.

This PR also fixes the problem of having multiple tabs of different versions of KIE Sandbox, by prefixing the Shared Worker name with the current version.