### PR TITLE
KOGITO-9076: Retrieve Dashbuilder DataSet Columns information for CSV and Metrics

### DIFF
--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/csv/CSVColumnsFunction.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/csv/CSVColumnsFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dashbuilder.client.external.csv;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.dashbuilder.dataset.ColumnType;
+import org.dashbuilder.dataset.def.DataColumnDef;
+
+/**
+ * Retrieves columns from CSV
+ *
+ */
+@ApplicationScoped
+public class CSVColumnsFunction implements Function<String, List<DataColumnDef>> {
+
+    @Override
+    public List<DataColumnDef> apply(String t) {
+        if (t.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var columnsLine = t.split("\n")[0];
+        var columnsNames = columnsLine.split(",");
+        return columnsLine.trim().isEmpty() ? Collections.emptyList() :
+                Arrays.stream(columnsNames)
+                        .map(cl -> new DataColumnDef(cl, ColumnType.LABEL))
+                        .collect(Collectors.toList());
+    }
+
+}

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/csv/CSVParser.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/csv/CSVParser.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.dashbuilder.client.external;
+package org.dashbuilder.client.external.csv;
 
 import java.util.Arrays;
 import java.util.function.UnaryOperator;
@@ -27,6 +27,7 @@ public class CSVParser implements UnaryOperator<String> {
 
     private static final char SEPARATOR = ',';
     private static final char QUOTE = '\"';
+    private static final char BACKSLASH = '\\';
 
     public String toJsonArray(String csvContent) {
         var jsonArray = new StringBuilder("[");
@@ -77,7 +78,8 @@ public class CSVParser implements UnaryOperator<String> {
     }
 
     boolean isEscapedQuote(String line, int i) {
-        return line.charAt(i) == QUOTE && i < line.length() - 1 && line.charAt(i + 1) == QUOTE;
+        return (line.charAt(i) == QUOTE || line.charAt(i) == BACKSLASH) &&
+               i < line.length() - 1 && line.charAt(i + 1) == QUOTE;
     }
 
     @Override

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsColumnsFunction.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsColumnsFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.client.external.metrics;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.dashbuilder.dataset.ColumnType;
+import org.dashbuilder.dataset.def.DataColumnDef;
+
+/**
+ * Default Micrometer columns definition
+ *
+ */
+public class MetricsColumnsFunction implements Function<String, List<DataColumnDef>> {
+
+    @Override
+    public List<DataColumnDef> apply(String t) {
+        return Arrays.asList(
+                new DataColumnDef("metric", ColumnType.LABEL),
+                new DataColumnDef("labels", ColumnType.LABEL),
+                new DataColumnDef("value", ColumnType.NUMBER));
+    }
+
+}

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.dashbuilder.client.external;
+package org.dashbuilder.client.external.metrics;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/RuntimeDataSetClientServices.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/RuntimeDataSetClientServices.java
@@ -15,32 +15,19 @@
  */
 package org.dashbuilder.client.services;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 
-import elemental2.dom.DomGlobal;
-import elemental2.dom.Headers;
-import elemental2.dom.RequestInit;
-import elemental2.dom.Response;
-import elemental2.dom.XMLHttpRequest;
-import elemental2.promise.IThenable;
 import org.dashbuilder.client.RuntimeClientLoader;
 import org.dashbuilder.client.error.DefaultRuntimeErrorCallback;
-import org.dashbuilder.client.error.DefaultRuntimeErrorCallback.DefaultErrorType;
 import org.dashbuilder.client.error.ErrorResponseVerifier;
 import org.dashbuilder.client.external.ExternalDataSetClientProvider;
 import org.dashbuilder.client.marshalling.ClientDataSetMetadataJSONMarshaller;
-import org.dashbuilder.common.client.error.ClientRuntimeError;
 import org.dashbuilder.dataprovider.DataSetProviderType;
-import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.DataSetLookup;
 import org.dashbuilder.dataset.DataSetMetadata;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
@@ -50,18 +37,11 @@ import org.dashbuilder.dataset.client.DataSetMetadataCallback;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
 import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.events.DataSetDefRemovedEvent;
-import org.dashbuilder.dataset.json.DataSetJSONMarshaller;
-import org.dashbuilder.dataset.json.DataSetLookupJSONMarshaller;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jboss.resteasy.util.HttpResponseCodes;
-
-import static elemental2.dom.DomGlobal.fetch;
 
 @Alternative
 @ApplicationScoped
 public class RuntimeDataSetClientServices implements DataSetClientServices {
-
-    private static final String LOOKUP_ENDPOINT = "/rest/dataset/lookup";
 
     @Inject
     ClientDataSetMetadataJSONMarshaller dataSetMetadataJsonMarshaller;
@@ -81,8 +61,6 @@ public class RuntimeDataSetClientServices implements DataSetClientServices {
     @Inject
     ExternalDataSetClientProvider externalDataSetClientProvider;
 
-    Map<String, DataSetMetadata> metadataCache = new HashMap<>();
-
     public RuntimeDataSetClientServices() {
         // empty
     }
@@ -94,46 +72,13 @@ public class RuntimeDataSetClientServices implements DataSetClientServices {
 
     @Override
     public void fetchMetadata(String uuid, DataSetMetadataCallback listener) throws Exception {
-        if (metadataCache.containsKey(uuid)) {
-            listener.callback(metadataCache.get(uuid));
-            return;
-        }
-        fetch(LOOKUP_ENDPOINT).then((Response response) -> {
-            verifier.verify(response);
-            response.text().then(responseText -> {
-                if (response.status == HttpResponseCodes.SC_INTERNAL_SERVER_ERROR) {
-                    listener.onError(new ClientRuntimeError("Not able to retrieve dataset metadata",
-                            new Exception(responseText)));
-                } else {
-                    var meta = parseMetadata(responseText);
-                    listener.callback(meta);
-                    metadataCache.put(uuid, meta);
-                }
-                return null;
-            }, error -> {
-                listener.onError(new ClientRuntimeError("Not able to read dataset metadata"));
-                return null;
-            });
-
-            return null;
-        }).catch_(this::handleError);
+        // empty
     }
 
     @Override
     public DataSetMetadata getMetadata(String uuid) {
-        if (metadataCache.containsKey(uuid)) {
-            return metadataCache.get(uuid);
-        }
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "/rest/dataset/" + uuid + "/metadata", false);
-        xhr.send();
-        verifier.verify(xhr);
-        if (xhr.status == HttpResponseCodes.SC_INTERNAL_SERVER_ERROR) {
-            throw new RuntimeException("Not able to retrieve data set metadata: " + xhr.responseText);
-        }
-        var metadata = parseMetadata(xhr.responseText);
-        metadataCache.put(uuid, metadata);
-        return metadata;
+        // empty
+        return null;
     }
 
     @Override
@@ -144,31 +89,7 @@ public class RuntimeDataSetClientServices implements DataSetClientServices {
             return;
         }
 
-        externalDataSetClientProvider.fetchAndRegister(lookup.getDataSetUUID(),
-                lookup,
-                new DataSetReadyCallback() {
-
-                    @Override
-                    public boolean onError(ClientRuntimeError error) {
-                        if (loader.isEditor() || loader.isClient()) {
-                            listener.onError(error);
-                        } else {
-                            DomGlobal.console.debug("Error retrieving dataset from client, trying from backend");
-                            backendLookup(def, lookup, listener);
-                        }
-                        return false;
-                    }
-
-                    @Override
-                    public void notFound() {
-                        backendLookup(def, lookup, listener);
-                    }
-
-                    @Override
-                    public void callback(DataSet dataSet) {
-                        listener.callback(dataSet);
-                    }
-                });
+        externalDataSetClientProvider.fetchAndRegister(lookup.getDataSetUUID(), lookup, listener);
     }
 
     private boolean isAccumulate(String uuid) {
@@ -200,88 +121,13 @@ public class RuntimeDataSetClientServices implements DataSetClientServices {
         // ignored in runtime
     }
 
-    private void backendLookup(DataSetDef def, DataSetLookup lookup, DataSetReadyCallback listener) {
-        var request = RequestInit.create();
-        var headers = new Headers();
-        request.setMethod("POST");
-        request.setBody(toJson(lookup));
-        headers.append(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-        request.setHeaders(headers);
-        fetch(LOOKUP_ENDPOINT, request).then((Response response) -> {
-            verifier.verify(response);
-            response.text().then(responseText -> handleResponseText(def, lookup, listener, response, responseText),
-                    error -> {
-                        listener.onError(new ClientRuntimeError("Error reading data set content: " + error));
-                        return null;
-                    });
-            return null;
-        }).catch_(this::handleError);
-    }
-
     void onDataSetDefRemovedEvent(@Observes DataSetDefRemovedEvent evt) {
         if (evt.getDataSetDef() != null) {
             var uuid = evt.getDataSetDef().getUUID();
-            metadataCache.remove(uuid);
             externalDataSetClientProvider.unregister(uuid);
             clientDataSetManager.removeDataSet(uuid);
         }
 
-    }
-
-    private IThenable<Object> handleResponseText(DataSetDef def,
-                                                 DataSetLookup lookup,
-                                                 DataSetReadyCallback listener,
-                                                 Response response,
-                                                 String responseText) {
-
-        switch (response.status) {
-            case (HttpResponseCodes.SC_INTERNAL_SERVER_ERROR):
-                listener.onError(buildError("Not able to retrieve data set: " + getName(lookup, def),
-                        responseText));
-                break;
-            case (HttpResponseCodes.SC_NOT_FOUND):
-                listener.onError(buildError("Data Set not found: " + getName(lookup, def), responseText));
-                break;
-            default:
-                DataSet dataSet = null;
-                try {
-                    dataSet = parseDataSet(responseText);
-                } catch (Exception e) {
-                    listener.onError(new ClientRuntimeError("Error reading data set content", e));
-                }
-
-                if (dataSet != null) {
-                    listener.callback(dataSet);
-                } else {
-                    listener.onError(new ClientRuntimeError("Not able to retrieve the dataset. Content is not valid."));
-                }
-        }
-        return null;
-    }
-
-    private ClientRuntimeError buildError(String message, String responseText) {
-        return new ClientRuntimeError(message, new Exception(responseText));
-    }
-
-    private DataSetMetadata parseMetadata(String jsonContent) {
-        return dataSetMetadataJsonMarshaller.fromJSON(jsonContent);
-    }
-
-    private String toJson(DataSetLookup lookup) {
-        return DataSetLookupJSONMarshaller.get().toJson(lookup).toJson();
-    }
-
-    private DataSet parseDataSet(String dataSetJson) {
-        return DataSetJSONMarshaller.get().fromJson(dataSetJson);
-    }
-
-    private IThenable<?> handleError(Object e) {
-        errorCallback.error(DefaultErrorType.OTHER, "Unexpected error retrieving data set metadata:" + e);
-        return null;
-    }
-
-    private String getName(DataSetLookup lookup, DataSetDef def) {
-        return def == null ? lookup.getDataSetUUID() : (def.getName() == null ? def.getUUID() : def.getName());
     }
 
 }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/csv/CSVColumnsFunctionTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/csv/CSVColumnsFunctionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.client.external.csv;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSVColumnsFunctionTest {
+
+    private static final String VALID_HEADERS = "a,b,c\n" +
+            "1,2,3";
+
+    private static final String EMPTY_HEADERS = "\n1,2,3";
+
+    private static final String EMPTY_CONTENT = " ";
+
+    private CSVColumnsFunction columnsFunction;
+
+    @Before
+    public void prepare() {
+        columnsFunction = new CSVColumnsFunction();
+
+    }
+
+    @Test
+    public void testColumns() {
+        var columns = columnsFunction.apply(VALID_HEADERS);
+        assertEquals(3, columns.size());
+        assertEquals("a", columns.get(0).getId());
+        assertEquals("b", columns.get(1).getId());
+        assertEquals("c", columns.get(2).getId());
+    }
+
+    @Test
+    public void testEmptyHeaders() {
+        var columns = columnsFunction.apply(EMPTY_HEADERS);
+        assertEquals(0, columns.size());        
+    }
+
+    @Test
+    public void testEmptyContent() {
+        var columns = columnsFunction.apply(EMPTY_CONTENT);
+        assertEquals(0, columns.size());
+    }
+
+}

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/csv/CSVParserTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/csv/CSVParserTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.dashbuilder.client.external;
+package org.dashbuilder.client.external.csv;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -127,5 +127,7 @@ public class CSVParserTest {
     public void testIsEscapedQuote() {
         assertTrue(parser.isEscapedQuote("\"\"", 0));
         assertFalse(parser.isEscapedQuote("\"a\",\"\"", 2));
+        assertTrue(parser.isEscapedQuote("\\\"", 0));
     }
+
 }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.dashbuilder.client.external;
+package org.dashbuilder.client.external.metrics;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Quick fix, now it gets the columns names from CSV:

```
datasets:
    - uuid: disasters
      url: https://vega.github.io/vega-lite/examples/data/disasters.csv
      cacheEnabled: true
pages:
    - components:

          - settings:
                type: table
                filter:
                    listening: true
                lookup:
                    uuid: disasters
```

Result

![image](https://user-images.githubusercontent.com/359820/234989166-e9da48c3-661f-46cc-9518-71e275a9465f.png)


