### PR TITLE
NO-ISSUE: Check test reports on normal CI too, not just in `main`

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -133,7 +133,7 @@ jobs:
           pnpm -F "...[${{ steps.checkout_pr.outputs.base_sha }}]" --workspace-concurrency=1 build:prod
 
       - name: "Check tests result (`main` only)"
-        if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request
+        if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none'
         uses: actions/github-script@v6
         env:
           KIE_TOOLS_CI__JUNIT_REPORT_RESULTS_PATTERNS: |-


### PR DESCRIPTION
Recently with https://github.com/kiegroup/kie-tools/pull/1686 being merged with green builds and breaking the CI on `main`, we saw that there's a problem that we don't test the test suite results on the PR CI builds. To address that, I'm simply removing the condition that prevented it from happening, as if all tests succeed on the PR, it will be green, but now the checks will run, catching possible inconsistencies on the test reports format.