### PR TITLE
kie-issues#174: Support constrained Data Types on inputs table of DMN Runner

### DIFF
--- a/packages/dmn-runner/package.json
+++ b/packages/dmn-runner/package.json
@@ -30,6 +30,7 @@
     "@patternfly/react-core": "^4.276.6",
     "@patternfly/react-icons": "^4.93.6",
     "ajv": "^6.12.6",
+    "moment": "^2.29.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uniforms": "^3.10.2",

--- a/packages/dmn-runner/src/ajv.ts
+++ b/packages/dmn-runner/src/ajv.ts
@@ -17,7 +17,12 @@
 import Ajv from "ajv";
 import * as metaSchemaDraft04 from "ajv/lib/refs/json-schema-draft-04.json";
 export { ValidateFunction } from "ajv";
+import { duration } from "moment";
 import {
+  DATE_AND_TIME_ENUM_REGEXP,
+  DATE_AND_TIME_FEEL_REGEXP,
+  DATE_ENUM_REGEXP,
+  DATE_FEEL_REGEXP,
   DAYS_AND_TIME_DURATION_FORMAT,
   DAYS_AND_TIME_DURATION_REGEXP,
   RECURSION_KEYWORD,
@@ -25,12 +30,107 @@ import {
   X_DMN_ALLOWED_VALUES_KEYWORD,
   X_DMN_DESCRIPTIONS_KEYWORD,
   X_DMN_TYPE_KEYWORD,
+  DURATION_ENUM_REGEXP,
+  DURATION_FEEL_REGEXP,
+  TIME_ENUM_REGEXP,
+  TIME_FEEL_REGEXP,
   YEARS_AND_MONTHS_DURATION_FORMAT,
   YEARS_AND_MONTHS_DURATION_REGEXP,
 } from "./constants";
 
+/**
+ * Please notice this is enum is slightly different from DMN built in types.
+ * These values are used in 'ajv' to represent corresponding DMN built-in types.
+ * This enum is primarily for 'ajv' validation code, where we want to validate DMN runner values according to X_DMN_ALLOWED_VALUES.
+ *
+ * There is this deviation for example:
+ * ajv: 'date-time'
+ * dmn: 'date and time'
+ */
+enum DmnAjvSchemaFormat {
+  DATE = "date",
+  TIME = "time",
+  DATE_TIME = "date-time",
+  DAYS_TIME_DURATION = "days and time duration",
+  YEARS_MONTHS_DURATION = "years and months duration",
+}
+
 export class DmnRunnerAjv {
   private ajv;
+
+  private parseRangeFromAllowedValues = (xDmnAllowedValues: string, type: DmnAjvSchemaFormat) => {
+    if (
+      (xDmnAllowedValues.startsWith("[") || xDmnAllowedValues.startsWith("(")) &&
+      (xDmnAllowedValues.endsWith("]") || xDmnAllowedValues.endsWith(")")) &&
+      xDmnAllowedValues.includes("..")
+    ) {
+      //It is a range
+      let feelFunction: string;
+      let regExp;
+      switch (type) {
+        case DmnAjvSchemaFormat.DATE:
+          feelFunction = "date";
+          regExp = DATE_FEEL_REGEXP;
+          break;
+        case DmnAjvSchemaFormat.TIME:
+          feelFunction = "time";
+          regExp = TIME_FEEL_REGEXP;
+          break;
+        case DmnAjvSchemaFormat.DATE_TIME:
+          feelFunction = "date and time";
+          regExp = DATE_AND_TIME_FEEL_REGEXP;
+          break;
+        case DmnAjvSchemaFormat.DAYS_TIME_DURATION:
+        case DmnAjvSchemaFormat.YEARS_MONTHS_DURATION:
+          feelFunction = "duration";
+          regExp = DURATION_FEEL_REGEXP;
+          break;
+      }
+      const matches = xDmnAllowedValues.match(regExp);
+      if (matches) {
+        const minAllowed = matches[0].replace(`${feelFunction}("`, "").replace('")', "");
+        const minAllowedIncluded = xDmnAllowedValues.startsWith("[");
+        const maxAllowed = matches[1].replace(`${feelFunction}("`, "").replace('")', "");
+        const maxAllowedIncluded = xDmnAllowedValues.endsWith("]");
+        return { minAllowed, minAllowedIncluded, maxAllowed, maxAllowedIncluded };
+      }
+    }
+    return {};
+  };
+
+  private parseEnumerationFromAllowedValues = (xDmnAllowedValues: string, type: DmnAjvSchemaFormat) => {
+    // try to check if it is enumeration
+    let feelFunction: string;
+    let regExp;
+    switch (type) {
+      case DmnAjvSchemaFormat.DATE:
+        feelFunction = "date";
+        regExp = DATE_ENUM_REGEXP;
+        break;
+      case DmnAjvSchemaFormat.TIME:
+        feelFunction = "time";
+        regExp = TIME_ENUM_REGEXP;
+        break;
+      case DmnAjvSchemaFormat.DATE_TIME:
+        feelFunction = "date and time";
+        regExp = DATE_AND_TIME_ENUM_REGEXP;
+        break;
+      case DmnAjvSchemaFormat.DAYS_TIME_DURATION:
+      case DmnAjvSchemaFormat.YEARS_MONTHS_DURATION:
+        feelFunction = "duration";
+        regExp = DURATION_ENUM_REGEXP;
+        break;
+    }
+    const matches = xDmnAllowedValues.match(regExp);
+    if (matches) {
+      return [
+        ...matches.map((matchedString) =>
+          matchedString.trim().replace(`${feelFunction}("`, "").replace('"),', "").replace('")', "")
+        ),
+      ];
+    }
+    return [];
+  };
 
   constructor() {
     this.ajv = new Ajv({
@@ -42,7 +142,85 @@ export class DmnRunnerAjv {
     });
     this.ajv.addMetaSchema(metaSchemaDraft04);
     this.ajv.addKeyword(X_DMN_TYPE_KEYWORD, {});
-    this.ajv.addKeyword(X_DMN_ALLOWED_VALUES_KEYWORD, {});
+    this.ajv.addKeyword(X_DMN_ALLOWED_VALUES_KEYWORD, {
+      compile: (schema, parentSchema: { format?: DmnAjvSchemaFormat }, it) => {
+        if (!parentSchema.format) {
+          return (data: string) => true;
+        }
+        const { minAllowed, minAllowedIncluded, maxAllowed, maxAllowedIncluded } = this.parseRangeFromAllowedValues(
+          schema ?? "",
+          parentSchema.format
+        );
+        const enumeratedValues = this.parseEnumerationFromAllowedValues(schema ?? "", parentSchema.format);
+        const isUnderTheMinBoundary: (value: Date | String | number, minBoundary: Date | String | number) => boolean =
+          minAllowedIncluded
+            ? (value, minBoundary) => value < minBoundary
+            : (value, minBoundary) => value <= minBoundary;
+        const isOverTheMaxBoundary: (value: Date | String | number, maxBoundary: Date | String | number) => boolean =
+          maxAllowedIncluded
+            ? (value, maxBoundary) => value > maxBoundary
+            : (value, maxBoundary) => value >= maxBoundary;
+
+        return (data: string) => {
+          if (data.includes(".") && data.endsWith("Z")) {
+            // adjusting from "2023-06-01T10:42:00.000Z" to "2023-06-01T10:42:00"
+            data = data.substring(0, data.lastIndexOf("."));
+          }
+          if (minAllowed && maxAllowed) {
+            // It is a Range constraint
+            if (parentSchema.format === "time") {
+              if (isUnderTheMinBoundary(data, minAllowed) || isOverTheMaxBoundary(data, maxAllowed)) {
+                return false;
+              }
+            } else if (parentSchema.format?.includes("duration")) {
+              const actualDuration = duration(data).asMilliseconds();
+              const minDuration = duration(minAllowed).asMilliseconds();
+              const maxDuration = duration(maxAllowed).asMilliseconds();
+              if (
+                isUnderTheMinBoundary(actualDuration, minDuration) ||
+                isOverTheMaxBoundary(actualDuration, maxDuration)
+              ) {
+                return false;
+              }
+            } else if (parentSchema.format?.includes("date")) {
+              const actualDate = new Date(data);
+              if (actualDate.toString() === "Invalid Date") {
+                return false;
+              }
+              const minAllowedDate = new Date(minAllowed);
+              if (minAllowedDate && isUnderTheMinBoundary(actualDate, minAllowedDate)) {
+                return false;
+              }
+              const maxAllowedDate = new Date(maxAllowed);
+              if (maxAllowedDate && isOverTheMaxBoundary(actualDate, maxAllowedDate)) {
+                return false;
+              }
+            }
+          } else if (enumeratedValues) {
+            if (parentSchema.format === "time") {
+              return enumeratedValues.includes(data);
+            } else if (parentSchema.format?.includes("duration")) {
+              const actualDuration = duration(data).asMilliseconds();
+              return enumeratedValues.some((value) => {
+                const enumeratedDurationValue = duration(value).asMilliseconds();
+                return enumeratedDurationValue === actualDuration;
+              });
+            } else if (parentSchema.format?.includes("date")) {
+              const actualDate = new Date(data);
+              if (actualDate.toString() === "Invalid Date") {
+                return false;
+              }
+              return enumeratedValues.some((value) => {
+                const enumeratedDateValue = new Date(value);
+                return !(enumeratedDateValue < actualDate) && !(enumeratedDateValue > actualDate);
+              });
+            }
+          }
+
+          return true;
+        };
+      },
+    });
     this.ajv.addKeyword(X_DMN_DESCRIPTIONS_KEYWORD, {});
     this.ajv.addKeyword(RECURSION_KEYWORD, {});
     this.ajv.addKeyword(RECURSION_REF_KEYWORD, {});

--- a/packages/dmn-runner/src/constants.ts
+++ b/packages/dmn-runner/src/constants.ts
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+export const TIME_FEEL_REGEXP = /time\("([^.,\s]*)"\)/g;
+export const TIME_ENUM_REGEXP = /time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
+export const DATE_FEEL_REGEXP = /date\("([^.,\s]*)"\)/g;
+export const DATE_ENUM_REGEXP = /date\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
+export const DATE_AND_TIME_FEEL_REGEXP = /date and time\("([^.,\s]*)"\)/g;
+export const DATE_AND_TIME_ENUM_REGEXP = /date and time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
+export const DURATION_FEEL_REGEXP = /duration\("([^.,\s]*)"\)/g;
+export const DURATION_ENUM_REGEXP = /duration\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
 export const DAYS_AND_TIME_DURATION_FORMAT = "days and time duration";
 export const DAYS_AND_TIME_DURATION_REGEXP =
   /^(-|\+)?P(?:([-+]?[0-9]*)D)?(?:T(?:([-+]?[0-9]*)H)?(?:([-+]?[0-9]*)M)?(?:([-+]?[0-9]*)S)?)?$/;

--- a/packages/form-dmn/src/FormDmnValidator.ts
+++ b/packages/form-dmn/src/FormDmnValidator.ts
@@ -16,8 +16,12 @@
 
 import { Validator } from "@kie-tools/form/dist/Validator";
 import { FormDmnI18n } from "./i18n";
-import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/constants";
 import { FormDmnJsonSchemaBridge } from "./uniforms";
+import {
+  DAYS_AND_TIME_DURATION_FORMAT,
+  X_DMN_ALLOWED_VALUES_KEYWORD,
+  YEARS_AND_MONTHS_DURATION_FORMAT,
+} from "@kie-tools/dmn-runner/dist/constants";
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
 import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
@@ -50,6 +54,9 @@ export class FormDmnValidator extends Validator {
             if ((error.params as any).format === YEARS_AND_MONTHS_DURATION_FORMAT) {
               return { ...error, message: (this.i18n as FormDmnI18n).validation.yearsAndMonthsError };
             }
+          }
+          if (error.keyword === X_DMN_ALLOWED_VALUES_KEYWORD) {
+            return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnAllowedValues };
           }
           return error;
         }),

--- a/packages/form-dmn/src/i18n/FormDmnI18n.ts
+++ b/packages/form-dmn/src/i18n/FormDmnI18n.ts
@@ -19,6 +19,7 @@ import { FormI18n } from "@kie-tools/form/dist/i18n/FormI18n";
 
 export interface FormDmnI18n extends FormI18n {
   validation: {
+    xDmnAllowedValues: string;
     daysAndTimeError: string;
     yearsAndMonthsError: string;
   };

--- a/packages/form-dmn/src/i18n/locales/en.ts
+++ b/packages/form-dmn/src/i18n/locales/en.ts
@@ -42,6 +42,7 @@ export const en: FormDmnI18n = {
     },
   },
   validation: {
+    xDmnAllowedValues: "does not belong to set of allowed values",
     daysAndTimeError: "should match format P1D(ays)T2H(ours)3M(inutes)1S(econds)",
     yearsAndMonthsError: "should match format P1Y(ears)2M(onths)",
   },

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -59,6 +59,7 @@
     "@patternfly/react-tokens": "^4.94.6",
     "bowser": "^2.10.0",
     "buffer": "^6.0.3",
+    "deep-object-diff": "^1.1.9",
     "history": "^4.9.0",
     "isomorphic-git": "^1.11.1",
     "js-yaml": "^4.1.0",

--- a/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
+++ b/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
@@ -161,13 +161,13 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
             type: field.type,
           };
         }
