### PR TITLE
kie-issue#226: Changing a nested data type will not erase the input value, making it possible to break the DMN Runner

### DIFF
--- a/packages/extended-services-api/src/jsonSchema.ts
+++ b/packages/extended-services-api/src/jsonSchema.ts
@@ -50,5 +50,6 @@ export interface DmnSchemaDefitionProperties {
 
 // JSON schema returned from extended-services /schema/form;
 export interface ExtendedServicesDmnJsonSchema {
+  $ref?: string;
   definitions?: Record<DmnSchemaDefinitions, DmnSchemaDefitionProperties>;
 }

--- a/packages/kubernetes-bridge/src/fetch/ResourceFetcher.ts
+++ b/packages/kubernetes-bridge/src/fetch/ResourceFetcher.ts
@@ -66,6 +66,6 @@ export class ResourceFetcher {
       }
     }
 
-    throw new Error(`Error fetching ${args.target.name()}`, { cause: error });
+    throw new Error(`Error fetching ${args.target.name()}`);
   }
 }

--- a/packages/kubernetes-bridge/src/fetch/ResourceFetcher.ts
+++ b/packages/kubernetes-bridge/src/fetch/ResourceFetcher.ts
@@ -66,6 +66,6 @@ export class ResourceFetcher {
       }
     }
 
-    throw new Error(`Error fetching ${args.target.name()}`);
+    throw new Error(`Error fetching ${args.target.name()}`, { cause: error });
   }
 }

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -148,7 +148,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   } = useDmnRunnerPersistenceDispatch();
   useDmnRunnerPersistence(props.workspaceFile.workspaceId, props.workspaceFile.relativePath);
   const prevKieSandboxExtendedServicesStatus = usePrevious(extendedServices.status);
-  const { panel, setNotifications, addToggleItem, removeToggleItem, onOpenPanel, onTogglePanel, errorBoundaryRef } =
+  const { panel, setNotifications, addToggleItem, removeToggleItem, onOpenPanel, onTogglePanel } =
     useEditorDockContext();
 
   const dmnRunnerInputs = useMemo(() => dmnRunnerPersistenceJson.inputs, [dmnRunnerPersistenceJson.inputs]);
@@ -167,11 +167,9 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     }
   }, [props.isEditorReady]);
 
-  // TODO: Luiz - create a wrapper in the DMNTable; it shouldnt reset all the EditorDock;
   useLayoutEffect(() => {
     setExtendedServicesError(false);
-    errorBoundaryRef.current?.reset();
-  }, [jsonSchema, errorBoundaryRef]);
+  }, [jsonSchema]);
 
   // Reset JSON Schema and PersistenceJson;
   useLayoutEffect(() => {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -148,7 +148,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   } = useDmnRunnerPersistenceDispatch();
   useDmnRunnerPersistence(props.workspaceFile.workspaceId, props.workspaceFile.relativePath);
   const prevKieSandboxExtendedServicesStatus = usePrevious(extendedServices.status);
-  const { panel, setNotifications, addToggleItem, removeToggleItem, onOpenPanel, onTogglePanel } =
+  const { panel, setNotifications, addToggleItem, removeToggleItem, onOpenPanel, onTogglePanel, errorBoundaryRef } =
     useEditorDockContext();
 
   const dmnRunnerInputs = useMemo(() => dmnRunnerPersistenceJson.inputs, [dmnRunnerPersistenceJson.inputs]);
@@ -167,9 +167,11 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     }
   }, [props.isEditorReady]);
 
+  // TODO: Luiz - create a wrapper in the DMNTable; it shouldnt reset all the EditorDock;
   useLayoutEffect(() => {
     setExtendedServicesError(false);
-  }, [jsonSchema]);
+    errorBoundaryRef.current?.reset();
+  }, [jsonSchema, errorBoundaryRef]);
 
   // Reset JSON Schema and PersistenceJson;
   useLayoutEffect(() => {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -583,15 +583,15 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
               }
 
               setJsonSchema((previousJsonSchema) => {
-                const dereferedJsonSchema = dereferenceExtendedServicesJsonSchema(cloneDeep(jsonSchema));
+                const derefererJsonSchema = dereferenceExtendedServicesJsonSchema(cloneDeep(jsonSchema));
                 // On the first render the previous will be undefined;
                 if (!previousJsonSchema) {
-                  return dereferedJsonSchema;
+                  return derefererJsonSchema;
                 }
 
                 const propertiesDifference = diff(
                   getObjectValueByPath(previousJsonSchema, JSON_SCHEMA_PROPERTIES_PATH) ?? {},
-                  getObjectValueByPath(dereferedJsonSchema, JSON_SCHEMA_PROPERTIES_PATH) ?? {}
+                  getObjectValueByPath(derefererJsonSchema, JSON_SCHEMA_PROPERTIES_PATH) ?? {}
                 );
 
                 // Add default values and delete changed data types;
@@ -604,7 +604,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
                     ),
                   cancellationToken: canceled,
                 });
-                return dereferedJsonSchema;
+                return derefererJsonSchema;
               });
             });
           })

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -71,7 +71,6 @@ import getObjectValueByPath from "lodash/get";
 import setObjectValueByPath from "lodash/set";
 import unsetObjectValueByPath from "lodash/unset";
 import { dereferenceProperties } from "../jsonSchema/dereference";
-import { property } from "lodash";
 
 const JSON_SCHEMA_PROPERTIES_PATH = "definitions.InputSet.properties";
 
@@ -222,6 +221,13 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   useCancelableEffect(
     useCallback(
       ({ canceled }) => {
+        if (
+          props.workspaceFile.extension !== "dmn" ||
+          extendedServices.status !== KieSandboxExtendedServicesStatus.RUNNING
+        ) {
+          return;
+        }
+
         Promise.all(dmnRunnerInputs.map((inputs) => extendedServicesModelPayload(inputs)))
           .then((payloads) =>
             Promise.all(
@@ -254,7 +260,13 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
             setDmnRunnerResults({ type: DmnRunnerResultsActionType.DEFAULT });
           });
       },
-      [extendedServicesModelPayload, dmnRunnerInputs, extendedServices.client]
+      [
+        props.workspaceFile.extension,
+        extendedServices.status,
+        extendedServices.client,
+        dmnRunnerInputs,
+        extendedServicesModelPayload,
+      ]
     )
   );
 
