### PR TITLE
kie-issues#221: Unable to upload/import a bpmn2 file, or any supported file extension containing capital letters, to KIE Sandbox

### DIFF
--- a/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
+++ b/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
@@ -15,19 +15,13 @@
  */
 
 const REGEX = {
-  supportedSingleExtension: /(\.bpmn|bpmn2|\.dmn|\.pmml)$/i,
-  supportedDoubleExtension: /(\.sw\.json|yml|yaml|\.yard\.json|yml|yaml|\.dash\.yml|yaml)$/i,
+  supportedSingleExtensions: /(\.bpmn|bpmn2|\.dmn|\.pmml)$/i,
+  supportedDoubleExtensions: /(\.sw\.json|yml|yaml|\.yard\.json|yml|yaml|\.dash\.yml|yaml)$/i,
   sw: /^.*\.sw\.(json|yml|yaml)$/i,
   swJson: /^.*\.sw\.json$/i,
-  swYml: /^.*\.sw\.yml$/i,
   swYaml: /^.*\.sw\.yaml$/i,
   yard: /^.*\.yard\.(json|yml|yaml)$/i,
-  yardJson: /^.*\.yard\.json$/i,
-  yardYml: /^.*\.yard\.yml$/i,
-  yardYaml: /^.*\.yard\.yaml$/i,
   dash: /^.*\.dash\.(yml|yaml)$/i,
-  dashYml: /^.*\.dash\.yml$/i,
-  dashYaml: /^.*\.dash\.yaml$/i,
   dmn: /^.*\.dmn$/i,
   bpmn: /^.*\.(bpmn|bpmn2)$/i,
   scesim: /^.*\.scesim$/i,

--- a/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
+++ b/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
@@ -15,6 +15,8 @@
  */
 
 const REGEX = {
+  supportedSingleExtension: /(\.bpmn|bpmn2|\.dmn|\.pmml)$/i,
+  supportedDoubleExtension: /(\.sw\.json|yml|yaml|\.yard\.json|yml|yaml|\.dash\.yml|yaml)$/i,
   sw: /^.*\.sw\.(json|yml|yaml)$/i,
   swJson: /^.*\.sw\.json$/i,
   swYml: /^.*\.sw\.yml$/i,

--- a/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
+++ b/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
@@ -33,11 +33,11 @@ export function extractExtension(relativePath: string) {
   const fileWithoutUltimateExtension = fileName.substring(0, fileName.lastIndexOf(ultimateExtension));
   const penultimateExtension = fileWithoutUltimateExtension.substring(fileWithoutUltimateExtension.lastIndexOf("."));
   if (fileName.includes(".")) {
-    if (isOfKind("supportedSingleExtension", fileName)) {
+    if (isOfKind("supportedSingleExtensions", fileName)) {
       //technically not needed as the else statement does the same thing. Only here for clarity
       return ultimateExtension.replace(".", "");
     }
-    if (isOfKind("supportedDoubleExtension", fileName)) {
+    if (isOfKind("supportedDoubleExtensions", fileName)) {
       return penultimateExtension.replace(".", "") + ultimateExtension;
     } else {
       return ultimateExtension.replace(".", "");

--- a/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
+++ b/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
@@ -34,12 +34,13 @@ export function extractExtension(relativePath: string) {
   const penultimateExtension = fileWithoutUltimateExtension.substring(fileWithoutUltimateExtension.lastIndexOf("."));
   if (fileName.includes(".")) {
     if (isOfKind("supportedSingleExtension", fileName)) {
+      //technically not needed as the else statement does the same thing. Only here for clarity
       return ultimateExtension.replace(".", "");
     }
     if (isOfKind("supportedDoubleExtension", fileName)) {
       return penultimateExtension.replace(".", "") + ultimateExtension;
     } else {
-      return fileName.substring(fileName.lastIndexOf(".") + 1);
+      return ultimateExtension.replace(".", "");
     }
   } else {
     return extname(relativePath);

--- a/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
+++ b/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { basename, extname, parse } from "path";
-import { isOfKind, FileTypes } from "../constants/ExtensionHelper";
+import { isOfKind } from "../constants/ExtensionHelper";
 
 export function parseWorkspaceFileRelativePath(relativePath: string) {
   const extension = extractExtension(relativePath);
@@ -28,40 +28,16 @@ export function parseWorkspaceFileRelativePath(relativePath: string) {
 }
 
 export function extractExtension(relativePath: string) {
-  const fileName = basename(relativePath).toLowerCase();
+  const fileName = basename(relativePath);
+  const ultimateExtension = fileName.substring(fileName.lastIndexOf("."));
+  const fileWithoutUltimateExtension = fileName.substring(0, fileName.lastIndexOf(ultimateExtension));
+  const penultimateExtension = fileWithoutUltimateExtension.substring(fileWithoutUltimateExtension.lastIndexOf("."));
   if (fileName.includes(".")) {
-    if (isOfKind("swJson", fileName)) {
-      return FileTypes.SW_JSON;
+    if (isOfKind("supportedSingleExtension", fileName)) {
+      return ultimateExtension.replace(".", "");
     }
-    if (isOfKind("swYml", fileName)) {
-      return FileTypes.SW_YML;
-    }
-    if (isOfKind("swYaml", fileName)) {
-      return FileTypes.SW_YAML;
-    }
-    if (isOfKind("yardJson", fileName)) {
-      return FileTypes.YARD_JSON;
-    }
-    if (isOfKind("yardYml", fileName)) {
-      return FileTypes.YARD_YML;
-    }
-    if (isOfKind("yardYaml", fileName)) {
-      return FileTypes.YARD_YAML;
-    }
-    if (isOfKind("dashYml", fileName)) {
-      return FileTypes.DASH_YML;
-    }
-    if (isOfKind("dashYaml", fileName)) {
-      return FileTypes.DASH_YAML;
-    }
-    if (isOfKind("dmn", fileName)) {
-      return FileTypes.DMN;
-    }
-    if (isOfKind("bpmn", fileName)) {
-      return FileTypes.BPMN;
-    }
-    if (isOfKind("pmml", fileName)) {
-      return FileTypes.PMML;
+    if (isOfKind("supportedDoubleExtension", fileName)) {
+      return penultimateExtension.replace(".", "") + ultimateExtension;
     } else {
       return fileName.substring(fileName.lastIndexOf(".") + 1);
     }

--- a/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
+++ b/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
@@ -21,11 +21,19 @@ describe("WorkspaceFileRelativePathParser :: extractExtension", () => {
     ["foo.json", "json"],
     [".gitignore", "gitignore"],
     ["noExtension", ""],
-    ["bar.sw.json", "sw.json"],
+    ["bar.sw.yml", "sw.yml"],
+    ["bar.yard.json", "yard.json"],
+    ["bar.yard.yaml.yard.yaml", "yard.yaml"],
+    ["bar.dash.yaml", "dash.yaml"],
     ["a/b/c/foo.json", "json"],
     ["a/b/c/.gitignore", "gitignore"],
     ["a/b/c/noExtension", ""],
     ["a/b/c/bar.sw.json", "sw.json"],
+    ["asd.dmn.dmn", "dmn"],
+    ["a/b/c'asd.DMn", "DMn"],
+    ["foo.bpmN2", "bpmN2"],
+    ["pmml.pmml", "pmml"],
+    ["TEST.BPMN", "BPMN"],
   ])("should extract extension properly for %p", (relativePath: string, extension: string) => {
     expect(extractExtension(relativePath)).toBe(extension);
   });


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/221
This is probably a more drastic change than is warranted by such a bug fix, but I believe it to be the best option and most inline with how KIE Sandbox currently operates. e.g. On live, when importing a file LoanEligibility.dMn, it will retain the exact case of the "dMn." I feel like the previous design is inherently flawed as it returns a hardcoded (lowercase) value as the extension, rather than the extension being defined dynamically by user input.