### PR TITLE
NO-ISSUE: Add 'patches' dir to the Sparse Checkout script

### DIFF
--- a/scripts/sparse-checkout/run.sh
+++ b/scripts/sparse-checkout/run.sh
@@ -7,7 +7,7 @@ KIE_TOOLS_PACKAGE_NAMES_TO_BUILD=("${ARGV[@]:2}")
 KIE_TOOLS_PACKAGES_PNPM_FILTER_STRING=$(echo ${KIE_TOOLS_PACKAGE_NAMES_TO_BUILD[@]} | xargs -n1 -I{} echo -n "-F {}... " | xargs)
 KIE_TOOLS_GIT_REMOTE_URL="https://github.com/$KIE_TOOLS_ORG/kie-tools"
 KIE_TOOLS_CLONE_DIR_PATH='kie-tools'
-KIE_TOOLS_PATHS_INCLUDED_BY_DEFAULT='scripts repo docs'
+KIE_TOOLS_PATHS_INCLUDED_BY_DEFAULT='scripts repo docs patches'
 
 echo "[kie-tools-sparse-checkout] Starting..."
 echo "KIE_TOOLS_ORG:                           $KIE_TOOLS_ORG"


### PR DESCRIPTION
Using `bash`:
```bash
ORG="tiagobento"
BRANCH="add-patches-dir-to-sparse-checkout-script"
PKGS="@kie-tools/serverless-workflow-language-service @kie-tools/kn-plugin-workflow"
bash <(curl -s https://raw.githubusercontent.com/$ORG/kie-tools/$BRANCH/scripts/sparse-checkout/run.sh) $ORG $BRANCH $PKGS
```

Using `zsh`:
```bash
ORG="tiagobento"
BRANCH="add-patches-dir-to-sparse-checkout-script"
PKGS="@kie-tools/serverless-workflow-language-service @kie-tools/kn-plugin-workflow"
bash <(curl -s https://raw.githubusercontent.com/$ORG/kie-tools/$BRANCH/scripts/sparse-checkout/run.sh) $ORG $BRANCH ${(z)PKGS}
```