@@ -299,6 +311,13 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
 
   // Set execution tab on Problems panel;
   useEffect(() => {
+    if (
+      props.workspaceFile.extension !== "dmn" ||
+      extendedServices.status !== KieSandboxExtendedServicesStatus.RUNNING
+    ) {
+      return;
+    }
+
     const decisionNameByDecisionId = results[currentInputIndex]?.reduce(
       (acc: Map<string, string>, decisionResult) => acc.set(decisionResult.decisionId, decisionResult.decisionName),
       new Map<string, string>()
@@ -328,7 +347,14 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     });
 
     setNotifications(i18n.terms.execution, "", notifications as any);
-  }, [setNotifications, i18n.terms.execution, results, currentInputIndex]);
+  }, [
+    setNotifications,
+    i18n.terms.execution,
+    results,
+    currentInputIndex,
+    props.workspaceFile.extension,
+    extendedServices.status,
+  ]);
 
   const setDmnRunnerPersistenceJson = useCallback(
     (args: {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -71,6 +71,7 @@ import getObjectValueByPath from "lodash/get";
 import setObjectValueByPath from "lodash/set";
 import unsetObjectValueByPath from "lodash/unset";
 import { dereferenceProperties } from "../jsonSchema/dereference";
+import { property } from "lodash";
 
 const JSON_SCHEMA_PROPERTIES_PATH = "definitions.InputSet.properties";
 
@@ -532,10 +533,12 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
 
         const fullKey = parentKey ? `${parentKey}.${propertyKey}` : propertyKey;
         if (
-          !propertyValue?.type &&
-          !propertyValue?.format &&
           propertyValue !== null &&
-          typeof propertyValue === "object"
+          typeof propertyValue === "object" &&
+          Object.prototype.hasOwnProperty.call(propertyValue, "type") &&
+          propertyValue.type !== undefined &&
+          Object.prototype.hasOwnProperty.call(propertyValue, "format") &&
+          propertyValue.format !== undefined
         ) {
           // not leaf;
           return handleJsonSchemaDifferences(inputs, propertyValue, fullKey);

--- a/packages/online-editor/src/dmnRunner/DmnRunnerDrawer.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerDrawer.tsx
@@ -18,10 +18,10 @@ import * as React from "react";
 import { DmnRunnerDrawerPanelContent } from "./DmnRunnerDrawerPanelContent";
 import { Drawer, DrawerContent, DrawerContentBody } from "@patternfly/react-core/dist/js/components/Drawer";
 import { useDmnRunnerState } from "./DmnRunnerContext";
-import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { DmnRunnerMode } from "./DmnRunnerStatus";
+import { DmnRunnerErrorBoundary } from "./DmnRunnerErrorBoundary";
 
-export function DmnRunnerDrawer(props: { workspaceFile: WorkspaceFile; children: React.ReactNode }) {
+export function DmnRunnerDrawer(props: React.PropsWithChildren<{}>) {
   const dmnRunnerState = useDmnRunnerState();
   return (
     <Drawer isInline={true} isExpanded={dmnRunnerState.isExpanded && dmnRunnerState.mode === DmnRunnerMode.FORM}>
@@ -29,7 +29,11 @@ export function DmnRunnerDrawer(props: { workspaceFile: WorkspaceFile; children:
         className={
           !dmnRunnerState.isExpanded ? "kogito--editor__drawer-content-onClose" : "kogito--editor__drawer-content-open"
         }
-        panelContent={<DmnRunnerDrawerPanelContent workspaceFile={props.workspaceFile} />}
+        panelContent={
+          <DmnRunnerErrorBoundary>
+            <DmnRunnerDrawerPanelContent />
+          </DmnRunnerErrorBoundary>
+        }
       >
         <DrawerContentBody className={"kogito--editor__drawer-content-body"}>{props.children}</DrawerContentBody>
       </DrawerContent>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerDrawerPanelContent.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerDrawerPanelContent.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { DrawerCloseButton, DrawerPanelContent } from "@patternfly/react-core/dist/js/components/Drawer";
@@ -24,11 +24,6 @@ import { DmnRunnerMode } from "./DmnRunnerStatus";
 import { TableIcon } from "@patternfly/react-icons/dist/js/icons/table-icon";
 import { useOnlineI18n } from "../i18n";
 import { DmnForm, DmnFormResult, InputRow } from "@kie-tools/form-dmn";
-import { ErrorBoundary } from "../reactExt/ErrorBoundary";
-import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
-import { I18nWrapped } from "@kie-tools-core/i18n/dist/react-components";
-import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
-import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { Dropdown, DropdownItem, DropdownToggle } from "@patternfly/react-core/dist/js/components/Dropdown";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
@@ -41,15 +36,9 @@ import { DmnRunnerProviderActionType } from "./DmnRunnerTypes";
 import { PanelId, useEditorDockContext } from "../editor/EditorPageDockContextProvider";
 import { DmnRunnerExtendedServicesError } from "./DmnRunnerContextProvider";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
-
 enum ButtonPosition {
   INPUT,
   OUTPUT,
-}
-
-interface Props {
-  workspaceFile: WorkspaceFile;
 }
 
 const DMN_RUNNER_MIN_WIDTH_TO_ROW_DIRECTION = 711;
@@ -61,7 +50,7 @@ interface DmnRunnerStylesConfig {
   buttonPosition: ButtonPosition;
 }
 
-export function DmnRunnerDrawerPanelContent(props: Props) {
+export function DmnRunnerDrawerPanelContent() {
   // STATEs
   const [drawerError, setDrawerError] = useState<boolean>(false);
   const [dmnRunnerStylesConfig, setDmnRunnerStylesConfig] = useState<DmnRunnerStylesConfig>({
@@ -71,9 +60,6 @@ export function DmnRunnerDrawerPanelContent(props: Props) {
     buttonPosition: ButtonPosition.OUTPUT,
   });
   const [rowSelectionIsOpen, openRowSelection] = useState<boolean>(false);
-
-  // REFs
-  const errorBoundaryRef = useRef<ErrorBoundary>(null);
 
   const { i18n, locale } = useOnlineI18n();
   const { currentInputIndex, extendedServicesError, inputs, jsonSchema, results, resultsDifference } =
@@ -116,39 +102,8 @@ export function DmnRunnerDrawerPanelContent(props: Props) {
     notificationsPanel?.setActiveTab(i18n.terms.execution);
   }, [i18n.terms.execution, notificationsPanel, onOpenPanel]);
 
-  const drawerErrorMessage = useMemo(
-    () => (
-      <div>
-        <EmptyState>
-          <EmptyStateIcon icon={ExclamationTriangleIcon} />
-          <TextContent>
-            <Text component={"h2"}>{i18n.dmnRunner.drawer.error.title}</Text>
-          </TextContent>
-          <EmptyStateBody>
-            <TextContent>{i18n.dmnRunner.drawer.error.explanation}</TextContent>
-            <br />
-            <TextContent>
-              <I18nWrapped
-                components={{
-                  jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
-                    </a>
-                  ),
-                }}
-              >
-                {i18n.dmnRunner.drawer.error.message}
-              </I18nWrapped>
-            </TextContent>
-          </EmptyStateBody>
-        </EmptyState>
-      </div>
-    ),
-    [i18n]
-  );
-
   useEffect(() => {
-    errorBoundaryRef.current?.reset();
+    setDrawerError(false);
   }, [jsonSchema]);
 
   // changing between rows re-calculate this function;
@@ -214,165 +169,163 @@ export function DmnRunnerDrawerPanelContent(props: Props) {
         <DmnRunnerExtendedServicesError />
       ) : (
         <DmnRunnerLoading>
-          <ErrorBoundary error={drawerErrorMessage} setHasError={setDrawerError} ref={errorBoundaryRef}>
+          <div
+            className={"kogito--editor__dmn-runner"}
+            style={{ flexDirection: dmnRunnerStylesConfig.contentFlexDirection }}
+          >
             <div
-              className={"kogito--editor__dmn-runner"}
-              style={{ flexDirection: dmnRunnerStylesConfig.contentFlexDirection }}
+              className={"kogito--editor__dmn-runner-content"}
+              style={{
+                width: dmnRunnerStylesConfig.contentWidth,
+                height: dmnRunnerStylesConfig.contentHeight,
+              }}
             >
-              <div
-                className={"kogito--editor__dmn-runner-content"}
-                style={{
-                  width: dmnRunnerStylesConfig.contentWidth,
-                  height: dmnRunnerStylesConfig.contentHeight,
-                }}
-              >
-                <Page className={"kogito--editor__dmn-runner-content-page"}>
-                  <PageSection className={"kogito--editor__dmn-runner-content-header"}>
-                    <Flex
-                      flexWrap={{ default: "nowrap" }}
-                      style={{ width: "100%" }}
-                      justifyContent={{ default: "justifyContentSpaceBetween" }}
-                      alignItems={{ default: "alignItemsCenter" }}
-                    >
-                      <FlexItem>
-                        {inputs.length <= 1 ? (
-                          <Button
-                            variant={ButtonVariant.plain}
-                            className={"kie-tools--masthead-hoverable"}
-                            style={{ cursor: "default" }}
-                          >
-                            <TextContent>
-                              <Text component={"h3"}>{i18n.terms.inputs}</Text>
-                            </TextContent>
-                          </Button>
-                        ) : (
-                          <div>
-                            <Dropdown
-                              className={"kie-tools--masthead-hoverable"}
-                              isPlain={true}
-                              aria-label="Select Row Input"
-                              toggle={
-                                <DropdownToggle
-                                  toggleIndicator={null}
-                                  onToggle={() => openRowSelection((prevState) => !prevState)}
-                                >
-                                  <TextContent>
-                                    <Text component={"h3"}>
-                                      {i18n.terms.inputs} ({getRow(currentInputIndex + 1)}) <CaretDownIcon />
-                                    </Text>
-                                  </TextContent>
-                                </DropdownToggle>
-                              }
-                              onSelect={onSelectRow}
-                              dropdownItems={rowOptions}
-                              isOpen={rowSelectionIsOpen}
-                            />
-                          </div>
-                        )}
-                      </FlexItem>
-                      <FlexItem>
-                        <ToolbarItem>
-                          <Tooltip content={"Add new input row"}>
-                            <Button
-                              className={"kie-tools--masthead-hoverable"}
-                              variant={ButtonVariant.plain}
-                              onClick={onAddNewRow}
-                            >
-                              <PlusIcon />
-                            </Button>
-                          </Tooltip>
-                        </ToolbarItem>
-                        <ToolbarItem>
-                          <Tooltip content={"Switch to table view"}>
-                            <Button
-                              ouiaId="switch-dmn-runner-to-table-view"
-                              className={"kie-tools--masthead-hoverable"}
-                              variant={ButtonVariant.plain}
-                              onClick={onChangeToTableView}
-                            >
-                              <TableIcon />
-                            </Button>
-                          </Tooltip>
-                        </ToolbarItem>
-                      </FlexItem>
-                    </Flex>
-                    {dmnRunnerStylesConfig.buttonPosition === ButtonPosition.INPUT && (
-                      <DrawerCloseButton
-                        onClick={() =>
-                          setDmnRunnerContextProviderState({
-                            type: DmnRunnerProviderActionType.DEFAULT,
-                            newState: { isExpanded: false },
-                          })
-                        }
-                      />
-                    )}
-                  </PageSection>
-                  <div className={"kogito--editor__dmn-runner-drawer-content-body"}>
-                    <PageSection className={"kogito--editor__dmn-runner-drawer-content-body-input"}>
-                      <DmnForm
-                        // force a re-render when the row is changed;
-                        key={formInputs?.id}
-                        formInputs={formInputs}
-                        setFormInputs={setFormInputs}
-                        formError={drawerError}
-                        setFormError={setDrawerError}
-                        formSchema={jsonSchema}
-                        id={"form"}
-                        showInlineError={true}
-                        autoSave={true}
-                        autoSaveDelay={400}
-                        placeholder={true}
-                        errorsField={() => <></>}
-                        submitField={() => <></>}
-                        locale={locale}
-                        notificationsPanel={true}
-                        openValidationTab={openValidationTab}
-                      />
-                    </PageSection>
-                  </div>
-                </Page>
-              </div>
-              <div
-                className={"kogito--editor__dmn-runner-content"}
-                style={{
-                  width: dmnRunnerStylesConfig.contentWidth,
-                  height: dmnRunnerStylesConfig.contentHeight,
-                }}
-              >
-                <Page className={"kogito--editor__dmn-runner-content-page"}>
-                  <PageSection className={"kogito--editor__dmn-runner-content-header"}>
-                    <TextContent>
-                      <Text component={"h3"}>{i18n.terms.outputs}</Text>
-                    </TextContent>
-                    {dmnRunnerStylesConfig.buttonPosition === ButtonPosition.OUTPUT && (
-                      <DrawerCloseButton
-                        onClick={() =>
-                          setDmnRunnerContextProviderState({
-                            type: DmnRunnerProviderActionType.DEFAULT,
-                            newState: { isExpanded: false },
-                          })
-                        }
-                      />
-                    )}
-                  </PageSection>
-                  <div
-                    className={"kogito--editor__dmn-runner-drawer-content-body"}
-                    data-ouia-component-id={"dmn-runner-results"}
+              <Page className={"kogito--editor__dmn-runner-content-page"}>
+                <PageSection className={"kogito--editor__dmn-runner-content-header"}>
+                  <Flex
+                    flexWrap={{ default: "nowrap" }}
+                    style={{ width: "100%" }}
+                    justifyContent={{ default: "justifyContentSpaceBetween" }}
+                    alignItems={{ default: "alignItemsCenter" }}
                   >
-                    <PageSection className={"kogito--editor__dmn-runner-drawer-content-body-output"}>
-                      <DmnFormResult
-                        results={results[currentInputIndex]}
-                        differences={resultsDifference[currentInputIndex]}
-                        locale={locale}
-                        notificationsPanel={true}
-                        openExecutionTab={openExecutionTab}
-                      />
-                    </PageSection>
-                  </div>
-                </Page>
-              </div>
+                    <FlexItem>
+                      {inputs.length <= 1 ? (
+                        <Button
+                          variant={ButtonVariant.plain}
+                          className={"kie-tools--masthead-hoverable"}
+                          style={{ cursor: "default" }}
+                        >
+                          <TextContent>
+                            <Text component={"h3"}>{i18n.terms.inputs}</Text>
+                          </TextContent>
+                        </Button>
+                      ) : (
+                        <div>
+                          <Dropdown
+                            className={"kie-tools--masthead-hoverable"}
+                            isPlain={true}
+                            aria-label="Select Row Input"
+                            toggle={
+                              <DropdownToggle
+                                toggleIndicator={null}
+                                onToggle={() => openRowSelection((prevState) => !prevState)}
+                              >
+                                <TextContent>
+                                  <Text component={"h3"}>
+                                    {i18n.terms.inputs} ({getRow(currentInputIndex + 1)}) <CaretDownIcon />
+                                  </Text>
+                                </TextContent>
+                              </DropdownToggle>
+                            }
+                            onSelect={onSelectRow}
+                            dropdownItems={rowOptions}
+                            isOpen={rowSelectionIsOpen}
+                          />
+                        </div>
+                      )}
+                    </FlexItem>
+                    <FlexItem>
+                      <ToolbarItem>
+                        <Tooltip content={"Add new input row"}>
+                          <Button
+                            className={"kie-tools--masthead-hoverable"}
+                            variant={ButtonVariant.plain}
+                            onClick={onAddNewRow}
+                          >
+                            <PlusIcon />
+                          </Button>
+                        </Tooltip>
+                      </ToolbarItem>
+                      <ToolbarItem>
+                        <Tooltip content={"Switch to table view"}>
+                          <Button
+                            ouiaId="switch-dmn-runner-to-table-view"
+                            className={"kie-tools--masthead-hoverable"}
+                            variant={ButtonVariant.plain}
+                            onClick={onChangeToTableView}
+                          >
+                            <TableIcon />
+                          </Button>
+                        </Tooltip>
+                      </ToolbarItem>
+                    </FlexItem>
+                  </Flex>
+                  {dmnRunnerStylesConfig.buttonPosition === ButtonPosition.INPUT && (
+                    <DrawerCloseButton
+                      onClick={() =>
+                        setDmnRunnerContextProviderState({
+                          type: DmnRunnerProviderActionType.DEFAULT,
+                          newState: { isExpanded: false },
+                        })
+                      }
+                    />
+                  )}
+                </PageSection>
+                <div className={"kogito--editor__dmn-runner-drawer-content-body"}>
+                  <PageSection className={"kogito--editor__dmn-runner-drawer-content-body-input"}>
+                    <DmnForm
+                      // force a re-render when the row is changed;
+                      key={formInputs?.id}
+                      formInputs={formInputs}
+                      setFormInputs={setFormInputs}
+                      formError={drawerError}
+                      setFormError={setDrawerError}
+                      formSchema={jsonSchema}
+                      id={"form"}
+                      showInlineError={true}
+                      autoSave={true}
+                      autoSaveDelay={400}
+                      placeholder={true}
+                      errorsField={() => <></>}
+                      submitField={() => <></>}
+                      locale={locale}
+                      notificationsPanel={true}
+                      openValidationTab={openValidationTab}
+                    />
+                  </PageSection>
+                </div>
+              </Page>
             </div>
-          </ErrorBoundary>
+            <div
+              className={"kogito--editor__dmn-runner-content"}
+              style={{
+                width: dmnRunnerStylesConfig.contentWidth,
+                height: dmnRunnerStylesConfig.contentHeight,
+              }}
+            >
+              <Page className={"kogito--editor__dmn-runner-content-page"}>
+                <PageSection className={"kogito--editor__dmn-runner-content-header"}>
+                  <TextContent>
+                    <Text component={"h3"}>{i18n.terms.outputs}</Text>
+                  </TextContent>
+                  {dmnRunnerStylesConfig.buttonPosition === ButtonPosition.OUTPUT && (
+                    <DrawerCloseButton
+                      onClick={() =>
+                        setDmnRunnerContextProviderState({
+                          type: DmnRunnerProviderActionType.DEFAULT,
+                          newState: { isExpanded: false },
+                        })
+                      }
+                    />
+                  )}
+                </PageSection>
+                <div
+                  className={"kogito--editor__dmn-runner-drawer-content-body"}
+                  data-ouia-component-id={"dmn-runner-results"}
+                >
+                  <PageSection className={"kogito--editor__dmn-runner-drawer-content-body-output"}>
+                    <DmnFormResult
+                      results={results[currentInputIndex]}
+                      differences={resultsDifference[currentInputIndex]}
+                      locale={locale}
+                      notificationsPanel={true}
+                      openExecutionTab={openExecutionTab}
+                    />
+                  </PageSection>
+                </div>
+              </Page>
+            </div>
+          </div>
         </DmnRunnerLoading>
       )}
     </DrawerPanelContent>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ErrorBoundary } from "../reactExt/ErrorBoundary";
+import { useDmnRunnerState } from "./DmnRunnerContext";
+import { useOnlineI18n } from "../i18n";
+import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
+import { I18nWrapped } from "@kie-tools-core/i18n/dist/react-components";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
+
+const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+
+export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>) {
+  const [_, setDmnRunnerError] = useState<boolean>(false);
+  const errorBoundaryRef = useRef<ErrorBoundary>(null);
+  const { jsonSchema } = useDmnRunnerState();
+  const { i18n } = useOnlineI18n();
+
+  useEffect(() => {
+    errorBoundaryRef.current?.reset();
+  }, [jsonSchema]);
+
+  const errorMessage = useMemo(
+    () => (
+      <div>
+        <EmptyState>
+          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <TextContent>
+            <Text component={"h2"}>{i18n.dmnRunner.drawer.error.title}</Text>
+          </TextContent>
+          <EmptyStateBody>
+            <TextContent>{i18n.dmnRunner.drawer.error.explanation}</TextContent>
+            <br />
+            <TextContent>
+              <I18nWrapped
+                components={{
+                  jira: (
+                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
+                      {KOGITO_JIRA_LINK}
+                    </a>
+                  ),
+                }}
+              >
+                {i18n.dmnRunner.drawer.error.message}
+              </I18nWrapped>
+            </TextContent>
+          </EmptyStateBody>
+        </EmptyState>
+      </div>
+    ),
+    [i18n]
+  );
+
+  return (
+    <>
+      <ErrorBoundary ref={errorBoundaryRef} error={errorMessage} setHasError={setDmnRunnerError}>
+        {children}
+      </ErrorBoundary>
+    </>
+  );
+}

--- a/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
@@ -42,10 +42,10 @@ export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>
         <EmptyState>
           <EmptyStateIcon icon={ExclamationTriangleIcon} />
           <TextContent>
-            <Text component={"h2"}>{i18n.dmnRunner.drawer.error.title}</Text>
+            <Text component={"h2"}>{i18n.dmnRunner.error.title}</Text>
           </TextContent>
           <EmptyStateBody>
-            <TextContent>{i18n.dmnRunner.drawer.error.explanation}</TextContent>
+            <TextContent>{i18n.dmnRunner.error.explanation}</TextContent>
             <br />
             <TextContent>
               <I18nWrapped
@@ -57,7 +57,7 @@ export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>
                   ),
                 }}
               >
-                {i18n.dmnRunner.drawer.error.message}
+                {i18n.dmnRunner.error.message}
               </I18nWrapped>
             </TextContent>
           </EmptyStateBody>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ErrorBoundary } from "../reactExt/ErrorBoundary";
 import { useDmnRunnerState } from "./DmnRunnerContext";
 import { useOnlineI18n } from "../i18n";
@@ -24,7 +24,7 @@ import { I18nWrapped } from "@kie-tools-core/i18n/dist/react-components";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
 import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const KIE_ISSUES_LINK = "https://github.com/kiegroup/kie-issues/issues";
 
 export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>) {
   const [_, setDmnRunnerError] = useState<boolean>(false);
@@ -50,9 +50,9 @@ export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>
             <TextContent>
               <I18nWrapped
                 components={{
-                  jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                  issues: (
+                    <a href={KIE_ISSUES_LINK} target={"_blank"}>
+                      {KIE_ISSUES_LINK}
                     </a>
                   ),
                 }}

--- a/packages/online-editor/src/dmnRunner/DmnRunnerTable.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerTable.tsx
@@ -23,7 +23,6 @@ import { Drawer, DrawerContent, DrawerPanelContent } from "@patternfly/react-cor
 import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { ExclamationIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-icon";
 import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
-import { ErrorBoundary } from "../reactExt/ErrorBoundary";
 import { useOnlineI18n } from "../i18n";
 import { UnitablesWrapper } from "@kie-tools/unitables/dist/UnitablesWrapper";
 import { DmnRunnerOutputsTable } from "@kie-tools/unitables-dmn/dist/DmnRunnerOutputsTable";
@@ -39,7 +38,6 @@ export function DmnRunnerTable() {
   const [dmnRunnerTableError, setDmnRunnerTableError] = useState<boolean>(false);
 
   // REFs
-  const dmnRunnerTableErrorBoundaryRef = useRef<ErrorBoundary>(null);
   const [inputsContainerRef, setInputsContainerRef] = useState<HTMLDivElement | null>(null);
   const outputsContainerRef = useRef<HTMLDivElement>(null);
   const inputsScrollableElementRef = useRef<{ current: HTMLDivElement | null }>({ current: null });
@@ -72,7 +70,7 @@ export function DmnRunnerTable() {
   );
 
   useEffect(() => {
-    dmnRunnerTableErrorBoundaryRef.current?.reset();
+    setDmnRunnerTableError(false);
   }, [jsonSchema]);
 
   useEffect(() => {
@@ -119,56 +117,50 @@ export function DmnRunnerTable() {
       ) : (
         <div style={{ height: "100%" }}>
           <DmnRunnerLoading>
-            <ErrorBoundary
-              ref={dmnRunnerTableErrorBoundaryRef}
-              setHasError={setDmnRunnerTableError}
-              error={DmnRunnerTableError}
-            >
-              <Drawer isInline={true} isExpanded={true} className={"kie-tools--dmn-runner-table--drawer"}>
-                {/* DMN Runner Outputs */}
-                <DrawerContent
-                  panelContent={
-                    <>
-                      <DrawerPanelContent
-                        isResizable={true}
-                        minSize={rowCount > 0 ? drawerPanelMinSize : "30%"}
-                        maxSize={drawerPanelMaxSize}
-                        defaultSize={drawerPanelDefaultSize}
-                      >
-                        <div ref={outputsContainerRef}>
-                          <DmnRunnerOutputsTable
-                            scrollableParentRef={outputsScrollableElementRef.current}
-                            i18n={i18n.dmnRunner.table}
-                            jsonSchemaBridge={jsonSchemaBridge}
-                            results={results}
-                          />
-                        </div>
-                      </DrawerPanelContent>
-                    </>
-                  }
-                >
-                  {/* DMN Runner Inputs */}
-                  <div ref={(ref) => setInputsContainerRef(ref)}>
-                    <UnitablesWrapper
-                      scrollableParentRef={inputsScrollableElementRef.current}
-                      i18n={i18n.dmnRunner.table}
-                      openRow={openRow}
-                      rows={inputs}
-                      setRows={setDmnRunnerInputs}
-                      error={dmnRunnerTableError}
-                      setError={setDmnRunnerTableError}
-                      jsonSchemaBridge={jsonSchemaBridge}
-                      onRowAdded={onRowAdded}
-                      onRowDuplicated={onRowDuplicated}
-                      onRowReset={onRowReset}
-                      onRowDeleted={onRowDeleted}
-                      configs={configs}
-                      setWidth={setWidth}
-                    />
-                  </div>
-                </DrawerContent>
-              </Drawer>
-            </ErrorBoundary>
+            <Drawer isInline={true} isExpanded={true} className={"kie-tools--dmn-runner-table--drawer"}>
+              {/* DMN Runner Outputs */}
+              <DrawerContent
+                panelContent={
+                  <>
+                    <DrawerPanelContent
+                      isResizable={true}
+                      minSize={rowCount > 0 ? drawerPanelMinSize : "30%"}
+                      maxSize={drawerPanelMaxSize}
+                      defaultSize={drawerPanelDefaultSize}
+                    >
+                      <div ref={outputsContainerRef}>
+                        <DmnRunnerOutputsTable
+                          scrollableParentRef={outputsScrollableElementRef.current}
+                          i18n={i18n.dmnRunner.table}
+                          jsonSchemaBridge={jsonSchemaBridge}
+                          results={results}
+                        />
+                      </div>
+                    </DrawerPanelContent>
+                  </>
+                }
+              >
+                {/* DMN Runner Inputs */}
+                <div ref={(ref) => setInputsContainerRef(ref)}>
+                  <UnitablesWrapper
+                    scrollableParentRef={inputsScrollableElementRef.current}
+                    i18n={i18n.dmnRunner.table}
+                    openRow={openRow}
+                    rows={inputs}
+                    setRows={setDmnRunnerInputs}
+                    error={dmnRunnerTableError}
+                    setError={setDmnRunnerTableError}
+                    jsonSchemaBridge={jsonSchemaBridge}
+                    onRowAdded={onRowAdded}
+                    onRowDuplicated={onRowDuplicated}
+                    onRowReset={onRowReset}
+                    onRowDeleted={onRowDeleted}
+                    configs={configs}
+                    setWidth={setWidth}
+                  />
+                </div>
+              </DrawerContent>
+            </Drawer>
           </DmnRunnerLoading>
         </div>
       )}

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -381,7 +381,7 @@ export function EditorPage(props: Props) {
                   <EditorToolbar workspaceFile={file.workspaceFile} editor={editor} />
                   <Divider />
                   <PageSection hasOverflowScroll={true} padding={{ default: "noPadding" }} aria-label="Editor section">
-                    <DmnRunnerDrawer workspaceFile={file.workspaceFile}>
+                    <DmnRunnerDrawer>
                       <EditorPageDockDrawer>
                         {embeddedEditorFile && (
                           <EmbeddedEditor

--- a/packages/online-editor/src/editor/EditorPageDockContextProvider.tsx
+++ b/packages/online-editor/src/editor/EditorPageDockContextProvider.tsx
@@ -16,7 +16,7 @@
 
 import { useController } from "@kie-tools-core/react-hooks/dist/useController";
 import * as React from "react";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState, useRef } from "react";
 import {
   NotificationsPanelDockToggle,
   NotificationsPanelDockToggleRef,
@@ -30,6 +30,7 @@ import { KieSandboxExtendedServicesStatus } from "../kieSandboxExtendedServices/
 import { useFileValidation } from "./Validation";
 import { DmnLanguageService } from "@kie-tools/dmn-language-service";
 import { DmnRunnerTable } from "../dmnRunner/DmnRunnerTable";
+import { ErrorBoundary } from "../reactExt/ErrorBoundary";
 
 interface EditorPageDockContextType {
   panel: PanelId;
@@ -43,6 +44,9 @@ interface EditorPageDockContextType {
   toggleGroupItems: Map<PanelId, JSX.Element>;
   panelContent?: JSX.Element;
   notificationsPanel?: NotificationsPanelRef;
+  error: boolean;
+  setHasError: React.Dispatch<React.SetStateAction<boolean>>;
+  errorBoundaryRef: React.MutableRefObject<ErrorBoundary | null>;
 }
 
 export const EditorPageDockContext = React.createContext<EditorPageDockContextType>({} as any);
@@ -77,6 +81,8 @@ export function EditorPageDockContextProvider({
   const [notificationsToggle, notificationsToggleRef] = useController<NotificationsPanelDockToggleRef>();
   const [notificationsPanel, notificationsPanelRef] = useController<NotificationsPanelRef>();
   const { status: extendedServicesStatus } = useExtendedServices();
+  const errorBoundaryRef = useRef<ErrorBoundary>(null);
+  const [error, setHasError] = useState<boolean>(false);
   const [panel, setPanel] = useState<PanelId>(PanelId.NONE);
   const [toggleGroupItems, setToggleGroupItem] = useState(
     new Map([
@@ -220,12 +226,15 @@ export function EditorPageDockContextProvider({
         toggleGroupItems,
         panelContent,
         notificationsPanel,
+        error,
+        errorBoundaryRef,
 
         addToggleItem,
         removeToggleItem,
         onTogglePanel,
         onOpenPanel,
         setNotifications,
+        setHasError,
       }}
     >
       {children}

--- a/packages/online-editor/src/editor/EditorPageDockContextProvider.tsx
+++ b/packages/online-editor/src/editor/EditorPageDockContextProvider.tsx
@@ -31,6 +31,7 @@ import { useFileValidation } from "./Validation";
 import { DmnLanguageService } from "@kie-tools/dmn-language-service";
 import { DmnRunnerTable } from "../dmnRunner/DmnRunnerTable";
 import { ErrorBoundary } from "../reactExt/ErrorBoundary";
+import { DmnRunnerErrorBoundary } from "../dmnRunner/DmnRunnerErrorBoundary";
 
 interface EditorPageDockContextType {
   panel: PanelId;
@@ -171,7 +172,11 @@ export function EditorPageDockContextProvider({
       case PanelId.NOTIFICATIONS_PANEL:
         return <NotificationsPanel ref={notificationsPanelRef} tabNames={notificationsPanelTabNames} />;
       case PanelId.DMN_RUNNER_TABLE:
-        return <DmnRunnerTable />;
+        return (
+          <DmnRunnerErrorBoundary>
+            <DmnRunnerTable />
+          </DmnRunnerErrorBoundary>
+        );
       default:
         return undefined;
     }

--- a/packages/online-editor/src/editor/EditorPageDockDrawer.tsx
+++ b/packages/online-editor/src/editor/EditorPageDockDrawer.tsx
@@ -21,6 +21,7 @@ import { NotificationsPanelRef } from "./NotificationsPanel/NotificationsPanel";
 import { Drawer, DrawerContent, DrawerPanelContent } from "@patternfly/react-core/dist/js/components/Drawer";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { PanelId, useEditorDockContext } from "./EditorPageDockContextProvider";
+import { ErrorBoundary } from "../reactExt/ErrorBoundary";
 
 export interface EditorPageDockDrawerRef {
   open: (panelId: PanelId) => void;
@@ -31,7 +32,7 @@ export interface EditorPageDockDrawerRef {
 }
 
 export function EditorPageDockDrawer({ children }: React.PropsWithChildren<{}>) {
-  const { panel, toggleGroupItems, panelContent } = useEditorDockContext();
+  const { panel, toggleGroupItems, panelContent, error, setHasError, errorBoundaryRef } = useEditorDockContext();
 
   const toggleGroup = useMemo(() => {
     return [...toggleGroupItems.entries()].map(([key, value]) => value).reverse();
@@ -44,7 +45,9 @@ export function EditorPageDockDrawer({ children }: React.PropsWithChildren<{}>) 
           panelContent={
             panelContent ? (
               <DrawerPanelContent style={{ height: "100%" }} isResizable={true}>
-                {panelContent}
+                <ErrorBoundary ref={errorBoundaryRef} error={error} setHasError={setHasError}>
+                  {panelContent}
+                </ErrorBoundary>
               </DrawerPanelContent>
             ) : undefined
           }

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -390,12 +390,10 @@ interface OnlineDictionary extends ReferenceDictionary {
     };
   };
   dmnRunner: {
-    drawer: {
-      error: {
-        title: string;
-        explanation: string;
-        message: Array<string | Wrapped<"jira">>;
-      };
+    error: {
+      title: string;
+      explanation: string;
+      message: Array<string | Wrapped<"jira">>;
     };
     table: DmnUnitablesI18n;
     modal: {

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -48,6 +48,11 @@ interface OnlineDictionary extends ReferenceDictionary {
         proceedAnyway: string;
       };
     };
+    error: {
+      title: string;
+      explanation: string;
+      message: Array<string | Wrapped<"issues">>;
+    };
   };
   editorToolbar: {
     closeAndReturnHome: string;
@@ -393,7 +398,7 @@ interface OnlineDictionary extends ReferenceDictionary {
     error: {
       title: string;
       explanation: string;
-      message: Array<string | Wrapped<"jira">>;
+      message: Array<string | Wrapped<"issues">>;
     };
     table: DmnUnitablesI18n;
     modal: {

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -435,16 +435,14 @@ export const en: OnlineI18n = {
     },
   },
   dmnRunner: {
-    drawer: {
-      error: {
-        title: `${en_common.terms.oops}!`,
-        explanation: `The ${en_common.names.dmnRunner} drawer couldn't be rendered due to an error.`,
-        message: [
-          `This ${en_common.names.dmn} has a construct that is not supported. Please refer to `,
-          wrapped("jira"),
-          " and report an issue. Don't forget to upload the current file, and the used inputs",
-        ],
-      },
+    error: {
+      title: `${en_common.terms.oops}!`,
+      explanation: `The ${en_common.names.dmnRunner} couldn't be rendered due to an error.`,
+      message: [
+        `This ${en_common.names.dmn} has a construct that is not supported. Please refer to `,
+        wrapped("jira"),
+        " and report an issue. Don't forget to upload the current file, and the used inputs",
+      ],
     },
     table: { ...en_unitables },
     modal: {

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -48,6 +48,15 @@ export const en: OnlineI18n = {
         message: "Your files are temporarily persisted on your browser, but may be erased before you come back.",
       },
     },
+    error: {
+      title: `${en_common.terms.oops}!`,
+      explanation: `The ${en_common.names.dmnRunner} couldn't be rendered due to an error.`,
+      message: [
+        `This ${en_common.names.dmn} has a construct that is not supported. Please refer to `,
+        wrapped("issues"),
+        " and report an issue. Don't forget to upload the current file, and the used inputs",
+      ],
+    },
   },
   editorToolbar: {
     closeAndReturnHome: "Close and return Home",
@@ -440,7 +449,7 @@ export const en: OnlineI18n = {
       explanation: `The ${en_common.names.dmnRunner} couldn't be rendered due to an error.`,
       message: [
         `This ${en_common.names.dmn} has a construct that is not supported. Please refer to `,
-        wrapped("jira"),
+        wrapped("issues"),
         " and report an issue. Don't forget to upload the current file, and the used inputs",
       ],
     },

--- a/packages/online-editor/src/jsonSchema/dereference.ts
+++ b/packages/online-editor/src/jsonSchema/dereference.ts
@@ -51,7 +51,12 @@ export function dereferenceProperties<
       const referenceField = getObjectValueByPath(jsonSchema, refPathToObjectPath(jsonSchemaField.$ref));
       setObjectValueByPath(dereferencedJsonSchema, getPropertiesFullKey(fieldKey, parentKey), referenceField);
       if (referenceField.properties) {
-        dereferenceProperties(jsonSchema, referenceField.properties, fieldKey, dereferencedJsonSchema);
+        dereferenceProperties(
+          jsonSchema,
+          referenceField.properties,
+          getPropertiesFullKey(fieldKey, parentKey),
+          dereferencedJsonSchema
+        );
       }
     } else {
       setObjectValueByPath(dereferencedJsonSchema, getPropertiesFullKey(fieldKey, parentKey), jsonSchemaField);

--- a/packages/online-editor/src/jsonSchema/dereference.ts
+++ b/packages/online-editor/src/jsonSchema/dereference.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import getObjectValueByPath from "lodash/get";
+import setObjectValueByPath from "lodash/set";
+
+interface RefProperty {
+  $ref?: string;
+}
+
+function getPropertiesFullKey(fieldKey: string, parentKey?: string) {
+  return parentKey ? `${parentKey}.properties.${fieldKey}` : fieldKey;
+}
+
+function refPathToObjectPath(path: string) {
+  return path.split("/").splice(1).join(".");
+}
+
+// Pass the JSON Schema and which property should be dereferenced
+// if no property is passed down, it will dereference the entire JSON Schema
+export function dereferenceProperties<
+  JSONSchema extends Record<string, any>,
+  Properties extends Record<string, RefProperty>
+>(
+  jsonSchema: JSONSchema,
+  properties?: Properties,
+  parentKey?: string,
+  dereferencedJsonSchema?: Record<string, any>
+): Record<string, any> {
+  if (properties === undefined && jsonSchema.$ref) {
+    return dereferenceProperties(
+      jsonSchema,
+      getObjectValueByPath(jsonSchema, refPathToObjectPath(jsonSchema.$ref) + ".properties")
+    );
+  }
+  return Object.entries(properties ?? {}).reduce((dereferencedJsonSchema, [fieldKey, jsonSchemaField]) => {
+    if (jsonSchemaField.$ref) {
+      const referenceField = getObjectValueByPath(jsonSchema, refPathToObjectPath(jsonSchemaField.$ref));
+      setObjectValueByPath(dereferencedJsonSchema, getPropertiesFullKey(fieldKey, parentKey), referenceField);
+      if (referenceField.properties) {
+        dereferenceProperties(jsonSchema, referenceField.properties, fieldKey, dereferencedJsonSchema);
+      }
+    } else {
+      setObjectValueByPath(dereferencedJsonSchema, getPropertiesFullKey(fieldKey, parentKey), jsonSchemaField);
+    }
+    return dereferencedJsonSchema;
+  }, dereferencedJsonSchema ?? ({} as Record<string, any>));
+}

--- a/packages/online-editor/src/jsonSchema/dereference.ts
+++ b/packages/online-editor/src/jsonSchema/dereference.ts
@@ -41,10 +41,11 @@ export function dereferenceProperties<
   dereferencedJsonSchema?: Record<string, any>
 ): Record<string, any> {
   if (properties === undefined && jsonSchema.$ref) {
-    return dereferenceProperties(
-      jsonSchema,
-      getObjectValueByPath(jsonSchema, refPathToObjectPath(jsonSchema.$ref) + ".properties")
-    );
+    const properties = getObjectValueByPath(jsonSchema, refPathToObjectPath(jsonSchema.$ref) + ".properties");
+    if (properties !== undefined) {
+      return dereferenceProperties(jsonSchema, properties);
+    }
+    return jsonSchema;
   }
   return Object.entries(properties ?? {}).reduce((dereferencedJsonSchema, [fieldKey, jsonSchemaField]) => {
     if (jsonSchemaField.$ref) {

--- a/packages/unitables/src/Unitables.tsx
+++ b/packages/unitables/src/Unitables.tsx
@@ -235,7 +235,6 @@ export const Unitables = ({
             ))}
           </div>
           <UnitablesBeeTable
-            rowsRefs={rowsRefs}
             rowWrapper={rowWrapper}
             scrollableParentRef={scrollableParentRef}
             i18n={i18n}

--- a/packages/unitables/src/bee/UnitablesBeeTable.tsx
+++ b/packages/unitables/src/bee/UnitablesBeeTable.tsx
@@ -41,7 +41,6 @@ import { useField } from "uniforms";
 import { AUTO_ROW_ID } from "../uniforms/UnitablesJsonSchemaBridge";
 import getObjectValueByPath from "lodash/get";
 import { useUnitablesContext, useUnitablesRow } from "../UnitablesContext";
-import { UnitablesRowApi } from "../UnitablesRow";
 import moment from "moment";
 import { X_DMN_TYPE } from "@kie-tools/extended-services-api";
 
@@ -62,7 +61,6 @@ export interface UnitablesBeeTable {
   onRowDeleted: (args: { rowIndex: number }) => void;
   configs: UnitablesInputsConfigs;
   setWidth: (newWidth: number, fieldName: string) => void;
-  rowsRefs: Map<number, UnitablesRowApi>;
 }
 
 export function UnitablesBeeTable({
@@ -78,7 +76,6 @@ export function UnitablesBeeTable({
   onRowDeleted,
   configs,
   setWidth,
-  rowsRefs,
 }: UnitablesBeeTable) {
   const beeTableOperationConfig = useMemo<BeeTableOperationConfig>(
     () => [


### PR DESCRIPTION
## kie-issue
Closes https://github.com/kiegroup/kie-issues/issues/226

## On this PR
After a change in a `Structure` Data Type, the DMN Runner wasn't erasing its input fields, causing it to break. This was happening because the comparison method was checking the first property level of the JSON Schema and not taking into account the $refs properties.

The inputs and outputs JSON Schema of a DMN model changes as the user creates Data Types and attributes them to input or decision nodes. The JSON Schema is built using references (the $ref property) for `Structure` or custom Data Types. So if a user creates a `Structure` Data Type with another `Structure` and inside of it a `number` property, we will have:
![image](https://user-images.githubusercontent.com/24302289/234695770-593a9763-ac23-4925-927f-e63d29e47d9d.png)

And the generated JSON Schema:
```json
{
    "$ref": "#/definitions/InputSet",
    "definitions": {
        "a": {
            "type": "object",
            "properties": {
                "b": {
                    "$ref": "#/definitions/a__b"
                }
            },
        },
        "a__b": {
            "type": "object",
            "properties": {
                "c": {
                    "type": "number",
                }
            }
        }
        "InputSet": {
            "type": "object",
            "properties": {
                "myInput": {
                    "$ref": "#/definitions/a"
                }
            },
        },
    }
}
```
It's difficult to check for differences in a schema with references, so this PR adds a JSON schema dereference method. So the above schema becomes:
```json
{
    "$ref": "#/definitions/InputSet",
    "definitions": {
        "InputSet": {
            "properties": {
                "myInput": {
                    "type": "object",
                    "properties": {
                        "b": {
                            "type": "object",
                            "properties": {
                                "c": {
                                    "type": "number",
                                }
                            }
                        }
                    }
                }
            },
            "type": "object"
        }
    }
}
```
With this PR, when the user changes the DMN model, it happens a comparison between the previous schema and the newly generated one and the changes, if any, are properly handled.

Another changes:
 - Removed some code redundancy;
 - Created a `DmnRunnerErrorBoundary` component to wrap up the DMN Runner form and table to give them the same error message;
 - Added EditorPage ErrorBoundary;