### PR TITLE
KOGITO-7066: SWF - Expose Stunner API through multiplying architecture

### DIFF
--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -34,6 +34,8 @@ import {
   ServerlessWorkflowDiagramEditorChannelApi,
   ServerlessWorkflowDiagramEditorEnvelopeApi,
 } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/api";
+import { SwfStunnerEditorAPI } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/api/SwfStunnerEditorAPI";
+import { SwfStunnerEditor } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/envelope/ServerlessWorkflowStunnerEditor";
 import {
   ServerlessWorkflowTextEditorChannelApi,
   ServerlessWorkflowTextEditorEnvelopeApi,
@@ -80,6 +82,12 @@ interface File {
 }
 
 const ENVELOPE_LOCATOR_TYPE = "swf";
+
+declare global {
+  interface Window {
+    editor: SwfStunnerEditorAPI;
+  }
+}
 
 const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
   ServerlessWorkflowCombinedEditorRef | undefined,
@@ -398,6 +406,15 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
       },
       [textEditor]
     )
+  );
+
+  window.editor = useMemo(
+    () =>
+      new SwfStunnerEditor(
+        diagramEditor?.getEnvelopeServer()
+          .envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>
+      ),
+    [diagramEditor]
   );
 
   return (

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/ServerlessWorkflowDiagramEditorEnvelopeApi.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/ServerlessWorkflowDiagramEditorEnvelopeApi.ts
@@ -15,8 +15,8 @@
  */
 
 import { KogitoEditorEnvelopeApi } from "@kie-tools-core/editor/dist/api";
-import { CanvasEnvelopeApi } from "@kie-tools/kie-bc-editors/dist/canvas/CanvasEnvelopeApi";
+import { StunnerEditorEnvelopeAPI } from "./StunnerEditorEnvelopeAPI";
 
-export interface ServerlessWorkflowDiagramEditorEnvelopeApi extends KogitoEditorEnvelopeApi, CanvasEnvelopeApi {
+export interface ServerlessWorkflowDiagramEditorEnvelopeApi extends KogitoEditorEnvelopeApi, StunnerEditorEnvelopeAPI {
   kogitoSwfDiagramEditor__highlightNode(args: { nodeName: string | null }): void;
 }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerAPI.ts
@@ -25,7 +25,7 @@ export interface StunnerSession {
   getNodeByUUID(uuid: string): StunnerNode;
   getDefinitionByElementUUID(uuid: string): Object;
   getNodeByName(name: string): StunnerNode;
-  getNodeName(uuid: string): string;
+  getNodeName(node: StunnerNode): string;
   getDefinitionId(bean: Object): string;
   getDefinitionName(bean: Object): string;
   getSelectedElementUUID(): string;

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerAPI.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface StunnerEditor {
+  session: StunnerSession;
+  canvas: StunnerCanvas;
+}
+
+export interface StunnerSession {
+  getGraph(): StunnerGraph;
+  getEdgeByUUID(uuid: string): StunnerEdge;
+  getNodeByUUID(uuid: string): StunnerNode;
+  getDefinitionByElementUUID(uuid: string): Object;
+  getNodeByName(name: string): StunnerNode;
+  getNodeName(uuid: string): string;
+  getDefinitionId(bean: Object): string;
+  getDefinitionName(bean: Object): string;
+  getSelectedElementUUID(): string;
+  getSelectedNode(): StunnerNode;
+  getSelectedEdge(): StunnerEdge;
+  getSelectedDefinition(): Object;
+  selectByUUID(uuid: string): void;
+  selectByName(name: string): void;
+  clearSelection(): void;
+}
+
+export interface StunnerGraph {
+  getUUID(): string;
+  nodes(): Iterable<StunnerNode>;
+  nodesArray(): StunnerNode[];
+}
+
+export interface StunnerElement {
+  getUUID(): string;
+  getContent(): StunnerContentView;
+}
+
+export interface StunnerNode extends StunnerElement {
+  inConnectors(): StunnerEdge[];
+  outConnectors(): StunnerEdge[];
+}
+
+export interface StunnerEdge extends StunnerElement {
+  getSourceNode(): StunnerNode;
+  getTargetNode(): StunnerNode;
+}
+
+export interface StunnerContentView {
+  getDefinition(): Object;
+}
+
+export interface StunnerCanvas {
+  getShapeIds(): string[];
+  getBackgroundColor(uuid: string): string;
+  setBackgroundColor(uuid: string, backgroundColor: string): void;
+  getBorderColor(uuid: string): string;
+  setBorderColor(uuid: string, backgroundColor: string): void;
+  getLocation(uuid: string): number[];
+  getAbsoluteLocation(uuid: string): number[];
+  getDimensions(uuid: string): number[];
+  center(uuid: string): void;
+  draw(): void;
+}

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface StunnerEditorEnvelopeAPI {
+  // Session API.
+  editor_session_getAllNodesUUID(): Promise<string[]>;
+  editor_session_getEdgeByUUID(uuid: string): Promise<Edge>;
+  editor_session_getNodeByUUID(uuid: string): Promise<Node>;
+  editor_session_getDefinitionByElementUUID(uuid: string): Promise<Object>;
+  editor_session_getNodeByName(name: string): Promise<Node>;
+  editor_session_getNodeName(uuid: string): Promise<string>;
+  editor_session_getSelectedElementUUID(): Promise<string>;
+  editor_session_getSelectedNode(): Promise<Node>;
+  editor_session_getSelectedEdge(): Promise<Edge>;
+  editor_session_getSelectedDefinition(): Promise<Object>;
+  editor_session_selectByUUID(uuid: string): Promise<void>;
+  editor_session_selectByName(name: string): Promise<void>;
+  editor_session_clearSelection(): Promise<void>;
+  // Canvas API.
+  editor_canvas_getShapeIds(): Promise<string[]>;
+  editor_canvas_getBackgroundColor(uuid: string): Promise<string>;
+  editor_canvas_setBackgroundColor(uuid: string, backgroundColor: string): Promise<void>;
+  editor_canvas_getBorderColor(uuid: string): Promise<string>;
+  editor_canvas_setBorderColor(uuid: string, borderColor: string): Promise<void>;
+  editor_canvas_getLocation(uuid: string): Promise<number[]>;
+  editor_canvas_getAbsoluteLocation(uuid: string): Promise<number[]>;
+  editor_canvas_getDimensions(uuid: string): Promise<number[]>;
+  editor_canvas_center(uuid: string): Promise<void>;
+  editor_canvas_draw(): Promise<void>;
+}
+
+/**
+ * Represents an element in a graph, either a Node or an Edge.
+ */
+export class Element {
+  /**
+   * The unique element's identifier in the graph.
+   */
+  uuid: string;
+  /**
+   * A representation for the domain model object, associated to this element.
+   */
+  definition: Definition;
+}
+
+/**
+ * Represents a vertex in a graph.
+ */
+export class Node extends Element {
+  /**
+   * The incomming edges (in this node).
+   */
+  inEdges: Edge[];
+  /**
+   * The outgoing edges (from this node).
+   */
+  outEdges: Edge[];
+}
+
+/**
+ * Represents a connection between vertexes, in a graph.
+ */
+export class Edge extends Element {
+  /**
+   * The source node's identifier (UUID), if any.
+   */
+  source: string;
+  /**
+   * The target node's identifier (UUID), if any.
+   */
+  target: string;
+}
+
+/**
+ * Represents a domain model object by some of its attributes.
+ * So notice it does not correspond to the object in memory for the domain model.
+ */
+export class Definition {
+  /**
+   * The domain model object's identifier.
+   * It uses to match with FQCN of the objec'ts class.
+   * Examples:
+   * - org.kie.workbench.common.stunner.sw.definition.InjectState
+   * - org.kie.workbench.common.stunner.sw.definition.OperationState
+   * - org.kie.workbench.common.stunner.sw.definition.End
+   */
+  id: string;
+  /**
+   * The domain model object's name.
+   * It returns the value for the field that represents the name for a graph element.
+   */
+  name: string;
+}

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
@@ -100,7 +100,8 @@ export class Definition {
   id: string;
   /**
    * The domain model object's name.
-   * It returns the value for the field that represents the name for a graph element.
+   * It returns the value for the name field for the object that this definition represents (eg: the name of an InjectState, or an OperationState).
+   * The returned name is also the one being displayed on the shape.
    */
   name: string;
 }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
@@ -86,12 +86,12 @@ export class Edge extends Element {
 
 /**
  * Represents a domain model object by some of its attributes.
- * So notice it does not correspond to the object in memory for the domain model.
+ * It does not correspond to the object in memory for the domain model.
  */
 export class Definition {
   /**
    * The domain model object's identifier.
-   * It uses to match with FQCN of the objec'ts class.
+   * It is used to match with FQCN of the object's fully qualified class name.
    * Examples:
    * - org.kie.workbench.common.stunner.sw.definition.InjectState
    * - org.kie.workbench.common.stunner.sw.definition.OperationState

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
@@ -100,7 +100,7 @@ export class Definition {
   id: string;
   /**
    * The domain model object's name.
-   * It returns the value for the name field for the object that this definition represents (eg: the name of an InjectState, or an OperationState).
+   * Returns the value for the name field for the object that this definition represents (eg: the name of an InjectState, or an OperationState).
    * The returned name is also the one being displayed on the shape.
    */
   name: string;

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPI.ts
@@ -21,7 +21,7 @@ export interface StunnerEditorEnvelopeAPI {
   editor_session_getNodeByUUID(uuid: string): Promise<Node>;
   editor_session_getDefinitionByElementUUID(uuid: string): Promise<Object>;
   editor_session_getNodeByName(name: string): Promise<Node>;
-  editor_session_getNodeName(uuid: string): Promise<string>;
+  editor_session_getNodeName(node: Node): Promise<string>;
   editor_session_getSelectedElementUUID(): Promise<string>;
   editor_session_getSelectedNode(): Promise<Node>;
   editor_session_getSelectedEdge(): Promise<Edge>;

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPIFactory.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/StunnerEditorEnvelopeAPIFactory.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StunnerEdge, StunnerNode } from "./StunnerAPI";
+import { Definition, Edge, Node } from "./StunnerEditorEnvelopeAPI";
+
+export function createNode(node: StunnerNode, mapper: DefinitionMapper) {
+  const jsNode = new Node();
+  jsNode.uuid = node.getUUID();
+  jsNode.definition = createDefinition(node.getContent().getDefinition(), mapper);
+  jsNode.inEdges = node.inConnectors().map((edge) => createEdge(edge, mapper));
+  jsNode.outEdges = node.outConnectors().map((edge) => createEdge(edge, mapper));
+  return jsNode;
+}
+
+export function createEdge(edge: StunnerEdge, mapper: DefinitionMapper) {
+  const jsEdgr: Edge = new Edge();
+  jsEdgr.uuid = edge.getUUID();
+  jsEdgr.definition = createDefinition(edge.getContent().getDefinition(), mapper);
+  jsEdgr.source = edge.getSourceNode().getUUID();
+  jsEdgr.target = edge.getTargetNode().getUUID();
+  return jsEdgr;
+}
+
+export function createDefinition(bean: Object, mapper: DefinitionMapper) {
+  const result: Definition = new Definition();
+  result.id = mapper.getId(bean);
+  result.name = mapper.getName(bean);
+  return result;
+}
+
+export interface DefinitionMapper {
+  getId(bean: Object): string;
+  getName(bean: Object): string;
+}

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Node, Edge } from "./StunnerEditorEnvelopeAPI";
+
+/**
+ * Javascript's main entry point for the 'Serverless Workflow Diagram Editor' API.
+ * This API is exposed in the editor's envelope, so it allows communication between app-shells by relying on the envelope bus.
+ */
+export interface SwfStunnerEditorAPI {
+  /**
+   * The diagram editor's session object. It provides access to the
+   * editor's model objects, as well as access to controls like selection.
+   */
+  session: SwfStunnerEditoSession;
+  /**
+   * The diagram editor's canvas object. It allows to get or update shape attributes' values,
+   * as well other methods related to the management of the editor's view.
+   */
+  canvas: SwfStunnerEditorCanvas;
+}
+
+/**
+ * The diagram editor's session object (API).
+ */
+export interface SwfStunnerEditoSession {
+  /**
+   * It returns all nodes' identifiers (UUID).
+   * @returns Asyncrhonously returns the UUID for all nodes in graph.
+   */
+  getAllNodesUUID(): Promise<string[]>;
+  /**
+   * It return the Edge for the given identifier (UUID).
+   * @param uuid The edge's identifier (UUID).
+   * @returns Asyncrhonously returns the edge object.
+   */
+  getEdgeByUUID(uuid: string): Promise<Edge>;
+  /**
+   * It return the Node for the given identifier (UUID).
+   * @param uuid The node's identifier (UUID).
+   * @returns Asyncrhonously returns the node object.
+   */
+  getNodeByUUID(uuid: string): Promise<Node>;
+  /**
+   * It returns the node's or edge's definition object.
+   * The definition object must be cloneable, in order to travel across the envelope bus.
+   * So it is up to third parties to ensure the object is cloneable, otherwise this method will return an exception.
+   * @param uuid The node's or edge's identifier (UUID).
+   * @returns Asyncrhonously returns the definition object (eg: InjectState object)
+   */
+  getDefinitionByElementUUID(uuid: string): Promise<Object>;
+  /**
+   * It return the Node which has a given name.
+   * @param uuid The node's name.
+   * @returns Asyncrhonously returns the node object.
+   */
+  getNodeByName(name: string): Promise<Node>;
+  /**
+   * It return the name for a Node.
+   * @param uuid The node's identifier (UUID).
+   * @returns Asyncrhonously returns the name.
+   */
+  getNodeName(uuid: string): Promise<string>;
+  /**
+   * It returns the graph element (Node, Edge) identifier (UUID) for the selected shape in the editor's view.
+   * @returns Asyncrhonously returns the element's identifier (UUID).
+   */
+  getSelectedElementUUID(): Promise<string>;
+  /**
+   * It returns the Node identifier (UUID) for the selected shape in the editor's view.
+   * @returns Asyncrhonously returns the node object.
+   */
+  getSelectedNode(): Promise<Node>;
+  /**
+   * It returns the Edge identifier (UUID) for the selected shape in the editor's view.
+   * @returns Asyncrhonouly returns the edge object.
+   */
+  getSelectedEdge(): Promise<Edge>;
+  /**
+   * It returns the node's or edge's definition object, for the selected shape in the editor's view.
+   * @returns Asyncrhonously returns the node's or edge's defnition object (eg: InjectState object).
+   */
+  getSelectedDefinition(): Promise<Object>;
+  /**
+   * Selects an element (Node or Edge).
+   * @param uuid The elements's identifier (UUID).
+   * @returns Asyncrhonously notifies about selection being performed.
+   */
+  selectByUUID(uuid: string): Promise<void>;
+  /**
+   * Selects an element (Node or Edge).
+   * @param uuid The elements's name.
+   * @returns Asyncrhonously notifies about selection being performed.
+   */
+  selectByName(name: string): Promise<void>;
+  /**
+   * Clears the selection state, also updates the editor's view.
+   * @returns Asyncrhonously notifies about selection being properly cleaned.
+   */
+  clearSelection(): Promise<void>;
+}
+
+/**
+ * The diagram editor's canvas object (API).
+ */
+export interface SwfStunnerEditorCanvas {
+  /**
+   * Looks for all canvas' shape identifiers.
+   * Notice result may not match with all graph elements' identifiers.
+   * @returns Asyncrhonously returns the identifiers for canvas' shapes.
+   */
+  getShapeIds(): Promise<string[]>;
+  /**
+   * Obtain the shape's background (fill) color.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously returns the background color (name or RGB formatted value) for the shape.
+   */
+  getBackgroundColor(uuid: string): Promise<string>;
+  /**
+   * Sets the shape's background (fill) color.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @param backgroundColor The color name or RGB value for the background color.
+   * @returns Asyncrhonously notifies when the background color is being changed. Notice you may call draw once all attributes have been changed.
+   */
+  setBackgroundColor(uuid: string, backgroundColor: string): Promise<void>;
+  /**
+   * Obtain the shape's border (stroke) color.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously returns the border color (name or RGB formatted value) for the shape.
+   */
+  getBorderColor(uuid: string): Promise<string>;
+  /**
+   * Sets the shape's border (stroke) color.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @param backgroundColor The color name or RGB value for the border color.
+   * @returns Asyncrhonously notifies when the border color is being changed. Notice you may call draw once all attributes have been changed.
+   */
+  setBorderColor(uuid: string, backgroundColor: string): Promise<void>;
+  /**
+   * Obtain the shape's location relative to the parent, if any.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously returns the location (X and Y coordinates in a 2D space) for the given shape.
+   */
+  getLocation(uuid: string): Promise<number[]>;
+  /**
+   * Obtain the shape's location relative to the viewport.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously returns the absolute location (X and Y coordinates in a 2D space) for the given shape.
+   */
+  getAbsoluteLocation(uuid: string): Promise<number[]>;
+  /**
+   * Compute the shape's dimensions.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously returns the width and height values (in PX units) for the given shape.
+   */
+  getDimensions(uuid: string): Promise<number[]>;
+  /**
+   * Changes the viewport accordingly to render a shape in its center.
+   * Only applies when shapes is not visible at all, in the viewport area.
+   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @returns Asyncrhonously notifies when operations are being completed.
+   */
+  center(uuid: string): Promise<void>;
+  /**
+   * It performs the screen rendering for the changed objects or shapes' attributes in the editor's view.
+   * @returns Asyncrhonously notifies when operations are being completed.
+   */
+  draw(): Promise<void>;
+}

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
@@ -43,13 +43,13 @@ export interface SwfStunnerEditoSession {
    */
   getAllNodesUUID(): Promise<string[]>;
   /**
-   * It return the Edge for the given identifier (UUID).
+   * It returns the Edge for the given identifier (UUID).
    * @param uuid The edge's identifier (UUID).
    * @returns Asynchronously returns the edge object.
    */
   getEdgeByUUID(uuid: string): Promise<Edge>;
   /**
-   * It return the Node for the given identifier (UUID).
+   * It returns the Node for the given identifier (UUID).
    * @param uuid The node's identifier (UUID).
    * @returns Asynchronously returns the node object.
    */
@@ -63,17 +63,17 @@ export interface SwfStunnerEditoSession {
    */
   getDefinitionByElementUUID(uuid: string): Promise<Object>;
   /**
-   * It return the Node which has a given name.
+   * It returns the Node which has a given name.
    * @param uuid The node's name.
    * @returns Asynchronously returns the node object.
    */
   getNodeByName(name: string): Promise<Node>;
   /**
-   * It return the name for a Node.
-   * @param uuid The node's identifier (UUID).
-   * @returns Asynchronously returns the name.
+   * It returns the name for a Node.
+   * @param node The Node instance.
+   * @returns Asynchronously returns the node's name.
    */
-  getNodeName(uuid: string): Promise<string>;
+  getNodeName(node: Node): Promise<string>;
   /**
    * Returns the graph element (Node, Edge) identifier (UUID) for the selected shape in the editor's view.
    * @returns Asynchronously returns the element's identifier (UUID).
@@ -86,12 +86,12 @@ export interface SwfStunnerEditoSession {
   getSelectedNode(): Promise<Node>;
   /**
    * Returns the Edge identifier (UUID) for the selected shape in the editor's view.
-   * @returns Asyncrhonouly returns the edge object.
+   * @returns Asynchronously returns the edge object.
    */
   getSelectedEdge(): Promise<Edge>;
   /**
    * Returns the node's or edge's definition object, for the selected shape in the editor's view.
-   * @returns Asynchronously returns the node's or edge's definition object (eg: InjectState object).
+   * @returns Asynchronously returns the node's or edge's definition object (eg: the InjectState object).
    */
   getSelectedDefinition(): Promise<Object>;
   /**
@@ -145,10 +145,10 @@ export interface SwfStunnerEditorCanvas {
   /**
    * Sets the shape's border (stroke) color.
    * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
-   * @param backgroundColor The color name or RGB value for the border color.
+   * @param borderColor The color name or RGB value for the border color.
    * @returns Asynchronously notifies when the border color is being changed. Notice you may need to call a draw function once all attributes have been changed.
    */
-  setBorderColor(uuid: string, backgroundColor: string): Promise<void>;
+  setBorderColor(uuid: string, borderColor: string): Promise<void>;
   /**
    * Obtains the shape's location relative to the parent, if any.
    * @param uuid The shape's identifier. It is used to match with the graph element's identifier.

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
@@ -28,7 +28,7 @@ export interface SwfStunnerEditorAPI {
   session: SwfStunnerEditoSession;
   /**
    * The diagram editor's canvas object. It allows to get or update shape attributes' values,
-   * as well other methods related to the management of the editor's view.
+   * as well as other methods related to the management of the editor's view.
    */
   canvas: SwfStunnerEditorCanvas;
 }
@@ -38,77 +38,77 @@ export interface SwfStunnerEditorAPI {
  */
 export interface SwfStunnerEditoSession {
   /**
-   * It returns all nodes' identifiers (UUID).
-   * @returns Asyncrhonously returns the UUID for all nodes in graph.
+   * Returns all nodes' identifiers (UUID).
+   * @returns Asynchronously returns the UUID for all nodes in graph.
    */
   getAllNodesUUID(): Promise<string[]>;
   /**
    * It return the Edge for the given identifier (UUID).
    * @param uuid The edge's identifier (UUID).
-   * @returns Asyncrhonously returns the edge object.
+   * @returns Asynchronously returns the edge object.
    */
   getEdgeByUUID(uuid: string): Promise<Edge>;
   /**
    * It return the Node for the given identifier (UUID).
    * @param uuid The node's identifier (UUID).
-   * @returns Asyncrhonously returns the node object.
+   * @returns Asynchronously returns the node object.
    */
   getNodeByUUID(uuid: string): Promise<Node>;
   /**
-   * It returns the node's or edge's definition object.
+   * Returns the node's or edge's definition object.
    * The definition object must be cloneable, in order to travel across the envelope bus.
-   * So it is up to third parties to ensure the object is cloneable, otherwise this method will return an exception.
+   * It is up to third parties to ensure the object is cloneable, otherwise this method will return an exception.
    * @param uuid The node's or edge's identifier (UUID).
-   * @returns Asyncrhonously returns the definition object (eg: InjectState object)
+   * @returns Asynchronously returns the definition object (eg: InjectState object)
    */
   getDefinitionByElementUUID(uuid: string): Promise<Object>;
   /**
    * It return the Node which has a given name.
    * @param uuid The node's name.
-   * @returns Asyncrhonously returns the node object.
+   * @returns Asynchronously returns the node object.
    */
   getNodeByName(name: string): Promise<Node>;
   /**
    * It return the name for a Node.
    * @param uuid The node's identifier (UUID).
-   * @returns Asyncrhonously returns the name.
+   * @returns Asynchronously returns the name.
    */
   getNodeName(uuid: string): Promise<string>;
   /**
-   * It returns the graph element (Node, Edge) identifier (UUID) for the selected shape in the editor's view.
-   * @returns Asyncrhonously returns the element's identifier (UUID).
+   * Returns the graph element (Node, Edge) identifier (UUID) for the selected shape in the editor's view.
+   * @returns Asynchronously returns the element's identifier (UUID).
    */
   getSelectedElementUUID(): Promise<string>;
   /**
-   * It returns the Node identifier (UUID) for the selected shape in the editor's view.
-   * @returns Asyncrhonously returns the node object.
+   * Returns the Node identifier (UUID) for the selected shape in the editor's view.
+   * @returns Asynchronously returns the node object.
    */
   getSelectedNode(): Promise<Node>;
   /**
-   * It returns the Edge identifier (UUID) for the selected shape in the editor's view.
+   * Returns the Edge identifier (UUID) for the selected shape in the editor's view.
    * @returns Asyncrhonouly returns the edge object.
    */
   getSelectedEdge(): Promise<Edge>;
   /**
-   * It returns the node's or edge's definition object, for the selected shape in the editor's view.
-   * @returns Asyncrhonously returns the node's or edge's defnition object (eg: InjectState object).
+   * Returns the node's or edge's definition object, for the selected shape in the editor's view.
+   * @returns Asynchronously returns the node's or edge's definition object (eg: InjectState object).
    */
   getSelectedDefinition(): Promise<Object>;
   /**
    * Selects an element (Node or Edge).
    * @param uuid The elements's identifier (UUID).
-   * @returns Asyncrhonously notifies about selection being performed.
+   * @returns Asynchronously notifies about selection being performed.
    */
   selectByUUID(uuid: string): Promise<void>;
   /**
    * Selects an element (Node or Edge).
    * @param uuid The elements's name.
-   * @returns Asyncrhonously notifies about selection being performed.
+   * @returns Asynchronously notifies about selection being performed.
    */
   selectByName(name: string): Promise<void>;
   /**
-   * Clears the selection state, also updates the editor's view.
-   * @returns Asyncrhonously notifies about selection being properly cleaned.
+   * Clears the selection state and  updates the editor's view.
+   * @returns Asynchronously notifies about selection being properly cleaned.
    */
   clearSelection(): Promise<void>;
 }
@@ -119,64 +119,64 @@ export interface SwfStunnerEditoSession {
 export interface SwfStunnerEditorCanvas {
   /**
    * Looks for all canvas' shape identifiers.
-   * Notice result may not match with all graph elements' identifiers.
-   * @returns Asyncrhonously returns the identifiers for canvas' shapes.
+   * Returned values may not match with all graph elements' identifiers.
+   * @returns Asynchronously returns the identifiers for canvas' shapes.
    */
   getShapeIds(): Promise<string[]>;
   /**
-   * Obtain the shape's background (fill) color.
+   * Obtains the shape's background (fill) color.
    * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously returns the background color (name or RGB formatted value) for the shape.
+   * @returns Asynchronously returns the background color (name or RGB formatted value) for the shape.
    */
   getBackgroundColor(uuid: string): Promise<string>;
   /**
    * Sets the shape's background (fill) color.
    * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
    * @param backgroundColor The color name or RGB value for the background color.
-   * @returns Asyncrhonously notifies when the background color is being changed. Notice you may call draw once all attributes have been changed.
+   * @returns Asynchronously notifies when the background color is being changed. Notice you may need to call a draw function once all attributes have been changed.
    */
   setBackgroundColor(uuid: string, backgroundColor: string): Promise<void>;
   /**
-   * Obtain the shape's border (stroke) color.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously returns the border color (name or RGB formatted value) for the shape.
+   * Obtains the shape's border (stroke) color.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
+   * @returns Asynchronously returns the border color (name or RGB formatted value) for the shape.
    */
   getBorderColor(uuid: string): Promise<string>;
   /**
    * Sets the shape's border (stroke) color.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
    * @param backgroundColor The color name or RGB value for the border color.
-   * @returns Asyncrhonously notifies when the border color is being changed. Notice you may call draw once all attributes have been changed.
+   * @returns Asynchronously notifies when the border color is being changed. Notice you may need to call a draw function once all attributes have been changed.
    */
   setBorderColor(uuid: string, backgroundColor: string): Promise<void>;
   /**
-   * Obtain the shape's location relative to the parent, if any.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously returns the location (X and Y coordinates in a 2D space) for the given shape.
+   * Obtains the shape's location relative to the parent, if any.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
+   * @returns Asynchronously returns the location (X and Y coordinates in a 2D space) for the given shape.
    */
   getLocation(uuid: string): Promise<number[]>;
   /**
-   * Obtain the shape's location relative to the viewport.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously returns the absolute location (X and Y coordinates in a 2D space) for the given shape.
+   * Obtains the shape's location relative to the viewport.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
+   * @returns Asynchronously returns the absolute location (X and Y coordinates in a 2D space) for the given shape.
    */
   getAbsoluteLocation(uuid: string): Promise<number[]>;
   /**
-   * Compute the shape's dimensions.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously returns the width and height values (in PX units) for the given shape.
+   * Computes the shape's dimensions.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
+   * @returns Asynchronously returns the width and height values (in PX units) for the given shape.
    */
   getDimensions(uuid: string): Promise<number[]>;
   /**
    * Changes the viewport accordingly to render a shape in its center.
-   * Only applies when shapes is not visible at all, in the viewport area.
-   * @param uuid The shape's identifier. It uses to match with the graph element's identifier.
-   * @returns Asyncrhonously notifies when operations are being completed.
+   * Only applies when shapes are not visible at all, in the viewport area.
+   * @param uuid The shape's identifier. It is used to match with the graph element's identifier.
+   * @returns Asynchronously notifies when operations are being completed.
    */
   center(uuid: string): Promise<void>;
   /**
-   * It performs the screen rendering for the changed objects or shapes' attributes in the editor's view.
-   * @returns Asyncrhonously notifies when operations are being completed.
+   * Performs the screen rendering for the changed objects or shapes' attributes in the editor's view.
+   * @returns Asynchronously notifies when operations are being completed.
    */
   draw(): Promise<void>;
 }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/SwfStunnerEditorAPI.ts
@@ -43,13 +43,13 @@ export interface SwfStunnerEditoSession {
    */
   getAllNodesUUID(): Promise<string[]>;
   /**
-   * It returns the Edge for the given identifier (UUID).
+   * Returns the Edge for the given identifier (UUID).
    * @param uuid The edge's identifier (UUID).
    * @returns Asynchronously returns the edge object.
    */
   getEdgeByUUID(uuid: string): Promise<Edge>;
   /**
-   * It returns the Node for the given identifier (UUID).
+   * Returns the Node for the given identifier (UUID).
    * @param uuid The node's identifier (UUID).
    * @returns Asynchronously returns the node object.
    */
@@ -63,13 +63,13 @@ export interface SwfStunnerEditoSession {
    */
   getDefinitionByElementUUID(uuid: string): Promise<Object>;
   /**
-   * It returns the Node which has a given name.
+   * Returns the Node which has a given name.
    * @param uuid The node's name.
    * @returns Asynchronously returns the node object.
    */
   getNodeByName(name: string): Promise<Node>;
   /**
-   * It returns the name for a Node.
+   * Returns the name for a Node.
    * @param node The Node instance.
    * @returns Asynchronously returns the node's name.
    */

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditor.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditor.ts
@@ -15,15 +15,16 @@
  */
 
 import { GwtEditorWrapper } from "@kie-tools/kie-bc-editors/dist/common";
-import { CanvasConsumedInteropApi } from "@kie-tools/kie-bc-editors/dist/canvas/CanvasConsumedInteropApi";
+import { StunnerCanvas, StunnerEditor, StunnerSession } from "../api/StunnerAPI";
 
 interface CustomWindow extends Window {
-  canvas: CanvasConsumedInteropApi;
+  canvas: StunnerCanvas;
+  editor: StunnerEditor;
 }
 
 declare let window: CustomWindow;
 
-export interface ServerlessWorkflowDiagramEditor extends GwtEditorWrapper, CanvasConsumedInteropApi {
+export interface ServerlessWorkflowDiagramEditor extends GwtEditorWrapper, StunnerCanvas, StunnerSession {
   myServerlessWorkflowDiagramMethod(): string;
 }
 
@@ -32,43 +33,103 @@ export class ServerlessWorkflowDiagramEditorImpl extends GwtEditorWrapper implem
     return "serverless-workflow-diagram-specific--configured";
   }
 
-  public getNodeIds() {
-    return window.canvas.getNodeIds();
+  public getGraph() {
+    return window.editor.session.getGraph();
+  }
+
+  public getEdgeByUUID(uuid: string) {
+    return window.editor.session.getEdgeByUUID(uuid);
+  }
+
+  public getNodeByUUID(uuid: string) {
+    return window.editor.session.getNodeByUUID(uuid);
+  }
+
+  public getDefinitionByElementUUID(uuid: string) {
+    return window.editor.session.getDefinitionByElementUUID(uuid);
+  }
+
+  public getNodeByName(name: string) {
+    return window.editor.session.getNodeByName(name);
+  }
+
+  public getNodeName(uuid: string) {
+    return window.editor.session.getNodeName(uuid);
+  }
+
+  public getDefinitionId(bean: Object) {
+    return window.editor.session.getDefinitionId(bean);
+  }
+
+  public getDefinitionName(bean: Object) {
+    return window.editor.session.getDefinitionName(bean);
+  }
+
+  public getSelectedElementUUID() {
+    return window.editor.session.getSelectedElementUUID();
+  }
+
+  public getSelectedNode() {
+    return window.editor.session.getSelectedNode();
+  }
+
+  public getSelectedEdge() {
+    return window.editor.session.getSelectedEdge();
+  }
+
+  public getSelectedDefinition() {
+    return window.editor.session.getSelectedDefinition();
+  }
+
+  public selectByUUID(uuid: string) {
+    window.editor.session.selectByUUID(uuid);
+  }
+
+  public selectByName(name: string) {
+    window.editor.session.selectByName(name);
+  }
+
+  public clearSelection() {
+    window.editor.session.clearSelection();
+  }
+
+  public getShapeIds() {
+    return window.editor.canvas.getShapeIds();
   }
 
   public getBackgroundColor(uuid: string) {
-    return window.canvas.getBackgroundColor(uuid);
+    return window.editor.canvas.getBackgroundColor(uuid);
   }
 
   public setBackgroundColor(uuid: string, backgroundColor: string) {
-    window.canvas.setBackgroundColor(uuid, backgroundColor);
+    window.editor.canvas.setBackgroundColor(uuid, backgroundColor);
   }
 
   public getBorderColor(uuid: string) {
-    return window.canvas.getBorderColor(uuid);
+    return window.editor.canvas.getBorderColor(uuid);
   }
 
   public setBorderColor(uuid: string, borderColor: string) {
-    window.canvas.setBorderColor(uuid, borderColor);
+    window.editor.canvas.setBorderColor(uuid, borderColor);
   }
 
   public getLocation(uuid: string) {
-    return window.canvas.getLocation(uuid);
+    return window.editor.canvas.getLocation(uuid);
   }
 
   public getAbsoluteLocation(uuid: string) {
-    return window.canvas.getAbsoluteLocation(uuid);
+    return window.editor.canvas.getAbsoluteLocation(uuid);
   }
 
   public getDimensions(uuid: string) {
-    return window.canvas.getDimensions(uuid);
+    return window.editor.canvas.getDimensions(uuid);
   }
 
-  public applyState(uuid: string, state: string) {
-    window.canvas.applyState(uuid, state);
+  public center(uuid: string) {
+    window.editor.canvas.center(uuid);
   }
 
-  public centerNode(uuid: string) {
-    window.canvas.centerNode(uuid);
+  public draw() {
+    window.editor.canvas.draw();
   }
 }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditor.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditor.ts
@@ -15,7 +15,7 @@
  */
 
 import { GwtEditorWrapper } from "@kie-tools/kie-bc-editors/dist/common";
-import { StunnerCanvas, StunnerEditor, StunnerSession } from "../api/StunnerAPI";
+import { StunnerCanvas, StunnerEditor, StunnerNode, StunnerSession } from "../api/StunnerAPI";
 
 interface CustomWindow extends Window {
   canvas: StunnerCanvas;
@@ -53,8 +53,8 @@ export class ServerlessWorkflowDiagramEditorImpl extends GwtEditorWrapper implem
     return window.editor.session.getNodeByName(name);
   }
 
-  public getNodeName(uuid: string) {
-    return window.editor.session.getNodeName(uuid);
+  public getNodeName(node: StunnerNode) {
+    return window.editor.session.getNodeName(node);
   }
 
   public getDefinitionId(bean: Object) {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
@@ -19,6 +19,8 @@ import { EditorEnvelopeViewApi, KogitoEditorEnvelopeApiImpl } from "@kie-tools-c
 import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
 import { ServerlessWorkflowDiagramEditorChannelApi, ServerlessWorkflowDiagramEditorEnvelopeApi } from "../api";
 import { ServerlessWorkflowDiagramEditor } from "./ServerlessWorkflowDiagramEditor";
+import { StunnerEdge, StunnerNode, StunnerGraph } from "../api/StunnerAPI";
+import { createEdge, createNode, DefinitionMapper } from "../api/StunnerEditorEnvelopeAPIFactory";
 
 export type ServerlessWorkflowDiagramEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   ServerlessWorkflowDiagramEditorEnvelopeApi,
@@ -42,44 +44,121 @@ export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
     super(serverlessWorkflowArgs, editorFactory);
   }
 
-  public async canvas_getNodeIds() {
-    return this.getEditorOrThrowError().getNodeIds();
+  public async editor_session_getAllNodesUUID() {
+    const graph: StunnerGraph = this.getEditorOrThrowError().getGraph();
+    return graph.nodesArray().map((node) => node.getUUID());
   }
 
-  public async canvas_getBackgroundColor(uuid: string) {
+  public async editor_session_getEdgeByUUID(uuid: string) {
+    const edge: StunnerEdge = this.getEditorOrThrowError().getEdgeByUUID(uuid);
+    return this.toEdge(edge);
+  }
+
+  public async editor_session_getNodeByUUID(uuid: string) {
+    const node: StunnerNode = this.getEditorOrThrowError().getNodeByUUID(uuid);
+    return this.toNode(node);
+  }
+
+  public async editor_session_getDefinitionByElementUUID(uuid: string): Promise<Object> {
+    return this.getEditorOrThrowError().getDefinitionByElementUUID(uuid);
+  }
+
+  public async editor_session_getNodeByName(name: string) {
+    const node: StunnerNode = this.getEditorOrThrowError().getNodeByName(name);
+    return this.toNode(node);
+  }
+
+  public async editor_session_getNodeName(uuid: string) {
+    return this.getEditorOrThrowError().getNodeName(uuid);
+  }
+
+  public async editor_session_getSelectedElementUUID() {
+    return this.getEditorOrThrowError().getSelectedElementUUID();
+  }
+
+  public async editor_session_getSelectedNode() {
+    const node: StunnerNode = this.getEditorOrThrowError().getSelectedNode();
+    return this.toNode(node);
+  }
+
+  public async editor_session_getSelectedEdge() {
+    const edge: StunnerEdge = this.getEditorOrThrowError().getSelectedEdge();
+    return this.toEdge(edge);
+  }
+
+  public async editor_session_getSelectedDefinition() {
+    return this.getEditorOrThrowError().getSelectedDefinition();
+  }
+
+  public async editor_session_selectByUUID(uuid: string) {
+    this.getEditorOrThrowError().selectByUUID(uuid);
+  }
+
+  public async editor_session_selectByName(name: string) {
+    this.getEditorOrThrowError().selectByName(name);
+  }
+
+  public async editor_session_clearSelection() {
+    this.getEditorOrThrowError().clearSelection();
+  }
+
+  private toNode(node: StunnerNode) {
+    return createNode(node, this.toDefinition(node));
+  }
+
+  private toEdge(edge: StunnerEdge) {
+    return createEdge(edge, this.toDefinition(edge));
+  }
+
+  private toDefinition(bean: Object): DefinitionMapper {
+    return {
+      getId: (bean) => {
+        return this.getEditorOrThrowError().getDefinitionId(bean);
+      },
+      getName: (bean) => {
+        return this.getEditorOrThrowError().getDefinitionName(bean);
+      },
+    };
+  }
+
+  public async editor_canvas_getShapeIds() {
+    return this.getEditorOrThrowError().getShapeIds();
+  }
+
+  public async editor_canvas_getBackgroundColor(uuid: string) {
     return this.getEditorOrThrowError().getBackgroundColor(uuid);
   }
 
-  public async canvas_setBackgroundColor(uuid: string, backgroundColor: string) {
+  public async editor_canvas_setBackgroundColor(uuid: string, backgroundColor: string) {
     return this.getEditorOrThrowError().setBackgroundColor(uuid, backgroundColor);
   }
 
-  public async canvas_getBorderColor(uuid: string) {
+  public async editor_canvas_getBorderColor(uuid: string) {
     return this.getEditorOrThrowError().getBorderColor(uuid);
   }
 
-  public async canvas_setBorderColor(uuid: string, borderColor: string) {
+  public async editor_canvas_setBorderColor(uuid: string, borderColor: string) {
     return this.getEditorOrThrowError().setBorderColor(uuid, borderColor);
   }
 
-  public async canvas_getLocation(uuid: string) {
+  public async editor_canvas_getLocation(uuid: string) {
     return this.getEditorOrThrowError().getLocation(uuid);
   }
 
-  public async canvas_getAbsoluteLocation(uuid: string) {
+  public async editor_canvas_getAbsoluteLocation(uuid: string) {
     return this.getEditorOrThrowError().getAbsoluteLocation(uuid);
   }
 
-  public async canvas_getDimensions(uuid: string) {
+  public async editor_canvas_getDimensions(uuid: string) {
     return this.getEditorOrThrowError().getDimensions(uuid);
   }
 
-  public async canvas_applyState(uuid: string, state: string) {
-    return this.getEditorOrThrowError().applyState(uuid, state);
+  public async editor_canvas_center(uuid: string) {
+    return this.getEditorOrThrowError().center(uuid);
   }
 
-  public async canvas_centerNode(uuid: string) {
-    return this.getEditorOrThrowError().centerNode(uuid);
+  public async editor_canvas_draw() {
+    return this.getEditorOrThrowError().draw();
   }
 
   public kogitoSwfDiagramEditor__highlightNode(args: { nodeName: string | null }) {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
@@ -20,6 +20,7 @@ import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
 import { ServerlessWorkflowDiagramEditorChannelApi, ServerlessWorkflowDiagramEditorEnvelopeApi } from "../api";
 import { ServerlessWorkflowDiagramEditor } from "./ServerlessWorkflowDiagramEditor";
 import { StunnerEdge, StunnerNode, StunnerGraph } from "../api/StunnerAPI";
+import { Node } from "../api/StunnerEditorEnvelopeAPI";
 import { createEdge, createNode, DefinitionMapper } from "../api/StunnerEditorEnvelopeAPIFactory";
 
 export type ServerlessWorkflowDiagramEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
@@ -68,8 +69,8 @@ export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
     return this.toNode(node);
   }
 
-  public async editor_session_getNodeName(uuid: string) {
-    return this.getEditorOrThrowError().getNodeName(uuid);
+  public async editor_session_getNodeName(node: Node) {
+    return this.getEditorOrThrowError().getNodeName(this.toStunnerNode(node));
   }
 
   public async editor_session_getSelectedElementUUID() {
@@ -100,6 +101,10 @@ export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
 
   public async editor_session_clearSelection() {
     this.getEditorOrThrowError().clearSelection();
+  }
+
+  private toStunnerNode(node: Node) {
+    return this.getEditorOrThrowError().getNodeByUUID(node.uuid);
   }
 
   private toNode(node: StunnerNode) {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowStunnerEditor.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowStunnerEditor.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { ServerlessWorkflowDiagramEditorEnvelopeApi } from "../api";
+import { SwfStunnerEditorAPI, SwfStunnerEditorCanvas, SwfStunnerEditoSession } from "../api/SwfStunnerEditorAPI";
+
+export class SwfStunnerEditor implements SwfStunnerEditorAPI {
+  session: SwfStunnerEditoSession;
+  canvas: SwfStunnerEditorCanvas;
+
+  constructor(envelopeApi: MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>) {
+    this.session = {
+      getAllNodesUUID: () => {
+        return envelopeApi.requests.editor_session_getAllNodesUUID();
+      },
+      getEdgeByUUID: (uuid: string) => {
+        return envelopeApi.requests.editor_session_getEdgeByUUID(uuid);
+      },
+      getNodeByUUID: (uuid: string) => {
+        return envelopeApi.requests.editor_session_getNodeByUUID(uuid);
+      },
+      getDefinitionByElementUUID: (uuid: string) => {
+        return envelopeApi.requests.editor_session_getDefinitionByElementUUID(uuid);
+      },
+      getNodeByName: (name: string) => {
+        return envelopeApi.requests.editor_session_getNodeByName(name);
+      },
+      getNodeName: (uuid: string) => {
+        return envelopeApi.requests.editor_session_getNodeName(uuid);
+      },
+      getSelectedElementUUID: () => {
+        return envelopeApi.requests.editor_session_getSelectedElementUUID();
+      },
+      getSelectedNode: () => {
+        return envelopeApi.requests.editor_session_getSelectedNode();
+      },
+      getSelectedEdge: () => {
+        return envelopeApi.requests.editor_session_getSelectedEdge();
+      },
+      getSelectedDefinition: () => {
+        return envelopeApi.requests.editor_session_getSelectedDefinition();
+      },
+      selectByUUID: (uuid: string) => {
+        envelopeApi.requests.editor_session_selectByUUID(uuid);
+        return Promise.resolve();
+      },
+      selectByName: (name: string) => {
+        envelopeApi.requests.editor_session_selectByName(name);
+        return Promise.resolve();
+      },
+      clearSelection: () => {
+        envelopeApi.requests.editor_session_clearSelection();
+        return Promise.resolve();
+      },
+    };
+    this.canvas = {
+      getShapeIds: () => {
+        return envelopeApi.requests.editor_canvas_getShapeIds();
+      },
+      getBackgroundColor: (uuid: string) => {
+        return envelopeApi.requests.editor_canvas_getBackgroundColor(uuid);
+      },
+      setBackgroundColor: (uuid: string, color: string) => {
+        envelopeApi.requests.editor_canvas_setBackgroundColor(uuid, color);
+        return Promise.resolve();
+      },
+      getBorderColor: (uuid: string) => {
+        return envelopeApi.requests.editor_canvas_getBorderColor(uuid);
+      },
+      setBorderColor: (uuid: string, color: string) => {
+        envelopeApi.requests.editor_canvas_setBorderColor(uuid, color);
+        return Promise.resolve();
+      },
+      getLocation: (uuid: string) => {
+        return envelopeApi.requests.editor_canvas_getLocation(uuid);
+      },
+      getAbsoluteLocation: (uuid: string) => {
+        return envelopeApi.requests.editor_canvas_getAbsoluteLocation(uuid);
+      },
+      getDimensions: (uuid: string) => {
+        return envelopeApi.requests.editor_canvas_getDimensions(uuid);
+      },
+      center: (uuid: string) => {
+        envelopeApi.requests.editor_canvas_center(uuid);
+        return Promise.resolve();
+      },
+      draw: () => {
+        envelopeApi.requests.editor_canvas_draw();
+        return Promise.resolve();
+      },
+    };
+  }
+}

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowStunnerEditor.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowStunnerEditor.ts
@@ -16,6 +16,7 @@
 
 import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
 import { ServerlessWorkflowDiagramEditorEnvelopeApi } from "../api";
+import { Node } from "../api/StunnerEditorEnvelopeAPI";
 import { SwfStunnerEditorAPI, SwfStunnerEditorCanvas, SwfStunnerEditoSession } from "../api/SwfStunnerEditorAPI";
 
 export class SwfStunnerEditor implements SwfStunnerEditorAPI {
@@ -39,8 +40,8 @@ export class SwfStunnerEditor implements SwfStunnerEditorAPI {
       getNodeByName: (name: string) => {
         return envelopeApi.requests.editor_session_getNodeByName(name);
       },
-      getNodeName: (uuid: string) => {
-        return envelopeApi.requests.editor_session_getNodeName(uuid);
+      getNodeName: (node: Node) => {
+        return envelopeApi.requests.editor_session_getNodeName(node);
       },
       getSelectedElementUUID: () => {
         return envelopeApi.requests.editor_session_getSelectedElementUUID();

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ControlPointControlImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/canvas/controls/ControlPointControlImpl.java
@@ -193,7 +193,7 @@ public class ControlPointControlImpl
                 final ControlPoint[] controlPoints = new ControlPoint[size];
                 for (int i = 1; i <= size; i++) {
                     com.ait.lienzo.client.core.types.Point2D point = pointsLocation.get(i);
-                    controlPoints[i - 1] = ControlPoint.build(Point2D.create(point.getX(),
+                    controlPoints[i - 1] = ControlPoint.create(Point2D.create(point.getX(),
                                                                              point.getY()));
                 }
                 control.updateControlPoints(edge,

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -175,6 +175,7 @@ public class StunnerEditor {
             }
         });
         JsWindow.canvas = jsCanvas;
+        JsWindow.editor.canvas = jsCanvas;
     }
 
     public int getCurrentContentHash() {

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/Bound.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/Bound.java
@@ -17,11 +17,8 @@
 package org.kie.workbench.common.stunner.core.graph.content;
 
 import jsinterop.annotations.JsType;
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
 @JsType
 public class Bound {
 
@@ -33,8 +30,8 @@ public class Bound {
     private Double x;
     private Double y;
 
-    public Bound(final @MapsTo("x") Double x,
-                 final @MapsTo("y") Double y) {
+    public Bound(Double x,
+                 Double y) {
         this.x = x;
         this.y = y;
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/Bounds.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/Bounds.java
@@ -19,11 +19,8 @@ package org.kie.workbench.common.stunner.core.graph.content;
 import java.util.Objects;
 
 import jsinterop.annotations.JsType;
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
 @JsType
 public class Bounds {
 
@@ -54,8 +51,8 @@ public class Bounds {
     private Bound lr;
     private Bound ul;
 
-    public Bounds(final @MapsTo("ul") Bound ul,
-                  final @MapsTo("lr") Bound lr) {
+    public Bounds(Bound ul,
+                  Bound lr) {
         this.ul = ul;
         this.lr = lr;
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ControlPoint.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ControlPoint.java
@@ -18,16 +18,15 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 
 import java.util.Objects;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
+import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
+@JsType
 public class ControlPoint {
 
     private Point2D location;
 
-    public static ControlPoint build(final Point2D location) {
+    public static ControlPoint create(final Point2D location) {
         return new ControlPoint(location);
     }
 
@@ -36,7 +35,7 @@ public class ControlPoint {
         return new ControlPoint(Point2D.create(x, y));
     }
 
-    public ControlPoint(final @MapsTo("location") Point2D location) {
+    public ControlPoint(Point2D location) {
         this.location = location;
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2D.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2D.java
@@ -18,13 +18,12 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 
 import java.util.Objects;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
+import jsinterop.annotations.JsType;
 
 /**
  * The values for the X/Y coordinates on the cartesian coordinates system.
  */
-@Portable
+@JsType
 public final class Point2D {
 
     private double x;
@@ -41,8 +40,8 @@ public final class Point2D {
                            point.getY());
     }
 
-    public Point2D(final @MapsTo("x") double x,
-                   final @MapsTo("y") double y) {
+    public Point2D(double x,
+                   double y) {
         this.x = x;
         this.y = y;
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerEditor.java
@@ -8,4 +8,6 @@ public class JsStunnerEditor {
 
     public JsDefinitionManager definitions;
     public JsStunnerSession session;
+    public Object canvas;
+
 }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
@@ -14,6 +14,7 @@ import org.kie.workbench.common.stunner.core.client.session.impl.AbstractSession
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.diagram.Diagram;
 import org.kie.workbench.common.stunner.core.graph.Edge;
+import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.Graph;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
@@ -52,11 +53,25 @@ public class JsStunnerSession {
 
     public String getNodeName(Node node) {
         Object definition = ((Node<Definition, Edge>) node).getContent().getDefinition();
-        return getName(definition);
+        return getDefinitionName(definition);
     }
 
-    public String getName(Object bean) {
+    public String getDefinitionId(Object bean) {
+        return JsWindow.editor.definitions.getId(bean).value();
+    }
+
+    public String getDefinitionName(Object bean) {
         return JsWindow.editor.definitions.getName(bean);
+    }
+
+    public Object getDefinitionByElementUUID(String uuid) {
+        Element e = getGraphIndex().get(uuid);
+        if (null == e) {
+            return null;
+        }
+        View<?> content = (View<?>) e.getContent();
+        Object definition = content.getDefinition();
+        return definition;
     }
 
     public Edge getEdgeByUUID(String uuid) {
@@ -80,11 +95,9 @@ public class JsStunnerSession {
 
     public Object getSelectedDefinition() {
         Node node = getSelectedNode();
-
         if (null == node) {
             return null;
         }
-
         View<?> content = (View<?>) node.getContent();
         Object definition = content.getDefinition();
         return definition;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsWindow.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsWindow.java
@@ -10,6 +10,7 @@ public class JsWindow {
     @JsProperty
     public static JsStunnerEditor editor;
 
+    @Deprecated // Use editor.canvas instead
     @JsProperty
     public static Object canvas;
 }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnection.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/MagnetConnection.java
@@ -19,15 +19,14 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
+import jsinterop.annotations.JsType;
 import org.jboss.errai.common.client.api.annotations.NonPortable;
-import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.graph.Element;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.graph.util.GraphUtils;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
+@JsType
 public class MagnetConnection extends DiscreteConnection {
 
     public static final int MAGNET_CENTER = 0;
@@ -39,8 +38,8 @@ public class MagnetConnection extends DiscreteConnection {
     private Point2D location;
     private Boolean auto;
 
-    private MagnetConnection(final @MapsTo("location") Point2D location,
-                             final @MapsTo("auto") Boolean auto) {
+    private MagnetConnection(Point2D location,
+                             Boolean auto) {
         Objects.requireNonNull(auto, "Parameter named 'auto' should be not null!");
         this.location = location;
         this.auto = auto;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2DConnection.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/Point2DConnection.java
@@ -18,11 +18,10 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 
 import java.util.Objects;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
+import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
+@JsType
 public class Point2DConnection implements Connection {
 
     private final Point2D location;
@@ -31,7 +30,7 @@ public class Point2DConnection implements Connection {
         return new Point2DConnection(location);
     }
 
-    public Point2DConnection(@MapsTo("location") final Point2D location) {
+    public Point2DConnection(Point2D location) {
         this.location = location;
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
@@ -20,12 +20,11 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
+import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
 
-@Portable
+@JsType
 public final class ViewConnectorImpl<W> implements ViewConnector<W> {
 
     protected W definition;
@@ -34,8 +33,8 @@ public final class ViewConnectorImpl<W> implements ViewConnector<W> {
     private Connection targetConnection;
     private ControlPoint[] controlPoints;
 
-    public ViewConnectorImpl(final @MapsTo("definition") W definition,
-                             final @MapsTo("bounds") Bounds bounds) {
+    public ViewConnectorImpl(W definition,
+                             Bounds bounds) {
         this.definition = definition;
         this.bounds = bounds;
         this.sourceConnection = null;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
@@ -17,19 +17,16 @@
 package org.kie.workbench.common.stunner.core.graph.content.view;
 
 import jsinterop.annotations.JsType;
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 
-@Portable
 @JsType
 public final class ViewImpl<W> implements View<W> {
 
     protected W definition;
     protected Bounds bounds;
 
-    public ViewImpl(final @MapsTo("definition") W definition,
-                    final @MapsTo("bounds") Bounds bounds) {
+    public ViewImpl(W definition,
+                    Bounds bounds) {
         this.definition = definition;
         this.bounds = bounds;
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/NodeImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/NodeImpl.java
@@ -43,8 +43,8 @@ public class NodeImpl<C> extends AbstractElement<C> implements Node<C, Edge> {
         return inEdges.toArray(new Edge[0]);
     }
 
-    public static Edge[] inConnectors(Node node) {
-        List<Edge> inEdges = node.getInEdges();
+    public Edge[] inConnectors() {
+        List<Edge> inEdges = getInEdges();
         return inEdges.stream()
                 .filter(e -> e.getContent() instanceof ViewConnector)
                 .toArray(Edge[]::new);
@@ -59,8 +59,8 @@ public class NodeImpl<C> extends AbstractElement<C> implements Node<C, Edge> {
         return outEdges.toArray(new Edge[0]);
     }
 
-    public static Edge[] outConnectors(Node node) {
-        List<Edge> outEdges = node.getOutEdges();
+    public Edge[] outConnectors() {
+        List<Edge> outEdges = getOutEdges();
         return outEdges.stream()
                 .filter(e -> e.getContent() instanceof ViewConnector)
                 .toArray(Edge[]::new);

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommandTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/command/impl/AbstractControlPointCommandTest.java
@@ -46,9 +46,9 @@ public class AbstractControlPointCommandTest extends AbstractGraphCommandTest {
         when(edge.getUUID()).thenReturn(EDGE_UUID);
         when(graphIndex.get(eq(EDGE_UUID))).thenReturn(edge);
         when(graphIndex.getEdge(eq(EDGE_UUID))).thenReturn(edge);
-        controlPoint1 = ControlPoint.build(new Point2D(1, 1));
-        controlPoint2 = ControlPoint.build(new Point2D(2, 2));
-        controlPoint3 = ControlPoint.build(new Point2D(3, 3));
+        controlPoint1 = ControlPoint.create(new Point2D(1, 1));
+        controlPoint2 = ControlPoint.create(new Point2D(2, 2));
+        controlPoint3 = ControlPoint.create(new Point2D(3, 3));
         when(edge.getContent()).thenReturn(viewConnector);
         when(viewConnector.getControlPoints())
                 .thenReturn(new ControlPoint[]{controlPoint1, controlPoint2, controlPoint3});

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -276,6 +276,11 @@ public class JsCanvas implements JsCanvasNodeLister {
         return dimensionsArray;
     }
 
+    public NFastArrayList<String> getShapeIds() {
+        return getNodeIds();
+    }
+
+    @Deprecated // Use getShapeIds() instaed.
     @Override
     public NFastArrayList<String> getNodeIds() {
         WiresShape[] shapes = WiresManager.get(getLayer()).getShapes();

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditor.java
@@ -264,7 +264,7 @@ public class DiagramEditor {
     }
 
     JsCanvas getJsCanvas() {
-        return Js.uncheckedCast(JsWindow.canvas);
+        return Js.uncheckedCast(JsWindow.editor.canvas);
     }
 
     @SuppressWarnings("all")

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
@@ -45,6 +45,7 @@ import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasVi
 import org.kie.workbench.common.stunner.client.widgets.canvas.ScrollableLienzoPanel;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
+import org.kie.workbench.common.stunner.core.client.api.JsStunnerEditor;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.AbstractSelectionControl;
@@ -143,6 +144,9 @@ public class DiagramEditorTest {
 
     @Mock
     private Graph graph;
+
+    @Mock
+    private JsStunnerEditor jsEditor;
 
     @Mock
     private JsCanvas jsCanvas;
@@ -246,7 +250,7 @@ public class DiagramEditorTest {
                                        diagramApi));
         tested.jsRegExpJson = jsRegExp;
         tested.domainInitializer = domainInitializer;
-        when(tested.getJsCanvas()).thenReturn(jsCanvas);
+        doReturn(jsCanvas).when(tested).getJsCanvas();
     }
 
     @Test


### PR DESCRIPTION
See [KOGITO-7066](https://issues.redhat.com/browse/KOGITO-7066)

**How to test the API from the UI**

Notice the API is implemented at _combined editor_ level, so it is accessible to most of the channels, except VSCode extension. Here will share some instructions about how to test it by using the _web-tools_ channel.

1. Download and extract the `build_artifacts.zip` , from this PR (_Checks_ tab)
2. Run a web server in the root folder: `build_artifacts/packages/serverless-logic-web-tools/dist`. _I personally use the Live Server extension in VSCode, I just open the dist/ folder and run the server._
4. Open `index.html` in your browser (located at root `build_artifacts/packages/serverless-logic-web-tools/dist/index.html`)
5. Once having the web-tools UI available, just create or open a workflow
6. Open the chrome _Console_ tab, from the web tools
7. TIP: Some errors are displayed, in order not to make noise, please filter our errors  from the console, Unselect the `errors` item here:
![stunner-envelope-api_filterout_errors](https://github.com/kiegroup/kie-tools/assets/4602417/d2a79e44-eb84-43c4-be14-548ffdddecbb)
8. In the console, choose the right context by selecting the `serverless-workflow-combined-editor  iframe `.  See:
![stunner-envelope-api_frame_selection](https://github.com/kiegroup/kie-tools/assets/4602417/35fb7ae9-3db3-4dc4-b7a2-b72f883995a1)



**Examples**
Notice the API is documented at https://github.com/kiegroup/kie-tools/pull/1589/files#diff-292fd900d04b40fbd39f26fefa506b17357917982fce264719152ed0ee62d913R23
From this point, you can use the API in the console, here are some examples:
**a) Obtain the selected node UIUID:**
a.1) Select a node from the UI, by clicking on any state
a.2) `editor.session.getSelectedElementUUID().then(uuid => console.log(uuid))`

**b) Change colors for an state**
b.1) Ensure nothing is selected on the UI
b.2) `editor.canvas.setBackgroundColor('_0757D1D8-C613-4B1A-955E-300BB2818D92', 'grey').then(done => {})`
b.3) `editor.canvas.setBorderColor('_0757D1D8-C613-4B1A-955E-300BB2818D92', 'black').then(done => {})`
b.4) `editor.canvas.draw().then(done => {})`
b.5) See results:
![stunner-envelope-api_canvas_example](https://github.com/kiegroup/kie-tools/assets/4602417/4956e5f8-59f8-40bd-8314-0635c8164754)
