### PR TITLE
kie-issues#258: Use data type current value when opening DMN constraint modal

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModal.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModal.java
@@ -26,7 +26,6 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
-import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.kie.workbench.common.dmn.client.editors.types.listview.DataTypeListItem;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.DataTypeConstraintComponent;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.DataTypeConstraintParserWarningEvent;
@@ -68,8 +67,6 @@ public class DataTypeConstraintModal extends Elemental2Modal<DataTypeConstraintM
     private BiConsumer<String, ConstraintType> onSave;
 
     private String constraintValueType = "";
-
-    private DataType dataType;
 
     @Inject
     public DataTypeConstraintModal(final View view,
@@ -113,7 +110,6 @@ public class DataTypeConstraintModal extends Elemental2Modal<DataTypeConstraintM
     void load(final DataTypeListItem dataTypeListItem) {
         this.constraintValue = dataTypeListItem.getDataType().getConstraint();
         this.constraintValueType = dataTypeListItem.getType();
-        this.dataType = dataTypeListItem.getDataType();
 
         if (!StringUtils.isEmpty(constraintValue) && isNone(constraintType)) {
             this.constraintType = inferComponentType(constraintValue);
@@ -172,7 +168,7 @@ public class DataTypeConstraintModal extends Elemental2Modal<DataTypeConstraintM
     void prepareView() {
 
         getView().setType(getConstraintValueType());
-        getView().setDataType(dataType);
+        getView().setDataType(constraintValueType);
 
         if (!isEmpty(getConstraintValue()) || !isNone(getConstraintType())) {
             getView().loadComponent(getConstraintType());
@@ -291,7 +287,7 @@ public class DataTypeConstraintModal extends Elemental2Modal<DataTypeConstraintM
 
         void setType(final String type);
 
-        void setDataType(final DataType dataType);
+        void setDataType(final String dataType);
 
         void setupEmptyContainer();
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalView.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalView.java
@@ -38,8 +38,8 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.common.RemoveHelper;
-import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
 import org.uberfire.client.views.pfly.selectpicker.JQuery;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPicker;
 import org.uberfire.client.views.pfly.selectpicker.JQuerySelectPickerEvent;
@@ -89,7 +89,7 @@ public class DataTypeConstraintModalView implements DataTypeConstraintModal.View
     private final HTMLButtonElement closeConstraintWarningMessage;
 
     private DataTypeConstraintModal presenter;
-    private DataType dataType;
+    private String dataType;
 
     @Inject
     public DataTypeConstraintModalView(final HTMLDivElement header,
@@ -174,7 +174,7 @@ public class DataTypeConstraintModalView implements DataTypeConstraintModal.View
     }
 
     @Override
-    public void setDataType(DataType dataType) {
+    public void setDataType(String dataType) {
         this.dataType = dataType;
     }
 
@@ -206,7 +206,7 @@ public class DataTypeConstraintModalView implements DataTypeConstraintModal.View
     public void onShow() {
         final HTMLSelectElement selectElement = (HTMLSelectElement) getSelectPicker();
         final HTMLOptionsCollection options = getSelectOptionsElement();
-        if (Objects.equals("Any", dataType.getType())) {
+        if (Objects.equals(BuiltInType.ANY.getName(), dataType)) {
             disableOptionElement(options.getAt(1));
             disableOptionElement(options.getAt(3));
         } else {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalViewTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/DataTypeConstraintModalViewTest.java
@@ -32,7 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.dmn.api.definition.model.ConstraintType;
-import org.kie.workbench.common.dmn.client.editors.types.common.DataType;
+import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.editors.types.listview.constraint.common.DataTypeConstraintComponent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -268,15 +268,12 @@ public class DataTypeConstraintModalViewTest {
         doReturn(optionOne).when(options).getAt(eq(1));
         doReturn(optionThree).when(options).getAt(eq(3));
 
-        final DataType dataType = mock(DataType.class);
-        when(dataType.getType()).thenReturn("string");
-
         when(presenter.getConstraintValue()).thenReturn(null);
         when(presenter.inferComponentType(any())).thenCallRealMethod();
         doReturn(selectPicker).when(view).getSelectPicker();
         doReturn(options).when(view).getSelectOptionsElement();
         doNothing().when(view).setPickerValue(any(), Mockito.<String>any());
-        view.setDataType(dataType);
+        view.setDataType(BuiltInType.STRING.getName());
 
         view.onShow();
 
@@ -298,15 +295,13 @@ public class DataTypeConstraintModalViewTest {
         doReturn(optionThree).when(options).getAt(eq(3));
 
         final String constraint = "1,2,3";
-        final DataType dataType = mock(DataType.class);
-        when(dataType.getType()).thenReturn("string");
 
         when(presenter.getConstraintValue()).thenReturn(constraint);
         when(presenter.inferComponentType(constraint)).thenReturn(ENUMERATION);
         doReturn(selectPicker).when(view).getSelectPicker();
         doReturn(options).when(view).getSelectOptionsElement();
         doNothing().when(view).setPickerValue(any(), Mockito.<String>any());
-        view.setDataType(dataType);
+        view.setDataType(BuiltInType.STRING.getName());
 
         view.onShow();
 
@@ -328,15 +323,13 @@ public class DataTypeConstraintModalViewTest {
         doReturn(optionThree).when(options).getAt(eq(3));
 
         final String constraint = "123";
-        final DataType dataType = mock(DataType.class);
-        when(dataType.getType()).thenReturn("Any");
 
         when(presenter.getConstraintValue()).thenReturn(constraint);
         when(presenter.inferComponentType(constraint)).thenReturn(EXPRESSION);
         doReturn(selectPicker).when(view).getSelectPicker();
         doReturn(options).when(view).getSelectOptionsElement();
         doNothing().when(view).setPickerValue(any(), Mockito.<String>any());
-        view.setDataType(dataType);
+        view.setDataType(BuiltInType.ANY.getName());
 
         view.onShow();
 


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/258

Currently when opening a DMN constraint modal, not the latest DMN entry data type is taken into account. 

After this fix, DMN constraint modal will allow to use `Enumeration`, `Range` and `Expression` constraint type according to the latest dmn entry data type, even not saved.