### PR TITLE
KOGITO-9186: Handle NaN values in Dashbuilder metrics dataset

### DIFF
--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
@@ -32,9 +32,12 @@ public class MetricsParser implements UnaryOperator<String> {
     private static final char LABEL_OPEN = '{';
     private static final char LABEL_CLOSE = '}';
     private static final String COMMENT = "#";
+    private static final String NAN = "NaN";
+    
+    static final String DEFAULT_NAN_VALUE = "-1";
 
     protected JsonArray metricToJsonArray(String line) {
-        var array = Json.createArray();
+        var array = Json.createArray();        
         var chars = line.toCharArray();
 
         var metricBuffer = new StringBuilder();
@@ -55,14 +58,14 @@ public class MetricsParser implements UnaryOperator<String> {
                 currentBuffer.append(ch);
             }
         }
-
+        var value = valueBuffer.toString().equals(NAN) ? DEFAULT_NAN_VALUE : valueBuffer.toString();
         if (metricBuffer.length() > 0 &&
             valueBuffer.length() > 0 &&
             !metricBuffer.toString().trim().isEmpty() &&
             !valueBuffer.toString().trim().isEmpty()) {
             array.set(0, metricBuffer.toString());
             array.set(1, labelsBuffer.toString());
-            array.set(2, valueBuffer.toString());
+            array.set(2, value);
         }
         return array;
     }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
@@ -33,11 +33,11 @@ public class MetricsParser implements UnaryOperator<String> {
     private static final char LABEL_CLOSE = '}';
     private static final String COMMENT = "#";
     private static final String NAN = "NaN";
-    
+
     static final String DEFAULT_NAN_VALUE = "-1";
 
     protected JsonArray metricToJsonArray(String line) {
-        var array = Json.createArray();        
+        var array = Json.createArray();
         var chars = line.toCharArray();
 
         var metricBuffer = new StringBuilder();

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
@@ -22,21 +22,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MetricsParserTest {
-    
+
     private MetricsParser parser;
-    
-    private static String METRICS = "# HELP process_start_time_seconds Start time of the process since unix epoch.\n" + 
-            "# TYPE process_start_time_seconds gauge\n" + 
+
+    private static String METRICS = "# HELP process_start_time_seconds Start time of the process since unix epoch.\n" +
+            "# TYPE process_start_time_seconds gauge\n" +
             "process_start_time_seconds 1.650302155929E9\n" +
-            "# HELP jvm_threads_states_threads The current number of threads having NEW state\n" + 
-            "# TYPE jvm_threads_states_threads gauge\n" + 
+            "# HELP jvm_threads_states_threads The current number of threads having NEW state\n" +
+            "# TYPE jvm_threads_states_threads gauge\n" +
             "jvm_threads_states_threads{state=\"runnable\",} 9.0";
-    
+
     @Before
     public void init() {
         parser = new MetricsParser();
     }
-    
+
     @Test
     public void testLabelMetricToArray() {
         var r = parser.metricToJsonArray("jvm_memory_max_bytes{area=\"nonheap\",id=\"Metaspace\",} -1.0");
@@ -44,8 +44,7 @@ public class MetricsParserTest {
         assertEquals("area=\"nonheap\",id=\"Metaspace\",", r.getString(1));
         assertEquals("-1.0", r.getString(2));
     }
-    
-    
+
     @Test
     public void testLabelWithSpaceMetricToArray() {
         var r = parser.metricToJsonArray("metric{l1=\"l1 val\",} -1.0");
@@ -53,7 +52,15 @@ public class MetricsParserTest {
         assertEquals("l1=\"l1 val\",", r.getString(1));
         assertEquals("-1.0", r.getString(2));
     }
-    
+
+    @Test
+    public void testMetricWithNaN() {
+        var r = parser.metricToJsonArray("metric{l1=\"l1 val\",} NaN");
+        assertEquals("metric", r.getString(0));
+        assertEquals("l1=\"l1 val\",", r.getString(1));
+        assertEquals(MetricsParser.DEFAULT_NAN_VALUE, r.getString(2));
+    }
+
     @Test
     public void testNoLabelMetricToArray() {
         var r = parser.metricToJsonArray("process_uptime_seconds 339164.251");
@@ -61,37 +68,35 @@ public class MetricsParserTest {
         assertEquals("", r.getString(1));
         assertEquals("339164.251", r.getString(2));
     }
-    
+
     @Test
     public void testEmptyMetricToArray() {
         var r = parser.metricToJsonArray("");
         assertTrue(r.isEmpty());
     }
-    
+
     @Test
     public void testNoValueMetricToArray() {
         var r = parser.metricToJsonArray("test      ");
         assertTrue(r.isEmpty());
-    }    
+    }
 
     @Test
     public void testMetricsToArray() {
         var r = parser.metricsToJsonArray(METRICS);
         assertEquals(2, r.length());
-        
+
         var processStartTimeSeconds = r.getArray(0);
-        
+
         assertEquals("process_start_time_seconds", processStartTimeSeconds.getString(0));
         assertEquals("", processStartTimeSeconds.getString(1));
         assertEquals("1.650302155929E9", processStartTimeSeconds.getString(2));
-        
-        
+
         var jvmThreadsStatesThreads = r.getArray(1);
-        
+
         assertEquals("jvm_threads_states_threads", jvmThreadsStatesThreads.getString(0));
         assertEquals("state=\"runnable\",", jvmThreadsStatesThreads.getString(1));
         assertEquals("9.0", jvmThreadsStatesThreads.getString(2));
     }
-
 
 }


### PR DESCRIPTION
Some metrics may come with "NaN" as the value and it may break Dashbuilder metrics datasets. This is a task to handle these kind of values and avoid user bad experiences when building monitoring dashboards.