### PR TITLE
NO-ISSUE: Fix `supportedDoubleExtensions` regex

### DIFF
--- a/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
+++ b/packages/workspaces-git-fs/src/constants/ExtensionHelper.ts
@@ -16,7 +16,7 @@
 
 const REGEX = {
   supportedSingleExtensions: /(\.bpmn|bpmn2|\.dmn|\.pmml)$/i,
-  supportedDoubleExtensions: /(\.sw\.json|yml|yaml|\.yard\.json|yml|yaml|\.dash\.yml|yaml)$/i,
+  supportedDoubleExtensions: /(\.sw\.(json|yml|yaml)|\.yard\.(json|yml|yaml)|\.dash\.(yml|yaml))$/i,
   sw: /^.*\.sw\.(json|yml|yaml)$/i,
   swJson: /^.*\.sw\.json$/i,
   swYaml: /^.*\.sw\.yaml$/i,

--- a/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
+++ b/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
@@ -18,6 +18,8 @@ import { extractExtension } from "../../src/relativePath/WorkspaceFileRelativePa
 
 describe("WorkspaceFileRelativePathParser :: extractExtension", () => {
   it.each([
+    ["foo.yaml", "yaml"],
+    ["foo.yml", "yml"],
     ["foo.json", "json"],
     [".gitignore", "gitignore"],
     ["noExtension", ""],


### PR DESCRIPTION
YAML files (not sw.yaml) are being treated as a doubled extension file due to the lack of parenthesis in the regex.