### PR TITLE
Revert "KOGITO-9256: kn-workflow fix reporting and broken test (#1686)"

### DIFF
--- a/packages/kn-plugin-workflow/package.json
+++ b/packages/kn-plugin-workflow/package.json
@@ -28,7 +28,7 @@
     "build:prod:win32": "rimraf dist && pnpm setup:env:win32 make build-all",
     "build:win32": "pnpm setup:env:win32 make build-win32-amd64",
     "debug:clean": "rimraf debug",
-    "go:test": "rimraf dist-tests && mkdir dist-tests && stdbuf -oL go test -v ./... 2>&1 | tee ./dist-tests/go-test-output.txt",
+    "go:test": "rimraf dist-tests && mkdir dist-tests && go test -v ./... | tee ./dist-tests/go-test-output.txt",
     "go:test:report": "go run github.com/jstemmer/go-junit-report/v2 -set-exit-code -in ./dist-tests/go-test-output.txt -out ./dist-tests/junit-report.xml",
     "install": "go mod tidy",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/create_test.go
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/create_test.go
@@ -29,13 +29,13 @@ import (
 )
 
 type testCreate struct {
-	input           CreateQuarkusProjectConfig
+	input           CreateCmdConfig
 	existingProject bool
 }
 
 var testRunCreateSuccess = []testCreate{
-	{input: CreateQuarkusProjectConfig{ProjectName: "new-project", Extensions: ""}},
-	{input: CreateQuarkusProjectConfig{
+	{input: CreateCmdConfig{ProjectName: "new-project", Extensions: ""}},
+	{input: CreateCmdConfig{
 		ProjectName: "second-project",
 		Extensions:  "extension-name",
 		DependenciesVersion: metadata.DependenciesVersion{
@@ -45,8 +45,8 @@ var testRunCreateSuccess = []testCreate{
 	}},
 }
 var testRunCreateFail = []testCreate{
-	{input: CreateQuarkusProjectConfig{ProjectName: "test-data"}, existingProject: true},
-	{input: CreateQuarkusProjectConfig{ProjectName: "wrong*project/name"}},
+	{input: CreateCmdConfig{ProjectName: "test-data"}, existingProject: true},
+	{input: CreateCmdConfig{ProjectName: "wrong*project/name"}},
 }
 
 func fakeRunCreate(testIndex int) func(command string, args ...string) *exec.Cmd {


### PR DESCRIPTION
This reverts commit 78a9383c2d1cb5bcb8abe982085b6f8ddd705912.

This commit is breaking CI main on macOS.
A fix will be worked on https://issues.redhat.com/browse/KOGITO-9278