### PR TITLE
NO-ISSUE: Stabilize randomly failing GraphUtilsTest#testComputeGraphHashCode

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/graph/util/GraphUtilsTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.core.graph.util;
 import java.util.List;
 import java.util.OptionalInt;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -245,7 +246,7 @@ public class GraphUtilsTest {
         Point2D tconnectionLocation = tconnection.getLocation();
         sconnection.setLocation(Point2D.create(123d, 123d));
         tconnection.setLocation(Point2D.create(321d, 321d));
-        assertNotEquals(hashCode, GraphUtils.computeGraphHashCode(graph), 0d);
+        Assertions.assertThat(hashCode).isNotEqualTo(GraphUtils.computeGraphHashCode(graph));
         sconnection.setLocation(sconnectionLocation);
         tconnection.setLocation(tconnectionLocation);
         // Rollback connection changed.


### PR DESCRIPTION
The mentioned test `GraphUtilsTest#testComputeGraphHashCode` started to fail in CI while locally is working fine. 

During investigation it was found we use `junit` method for comparing `double`s but real compared values are `int`s

The CI error message is
```
Error: s/stunner-editors build:prod: [ERROR] GraphUtilsTest.testComputeGraphHashCode:248 Values should be different. Actual: -1.8597954E7
```

It can be seen for example here https://github.com/kiegroup/kie-tools/actions/runs/4978117965/jobs/8910744518?pr=1634