### PR TITLE
KOGITO-9227: Make an internal Dashbuilder timeseries component

### DIFF
--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/AbstractDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/AbstractDisplayer.java
@@ -994,7 +994,6 @@ public abstract class AbstractDisplayer<V extends AbstractDisplayer.View> implem
         if (expression != null && !expression.trim().isEmpty()) {
             return getEvaluator().evalExpression(value, expression);
         }
-
         return value;
     }
 

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsAbstractDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsAbstractDisplayer.java
@@ -198,19 +198,10 @@ public abstract class EChartsAbstractDisplayer<V extends EChartsAbstractDisplaye
         toolbox.setShow(true);
         toolbox.setFeature(toolboxFeature);
 
-        switch (legendPosition) {
-            case BOTTOM:
-            case TOP:
-                legend.setLeft("center");
-                break;
-            case IN:
-                break;
-            case LEFT:
-                legend.setLeft("left");
-                break;
-            case RIGHT:
-                legend.setLeft("right");
-                break;
+        if (legendPosition == Position.BOTTOM || legendPosition == Position.TOP) {
+            legend.setLeft("center");
+        } else {
+            legend.setLeft(legendPosition.toString().toLowerCase());
         }
 
         if (bgColor != null && !bgColor.isEmpty()) {

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsBubbleChartDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsBubbleChartDisplayer.java
@@ -26,9 +26,9 @@ import org.dashbuilder.renderer.echarts.client.js.EChartsTypeFactory;
 @Dependent
 public class EChartsBubbleChartDisplayer extends EChartsXYDisplayer {
 
-    private static int VALUE_INDEX = 1;
-    private static int RADIUS_INDEX = 2;
-    private static int LABEL_INDEX = 3;
+    private static final int VALUE_INDEX = 1;
+    private static final int RADIUS_INDEX = 2;
+    private static final int LABEL_INDEX = 3;
 
     @Inject
     public EChartsBubbleChartDisplayer(EChartsDisplayerView<?> view, EChartsTypeFactory echartsFactory) {

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsRenderer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsRenderer.java
@@ -48,6 +48,7 @@ import static org.dashbuilder.displayer.DisplayerType.LINECHART;
 import static org.dashbuilder.displayer.DisplayerType.METERCHART;
 import static org.dashbuilder.displayer.DisplayerType.PIECHART;
 import static org.dashbuilder.displayer.DisplayerType.SCATTERCHART;
+import static org.dashbuilder.displayer.DisplayerType.TIMESERIES;
 
 @ApplicationScoped
 public class EChartsRenderer extends AbstractRendererLibrary {
@@ -56,13 +57,14 @@ public class EChartsRenderer extends AbstractRendererLibrary {
 
     public static final String UUID = "echarts";
 
-    private static List<DisplayerType> SUPPORTED_TYPES = Arrays.asList(LINECHART,
+    private static final List<DisplayerType> SUPPORTED_TYPES = Arrays.asList(LINECHART,
             BARCHART,
             PIECHART,
             AREACHART,
             BUBBLECHART,
             METERCHART, 
-            SCATTERCHART);
+            SCATTERCHART,
+            TIMESERIES);
 
     @PostConstruct
     public void prepare() {
@@ -107,6 +109,8 @@ public class EChartsRenderer extends AbstractRendererLibrary {
             case AREACHART:
             case SCATTERCHART:
                 return beanManager.lookupBean(EChartsXYChartDisplayer.class).newInstance();
+            case TIMESERIES:
+                return beanManager.lookupBean(EChartsTimeseriesDisplayer.class).newInstance();
             case BUBBLECHART:
                 return beanManager.lookupBean(EChartsBubbleChartDisplayer.class).newInstance();
             case PIECHART:

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsTimeseriesDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsTimeseriesDisplayer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.renderer.echarts.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+import org.dashbuilder.dataset.DataColumn;
+import org.dashbuilder.dataset.DataSetLookupConstraints;
+import org.dashbuilder.renderer.echarts.client.js.ECharts.Dataset;
+import org.dashbuilder.renderer.echarts.client.js.ECharts.Series;
+import org.dashbuilder.renderer.echarts.client.js.EChartsTypeFactory;
+
+@Default
+@Dependent
+public class EChartsTimeseriesDisplayer extends EChartsXYDisplayer {
+
+    @Inject
+    public EChartsTimeseriesDisplayer(EChartsDisplayerView<?> view, EChartsTypeFactory echartsFactory) {
+        super(view, echartsFactory);
+    }
+
+    @Override
+    DataSetLookupConstraints getDataSetLookupConstraints() {
+        return new DataSetLookupConstraints()
+                .setMaxColumns(3)
+                .setMinColumns(3);
+    }
+
+    @Override
+    protected Series[] buildSeries() {
+        var columns = dataSet.getColumns();
+        var nColumns = columns.size();
+        if (nColumns < 3) {
+            return new Series[0];
+        }
+        var seriesMap = new HashMap<String, List<Object[]>>();
+        var seriesColumn = columns.get(0);
+        var timestampColumn = columns.get(1);
+        var valuesColumn = columns.get(2);
+
+        for (var i = 0; i < dataSet.getRowCount(); i++) {
+            var serieName = getValue(seriesColumn, i).toString();
+            var data = seriesMap.getOrDefault(serieName, new ArrayList<>());
+            data.add(new Object[]{getValue(timestampColumn, i), getValue(valuesColumn, i)});
+            seriesMap.put(serieName, data);
+        }
+
+        var seriesList = new ArrayList<Series>();
+        seriesMap.forEach((k, v) -> {
+            var data = v.stream().toArray(String[]::new);
+            var series = echartsFactory.newSeries();
+
+            series.setName(k);
+            series.setType("line");
+            series.setSmooth(false);
+            series.setSymbol("none");
+
+            var areaStyle = echartsFactory.newAreaStyle();
+            areaStyle.setOpacity(0.2);
+            series.setAreaStyle(areaStyle);
+
+            series.setData(data);
+            seriesList.add(series);
+        });
+        return seriesList.stream().toArray(Series[]::new);
+    }
+
+    @Override
+    public Dataset buildDataSet() {
+        return null;
+    }
+
+    private Object getValue(DataColumn column, int i) {
+        return column.getValues().get(i);
+    }
+
+}

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsXYChartDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsXYChartDisplayer.java
@@ -21,7 +21,6 @@ import javax.inject.Inject;
 
 import org.dashbuilder.displayer.DisplayerSubType;
 import org.dashbuilder.displayer.DisplayerType;
-import org.dashbuilder.renderer.echarts.client.js.ECharts;
 import org.dashbuilder.renderer.echarts.client.js.ECharts.Series;
 import org.dashbuilder.renderer.echarts.client.js.EChartsTypeFactory;
 
@@ -37,41 +36,42 @@ public class EChartsXYChartDisplayer extends EChartsXYDisplayer {
     @Override
     protected Series[] buildSeries() {
         var nColumns = dataSet.getColumns().size();
-        var allSeries = new ECharts.Series[nColumns - 1];
         if (nColumns > 0) {
-            var catColumn = displayerSettings.getColumnSettings(dataSet.getColumnByIndex(0)).getColumnName();
-            for (int i = 1; i < nColumns; i++) {
-                var series = echartsFactory.newSeries();
-                var encode = echartsFactory.newEncode();
-                var column = dataSet.getColumnByIndex(i);
-                var settings = displayerSettings.getColumnSettings(column);
-                var seriesColumn = settings.getColumnName();
+            return new Series[0];
+        }
+        var allSeries = new Series[nColumns - 1];
+        var catColumn = displayerSettings.getColumnSettings(dataSet.getColumnByIndex(0)).getColumnName();
+        for (int i = 1; i < nColumns; i++) {
+            var series = echartsFactory.newSeries();
+            var encode = echartsFactory.newEncode();
+            var column = dataSet.getColumnByIndex(i);
+            var settings = displayerSettings.getColumnSettings(column);
+            var seriesColumn = settings.getColumnName();
 
-                if (displayerSettings.getType() == DisplayerType.AREACHART) {
-                    series.setAreaStyle(echartsFactory.newAreaStyle());
-                }
-
-                if (displayerSettings.getSubtype() == DisplayerSubType.SMOOTH) {
-                    series.setSmooth(true);
-                }
-                if (isBar) {
-                    encode.setX(seriesColumn);
-                    encode.setY(catColumn);
-                } else {
-                    encode.setX(catColumn);
-                    encode.setY(seriesColumn);
-                }
-
-                if (isStack) {
-                    series.setStack(catColumn);
-                }
-
-                series.setName(seriesColumn);
-                series.setEncode(encode);
-                series.setType(this.echartsType);
-
-                allSeries[i - 1] = series;
+            if (displayerSettings.getType() == DisplayerType.AREACHART) {
+                series.setAreaStyle(echartsFactory.newAreaStyle());
             }
+
+            if (displayerSettings.getSubtype() == DisplayerSubType.SMOOTH) {
+                series.setSmooth(true);
+            }
+            if (isBar) {
+                encode.setX(seriesColumn);
+                encode.setY(catColumn);
+            } else {
+                encode.setX(catColumn);
+                encode.setY(seriesColumn);
+            }
+
+            if (isStack) {
+                series.setStack(catColumn);
+            }
+
+            series.setName(seriesColumn);
+            series.setEncode(encode);
+            series.setType(this.echartsType);
+
+            allSeries[i - 1] = series;
         }
         return allSeries;
     }

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsXYDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/EChartsXYDisplayer.java
@@ -21,6 +21,7 @@ import org.dashbuilder.dataset.ColumnType;
 import org.dashbuilder.dataset.DataSetLookupConstraints;
 import org.dashbuilder.displayer.DisplayerAttributeDef;
 import org.dashbuilder.displayer.DisplayerSubType;
+import org.dashbuilder.displayer.DisplayerType;
 import org.dashbuilder.renderer.echarts.client.js.ECharts.Series;
 import org.dashbuilder.renderer.echarts.client.js.ECharts.XAxisType;
 import org.dashbuilder.renderer.echarts.client.js.EChartsTypeFactory;
@@ -28,6 +29,7 @@ import org.dashbuilder.renderer.echarts.client.js.EChartsTypeFactory;
 public abstract class EChartsXYDisplayer extends EChartsAbstractDisplayer<EChartsDisplayerView<?>> {
 
     protected boolean isBar;
+    protected boolean isTimeseries;
     protected boolean isStack;
 
     @Inject
@@ -51,7 +53,7 @@ public abstract class EChartsXYDisplayer extends EChartsAbstractDisplayer<EChart
         var splitLineX = echartsFactory.newSplitLine();
         var splitLineY = echartsFactory.newSplitLine();
 
-        
+        this.isTimeseries = displayerSettings.getType() == DisplayerType.TIMESERIES;
         this.isBar = subType != null && (subType == DisplayerSubType.BAR || subType == DisplayerSubType.BAR_STACKED);
         this.isStack = subType != null && (subType == DisplayerSubType.BAR_STACKED ||
                                            subType == DisplayerSubType.AREA_STACKED ||
@@ -63,20 +65,40 @@ public abstract class EChartsXYDisplayer extends EChartsAbstractDisplayer<EChart
         axisLabelX.setRotate(displayerSettings.getXAxisLabelsAngle());
         splitLineX.setShow(displayerSettings.isGridXOn(true));
         axisLabelX.setShow(displayerSettings.isXAxisShowLabels());
-        // must format columns 0 if number
-        axisLabelX.setFormatter(buildNumberLabelFormatterForColumn(0));
+
         xAxis.setSplitLine(splitLineX);
         xAxis.setName(displayerSettings.getXAxisTitle());
         xAxis.setAxisLabel(axisLabelX);
-        xAxis.setType(isBar ? XAxisType.value.name() : XAxisType.category.name());
 
         axisLabelY.setShow(displayerSettings.isYAxisShowLabels());
         splitLineY.setShow(displayerSettings.isGridYOn(true));
-        axisLabelY.setFormatter(buildNumberLabelFormatterForColumn(1));
+
         yAxis.setSplitLine(splitLineY);
         yAxis.setName(displayerSettings.getYAxisTitle());
         yAxis.setAxisLabel(axisLabelY);
-        yAxis.setType(isBar ? XAxisType.category.name() : XAxisType.value.name());
+
+        // timeseries do not support format
+        if (!isTimeseries) {
+            // must format columns 0 if number
+            axisLabelX.setFormatter(buildNumberLabelFormatterForColumn(0));
+            axisLabelY.setFormatter(buildNumberLabelFormatterForColumn(1));
+        }
+
+        if (isBar) {
+            xAxis.setType(XAxisType.value.name());
+            yAxis.setType(XAxisType.category.name());
+
+        } else if (isTimeseries) {
+            xAxis.setType(XAxisType.time.name());
+            yAxis.setType(XAxisType.value.name());
+
+            var tooltip = echartsFactory.newTooltip();
+            tooltip.setTrigger("axis");
+            option.setTooltip(tooltip);
+        } else {
+            xAxis.setType(XAxisType.category.name());
+            yAxis.setType(XAxisType.value.name());
+        }
 
         var allSeries = buildSeries();
 

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/js/ECharts.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-echarts/src/main/java/org/dashbuilder/renderer/echarts/client/js/ECharts.java
@@ -123,6 +123,8 @@ public interface ECharts {
     @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
     public class AreaStyle {
 
+        @JsProperty
+        public native void setOpacity(Double opacity);
     }
 
     @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
@@ -331,6 +333,12 @@ public interface ECharts {
         @JsProperty
         public native void setData(Object[] data);
 
+        @JsProperty
+        public native void setData(String[][] data);
+
+        @JsProperty
+        public native void setSymbol(String syumbol);
+
     }
 
     @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
@@ -460,6 +468,9 @@ public interface ECharts {
         @JsProperty
         public native void setValueFormatter(ValueFormatterCallback callback);
 
+        @JsProperty
+        public native void setTrigger(String trigger);
+
     }
 
     @JsFunction
@@ -588,6 +599,7 @@ public interface ECharts {
     }
 
     public enum XAxisType {
+        time,
         category,
         value;
     }
@@ -597,15 +609,14 @@ public interface ECharts {
         svg,
         canvas;
 
-        public static Renderer DEFAULT_RENDERER = canvas;
+        public static final Renderer DEFAULT_RENDERER = canvas;
 
         public static Renderer byName(String echartsRenderer) {
             if (echartsRenderer == null) {
                 return DEFAULT_RENDERER;
             }
             return Arrays.stream(Renderer.values())
-                    .filter(r -> r.name().toLowerCase().equals(echartsRenderer
-                            .toLowerCase()))
+                    .filter(r -> r.name().equalsIgnoreCase(echartsRenderer))
                     .findAny().orElse(DEFAULT_RENDERER);
         }
     }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/metrics/MetricsParser.java
@@ -32,6 +32,9 @@ public class MetricsParser implements UnaryOperator<String> {
     private static final char LABEL_OPEN = '{';
     private static final char LABEL_CLOSE = '}';
     private static final String COMMENT = "#";
+    private static final String NAN = "NaN";
+
+    static final String DEFAULT_NAN_VALUE = "-1";
 
     protected JsonArray metricToJsonArray(String line) {
         var array = Json.createArray();
@@ -55,14 +58,14 @@ public class MetricsParser implements UnaryOperator<String> {
                 currentBuffer.append(ch);
             }
         }
-
+        var value = valueBuffer.toString().equals(NAN) ? DEFAULT_NAN_VALUE : valueBuffer.toString();
         if (metricBuffer.length() > 0 &&
             valueBuffer.length() > 0 &&
             !metricBuffer.toString().trim().isEmpty() &&
             !valueBuffer.toString().trim().isEmpty()) {
             array.set(0, metricBuffer.toString());
             array.set(1, labelsBuffer.toString());
-            array.set(2, valueBuffer.toString());
+            array.set(2, value);
         }
         return array;
     }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/external/metrics/MetricsParserTest.java
@@ -22,21 +22,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MetricsParserTest {
-    
+
     private MetricsParser parser;
-    
-    private static String METRICS = "# HELP process_start_time_seconds Start time of the process since unix epoch.\n" + 
-            "# TYPE process_start_time_seconds gauge\n" + 
+
+    private static String METRICS = "# HELP process_start_time_seconds Start time of the process since unix epoch.\n" +
+            "# TYPE process_start_time_seconds gauge\n" +
             "process_start_time_seconds 1.650302155929E9\n" +
-            "# HELP jvm_threads_states_threads The current number of threads having NEW state\n" + 
-            "# TYPE jvm_threads_states_threads gauge\n" + 
+            "# HELP jvm_threads_states_threads The current number of threads having NEW state\n" +
+            "# TYPE jvm_threads_states_threads gauge\n" +
             "jvm_threads_states_threads{state=\"runnable\",} 9.0";
-    
+
     @Before
     public void init() {
         parser = new MetricsParser();
     }
-    
+
     @Test
     public void testLabelMetricToArray() {
         var r = parser.metricToJsonArray("jvm_memory_max_bytes{area=\"nonheap\",id=\"Metaspace\",} -1.0");
@@ -44,8 +44,7 @@ public class MetricsParserTest {
         assertEquals("area=\"nonheap\",id=\"Metaspace\",", r.getString(1));
         assertEquals("-1.0", r.getString(2));
     }
-    
-    
+
     @Test
     public void testLabelWithSpaceMetricToArray() {
         var r = parser.metricToJsonArray("metric{l1=\"l1 val\",} -1.0");
@@ -53,7 +52,15 @@ public class MetricsParserTest {
         assertEquals("l1=\"l1 val\",", r.getString(1));
         assertEquals("-1.0", r.getString(2));
     }
-    
+
+    @Test
+    public void testMetricWithNaN() {
+        var r = parser.metricToJsonArray("metric{l1=\"l1 val\",} NaN");
+        assertEquals("metric", r.getString(0));
+        assertEquals("l1=\"l1 val\",", r.getString(1));
+        assertEquals(MetricsParser.DEFAULT_NAN_VALUE, r.getString(2));
+    }
+
     @Test
     public void testNoLabelMetricToArray() {
         var r = parser.metricToJsonArray("process_uptime_seconds 339164.251");
@@ -61,37 +68,35 @@ public class MetricsParserTest {
         assertEquals("", r.getString(1));
         assertEquals("339164.251", r.getString(2));
     }
-    
+
     @Test
     public void testEmptyMetricToArray() {
         var r = parser.metricToJsonArray("");
         assertTrue(r.isEmpty());
     }
-    
+
     @Test
     public void testNoValueMetricToArray() {
         var r = parser.metricToJsonArray("test      ");
         assertTrue(r.isEmpty());
-    }    
+    }
 
     @Test
     public void testMetricsToArray() {
         var r = parser.metricsToJsonArray(METRICS);
         assertEquals(2, r.length());
-        
+
         var processStartTimeSeconds = r.getArray(0);
-        
+
         assertEquals("process_start_time_seconds", processStartTimeSeconds.getString(0));
         assertEquals("", processStartTimeSeconds.getString(1));
         assertEquals("1.650302155929E9", processStartTimeSeconds.getString(2));
-        
-        
+
         var jvmThreadsStatesThreads = r.getArray(1);
-        
+
         assertEquals("jvm_threads_states_threads", jvmThreadsStatesThreads.getString(0));
         assertEquals("state=\"runnable\",", jvmThreadsStatesThreads.getString(1));
         assertEquals("9.0", jvmThreadsStatesThreads.getString(2));
     }
-
 
 }

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerType.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerType.java
@@ -73,7 +73,7 @@ public enum DisplayerType {
      * Meter Chart
      */
     METERCHART(),
-    
+
     /**
      * Scatter Chart
      */
@@ -102,7 +102,12 @@ public enum DisplayerType {
     /**
      * External Component Displayer
      */
-    EXTERNAL_COMPONENT();
+    EXTERNAL_COMPONENT(),
+
+    /**
+     * Timeseries displayer
+     */
+    TIMESERIES();
 
     DisplayerType(DisplayerSubType... subtypes) {
         for (DisplayerSubType displayerSubType : subtypes) {

--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -44,7 +44,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <version.org.webjars.bower.d3js>5.5.0</version.org.webjars.bower.d3js>
-    <version.org.webjars.npm.echarts>5.4.0</version.org.webjars.npm.echarts>    
+    <version.org.webjars.npm.echarts>5.4.2</version.org.webjars.npm.echarts>
     <version.org.webjars.bower.c3>0.7.20</version.org.webjars.bower.c3>
     <version.org.webjars.npm.js-yaml>4.1.0</version.org.webjars.npm.js-yaml>
     <version.org.webjars.bower.d3geoprojection>2.5.1</version.org.webjars.bower.d3geoprojection>


### PR DESCRIPTION
Adding an internal timeseries component for Dashbuilder. It will result in better performance and reuse of documented Displayer attributes. Here's a sample YAML:


```
global:
   mode: dark
datasets:
    - uuid: timeseries
      url: https://gist.githubusercontent.com/jesuino/0b14e3d7ae84676792d1acf61b2d13e8/raw/0e6b0512e08976f705ea4275a73433a81edfdf27/sample_timeseries.json
      cacheEnabled: true
pages:
    - components:
          - settings:
                type: timeseries
                general:
                   title: New Internal Timeseries Component
                chart:
                   resizable: true
                   height: 500
                   legend:
                     show: true
                lookup:
                    uuid: timeseries 
``` 
Which results in the following timeseries chart:

![image](https://github.com/kiegroup/kie-tools/assets/359820/02525def-cfb1-4907-8ba2-d0bb4e8543b6)
