### PR TITLE
KOGITO-9033: SWF Viewer - Firefox Support

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/resources/org/kie/workbench/common/stunner/sw/KogitoSWEditor.gwt.xml
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/main/resources/org/kie/workbench/common/stunner/sw/KogitoSWEditor.gwt.xml
@@ -45,7 +45,7 @@
 
   <!-- We don't need to support IE10 or older -->
   <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
-  <set-property name="user.agent" value="safari"/>
+  <set-property name="user.agent" value="safari,gecko1_8"/>
 
   <!-- To change the default logLevel -->
   <set-property name="gwt.logging.logLevel" value="SEVERE"/>


### PR DESCRIPTION
Hello @LuboTerifaj, @romartin,

there is an enablement of Firefox permutations for GWT. **It increased the test WAR file for about 1 Mb from 14 to 15.**

I do not see any issues for compiled version of the plugin.

For development build it worked to me pretty well, both Super Dev Mode and Console are working but sometimes there is a need to fully reload the test browser to get clean cache to get working both Firefox and Chrome.

I didn't find any complications if work only with single browser.

To test the Firefox go to `kie-tools/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app` and execute `mvn -f ../../ clean install -DskipTests -Dgwt.compiler.skip && mvn gwt:run` After that you will be able to open a browser and open a page `http://127.0.0.1:8888/test.html`.

Thank you guys!