### PR TITLE
NO-ISSUE: Add option to set step value in the `uniforms-patternfly` NumField component

### DIFF
--- a/packages/uniforms-patternfly/src/NumField.tsx
+++ b/packages/uniforms-patternfly/src/NumField.tsx
@@ -49,7 +49,7 @@ function NumField(props: NumFieldProps) {
       onChange={onChange}
       placeholder={props.placeholder}
       ref={props.inputRef}
-      step={props.decimal ? 0.01 : 1}
+      step={props.step ?? (props.decimal ? 0.01 : 1)}
       type="number"
       value={props.value ?? ""}
       validated={props.error ? "error" : "default"}

--- a/packages/uniforms-patternfly/src/__tests__/NumField.test.tsx
+++ b/packages/uniforms-patternfly/src/__tests__/NumField.test.tsx
@@ -88,6 +88,13 @@ test("<NumField> - renders an input with correct step (integer)", () => {
   expect(screen.getByTestId("num-field").getAttribute("step")).toBe("1");
 });
 
+test("<NumField> - renders an input with correct step (set)", () => {
+  render(usingUniformsContext(<NumField name="x" step={3} />, { x: { type: Number } }));
+
+  expect(screen.getByTestId("num-field")).toBeInTheDocument();
+  expect(screen.getByTestId("num-field").getAttribute("step")).toBe("3");
+});
+
 test("<NumField> - renders an input with correct type", () => {
   render(usingUniformsContext(<NumField name="x" />, { x: { type: Number } }));
 


### PR DESCRIPTION
Fixes same issue as in https://github.com/vazco/uniforms/issues/855

Also added test for set step prop 