### PR TITLE
KOGITO-8817: kn-workflow is creating the project with RESTEasy Reactve dependencies

### DIFF
--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -151,7 +151,7 @@ func runCreateCmdConfig(cmd *cobra.Command) (cfg CreateCmdConfig, err error) {
 			metadata.KOGITO_QUARKUS_SERVERLESS_WORKFLOW_EXTENSION,
 			metadata.KOGITO_ADDONS_QUARKUS_KNATIVE_EVENTING_EXTENSION,
 			metadata.QUARKUS_KUBERNETES_EXTENSION,
-			metadata.QUARKUS_RESTEASY_REACTIVE_JACKSON_EXTENSION,
+			metadata.QUARKUS_RESTEASY_JACKSON_EXTENSION,
 			viper.GetString("extension"),
 		),
 

--- a/packages/kn-plugin-workflow/pkg/metadata/constants.go
+++ b/packages/kn-plugin-workflow/pkg/metadata/constants.go
@@ -19,7 +19,7 @@ package metadata
 const (
 	QUARKUS_MAVEN_PLUGIN                             = "quarkus-maven-plugin"
 	QUARKUS_KUBERNETES_EXTENSION                     = "quarkus-kubernetes"
-	QUARKUS_RESTEASY_REACTIVE_JACKSON_EXTENSION      = "quarkus-resteasy-reactive-jackson"
+	QUARKUS_RESTEASY_JACKSON_EXTENSION               = "quarkus-resteasy-jackson"
 	QUARKUS_CONTAINER_IMAGE_JIB                      = "quarkus-container-image-jib"
 	QUARKUS_CONTAINER_IMAGE_DOCKER                   = "quarkus-container-image-docker"
 	KOGITO_QUARKUS_SERVERLESS_WORKFLOW_EXTENSION     = "kogito-quarkus-serverless-workflow"


### PR DESCRIPTION
After changes:

cat /tmp/dep-after | grep easy
[INFO] |  +- org.jboss.resteasy:resteasy-multipart-provider:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-core-spi:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-core:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-jaxb-provider:jar:4.7.7.Final:compile
[INFO] |  +- org.jboss.resteasy:resteasy-jackson2-provider:jar:4.7.7.Final:compile
[INFO] |  +- org.jboss.resteasy:resteasy-client:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-client-api:jar:4.7.7.Final:compile
[INFO] |  |  +- io.quarkus:quarkus-resteasy-common:jar:2.16.0.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-client-microprofile:jar:4.7.7.Final:compile
[INFO] |  |  |  \- org.jboss.resteasy:resteasy-client-microprofile-base:jar:4.7.7.Final:compile
[INFO] |  |  |     \- org.jboss.resteasy:resteasy-cdi:jar:4.7.7.Final:compile
[INFO] +- io.quarkus:quarkus-resteasy-jackson:jar:2.16.0.Final:compile
[INFO] |  +- io.quarkus:quarkus-resteasy:jar:2.16.0.Final:compile
[INFO] |  |  \- io.quarkus:quarkus-resteasy-server-common:jar:2.16.0.Final:compile


Before:

[INFO] |  +- org.jboss.resteasy:resteasy-multipart-provider:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-core-spi:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-core:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-jaxb-provider:jar:4.7.7.Final:compile
[INFO] |  +- org.jboss.resteasy:resteasy-jackson2-provider:jar:4.7.7.Final:compile
[INFO] |  +- org.jboss.resteasy:resteasy-client:jar:4.7.7.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-client-api:jar:4.7.7.Final:compile
[INFO] |  |  +- io.quarkus:quarkus-resteasy-common:jar:2.16.0.Final:compile
[INFO] |  |  +- org.jboss.resteasy:resteasy-client-microprofile:jar:4.7.7.Final:compile
[INFO] |  |  |  \- org.jboss.resteasy:resteasy-client-microprofile-base:jar:4.7.7.Final:compile
[INFO] |  |  |     \- org.jboss.resteasy:resteasy-cdi:jar:4.7.7.Final:compile
[INFO] +- io.quarkus:quarkus-resteasy-reactive-jackson:jar:2.16.0.Final:compile
[INFO] |  +- io.quarkus:quarkus-resteasy-reactive:jar:2.16.0.Final:compile
[INFO] |  |  +- io.quarkus:quarkus-resteasy-reactive-common:jar:2.16.0.Final:compile
[INFO] |  |  |  \- io.quarkus.resteasy.reactive:resteasy-reactive-common:jar:2.16.0.Final:compile
[INFO] |  |  |     \- io.quarkus.resteasy.reactive:resteasy-reactive-common-types:jar:2.16.0.Final:compile
[INFO] |  |  +- io.quarkus.resteasy.reactive:resteasy-reactive-vertx:jar:2.16.0.Final:compile
[INFO] |  |  |  \- io.quarkus.resteasy.reactive:resteasy-reactive:jar:2.16.0.Final:compile
[INFO] |  \- io.quarkus:quarkus-resteasy-reactive-jackson-common:jar:2.16.0.Final:compile
[INFO] |     \- io.quarkus.resteasy.reactive:resteasy-reactive-jackson:jar:2.16.0.Final:compile