### PR TITLE
KOGITO-8780: Color nodes based on the timeline

### DIFF
--- a/packages/serverless-workflow-combined-editor/package.json
+++ b/packages/serverless-workflow-combined-editor/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@kie-tools-core/editor": "workspace:*",
+    "@kie-tools-core/envelope": "workspace:*",
     "@kie-tools-core/envelope-bus": "workspace:*",
     "@kie-tools-core/keyboard-shortcuts": "workspace:*",
     "@kie-tools-core/notifications": "workspace:*",

--- a/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
+++ b/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
@@ -34,6 +34,10 @@ export interface ServerlessWorkflowCombinedEditorChannelApi
    * @returns
    */
   kogitoSwfCombinedEditor_moveCursorToPosition(position: Position): void;
-  // TODO: remove after testing
+  /**
+   * Checks if combined editor is ready
+   *
+   * @returns
+   */
   kogitoSwfCombinedEditor_combinedEditorReady(): void;
 }

--- a/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
+++ b/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
@@ -34,4 +34,18 @@ export interface ServerlessWorkflowCombinedEditorChannelApi
    * @returns
    */
   kogitoSwfCombinedEditor_moveCursorToPosition(position: Position): void;
+  /**
+   * Colors nodes in the diagram based on the list of names provided.
+   *
+   * @param nodeNameList
+   * @param isWorkflowCompleted
+   * @returns
+   */
+  kogitoSwfCombinedEditor_colorNodesBasedOnNames(nodeNameList: string[], isWorkflowCompleted: boolean): void;
+  /**
+   * Checks combined editor ready state.
+   *
+   * @returns
+   */
+  kogitoSwfCombinedEditor_combinedEditorReady(): void;
 }

--- a/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
+++ b/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorChannelApi.ts
@@ -34,18 +34,6 @@ export interface ServerlessWorkflowCombinedEditorChannelApi
    * @returns
    */
   kogitoSwfCombinedEditor_moveCursorToPosition(position: Position): void;
-  /**
-   * Colors nodes in the diagram based on the list of names provided.
-   *
-   * @param nodeNameList
-   * @param isWorkflowCompleted
-   * @returns
-   */
-  kogitoSwfCombinedEditor_colorNodesBasedOnNames(nodeNameList: string[], isWorkflowCompleted: boolean): void;
-  /**
-   * Checks combined editor ready state.
-   *
-   * @returns
-   */
+  // TODO: remove after testing
   kogitoSwfCombinedEditor_combinedEditorReady(): void;
 }

--- a/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorEnvelopeApi.ts
+++ b/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorEnvelopeApi.ts
@@ -17,5 +17,5 @@
 import { KogitoEditorEnvelopeApi } from "@kie-tools-core/editor/dist/api";
 
 export interface ServerlessWorkflowCombinedEditorEnvelopeApi extends KogitoEditorEnvelopeApi {
-  kogitoSwfCombinedEditor_colorNodes(args: { nodeNames: string[]; color: string; isWorkflowCompleted: boolean }): void;
+  kogitoSwfCombinedEditor_colorNodes(args: { nodeNames: string[]; color: string; colorConnectedEnds: boolean }): void;
 }

--- a/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorEnvelopeApi.ts
+++ b/packages/serverless-workflow-combined-editor/src/api/ServerlessWorkflowCombinedEditorEnvelopeApi.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-export * from "./SwfCombinedEditorChannelApiImpl";
-export * from "./SwfFeatureToggleChannelApiImpl";
-export * from "./SwfLanguageServiceChannelApiImpl";
-export * from "./SwfServiceCatalogChannelApiImpl";
-export * from "./SwfPreviewOptionsChannelApiImpl";
-export * from "./NoOpSwfStaticEnvelopeContentProviderChannelApiImpl";
-export * from "./SwfStaticEnvelopeContentProviderChannelApiImpl";
-export * from "./NoOpSwfServiceCatalogChannelApiImpl";
-export * from "./ServerlessWorkflowCombinedEditorEnvelopeApiImpl";
+import { KogitoEditorEnvelopeApi } from "@kie-tools-core/editor/dist/api";
+
+export interface ServerlessWorkflowCombinedEditorEnvelopeApi extends KogitoEditorEnvelopeApi {
+  kogitoSwfCombinedEditor_colorNodes(args: { nodeNames: string[]; color: string; isWorkflowCompleted: boolean }): void;
+}

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -63,7 +63,7 @@ import { Position } from "monaco-editor";
 import { ServerlessWorkflowCombinedEditorChannelApi, SwfFeatureToggle, SwfPreviewOptions } from "../api";
 import { useSwfDiagramEditorChannelApi } from "./hooks/useSwfDiagramEditorChannelApi";
 import { useSwfTextEditorChannelApi } from "./hooks/useSwfTextEditorChannelApi";
