### PR TITLE
kie-issues#278: Duplicate row should not copy the inputEntry id of that row

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -22,6 +22,7 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   DecisionTableExpressionDefinition,
+  DecisionTableExpressionDefinitionRule,
   DecisionTableExpressionDefinitionBuiltInAggregation,
   DecisionTableExpressionDefinitionHitPolicy,
   DmnBuiltInDataType,
@@ -627,8 +628,16 @@ export function DecisionTableExpression(
     (args: { rowIndex: number }) => {
       setExpression((prev: DecisionTableExpressionDefinition) => {
         const duplicatedRule = {
-          ...JSON.parse(JSON.stringify(prev.rules?.[args.rowIndex])),
           id: generateUuid(),
+          inputEntries: prev.rules![args.rowIndex].inputEntries.map((input) => ({
+            ...input,
+            id: generateUuid(),
+          })),
+          outputEntries: prev.rules![args.rowIndex].outputEntries.map((output) => ({
+            ...output,
+            id: generateUuid(),
+          })),
+          annotationEntries: prev.rules![args.rowIndex].annotationEntries.slice(),
         };
 
         const newRules = [...(prev.rules ?? [])];

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -22,7 +22,6 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   DecisionTableExpressionDefinition,
-  DecisionTableExpressionDefinitionRule,
   DecisionTableExpressionDefinitionBuiltInAggregation,
   DecisionTableExpressionDefinitionHitPolicy,
   DmnBuiltInDataType,


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/278

To solve the issue, I just assigned a new UUID (calling `generateUuid()`) to all duplicated input and output entries. Annotations don't have IDs.