### PR TITLE
kie-issue#163: In DMN Editor's Boxed Expression Editor, long names are not being truncated in DecisionTable sub-headers and in the name of root expressions

### DIFF
--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
@@ -83,7 +83,7 @@ export function BeeTableThResizable<R extends object>({
     cssClasses.push(column.groupType ?? "");
     // cssClasses.push(column.cssClasses ?? ""); // FIXME: Breaking Decision tables because of positioning of rowSpan=2 column headers (See https://github.com/kiegroup/kie-issues/issues/162)
     return cssClasses.join(" ");
-  }, [column, columnKey]);
+  }, [columnKey, column.dataType, column.groupType]);
 
   const onClick = useMemo(() => {
     return onHeaderClick(columnKey);
@@ -106,53 +106,6 @@ export function BeeTableThResizable<R extends object>({
     return onGetWidthToFitData() + extraSpace;
   }, [onGetWidthToFitData]);
 
-  // const { updateColumnResizingWidths } = useBeeTableResizableColumnsDispatch();
-  // const [isCalcWidthResizing, setCalcWidthResizing] = useState<boolean>(false);
-  // const [calcWidth, setCalcWidth] = useState<number | undefined>(undefined);
-  // const [calcResizingWidth, setCalcResizingWidth] = useState<ResizingWidth | undefined>(undefined);
-
-  // useLayoutEffect(() => {
-  //   if (column.width) {
-  //     return;
-  //   }
-
-  //   const calcWidth = forwardRef?.current?.getBoundingClientRect().width;
-  //   if (!calcWidth) {
-  //     return;
-  //   }
-
-  //   setCalcWidth(calcWidth);
-  //   setCalcResizingWidth({ isPivoting: false, value: calcWidth ?? 0 });
-  // }, [column.width, forwardRef]);
-
-  // useEffect(() => {
-  //   if (!calcResizingWidth?.isPivoting) {
-  //     return;
-  //   }
-
-  //   const apportionedColumnWidths = apportionColumnWidths(
-  //     calcResizingWidth.value,
-  //     (column.columns ?? []).map((c) => ({
-  //       minWidth: c.minWidth ?? 0,
-  //       currentWidth: c.width ?? 0,
-  //       isFrozen: c.isWidthPinned ?? false,
-  //     }))
-  //   );
-
-  //   (column.columns ?? []).forEach((c, i) => {
-  //     updateColumnResizingWidths(firstColumnIndexOfGroup + i, (prev) => {
-  //       return { isPivoting: true, value: apportionedColumnWidths[i] };
-  //     });
-  //   });
-  // }, [
-  //   calcResizingWidth?.isPivoting,
-  //   calcResizingWidth?.value,
-  //   column.columns,
-  //   columnIndex,
-  //   firstColumnIndexOfGroup,
-  //   updateColumnResizingWidths,
-  // ]);
-
   const {
     // Filling resizing widths are used for header columns that are either parent or flexible.
     fillingResizingWidth,
@@ -168,15 +121,15 @@ export function BeeTableThResizable<R extends object>({
   useEffect(() => {
     function onEnter(e: MouseEvent) {
       e.stopPropagation();
-      setHoverInfo((prev) => getHoverInfo(e, th!));
+      setHoverInfo(() => getHoverInfo(e, th!));
     }
 
     function onMove(e: MouseEvent) {
-      setHoverInfo((prev) => getHoverInfo(e, th!));
+      setHoverInfo(() => getHoverInfo(e, th!));
     }
 
     function onLeave() {
-      setHoverInfo((prev) => ({ isHovered: false }));
+      setHoverInfo(() => ({ isHovered: false }));
     }
 
     const th = forwardRef?.current;
@@ -199,7 +152,12 @@ export function BeeTableThResizable<R extends object>({
         style: {
           width: column.width ? resizingWidth?.value : "100%",
           minWidth: column.width ? resizingWidth?.value : "100%",
-          maxWidth: column.width ? resizingWidth?.value : "100%",
+          maxWidth:
+            isParentColumn(column) || isFlexbileColumn(column)
+              ? fillingWidth
+              : column.width
+              ? resizingWidth?.value
+              : "100%",
         },
       }}
       onClick={onClick}


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/163

Literal:
![image](https://user-images.githubusercontent.com/7305741/236312875-761e1a61-f89b-47d2-8a8b-50e80fcf94a6.png)

Context:
![image](https://user-images.githubusercontent.com/7305741/236312954-a33b36ea-62b2-406e-8e5c-d971fcb63eda.png)

Decision Table:
![image](https://user-images.githubusercontent.com/7305741/236313018-4d37f38a-b96a-4d24-b55f-aa75e968e772.png)

Relation:
![image](https://user-images.githubusercontent.com/7305741/236313076-adde3983-ee87-4801-a698-10a0b5f99a60.png)

Invocation:
![image](https://user-images.githubusercontent.com/7305741/236313123-9c5ba2b9-db74-4abd-8205-013610b13f39.png)

List:
![image](https://user-images.githubusercontent.com/7305741/236313187-b71ffdb1-1f1e-4f98-9cfa-a74bf2b6b981.png)

Funcion (BKM):
![image](https://user-images.githubusercontent.com/7305741/236313333-4c34d2aa-a17c-4ca5-a5b4-ea9915ac2f49.png)