-        switch (field["format"]) {
+        switch (field.format) {
           case "date":
-            return { dataType: DmnBuiltInDataType.Date, width: DEFAULT_DATE_CELL_WIDTH, type: field.type, };
+            return { dataType: DmnBuiltInDataType.Date, width: DEFAULT_DATE_CELL_WIDTH, type: field.type };
           case "time":
-            return { dataType: DmnBuiltInDataType.Time, width: DEFAULT_TIME_CELL_WIDTH, type: field.type, };
+            return { dataType: DmnBuiltInDataType.Time, width: DEFAULT_TIME_CELL_WIDTH, type: field.type };
           case "date-time":
-            return { dataType: DmnBuiltInDataType.DateTime, width: DEFAULT_DATE_TIME_CELL_WDITH, type: field.type, };
+            return { dataType: DmnBuiltInDataType.DateTime, width: DEFAULT_DATE_TIME_CELL_WDITH, type: field.type };
         }
         return {
           dataType: (type as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined,

--- a/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
+++ b/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
@@ -161,6 +161,14 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
             type: field.type,
           };
         }
+        switch (field["format"]) {
+          case "date":
+            return { dataType: DmnBuiltInDataType.Date, width: DEFAULT_DATE_CELL_WIDTH, type: field.type, };
+          case "time":
+            return { dataType: DmnBuiltInDataType.Time, width: DEFAULT_TIME_CELL_WIDTH, type: field.type, };
+          case "date-time":
+            return { dataType: DmnBuiltInDataType.DateTime, width: DEFAULT_DATE_TIME_CELL_WDITH, type: field.type, };
+        }
         return {
           dataType: (type as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined,
           width: DEFAULT_COLUMN_MIN_WIDTH,

--- a/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
+++ b/packages/unitables/src/uniforms/UnitablesJsonSchemaBridge.tsx
@@ -21,12 +21,13 @@ import { JSONSchemaBridge } from "uniforms-bridge-json-schema";
 import { joinName } from "uniforms";
 import { UnitablesColumnType } from "../UnitablesTypes";
 import { DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
-import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/constants";
 
 export const DEFAULT_COLUMN_MIN_WIDTH = 150;
 const DEFAULT_DATE_TIME_CELL_WDITH = 210;
 const DEFAULT_DATE_CELL_WIDTH = 170;
 const DEFAULT_TIME_CELL_WIDTH = 150;
+const DEFAULT_DAYS_DURATION_CELL_WIDTH = 245;
+const DEFAULT_YEARS_DURATION_CELL_WIDTH = 180;
 
 export const FORMS_ID = "unitables-forms";
 export const AUTO_ROW_ID = "unitables-row";
@@ -73,15 +74,19 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
     if (!xDmnType) {
       type = field.type;
     } else {
-      const splitedXDmnType: string[] | undefined = xDmnType.split(":");
-      if (!splitedXDmnType) {
-        type = undefined;
-      } else if (splitedXDmnType.length > 2) {
-        type = splitedXDmnType[2].split("}")?.[0]?.trim();
-      } else if (splitedXDmnType.length === 2) {
-        type = splitedXDmnType[1];
+      if (field.format?.includes("date") || field.format?.includes("time") || field.format?.includes("duration")) {
+        type = field.format;
       } else {
-        type = splitedXDmnType[0];
+        const splitedXDmnType: string[] | undefined = xDmnType.split(":");
+        if (!splitedXDmnType) {
+          type = undefined;
+        } else if (splitedXDmnType.length > 2) {
+          type = splitedXDmnType[2].split("}")?.[0]?.trim();
+        } else if (splitedXDmnType.length === 2) {
+          type = splitedXDmnType[1];
+        } else {
+          type = splitedXDmnType[0];
+        }
       }
     }
 
@@ -116,6 +121,7 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
           width: DEFAULT_DATE_CELL_WIDTH,
           type: field.type,
         };
+      case "date-time":
       case "date and time":
         return {
           dataType: DmnBuiltInDataType.DateTime,
@@ -125,7 +131,7 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
       case "days and time duration":
         return {
           dataType: DmnBuiltInDataType.DateTimeDuration,
-          width: DEFAULT_COLUMN_MIN_WIDTH,
+          width: DEFAULT_DAYS_DURATION_CELL_WIDTH,
           type: field.type,
         };
       case "number":
@@ -149,7 +155,7 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
       case "years and months duration":
         return {
           dataType: DmnBuiltInDataType.YearsMonthsDuration,
-          width: DEFAULT_COLUMN_MIN_WIDTH,
+          width: DEFAULT_YEARS_DURATION_CELL_WIDTH,
           type: field.type,
         };
       default:
@@ -160,14 +166,6 @@ export class UnitablesJsonSchemaBridge extends JSONSchemaBridge {
             width: DEFAULT_COLUMN_MIN_WIDTH,
             type: field.type,
           };
-        }
-        switch (field.format) {
-          case "date":
-            return { dataType: DmnBuiltInDataType.Date, width: DEFAULT_DATE_CELL_WIDTH, type: field.type };
-          case "time":
-            return { dataType: DmnBuiltInDataType.Time, width: DEFAULT_TIME_CELL_WIDTH, type: field.type };
-          case "date-time":
-            return { dataType: DmnBuiltInDataType.DateTime, width: DEFAULT_DATE_TIME_CELL_WDITH, type: field.type };
         }
         return {
           dataType: (type as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3026,6 +3026,9 @@ importers:
       ajv:
         specifier: ^6.12.6
         version: 6.12.6
+      moment:
+        specifier: ^2.29.4
+        version: 2.29.4
       react:
         specifier: ^17.0.2
         version: 17.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5175,6 +5175,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      deep-object-diff:
+        specifier: ^1.1.9
+        version: 1.1.9
       history:
         specifier: ^4.9.0
         version: 4.10.1


### PR DESCRIPTION
Closes kiegroup/kie-issues#174

This PR:
- Set correct column minimal width for custom DMN data types that are date or time based, e.g. `myDateType: date`
- Check if there is `Range` constraint for dmn custom type and validates values put into DMN runner form [1]
- Check if there is `Enumeration` constraint for dmn custom type and validates values put into DMN runner form
- **does not** check free form **expression** constraints that can user put on DMN custom data types

[1]
![Screenshot 2023-06-05 155431](https://github.com/kiegroup/kie-tools/assets/8044780/cada76f1-9ead-471c-afb5-8d7468229f37)
![Screenshot 2023-06-05 155422](https://github.com/kiegroup/kie-tools/assets/8044780/4d0207a8-6cfe-4a47-a456-919161a2485c)
![Screenshot 2023-06-07 154347](https://github.com/kiegroup/kie-tools/assets/8044780/c26e6287-4125-4870-9282-1d5ab3a71ff7)

