### PR TITLE
kie-issues#287: After deleting a Decision Table row, cells are wrongly selected

### DIFF
--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -909,7 +909,7 @@ export function useBeeTableSelectableCellRef(
 
   const [status, setStatus] = useState<BeeTableCellStatus>(NEUTRAL_CELL_STATUS);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const ref = registerSelectableCellRef?.(rowIndex, columnIndex, {
       setStatus,
       setValue,


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/287

Before this change, the [registerSelectableCellRef](https://github.com/kiegroup/kie-tools/blob/f82f2244bc50fd47f46f6e08ed8c865b36b5af49/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx#L760) was being called with the old value of `selectionRef.current?`

The value of `selectionRef.current?` value changes after user delete a row/column and was being correctly set.

**So what was happening?**

Two `selectionRef.current?.active` cells was being rendered: the correct (set [here](https://github.com/kiegroup/kie-tools/blob/f82f2244bc50fd47f46f6e08ed8c865b36b5af49/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx#L524) by `adaptSelection`) and the old one 
from `registerSelectableCellRef`.

This was happening because [selectionRef](https://github.com/kiegroup/kie-tools/blob/f82f2244bc50fd47f46f6e08ed8c865b36b5af49/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx#L238) is only updated after the component is rendered and `useEffect` was happening before this updated since `useEffect` is asynchronous.

`useLayoutEffect` in other hand is synchronous and is called after [selectionRef](https://github.com/kiegroup/kie-tools/blob/f82f2244bc50fd47f46f6e08ed8c865b36b5af49/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx#L238) is updated.

Here is more info about this cycle: https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780

I didn't found any side-effect after this change but I can be wrong. Also, **if there is any issue that this change introduces and I'm not aware of, please, let me know.**