### PR TITLE
kie-issues#116: Upgrade 3rd party GitHub Actions that are deprecated because of Node 12 on kie-tools

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -23,7 +23,7 @@ runs:
         version: 7.26.3
 
     - name: "Setup Node"
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18.14.0
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -39,7 +39,7 @@ runs:
         go-version: "1.19"
 
     - name: "Set up Maven"
-      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f
+      uses: stCarolas/setup-maven@v4.5
       with:
         maven-version: 3.8.6
 
@@ -88,7 +88,7 @@ runs:
 
     - name: "Configure Pagefile (Windows only)"
       if: runner.os == 'Windows'
-      uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67
+      uses: al-cheb/configure-pagefile-action@v1.3
       with:
         minimum-size: 16GB
         maximum-size: 16GB

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -39,7 +39,7 @@ runs:
         go-version: "1.19"
 
     - name: "Set up Maven"
-      uses: stCarolas/setup-maven@v4.5
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f #v4.5
       with:
         maven-version: 3.8.6
 
@@ -88,7 +88,7 @@ runs:
 
     - name: "Configure Pagefile (Windows only)"
       if: runner.os == 'Windows'
-      uses: al-cheb/configure-pagefile-action@v1.3
+      uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 #v1.3
       with:
         minimum-size: 16GB
         maximum-size: 16GB

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -39,7 +39,7 @@ runs:
         go-version: "1.19"
 
     - name: "Set up Maven"
-      uses: stCarolas/setup-maven@417e1a9899611c0350621d1fb0c2770f35105c69
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f
       with:
         maven-version: 3.8.6
 
@@ -88,7 +88,7 @@ runs:
 
     - name: "Configure Pagefile (Windows only)"
       if: runner.os == 'Windows'
-      uses: al-cheb/configure-pagefile-action@7e234852c937eea04d6ee627c599fb24a5bfffee
+      uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67
       with:
         minimum-size: 16GB
         maximum-size: 16GB

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Start telemetry service (`main` only)"
         if: steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request
-        uses: runforesight/workflow-telemetry-action@7af88337f61e495d20c0ffa970cf7691532af740
+        uses: runforesight/workflow-telemetry-action@6705383eabd01833acfe8412ec697384830e1455
 
       - name: "Setup environment"
         if: steps.setup_build_mode.outputs.mode != 'none'

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Start telemetry service (`main` only)"
         if: steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request
-        uses: runforesight/workflow-telemetry-action@6705383eabd01833acfe8412ec697384830e1455
+        uses: runforesight/workflow-telemetry-action@v1.8.7
 
       - name: "Setup environment"
         if: steps.setup_build_mode.outputs.mode != 'none'

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Start telemetry service (`main` only)"
         if: steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request
-        uses: runforesight/workflow-telemetry-action@v1.8.7
+        uses: runforesight/workflow-telemetry-action@6705383eabd01833acfe8412ec697384830e1455 #v1.8.7
 
       - name: "Setup environment"
         if: steps.setup_build_mode.outputs.mode != 'none'

--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -242,42 +242,42 @@ jobs:
 
       - name: "Upload Serverless Workflow VS Code Extension (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: vscode-extension-serverless-workflow-editor
           path: kie-tools/packages/vscode-extension-serverless-workflow-editor/dist/vscode_extension_serverless_workflow_editor_${{ steps.version.outputs.version }}.vsix
 
       - name: "Upload Dashbuilder VS Code Extension (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: vscode-extension-dashbuilder-editor
           path: kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${{ steps.version.outputs.version }}.vsix
 
       - name: "Upload VS Code Extension (dev) (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: vscode-extension
           path: kie-tools/packages/vscode-extension-pack-kogito-kie-editors/dist/vscode_extension_kogito_kie_editors_${{ steps.version.outputs.version }}.vsix
 
       - name: "Upload Backend VS Code Extension (dev) (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: vscode-extension-backend
           path: kie-tools/packages/vscode-extension-backend/dist/vscode-extension-backend_${{ steps.version.outputs.version }}.vsix
 
       - name: "Upload Chrome Extension for KIE Editors (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: chrome-extension
           path: kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${{ steps.version.outputs.version }}.zip
 
       - name: "Upload Chrome Extension for Serverless Workflow Editor (Ubuntu only)"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: swf-chrome-extension
           path: kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
+        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
         with:
           java-version: 11
           graalvm-version: 22.3.0

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@4734b1a57b8b82fa2e5f89658726b3d419638b3c
+        uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.kogito_runtime_version }}
 
       - name: "Set up Maven"