-import { paintCompletedNodes } from "./helpers/PaintNodes";
+import { colorNodes } from "./helpers/PaintNodes";
 
 interface Props {
   locale: string;
@@ -75,7 +75,7 @@ interface Props {
 
 export type ServerlessWorkflowCombinedEditorRef = {
   setContent(path: string, content: string): Promise<void>;
-  colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void;
+  colorNodes(nodeNames: string[], color: string, colorConnectedEnds: boolean): void;
 };
 
 interface File {
@@ -248,7 +248,7 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
           diagramEditor?.setTheme(theme);
         },
         colorNodes: (nodeNames: string[], color: string, colorConnectedEnds: boolean) => {
-          paintCompletedNodes(nodeNames, color, colorConnectedEnds);
+          colorNodes(nodeNames, color, colorConnectedEnds);
         },
       };
     },

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -247,8 +247,8 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
           textEditor?.setTheme(theme);
           diagramEditor?.setTheme(theme);
         },
-        colorNodes: (nodeNames: string[], color: string, isWorkflowCompleted: boolean) => {
-          paintCompletedNodes(nodeNames, color, isWorkflowCompleted);
+        colorNodes: (nodeNames: string[], color: string, colorConnectedEnds: boolean) => {
+          paintCompletedNodes(nodeNames, color, colorConnectedEnds);
         },
       };
     },
@@ -408,6 +408,7 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
       ),
     [diagramEditor]
   );
+
   useEffect(() => {
     if (isCombinedEditorReady) {
       editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_combinedEditorReady.send();

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -63,7 +63,7 @@ import { Position } from "monaco-editor";
 import { ServerlessWorkflowCombinedEditorChannelApi, SwfFeatureToggle, SwfPreviewOptions } from "../api";
 import { useSwfDiagramEditorChannelApi } from "./hooks/useSwfDiagramEditorChannelApi";
 import { useSwfTextEditorChannelApi } from "./hooks/useSwfTextEditorChannelApi";
-import { colorNodes } from "./helpers/PaintNodes";
+import { colorNodes } from "./helpers/ColorNodes";
 
 interface Props {
   locale: string;

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -75,6 +75,7 @@ interface Props {
 
 export type ServerlessWorkflowCombinedEditorRef = {
   setContent(path: string, content: string): Promise<void>;
+  colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void;
 };
 
 interface File {
@@ -246,6 +247,9 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
           textEditor?.setTheme(theme);
           diagramEditor?.setTheme(theme);
         },
+        colorNodes: (nodeNames: string[], color: string, isWorkflowCompleted: boolean) => {
+          paintCompletedNodes(nodeNames, color, isWorkflowCompleted);
+        },
       };
     },
     [diagramEditor, file, props.isReadOnly, textEditor]
@@ -396,6 +400,14 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
     );
   };
 
+  window.editor = useMemo(
+    () =>
+      new SwfStunnerEditor(
+        diagramEditor?.getEnvelopeServer()
+          .envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>
+      ),
+    [diagramEditor]
+  );
   useEffect(() => {
     if (isCombinedEditorReady) {
       editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_combinedEditorReady.send();
@@ -412,27 +424,6 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
         swfTextEditorEnvelopeApi.notifications.kogitoSwfTextEditor__moveCursorToPosition.send(position);
       },
       [textEditor]
-    )
-  );
-
-  window.editor = useMemo(
-    () =>
-      new SwfStunnerEditor(
-        diagramEditor?.getEnvelopeServer()
-          .envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>
-      ),
-    [diagramEditor]
-  );
-
-  useSubscription(
-    editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_colorNodesBasedOnNames,
-    useCallback(
-      async (nodeNameList: string[], isWorkflowCompleted) => {
-        if (isDiagramEditorReady) {
-          paintCompletedNodes(nodeNameList, isWorkflowCompleted);
-        }
-      },
-      [isDiagramEditorReady]
     )
   );
 

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -63,6 +63,7 @@ import { Position } from "monaco-editor";
 import { ServerlessWorkflowCombinedEditorChannelApi, SwfFeatureToggle, SwfPreviewOptions } from "../api";
 import { useSwfDiagramEditorChannelApi } from "./hooks/useSwfDiagramEditorChannelApi";
 import { useSwfTextEditorChannelApi } from "./hooks/useSwfTextEditorChannelApi";
+import { paintCompletedNodes } from "./helpers/PaintNodes";
 
 interface Props {
   locale: string;
@@ -395,6 +396,12 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
     );
   };
 
