### PR TITLE
kie-issues#246: allow rootless container build

### DIFF
--- a/packages/dmn-dev-deployment-base-image/Containerfile
+++ b/packages/dmn-dev-deployment-base-image/Containerfile
@@ -18,15 +18,15 @@ ARG QUARKUS_PLATFORM_VERSION
 ARG KOGITO_RUNTIME_VERSION
 ARG ROOT_PATH
 
+USER 1000
+
 RUN mkdir /tmp/kogito/
 
-COPY --chown=185:root dist-dev/dmn-dev-deployment-quarkus-app /tmp/kogito/dmn-dev-deployment-quarkus-app/
-COPY --chown=185:root dist-dev/dmn-dev-deployment-form-webapp/ /tmp/kogito/dmn-dev-deployment-quarkus-app/src/main/resources/META-INF/resources/
+COPY --chown=1000:1000 --chmod=775 dist-dev/dmn-dev-deployment-quarkus-app /tmp/kogito/dmn-dev-deployment-quarkus-app/
+COPY --chown=1000:1000 --chmod=775 dist-dev/dmn-dev-deployment-form-webapp/ /tmp/kogito/dmn-dev-deployment-quarkus-app/src/main/resources/META-INF/resources/
 
 WORKDIR /tmp/kogito/dmn-dev-deployment-quarkus-app/
 
-RUN ./mvnw clean package -B -ntp -Dmaven.test.skip -DQUARKUS_PLATFORM_VERSION=${QUARKUS_PLATFORM_VERSION} -DKOGITO_RUNTIME_VERSION=${KOGITO_RUNTIME_VERSION} -Dquarkus.http.root-path=${ROOT_PATH} \
-    && mv ~/.m2 /tmp/kogito \
-    && chmod -R 775 /tmp/kogito
-
+RUN ./mvnw clean package -B -ntp -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -DQUARKUS_PLATFORM_VERSION=${QUARKUS_PLATFORM_VERSION} -DKOGITO_RUNTIME_VERSION=${KOGITO_RUNTIME_VERSION} -Dquarkus.http.root-path=${ROOT_PATH} \
+    && chmod -R 775 /tmp/kogito/
 ENTRYPOINT ./mvnw quarkus:dev -Ddebug=false -Dmaven.repo.local=/tmp/kogito/.m2/repository -DQUARKUS_PLATFORM_VERSION=${QUARKUS_PLATFORM_VERSION} -DKOGITO_RUNTIME_VERSION=${KOGITO_RUNTIME_VERSION} -Dquarkus.http.root-path=${ROOT_PATH}


### PR DESCRIPTION
Closes kiegroup/kie-issues#246

Adjusting Containerfile so that when being run rootless, it would not fail due to permission issues.

@thiagoelg @caponetto please check if the changes make sense to you.