### PR TITLE
kie-issues#288: [DMN Editor] the dmn:literalExpression id must not be modified on editing some text

### DIFF
--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -238,19 +238,19 @@ export function JavaFunctionExpression({
       for (const u of cellUpdates) {
         // Class
         if (u.rowIndex === 0) {
-          setExpression((prev) => ({
+          setExpression((prev: JavaFunctionExpressionDefinition) => ({
             ...prev,
             className: u.value,
-            classFieldId: u.value,
+            classFieldId: prev.classFieldId ?? generateUuid(),
           }));
         }
 
         // Method
         else if (u.rowIndex === 1) {
-          setExpression((prev) => ({
+          setExpression((prev: JavaFunctionExpressionDefinition) => ({
             ...prev,
             methodName: u.value,
-            methodFieldId: u.value,
+            methodFieldId: prev.methodFieldId ?? generateUuid(),
           }));
         }
       }


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/288

Just passing the correct value to the Java parameters IDs.