### PR TITLE
KOGITO-9035: SWF Editor - Skip IT tests faling on CI only

### DIFF
--- a/packages/serverless-logic-web-tools/it-tests/e2e/CreateNewFile.cy.ts
+++ b/packages/serverless-logic-web-tools/it-tests/e2e/CreateNewFile.cy.ts
@@ -70,7 +70,8 @@ describe("Serverless Logic Web Tools - Create and edit test", () => {
     cy.get("#total-notifications").should("have.text", 0);
   });
 
-  it("should create a new YAML serverless workflow", () => {
+  //The following test is being skipped due to the issue: https://issues.redhat.com/browse/KOGITO-9036
+  it.skip("should create a new YAML serverless workflow", () => {
     cy.ouia({ ouiaId: "new-sw.yaml-button" }).click();
     cy.loadEditor();
 

--- a/packages/serverless-logic-web-tools/it-tests/e2e/UploadFiles.cy.ts
+++ b/packages/serverless-logic-web-tools/it-tests/e2e/UploadFiles.cy.ts
@@ -44,7 +44,8 @@ describe("Serverless Logic Web Tools - Upload files test", () => {
     cy.get("#total-notifications").should("have.text", 0);
   });
 
-  it("should upload 2 files (JSON and YAML) and check editors and diagrams content", () => {
+  //The following test is being skipped due to the issue: https://issues.redhat.com/browse/KOGITO-9036
+  it.skip("should upload 2 files (JSON and YAML) and check editors and diagrams content", () => {
     // upload JSON and YAML files
     cy.get("#upload-field").attachFile(
       ["uploadFile/helloJsonWorkflow.sw.json", "uploadFile/helloYamlWorkflow.sw.yaml"],

--- a/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-diagram-navigation.test.ts
+++ b/packages/vscode-extension-serverless-workflow-editor/it-tests/serverless-workflow-editor-extension-diagram-navigation.test.ts
@@ -45,7 +45,8 @@ describe("Serverless workflow editor - Diagram navigation tests", () => {
     await testHelper.closeAllNotifications();
   });
 
-  it("Select states", async function () {
+  //The following test is being skipped due to the issue: https://issues.redhat.com/browse/KOGITO-9036
+  it.skip("Select states", async function () {
     this.timeout(30000);
 
     const WORKFLOW_NAME = "applicant-request-decision.sw.json";


### PR DESCRIPTION
Hey @romartin, could you please review this PR?

It temporarily skips faling IT tests on the CI only so we can move forward with the YAML PR:
**YAML**: [KOGITO-6864](https://github.com/kiegroup/kie-tools/pull/1444)  

**JIRA to skip the failing IT tests**: [KOGITO-9035](https://issues.redhat.com/browse/KOGITO-9035)

**JIRA to reenable and fix IT failing tests**: [KOGITO-9036](https://issues.redhat.com/browse/KOGITO-9036)

Thanks!