### PR TITLE
kie-issues#309: User is not able to specify DMN Range constraint for `date and time` and `years and months duration` custom type

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverter.java
@@ -95,7 +95,7 @@ public class DateTimeValueConverter {
     }
 
     String extractDate(final String value) {
-        return value.substring(0, DATE_LENGTH);
+        return (StringUtils.isEmpty(value) || value.trim().length() < DATE_LENGTH) ? "" : value.substring(0, DATE_LENGTH);
     }
 
     public String toDisplay(final String rawValue) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverter.java
@@ -95,7 +95,8 @@ public class DateTimeValueConverter {
     }
 
     String extractDate(final String value) {
-        return (StringUtils.isEmpty(value) || value.trim().length() < DATE_LENGTH) ? "" : value.substring(0, DATE_LENGTH);
+        return (StringUtils.isEmpty(value) || value.trim().length() < DATE_LENGTH) ? ""
+                : value.substring(0, DATE_LENGTH);
     }
 
     public String toDisplay(final String rawValue) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverter.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverter.java
@@ -155,6 +155,6 @@ public class YearsMonthsValueConverter {
     }
 
     String removePrefixAndSuffix(final String dmnString) {
-        return DurationHelper.getFunctionParameter(dmnString).substring(1);
+        return StringUtils.isEmpty(dmnString) ? "" : DurationHelper.getFunctionParameter(dmnString).substring(1);
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverterTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/date/time/DateTimeValueConverterTest.java
@@ -130,6 +130,14 @@ public class DateTimeValueConverterTest {
     }
 
     @Test
+    public void testExtractDateMissingValue() {
+
+        final String actual = converter.extractDate("");
+
+        assertEquals("", actual);
+    }
+
+    @Test
     public void testFromDMNString() {
 
         final String input = "some dmn string";

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverterTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/types/listview/constraint/common/typed/years/months/YearsMonthsValueConverterTest.java
@@ -280,6 +280,16 @@ public class YearsMonthsValueConverterTest {
     }
 
     @Test
+    public void testRemovePrefixAndSuffixMissingValue() {
+
+        final String input = " ";
+
+        final String actual = converter.removePrefixAndSuffix(input);
+
+        assertEquals("", actual);
+    }
+
+    @Test
     public void testAddPrefixAndSuffix() {
 
         final String expected = "duration(\"P1Y2M\")";


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/309

There was an issue we tried to cut substring with length of 10 characters, what is however not pssible for a freshly created `date and time` constraint value. Because such sontraint value is empty string, that has length equal to 0.