### PR TITLE
kie-issues#222: When editing a BeeTable cell with selected text, the selection is lost when mouse hovers in or out of it

### DIFF
--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
@@ -134,9 +134,6 @@ export function BeeTableTd<R extends object>({
     }
 
     function onLeave() {
-      if (hasTextSelectedInBoxedExpressionEditor()) {
-        return;
-      }
       setHoverInfo((prev) => ({ isHovered: false }));
     }
     td?.addEventListener("mouseenter", onEnter);

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
@@ -66,6 +66,7 @@ export function BeeTableTd<R extends object>({
 }: BeeTableTdProps<R>) {
   const [isResizing, setResizing] = useState(false);
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>({ isHovered: false });
+  const [isFocused, setIsFocused] = useState(false);
 
   const tdRef = useRef<HTMLTableCellElement>(null);
 
@@ -122,14 +123,26 @@ export function BeeTableTd<R extends object>({
       setHoverInfo((prev) => ({ isHovered: false }));
     }
 
+    function onFocusIn() {
+      setIsFocused(true);
+    }
+
+    function onFocusOut() {
+      setIsFocused(false);
+    }
+
     const td = tdRef.current;
     td?.addEventListener("mouseenter", onEnter);
     td?.addEventListener("mousemove", onMove);
     td?.addEventListener("mouseleave", onLeave);
+    td?.addEventListener("focusin", onFocusIn);
+    td?.addEventListener("focusout", onFocusOut);
     return () => {
       td?.removeEventListener("mouseleave", onLeave);
       td?.removeEventListener("mousemove", onMove);
       td?.removeEventListener("mouseenter", onEnter);
+      td?.removeEventListener("focusin", onFocusIn);
+      td?.removeEventListener("focusout", onFocusOut);
     };
   }, []);
 
@@ -205,17 +218,18 @@ export function BeeTableTd<R extends object>({
           <>
             {tdContent}
 
-            {!column.isWidthConstant && (hoverInfo.isHovered || (resizingWidth?.isPivoting && isResizing)) && (
-              <Resizer
-                getWidthToFitData={cellWidthToFitDataRef?.getWidthToFitData}
-                minWidth={lastColumnMinWidth ?? cell.column.minWidth}
-                width={cell.column.width}
-                setWidth={cell.column.setWidth}
-                resizingWidth={resizingWidth}
-                setResizingWidth={setResizingWidth}
-                setResizing={setResizing}
-              />
-            )}
+            {!column.isWidthConstant &&
+              (hoverInfo.isHovered || isFocused || (resizingWidth?.isPivoting && isResizing)) && (
+                <Resizer
+                  getWidthToFitData={cellWidthToFitDataRef?.getWidthToFitData}
+                  minWidth={lastColumnMinWidth ?? cell.column.minWidth}
+                  width={cell.column.width}
+                  setWidth={cell.column.setWidth}
+                  resizingWidth={resizingWidth}
+                  setResizingWidth={setResizingWidth}
+                  setResizing={setResizing}
+                />
+              )}
           </>
         )}
 

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
@@ -30,6 +30,7 @@ import {
   isParentColumn,
   useFillingResizingWidth,
 } from "../../resizing/FillingColumnResizingWidth";
+import { useBoxedExpressionEditor } from "../../expressions/BoxedExpressionEditor/BoxedExpressionEditorContext";
 
 export interface BeeTableThResizableProps<R extends object> {
   onColumnAdded?: (args: { beforeIndex: number; groupType: string | undefined }) => void;
@@ -118,17 +119,36 @@ export function BeeTableThResizable<R extends object>({
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>({ isHovered: false });
   const [isResizing, setResizing] = useState<boolean>(false);
 
+  const { editorRef } = useBoxedExpressionEditor();
+
   useEffect(() => {
+    function hasTextSelectedInBoxedExpressionEditor() {
+      const selection = window.getSelection();
+      if (selection) {
+        return selection?.toString() && editorRef.current?.contains(selection.focusNode);
+      }
+      return false;
+    }
+
     function onEnter(e: MouseEvent) {
       e.stopPropagation();
+      if (hasTextSelectedInBoxedExpressionEditor()) {
+        return;
+      }
       setHoverInfo(() => getHoverInfo(e, th!));
     }
 
     function onMove(e: MouseEvent) {
+      if (hasTextSelectedInBoxedExpressionEditor()) {
+        return;
+      }
       setHoverInfo(() => getHoverInfo(e, th!));
     }
 
     function onLeave() {
+      if (hasTextSelectedInBoxedExpressionEditor()) {
+        return;
+      }
       setHoverInfo(() => ({ isHovered: false }));
     }
 
@@ -141,7 +161,7 @@ export function BeeTableThResizable<R extends object>({
       th?.removeEventListener("mousemove", onMove);
       th?.removeEventListener("mouseenter", onEnter);
     };
-  }, [columnIndex, rowIndex, forwardRef]);
+  }, [columnIndex, rowIndex, forwardRef, editorRef]);
 
   return (
     <BeeTableTh<R>

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
@@ -146,9 +146,6 @@ export function BeeTableThResizable<R extends object>({
     }
 
     function onLeave() {
-      if (hasTextSelectedInBoxedExpressionEditor()) {
-        return;
-      }
       setHoverInfo(() => ({ isHovered: false }));
     }
 


### PR DESCRIPTION
Closes kiegroup/kie-issues/issues/222

### Previously
We rendered `Resizer` for any hovered cell of the boxed expression table component (currently used in DMN editor and DMN Runner Tabular view). It causes issues because you can have at the same time One cell being edited and another cell just hovered. In other words during editing one cell, resizer were dynamically added and removed form the html DOM. Such dynamic removal of DOM elements causes window selection to be cleared, as described in https://github.com/kiegroup/kie-issues/issues/222#issuecomment-1543784277

### Currently
We decided to eliminate shown resizers. From now on it is not enough to hover cell with mouse to display the `Resizer`, but we also check if there is some selected text. If yes, we stop to display `Resizer`s until there is some selected text.