+  useEffect(() => {
+    if (isCombinedEditorReady) {
+      editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_combinedEditorReady.send();
+    }
+  }, [isCombinedEditorReady]);
+
   useSubscription(
     editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_moveCursorToPosition,
     useCallback(
@@ -415,6 +422,18 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
           .envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>
       ),
     [diagramEditor]
+  );
+
+  useSubscription(
+    editorEnvelopeCtx.channelApi.notifications.kogitoSwfCombinedEditor_colorNodesBasedOnNames,
+    useCallback(
+      async (nodeNameList: string[], isWorkflowCompleted) => {
+        if (isDiagramEditorReady) {
+          paintCompletedNodes(nodeNameList, isWorkflowCompleted);
+        }
+      },
+      [isDiagramEditorReady]
+    )
   );
 
   return (

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
@@ -25,9 +25,11 @@ import { Notification } from "@kie-tools-core/notifications/dist/api";
 import * as React from "react";
 import { ServerlessWorkflowCombinedEditorChannelApi } from "../api";
 import { ServerlessWorkflowCombinedEditor } from "./ServerlessWorkflowCombinedEditor";
-
+export interface ServerlessWorkflowCombinedEditorApi extends Editor {
+  colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void;
+}
 export class ServerlessWorkflowCombinedEditorView implements Editor {
-  private readonly editorRef: React.RefObject<EditorApi>;
+  private readonly editorRef: React.RefObject<ServerlessWorkflowCombinedEditorApi>;
   public af_isReact = true;
   public af_componentId: "serverless-workflow-combined-editor";
   public af_componentTitle: "Serverless Workflow Combined Editor";
@@ -36,7 +38,7 @@ export class ServerlessWorkflowCombinedEditorView implements Editor {
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>,
     private readonly initArgs: EditorInitArgs
   ) {
-    this.editorRef = React.createRef<EditorApi>();
+    this.editorRef = React.createRef<ServerlessWorkflowCombinedEditorApi>();
   }
 
   public setContent(path: string, content: string): Promise<void> {
@@ -78,5 +80,9 @@ export class ServerlessWorkflowCombinedEditorView implements Editor {
 
   public async setTheme(theme: EditorTheme) {
     return this.editorRef.current!.setTheme(theme);
+  }
+
+  public colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void {
+    return this.editorRef.current!.colorNodes(nodeNames, color, isWorkflowCompleted);
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
@@ -26,9 +26,9 @@ import * as React from "react";
 import { ServerlessWorkflowCombinedEditorChannelApi } from "../api";
 import { ServerlessWorkflowCombinedEditor } from "./ServerlessWorkflowCombinedEditor";
 export interface ServerlessWorkflowCombinedEditorApi extends Editor {
-  colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void;
+  colorNodes(nodeNames: string[], color: string, colorConnectedEnds: boolean): void;
 }
-export class ServerlessWorkflowCombinedEditorView implements Editor {
+export class ServerlessWorkflowCombinedEditorView implements ServerlessWorkflowCombinedEditorApi {
   private readonly editorRef: React.RefObject<ServerlessWorkflowCombinedEditorApi>;
   public af_isReact = true;
   public af_componentId: "serverless-workflow-combined-editor";
@@ -82,7 +82,7 @@ export class ServerlessWorkflowCombinedEditorView implements Editor {
     return this.editorRef.current!.setTheme(theme);
   }
 
-  public colorNodes(nodeNames: string[], color: string, isWorkflowCompleted: boolean): void {
-    return this.editorRef.current!.colorNodes(nodeNames, color, isWorkflowCompleted);
+  public colorNodes(nodeNames: string[], color: string, colorConnectedEnds: boolean): void {
+    return this.editorRef.current!.colorNodes(nodeNames, color, colorConnectedEnds);
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/editor/helpers/ColorNodes.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/helpers/ColorNodes.ts
@@ -25,17 +25,19 @@ export const colorNodes = (nodeNameList: string[], color: string, colorConnected
     .then((nodeListToColor) => {
       const nodeList = nodeListToColor.filter((node) => node !== null) as Node[];
       return nodeList.forEach((node) => {
-        if (node.definition.name !== "End") colorNode(node, color);
-        if (colorConnectedEnds) {
-          Promise.all(
-            node.outEdges.map((edge) => edge.target).map((target) => window.editor.session.getNodeByUUID(target))
-          )
-            .then((outNodes) => {
-              return outNodes
-                .filter((outNode) => outNode.definition.id === "org.kie.workbench.common.stunner.sw.definition.End")
-                .forEach((outNode) => colorNode(outNode, color));
-            })
-            .then((_) => window.editor.canvas.draw());
+        if (node.definition.name !== "End") {
+          colorNode(node, color);
+          if (colorConnectedEnds) {
+            Promise.all(
+              node.outEdges.map((edge) => edge.target).map((target) => window.editor.session.getNodeByUUID(target))
+            )
+              .then((outNodes) => {
+                return outNodes
+                  .filter((outNode) => outNode.definition.id === "org.kie.workbench.common.stunner.sw.definition.End")
+                  .forEach((outNode) => colorNode(outNode, color));
+              })
+              .then((_) => window.editor.canvas.draw());
+          }
         }
       });
     })

--- a/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Node } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/api/StunnerEditorEnvelopeAPI";
+
+const paintCompletedNode = async (node: Node) => {
+  await window.editor.canvas.setBackgroundColor(node.uuid, "#d5f4e6");
+};
+
+const isPointingToAnyCompletedNode = (completedNodes: (Node | null)[], node: Node): boolean => {
+  return (
+    node.outEdges.filter((edge) => completedNodes.filter((node) => node && edge.target === node.uuid).length > 0)
+      .length > 0
+  );
+};
+
+export const paintCompletedNodes = (nodeNameList: string[], isWorkflowCompleted: boolean): void => {
+  Promise.all(nodeNameList.map((name) => window.editor.session.getNodeByName(name).catch(() => null)))
+    .then((completedNodes) =>
+      completedNodes.forEach((completedNode) => {
+        if (completedNode) {
+          paintCompletedNode(completedNode);
+          if (isWorkflowCompleted && !isPointingToAnyCompletedNode(completedNodes, completedNode)) {
+            Promise.all(
+              completedNode.outEdges
+                .map((edge) => edge.target)
+                .map((target) => window.editor.session.getNodeByUUID(target))
+            )
+              .then((outNodes) =>
+                outNodes
+                  .filter((outNode) => outNode.definition.id === "org.kie.workbench.common.stunner.sw.definition.End")
+                  .forEach((outNode) => paintCompletedNode(outNode))
+              )
+              .then((_) => window.editor.canvas.draw());
+          }
+        }
+      })
+    )
+    .then((_) => window.editor.canvas.draw());
+};

--- a/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
@@ -16,8 +16,9 @@
 
 import { Node } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/api/StunnerEditorEnvelopeAPI";
 
-const paintCompletedNode = async (node: Node) => {
-  await window.editor.canvas.setBackgroundColor(node.uuid, "#d5f4e6");
+const paintCompletedNode = async (node: Node, color: string) => {
+  //"#d5f4e6"
+  await window.editor.canvas.setBackgroundColor(node.uuid, color);
 };
 
 const isPointingToAnyCompletedNode = (completedNodes: (Node | null)[], node: Node): boolean => {
@@ -27,12 +28,12 @@ const isPointingToAnyCompletedNode = (completedNodes: (Node | null)[], node: Nod
   );
 };
 
-export const paintCompletedNodes = (nodeNameList: string[], isWorkflowCompleted: boolean): void => {
+export const paintCompletedNodes = (nodeNameList: string[], color: string, isWorkflowCompleted: boolean): void => {
   Promise.all(nodeNameList.map((name) => window.editor.session.getNodeByName(name).catch(() => null)))
     .then((completedNodes) =>
       completedNodes.forEach((completedNode) => {
         if (completedNode) {
-          paintCompletedNode(completedNode);
+          paintCompletedNode(completedNode, color);
           if (isWorkflowCompleted && !isPointingToAnyCompletedNode(completedNodes, completedNode)) {
             Promise.all(
               completedNode.outEdges
@@ -42,7 +43,7 @@ export const paintCompletedNodes = (nodeNameList: string[], isWorkflowCompleted:
               .then((outNodes) =>
                 outNodes
                   .filter((outNode) => outNode.definition.id === "org.kie.workbench.common.stunner.sw.definition.End")
-                  .forEach((outNode) => paintCompletedNode(outNode))
+                  .forEach((outNode) => paintCompletedNode(outNode, color))
               )
               .then((_) => window.editor.canvas.draw());
           }

--- a/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/helpers/PaintNodes.ts
@@ -17,7 +17,6 @@
 import { Node } from "@kie-tools/serverless-workflow-diagram-editor-envelope/dist/api/StunnerEditorEnvelopeAPI";
 
 const paintCompletedNode = async (node: Node, color: string) => {
-  //"#d5f4e6"
   await window.editor.canvas.setBackgroundColor(node.uuid, color);
 };
 
@@ -28,13 +27,13 @@ const isPointingToAnyCompletedNode = (completedNodes: (Node | null)[], node: Nod
   );
 };
 
-export const paintCompletedNodes = (nodeNameList: string[], color: string, isWorkflowCompleted: boolean): void => {
+export const paintCompletedNodes = (nodeNameList: string[], color: string, colorConnectedEnds: boolean): void => {
   Promise.all(nodeNameList.map((name) => window.editor.session.getNodeByName(name).catch(() => null)))
     .then((completedNodes) =>
       completedNodes.forEach((completedNode) => {
         if (completedNode) {
           paintCompletedNode(completedNode, color);
-          if (isWorkflowCompleted && !isPointingToAnyCompletedNode(completedNodes, completedNode)) {
+          if (colorConnectedEnds && !isPointingToAnyCompletedNode(completedNodes, completedNode)) {
             Promise.all(
               completedNode.outEdges
                 .map((edge) => edge.target)

--- a/packages/serverless-workflow-combined-editor/src/impl/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/impl/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
@@ -16,22 +16,21 @@
 
 import { EditorEnvelopeViewApi, KogitoEditorEnvelopeApiImpl } from "@kie-tools-core/editor/dist/envelope";
 import { ServerlessWorkflowCombinedEditorEnvelopeApi } from "../api/ServerlessWorkflowCombinedEditorEnvelopeApi";
-import { ServerlessWorkflowCombinedEditorView } from "../editor";
+import { ServerlessWorkflowCombinedEditorApi, ServerlessWorkflowCombinedEditorView } from "../editor";
 import { ServerlessWorkflowCombinedEditorChannelApi } from "../api";
 import { EditorFactory, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
-//add it to pck.json
 import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
 
 export type ServerlessWorkflowCombinedEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   ServerlessWorkflowCombinedEditorEnvelopeApi,
   ServerlessWorkflowCombinedEditorChannelApi,
-  EditorEnvelopeViewApi<ServerlessWorkflowCombinedEditorView>,
+  EditorEnvelopeViewApi<ServerlessWorkflowCombinedEditorApi>,
   KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>
 >;
 
 export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
   extends KogitoEditorEnvelopeApiImpl<
-    ServerlessWorkflowCombinedEditorView,
+    ServerlessWorkflowCombinedEditorApi,
     ServerlessWorkflowCombinedEditorEnvelopeApi,
     ServerlessWorkflowCombinedEditorChannelApi
   >
@@ -39,15 +38,15 @@ export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
 {
   constructor(
     private readonly serverlessWorkflowArgs: ServerlessWorkflowCombinedEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<ServerlessWorkflowCombinedEditorView, ServerlessWorkflowCombinedEditorChannelApi>
+    editorFactory: EditorFactory<ServerlessWorkflowCombinedEditorApi, ServerlessWorkflowCombinedEditorChannelApi>
   ) {
     super(serverlessWorkflowArgs, editorFactory);
   }
   public kogitoSwfCombinedEditor_colorNodes(args: {
     nodeNames: string[];
     color: string;
-    isWorkflowCompleted: boolean;
+    colorConnectedEnds: boolean;
   }): void {
-    this.getEditorOrThrowError().colorNodes(args.nodeNames, args.color, args.isWorkflowCompleted);
+    this.getEditorOrThrowError().colorNodes(args.nodeNames, args.color, args.colorConnectedEnds);
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/impl/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/impl/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EditorEnvelopeViewApi, KogitoEditorEnvelopeApiImpl } from "@kie-tools-core/editor/dist/envelope";
+import { ServerlessWorkflowCombinedEditorEnvelopeApi } from "../api/ServerlessWorkflowCombinedEditorEnvelopeApi";
+import { ServerlessWorkflowCombinedEditorView } from "../editor";
+import { ServerlessWorkflowCombinedEditorChannelApi } from "../api";
+import { EditorFactory, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
+//add it to pck.json
+import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
+
+export type ServerlessWorkflowCombinedEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
+  ServerlessWorkflowCombinedEditorEnvelopeApi,
+  ServerlessWorkflowCombinedEditorChannelApi,
+  EditorEnvelopeViewApi<ServerlessWorkflowCombinedEditorView>,
+  KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>
+>;
+
+export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
+  extends KogitoEditorEnvelopeApiImpl<
+    ServerlessWorkflowCombinedEditorView,
+    ServerlessWorkflowCombinedEditorEnvelopeApi,
+    ServerlessWorkflowCombinedEditorChannelApi
+  >
+  implements ServerlessWorkflowCombinedEditorEnvelopeApi
+{
+  constructor(
+    private readonly serverlessWorkflowArgs: ServerlessWorkflowCombinedEnvelopeApiFactoryArgs,
+    editorFactory: EditorFactory<ServerlessWorkflowCombinedEditorView, ServerlessWorkflowCombinedEditorChannelApi>
+  ) {
+    super(serverlessWorkflowArgs, editorFactory);
+  }
+  public kogitoSwfCombinedEditor_colorNodes(args: {
+    nodeNames: string[];
+    color: string;
+    isWorkflowCompleted: boolean;
+  }): void {
+    this.getEditorOrThrowError().colorNodes(args.nodeNames, args.color, args.isWorkflowCompleted);
+  }
+}

--- a/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
@@ -55,10 +55,6 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
     private readonly swfPreviewOptionsChannelApiImpl?: SwfPreviewOptionsChannelApi,
     private readonly swfStaticEnvelopeContentProviderChannelApi?: SwfStaticEnvelopeContentProviderChannelApi
   ) {}
-  // TODO: remove after testing
-  kogitoSwfCombinedEditor_combinedEditorReady(): void {
-    // no -op
-  }
 
   public kogitoEditor_contentRequest(): Promise<EditorContent> {
     return this.defaultApiImpl.kogitoEditor_contentRequest();
@@ -194,5 +190,9 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
 
   public kogitoSwfCombinedEditor_moveCursorToPosition(_position: MonacoPosition): void {
     // no-op
+  }
+
+  kogitoSwfCombinedEditor_combinedEditorReady(): void {
+    // no -op
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
@@ -55,6 +55,10 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
     private readonly swfPreviewOptionsChannelApiImpl?: SwfPreviewOptionsChannelApi,
     private readonly swfStaticEnvelopeContentProviderChannelApi?: SwfStaticEnvelopeContentProviderChannelApi
   ) {}
+  // TODO: remove after testing
+  kogitoSwfCombinedEditor_combinedEditorReady(): void {
+    // no -op
+  }
 
   public kogitoEditor_contentRequest(): Promise<EditorContent> {
     return this.defaultApiImpl.kogitoEditor_contentRequest();
@@ -190,13 +194,5 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
 
   public kogitoSwfCombinedEditor_moveCursorToPosition(_position: MonacoPosition): void {
     // no-op
-  }
-
-  public kogitoSwfCombinedEditor_colorNodesBasedOnNames(_nodeNameList: string[], _isWorkflowCompleted: boolean): void {
-    // no-op
-  }
-
-  public kogitoSwfCombinedEditor_combinedEditorReady(): void {
-    //no-op
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/impl/SwfCombinedEditorChannelApiImpl.ts
@@ -191,4 +191,12 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
   public kogitoSwfCombinedEditor_moveCursorToPosition(_position: MonacoPosition): void {
     // no-op
   }
+
+  public kogitoSwfCombinedEditor_colorNodesBasedOnNames(_nodeNameList: string[], _isWorkflowCompleted: boolean): void {
+    // no-op
+  }
+
+  public kogitoSwfCombinedEditor_combinedEditorReady(): void {
+    //no-op
+  }
 }

--- a/packages/serverless-workflow-standalone-editor/src/swf/channel/StandaloneServerlessWorkflowCombinedEditorChannelApi.ts
+++ b/packages/serverless-workflow-standalone-editor/src/swf/channel/StandaloneServerlessWorkflowCombinedEditorChannelApi.ts
@@ -204,4 +204,11 @@ export class StandaloneServerlessWorkflowCombinedEditorChannelApi
   public kogitoSwfCombinedEditor_moveCursorToPosition(_position: MonacoPosition): void {
     // no-op
   }
+
+  kogitoSwfCombinedEditor_colorNodesBasedOnNames(_nodeNameList: string[], _isWorkflowCompleted: boolean): void {
+    // no-op
+  }
+  kogitoSwfCombinedEditor_combinedEditorReady(): void {
+    // no-op
+  }
 }

--- a/packages/serverless-workflow-standalone-editor/src/swf/channel/StandaloneServerlessWorkflowCombinedEditorChannelApi.ts
+++ b/packages/serverless-workflow-standalone-editor/src/swf/channel/StandaloneServerlessWorkflowCombinedEditorChannelApi.ts
@@ -205,9 +205,6 @@ export class StandaloneServerlessWorkflowCombinedEditorChannelApi
     // no-op
   }
 
-  kogitoSwfCombinedEditor_colorNodesBasedOnNames(_nodeNameList: string[], _isWorkflowCompleted: boolean): void {
-    // no-op
-  }
   kogitoSwfCombinedEditor_combinedEditorReady(): void {
     // no-op
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6416,6 +6416,9 @@ importers:
       "@kie-tools-core/editor":
         specifier: workspace:*
         version: link:../editor
+      "@kie-tools-core/envelope":
+        specifier: workspace:*
+        version: link:../envelope
       "@kie-tools-core/envelope-bus":
         specifier: workspace:*
         version: link:../envelope-bus


### PR DESCRIPTION
This pr is the first step to provide support for coloring nodes in the diagram from the DEV UI.
To test it locally(kie-tools), the easiest way is to use `serverless-logic-web-tools` and in the file 
`kie-tools/packages/serverless-logic-web-tools/src/editor/channel/SwfChannelComponent.tsx`

use the following piece of code

```
useEffect(() => {
  const combinedEditorChannelApi = editor.getEnvelopeServer()
.envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowCombinedEditorChannelApi>;
const combinedEditorEnvelopeApi = editor.getEnvelopeServer()
    .envelopeApi as unknown as MessageBusClientApi<ServerlessWorkflowCombinedEditorEnvelopeApi>;
  if (combinedEditorEnvelopeApi) {
    combinedEditorChannelApi.notifications.kogitoSwfCombinedEditor_combinedEditorReady.subscribe(() => {
      combinedEditorEnvelopeApi.notifications.kogitoSwfCombinedEditor_colorNodes.send({
      nodeNames:["Start", "printStatus", "branch", "finish_compensate", "compensating", "compensating_more", "End", "End","some random value"],
      color:"#d5f4e6",
      colorConnectedEnds:true
    })
    });
  }
}, [editor]);
```
Also the following change in required in the `packages/serverless-logic-web-tools/src/envelope/ServerlessWorkflowCombinedEditorEnvelopeApp.ts`
```
EditorEnvelope.initCustom<
  ServerlessWorkflowCombinedEditorApi,
  ServerlessWorkflowCombinedEditorEnvelopeApi,
  ServerlessWorkflowCombinedEditorChannelApi
>({
  container: document.getElementById("swf-combined-editor-envelope-app")!,
  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, targetOrigin!, _) },
  apiImplFactory: {
    create: (args) => 
    new ServerlessWorkflowCombinedEditorEnvelopeApiImpl(args, new ServerlessWorkflowCombinedEditorFactory()),
  },
  keyboardShortcutsService: new NoOpKeyboardShortcutsService()
});
```

Note that the following piece of code works with this swf file : https://github.com/kiegroup/kogito-examples/blob/stable/serverless-workflow-examples/serverless-workflow-compensation-quarkus/src/main/resources/compensation.sw.json

I have also attached how it looks on DEV UI below:
<img width="1721" alt="Screenshot 2023-05-23 at 1 00 07 PM" src="https://github.com/kiegroup/kie-tools/assets/36824134/48671e71-befd-454b-a339-efe2e20af9e6">


