### PR TITLE
NO-ISSUE: Bump `vcse` to `2.19.0`

### DIFF
--- a/examples/base64png-editor-vscode-extension/package.json
+++ b/examples/base64png-editor-vscode-extension/package.json
@@ -35,7 +35,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.2",
     "webpack": "^5.36.2",

--- a/examples/todo-list-view-vscode-extension/package.json
+++ b/examples/todo-list-view-vscode-extension/package.json
@@ -33,7 +33,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.2",
     "webpack": "^5.36.2",

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "copy-webpack-plugin": "^11.0.0",
     "rimraf": "^3.0.2",
     "webpack": "^5.36.2",

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "copy-webpack-plugin": "^11.0.0",
     "rimraf": "^3.0.2",
     "webpack": "^5.36.2",

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -65,7 +65,7 @@
     "@types/vscode": "^1.66.0",
     "@vscode/test-electron": "^2.3.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/pmml-vscode-extension/package.json
+++ b/packages/pmml-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "file-loader": "^6.2.0",
     "rimraf": "^3.0.2",
     "webpack": "^5.36.2",

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -68,7 +68,7 @@
     "@types/vscode": "^1.66.0",
     "@vscode/test-electron": "^2.3.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/vscode-extension-dashbuilder-editor/package.json
+++ b/packages/vscode-extension-dashbuilder-editor/package.json
@@ -57,7 +57,7 @@
     "@types/selenium-webdriver": "^4.1.12",
     "@types/vscode": "^1.66.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/vscode-extension-kie-ba-bundle/package.json
+++ b/packages/vscode-extension-kie-ba-bundle/package.json
@@ -28,7 +28,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "rimraf": "^3.0.2",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.10.0",

--- a/packages/vscode-extension-kogito-bundle/package.json
+++ b/packages/vscode-extension-kogito-bundle/package.json
@@ -28,7 +28,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "^1.66.0",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "rimraf": "^3.0.2",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.10.0",

--- a/packages/vscode-extension-serverless-workflow-editor/package.json
+++ b/packages/vscode-extension-serverless-workflow-editor/package.json
@@ -68,7 +68,7 @@
     "@types/vscode": "^1.66.0",
     "@vscode/test-electron": "^2.3.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "chai": "^4.3.4",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -60,7 +60,7 @@
     "@types/vscode": "^1.66.0",
     "@vscode/test-electron": "^2.3.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.18.0",
+    "@vscode/vsce": "^2.19.0",
     "chai": "^4.3.4",
     "cpr": "^3.0.1",
     "fs-extra": "^11.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: ^1.66.0
         version: 1.66.0
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -437,8 +437,8 @@ importers:
         specifier: ^1.66.0
         version: 1.66.0
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -976,8 +976,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.70.0)
@@ -3095,8 +3095,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.70.0)
@@ -4528,8 +4528,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       chai:
         specifier: ^4.3.4
         version: 4.3.4
@@ -5763,8 +5763,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.70.0)
@@ -7306,8 +7306,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       chai:
         specifier: ^4.3.4
         version: 4.3.4
@@ -8393,8 +8393,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       chai:
         specifier: ^4.3.4
         version: 4.3.4
@@ -8532,8 +8532,8 @@ importers:
         specifier: ^1.66.0
         version: 1.66.0
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -8568,8 +8568,8 @@ importers:
         specifier: ^1.66.0
         version: 1.66.0
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -8931,8 +8931,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       chai:
         specifier: ^4.3.4
         version: 4.3.4
@@ -9672,8 +9672,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       "@vscode/vsce":
-        specifier: ^2.18.0
-        version: 2.18.0
+        specifier: ^2.19.0
+        version: 2.19.0
       chai:
         specifier: ^4.3.4
         version: 4.3.4
@@ -15928,6 +15928,36 @@ packages:
       typed-rest-client: 1.8.4
       url-join: 4.0.1
       xml2js: 0.4.23
+      yauzl: 2.10.0
+      yazl: 2.5.1
+    optionalDependencies:
+      keytar: 7.7.0
+    dev: true
+
+  /@vscode/vsce@2.19.0:
+    resolution:
+      { integrity: sha512-dAlILxC5ggOutcvJY24jxz913wimGiUrHaPkk16Gm9/PGFbz1YezWtrXsTKUtJws4fIlpX2UIlVlVESWq8lkfQ== }
+    engines: { node: ">= 14" }
+    hasBin: true
+    dependencies:
+      azure-devops-node-api: 11.0.1
+      chalk: 2.4.2
+      cheerio: 1.0.0-rc.10
+      commander: 6.2.1
+      glob: 7.2.0
+      hosted-git-info: 4.1.0
+      jsonc-parser: 3.2.0
+      leven: 3.1.0
+      markdown-it: 12.3.2
+      mime: 1.6.0
+      minimatch: 3.0.5
+      parse-semver: 1.1.1
+      read: 1.0.7
+      semver: 5.7.1
+      tmp: 0.2.1
+      typed-rest-client: 1.8.4
+      url-join: 4.0.1
+      xml2js: 0.5.0
       yauzl: 2.10.0
       yazl: 2.5.1
     optionalDependencies:
@@ -31767,7 +31797,7 @@ packages:
       typescript: ">=4.6.2"
     dependencies:
       "@types/selenium-webdriver": 4.1.12
-      "@vscode/vsce": 2.18.0
+      "@vscode/vsce": 2.19.0
       commander: 10.0.0
       compare-versions: 5.0.1
       fs-extra: 11.1.1
@@ -31797,7 +31827,7 @@ packages:
       typescript: ">=4.6.2"
     dependencies:
       "@types/selenium-webdriver": 4.1.12
-      "@vscode/vsce": 2.18.0
+      "@vscode/vsce": 2.19.0
       commander: 10.0.0
       compare-versions: 5.0.1
       fs-extra: 11.1.1
@@ -32508,6 +32538,15 @@ packages:
   /xml2js@0.4.23:
     resolution:
       { integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug== }
+    engines: { node: ">=4.0.0" }
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: true
+
+  /xml2js@0.5.0:
+    resolution:
+      { integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA== }
     engines: { node: ">=4.0.0" }
     dependencies:
       sax: 1.2.4


### PR DESCRIPTION
Bump `vcse` to the latest version: `2.19.0`