### PR TITLE
NO-ISSUE: Fix dmn-dev-deployment-base-image image:tags command to allow multiple tags

### DIFF
--- a/packages/dmn-dev-deployment-base-image/package.json
+++ b/packages/dmn-dev-deployment-base-image/package.json
@@ -23,14 +23,14 @@
     "copy:dmn-dev-deployment-form-webapp": "cp -R ../dmn-dev-deployment-form-webapp/dist ./dist-dev/dmn-dev-deployment-form-webapp",
     "copy:dmn-dev-deployment-quarkus-app": "cp -R ../dmn-dev-deployment-quarkus-app ./dist-dev/dmn-dev-deployment-quarkus-app",
     "create-test-image": "pnpm cleanup && pnpm copy:assets && node scripts/createTestImage.js",
-    "create-test-image:build-only": "pnpm create-test-image build-only -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
-    "create-test-image:kind": "pnpm create-test-image kind -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) --k kie-sandbox-dev-cluster",
-    "create-test-image:minikube": "pnpm create-test-image minikube -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
-    "create-test-image:openshift": "pnpm create-test-image openshift -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
+    "create-test-image:build-only": "pnpm create-test-image build-only $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
+    "create-test-image:kind": "pnpm create-test-image kind $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) --k kie-sandbox-dev-cluster",
+    "create-test-image:minikube": "pnpm create-test-image minikube $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
+    "create-test-image:openshift": "pnpm create-test-image openshift $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1)",
     "image:args": "echo \"--build-arg QUARKUS_PLATFORM_VERSION=$(build-env quarkusPlatform.version) --build-arg KOGITO_RUNTIME_VERSION=$(build-env kogitoRuntime.version) --build-arg ROOT_PATH=/\"",
-    "image:docker:build": "run-script-if --bool $([ $(command -v docker) ] && echo true || echo false) --then \"docker build -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) . -f Containerfile\" --else \"echo Docker not found, skipping image build.\"",
-    "image:podman:build": "run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build -t $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) -f Containerfile\" --else \"echo Podman not found, skipping image build.\"",
-    "image:tag": "echo $(build-env dmnDevDeploymentBaseImageEnv.tags) | xargs printf -- \"$(build-env dmnDevDeploymentBaseImageEnv.registry)/$(build-env dmnDevDeploymentBaseImageEnv.account)/$(build-env dmnDevDeploymentBaseImageEnv.name):%s\n\" | xargs echo"
+    "image:docker:build": "run-script-if --bool $([ $(command -v docker) ] && echo true || echo false) --then \"docker build $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) . -f Containerfile\" --else \"echo Docker not found, skipping image build.\"",
+    "image:podman:build": "run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build $(pnpm image:tag | tail -1) $(pnpm image:args | tail -1) -f Containerfile\" --else \"echo Podman not found, skipping image build.\"",
+    "image:tag": "echo $(build-env dmnDevDeploymentBaseImageEnv.tags) | xargs printf -- \"-t $(build-env dmnDevDeploymentBaseImageEnv.registry)/$(build-env dmnDevDeploymentBaseImageEnv.account)/$(build-env dmnDevDeploymentBaseImageEnv.name):%s\n\" | xargs echo"
   },
   "dependencies": {
     "@kie-tools/dmn-dev-deployment-form-webapp": "workspace:*",


### PR DESCRIPTION
Previously the command wouldn't add a `-t` to each tag, generating something like:
- `-t my_tag:version my_second_tag:another_version`
instead of:
- `-t my_tag:version -t my_second_tag:another_version`