### PR TITLE
NO-ISSUE: Bump `moment` dependencies version

### DIFF
--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -166,8 +166,8 @@
     <!-- Properties from APPFORMER parent POM -->
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>
-    <version.org.webjars.bower.moment>2.14.1</version.org.webjars.bower.moment>
-    <version.org.webjars.bower.moment-timezone>0.5.17</version.org.webjars.bower.moment-timezone>
+    <version.org.webjars.bower.moment>2.29.4</version.org.webjars.bower.moment>
+    <version.org.webjars.bower.moment-timezone>0.5.34</version.org.webjars.bower.moment-timezone>
     <version.org.webjars.bower.bootstrap-daterangepicker>2.1.25</version.org.webjars.bower.bootstrap-daterangepicker>
     <version.org.webjars.bower.filesaver>1.3.3</version.org.webjars.bower.filesaver>
     <!-- Notice actually there exists a 1.3.3 version for jsPDF, but using this one


### PR DESCRIPTION
Current versions are affected by Critical (and High) level Vulnerabilities.