### PR TITLE
KOGITO-8995: Fix interaction between Web Tools and Managed Service Registry

### DIFF
--- a/packages/extended-services/pkg/server.go
+++ b/packages/extended-services/pkg/server.go
@@ -175,6 +175,8 @@ func (p *Proxy) corsProxyHandler() func(rw http.ResponseWriter, req *http.Reques
 		req.URL = emptyUrl
 		req.Host = req.URL.Host
 
+		req.Header.Del("Origin")
+
 		proxy := httputil.NewSingleHostReverseProxy(targetUrl)
 
 		// tolerate p-signed certificates


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8995

The interaction between Serverless Logic Web Tools and the managed Service Registry stopped working in the past few days (Error 403 Forbidden). After an investigation, I have concluded that they are probably blocking requests that contain the `Origin` header (or only accept specific origins). If you try to simulate the same request using Postman or curl, the requests will succeed because the `Origin` header is not provided there. On the other hand, the same error 403 will be returned if you start providing the `Origin` header. Since the purpose of the cors-proxy is to simulate a server request, it does not make sense to propagate the `Origin` header that comes from the browser.

Validated on
- https://start.kubesmarts.org/dev
- https://sandbox.kie.org/dev