### PR TITLE
KOGITO-9175: Support types for Dashbuilder external datasets

### DIFF
--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -188,6 +188,10 @@ public class ExternalDataSetClientProvider {
         DataSet dataSet = null;
         var content = contentType.tranformer.apply(responseText);
 
+        if (def.getType() != null) {
+            def.setExpression(def.getType().getExpression());
+        }
+
         if (def.getExpression() != null && !def.getExpression().trim().isEmpty()) {
             try {
                 content = applyExpression(def.getExpression(), content);

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -34,6 +34,7 @@ import elemental2.dom.Response;
 import elemental2.promise.IThenable;
 import org.dashbuilder.client.external.transformer.JSONAtaInjector;
 import org.dashbuilder.client.external.transformer.JSONAtaTransformer;
+import org.dashbuilder.common.client.StringUtils;
 import org.dashbuilder.common.client.error.ClientRuntimeError;
 import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.DataSetLookup;
@@ -188,7 +189,7 @@ public class ExternalDataSetClientProvider {
         DataSet dataSet = null;
         var content = contentType.tranformer.apply(responseText);
 
-        if (def.getType() != null) {
+        if (def.getType() != null && StringUtils.isBlank(def.getExpression())) {
             def.setExpression(def.getType().getExpression());
         }
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
@@ -40,6 +40,8 @@ public class ExternalDataSetDef extends DataSetDef {
 
     private boolean accumulate;
 
+    private ExternalServiceType type;
+
     public ExternalDataSetDef() {
         super.setProvider(DataSetProviderType.EXTERNAL);
     }
@@ -99,6 +101,14 @@ public class ExternalDataSetDef extends DataSetDef {
         this.accumulate = accumulate;
     }
 
+    public ExternalServiceType getType() {
+        return type;
+    }
+
+    public void setType(ExternalServiceType type) {
+        this.type = type;
+    }
+
     @Override
     public DataSetDef clone() {
         var def = new ExternalDataSetDef();
@@ -107,6 +117,7 @@ public class ExternalDataSetDef extends DataSetDef {
         def.setDynamic(isDynamic());
         def.setHeaders(getHeaders());
         def.setAccumulate(isAccumulate());
+        def.setType(getType());
         return def;
     }
 
@@ -124,7 +135,8 @@ public class ExternalDataSetDef extends DataSetDef {
                Objects.equals(expression, other.expression) &&
                Objects.equals(headers, other.headers) &&
                Objects.equals(url, other.url) &&
-               Objects.equals(accumulate, other.accumulate);
+               Objects.equals(accumulate, other.accumulate) &&
+               Objects.equals(type, other.type);
     }
 
     public String toString() {
@@ -139,7 +151,8 @@ public class ExternalDataSetDef extends DataSetDef {
         out.append("Expression=").append(expression).append("\n");
         out.append("Content=").append(content).append("\n");
         out.append("Headers=").append(headers).append("\n");
-        out.append("Accumulate=").append(accumulate);
+        out.append("Accumulate=").append(accumulate).append("\n");
+        out.append("Type=").append(type);
         return out.toString();
     }
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataset.def;
+
+public enum ExternalServiceType {
+
+    PROMETHEUS("$.data.(\n" +
+            "    {\n" +
+            "        \"columns\": result[0].(\n" +
+            "            [\n" +
+            "                {\"id\" : \"timestamp\", \"type\": \"number\"},\n" +
+            "                {\"id\" : \"value\", \"type\": \"number\"},\n" +
+            "                $keys(metric).({\"id\" : $, \"type\": \"label\"})\n" +
+            "            ];\n" +
+            "        ),\n" +
+            "        \"values\": (\n" +
+            "            resultType = \"scalar\" ? [result[0] * 1000, result[1]] :\n" +
+            "            resultType = \"matrix\" ? result.( $metric := metric.*; values.[ $[0] * 1000, $[1], $metric ] ) :\n" +
+            "            resultType = \"vector\" ?  result.[ value[0] * 1000, value[1],  metric.* ]\n" +
+            "        )\n" +
+            "    }\n" +
+            ")");
+
+    private ExternalServiceType(String expression) {
+        this.expression = expression;
+    }
+
+    private String expression;
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public static ExternalServiceType byName(String type) {
+        if (type != null) {
+            for (var t : ExternalServiceType.values()) {
+                if (t.name().equalsIgnoreCase(type)) {
+                    return t;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
+import org.dashbuilder.dataset.def.ExternalServiceType;
 import org.dashbuilder.json.Json;
 import org.dashbuilder.json.JsonObject;
 
@@ -34,6 +35,7 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
     public static final String CONTENT = "content";
     public static final String HEADERS = "headers";
     public static final String ACCUMULATE = "accumulate";
+    public static final String TYPE = "type";
 
     @Override
     public void fromJson(ExternalDataSetDef def, JsonObject json) {
@@ -43,7 +45,8 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         var expression = json.getString(EXPRESSION);
         var headers = json.getObject(HEADERS);
         var accumulate = json.getBoolean(ACCUMULATE);
-        
+        var type = json.getString(TYPE);
+
         if (isBlank(url) && isBlank(content)) {
             throw new IllegalArgumentException("External Data Sets must have \"url\" or \"content\" field");
         }
@@ -54,8 +57,8 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
 
         if (!isBlank(content)) {
             def.setContent(content);
-        }       
-        
+        }
+
         if (!isBlank(expression)) {
             def.setExpression(expression);
         }
@@ -63,6 +66,11 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         if (headers != null) {
             var headersMap = getHeaders(headers);
             def.setHeaders(headersMap);
+        }
+
+        if (!isBlank(type)) {
+            var serviceType = ExternalServiceType.byName(type);
+            def.setType(serviceType);
         }
 
         def.setDynamic(dynamic);
@@ -76,6 +84,10 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         json.put(EXPRESSION, def.getExpression());
         json.put(CONTENT, def.getContent());
         json.put(ACCUMULATE, def.isAccumulate());
+
+        if (def.getType() != null) {
+            json.put(TYPE, def.getType().name());
+        }
 
         if (def.getHeaders() != null) {
             var headers = Json.createObject();


### PR DESCRIPTION
We add a support for service type on Dashbuilder, this way we can have internal expression and users will write less code to use prometheus:


![image](https://github.com/tiagobento/kie-tools/assets/359820/7a622ce1-2657-406a-a590-e5121e1f6c39)