-        uses: stCarolas/setup-maven@417e1a9899611c0350621d1fb0c2770f35105c69
+        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f
         with:
           maven-version: 3.8.6
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Configure Pagefile"
         if: runner.os == 'Windows'
-        uses: al-cheb/configure-pagefile-action@7e234852c937eea04d6ee627c599fb24a5bfffee
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67
         with:
           minimum-size: 16GB
           maximum-size: 16GB

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -88,8 +88,8 @@ jobs:
         if: runner.os == 'Windows'
         uses: graalvm/setup-graalvm@babc303d7e5b8f3062a94b90b49c3444cf291633 #v1
         with:
-          version: 22.3.0
-          java-version: 11
+          version: "22.3.0"
+          java-version: "11"
           components: "native-image"
 
       - name: "Build Windows"

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.kogito_runtime_version }}
 
       - name: "Set up Maven"
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f #v4.5
         with:
           maven-version: 3.8.6
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Configure Pagefile"
         if: runner.os == 'Windows'
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67 #v1.3
         with:
           minimum-size: 16GB
           maximum-size: 16GB
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1.12.1
+        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 #v1.12.1
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'
@@ -86,11 +86,11 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
+        uses: graalvm/setup-graalvm@babc303d7e5b8f3062a94b90b49c3444cf291633 #v1
         with:
+          version: 22.3.0
           java-version: 11
-          graalvm-version: 22.3.0
-          native-image: true
+          components: "native-image"
 
       - name: "Build Windows"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
+        uses: ilammy/msvc-dev-cmd@a742a854f54111d83b78e97091b5d85ccdaa3e89
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
+        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
         with:
           java-version: 11
           graalvm-version: 22.3.0
@@ -99,7 +99,7 @@ jobs:
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Upload JIT Executor binary"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jitexecutor_${{ runner.os }}
           path: ./jitexecutor/jitexecutor-runner/target/jitexecutor-runner-${{ github.event.inputs.kogito_runtime_version }}-run*

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@a742a854f54111d83b78e97091b5d85ccdaa3e89
+        uses: ilammy/msvc-dev-cmd@4734b1a57b8b82fa2e5f89658726b3d419638b3c
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
+        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
         with:
           java-version: 11
           graalvm-version: 22.3.0

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@376515093de803c897e7e6d576553c3104267e17
+        uses: ilammy/msvc-dev-cmd@a742a854f54111d83b78e97091b5d85ccdaa3e89
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -86,11 +86,11 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: graalvm/setup-graalvm@babc303d7e5b8f3062a94b90b49c3444cf291633 #v1
+        uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
         with:
-          version: "22.3.0"
-          java-version: "11"
-          components: "native-image"
+          java-version: 11
+          graalvm-version: 22.3.0
+          native-image: true
 
       - name: "Build Windows"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -86,11 +86,11 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
+        uses: graalvm/setup-graalvm@babc303d7e5b8f3062a94b90b49c3444cf291633 #v1
         with:
-          java-version: 11
-          graalvm-version: 22.3.0
-          native-image: true
+          version: "22.3.0"
+          java-version: "11"
+          components: "native-image"
 
       - name: "Build Windows"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Setup GraalVM"
         if: runner.os == 'Windows'
-        uses: ayltai/setup-graalvm@86a8e4b2b8ba8ac3e689673d56184de958ce5add
+        uses: ayltai/setup-graalvm@3789c9412212eb6d435725e49d28e179a46b1aaa
         with:
           java-version: 11
           graalvm-version: 22.3.0

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@a742a854f54111d83b78e97091b5d85ccdaa3e89
+        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.kogito_runtime_version }}
 
       - name: "Set up Maven"
-        uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f
+        uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.6
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: "Configure Pagefile"
         if: runner.os == 'Windows'
-        uses: al-cheb/configure-pagefile-action@86589fd789a4de3e62ba628dda2cb10027b66d67
+        uses: al-cheb/configure-pagefile-action@v1.3
         with:
           minimum-size: 16GB
           maximum-size: 16GB
@@ -78,7 +78,7 @@ jobs:
 
       - name: "Setup MSCV"
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
+        uses: ilammy/msvc-dev-cmd@v1.12.1
 
       - name: "Setup MSBUILD"
         if: runner.os == 'Windows'


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/116
Updated the 4 mentioned deprecated GitHub Actions to use the latest commits (that use Node 16) as well as actions/upload-artifact. Another 2 deprecated actions that weren't mentioned in the original PR are: ilammy/msvc-dev-cmd  and ayltai/setup-graalvm.
- ilammy/msvc-dev-cmd - tried switching to the latest commit and the commit that changed it to node 16, but it throws an error
- ayltai/setup-graalvm - Switched to latest commit SHA successfully, however it was archived and was not updated to use node 16.