### PR TITLE
kie-issues#317: Fix WS-2022-0280 & WS-2022-0280

### DIFF
--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -48,9 +48,9 @@
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.google-code-prettify>1.0.4</version.org.webjars.bower.google-code-prettify>
     <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>
-    <version.org.webjars.bower.moment>2.14.1</version.org.webjars.bower.moment>
-    <version.org.webjars.bower.moment-timezone>0.5.17</version.org.webjars.bower.moment-timezone>
     <version.org.webjars.bower.bluebird>3.1.1</version.org.webjars.bower.bluebird>
+    <version.org.webjars.npm.moment>2.29.4</version.org.webjars.npm.moment>
+    <version.org.webjars.npm.moment-timezone>0.5.43</version.org.webjars.npm.moment-timezone>
     <version.org.webjars.npm.react>16.6.0</version.org.webjars.npm.react>
     <version.org.webjars.npm.react-dom>16.6.0</version.org.webjars.npm.react-dom>
     <version.org.webjars.bower.bootstrap-daterangepicker>2.1.25</version.org.webjars.bower.bootstrap-daterangepicker>

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -206,9 +206,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment</artifactId>
-                  <version>${version.org.webjars.bower.moment}</version>
+                  <version>${version.org.webjars.npm.moment}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment</outputDirectory>
@@ -227,9 +227,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment-timezone</artifactId>
-                  <version>${version.org.webjars.bower.moment-timezone}</version>
+                  <version>${version.org.webjars.npm.moment-timezone}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment-timezone</outputDirectory>
@@ -336,7 +336,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.bower.moment}/min/</directory>
+                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.npm.moment}/min/</directory>
                   <includes>
                     <include>moment-with-locales.min.js</include>
                   </includes>
@@ -354,7 +354,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment-timezone</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.bower.moment-timezone}/builds/</directory>
+                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.npm.moment-timezone}/builds/</directory>
                   <includes>
                     <include>moment-timezone-with-data-2012-2022.min.js</include>
                   </includes>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -162,8 +162,8 @@
     <!-- Properties from APPFORMER parent POM -->
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>
-    <version.org.webjars.bower.moment>2.14.1</version.org.webjars.bower.moment>
-    <version.org.webjars.bower.moment-timezone>0.5.17</version.org.webjars.bower.moment-timezone>
+    <version.org.webjars.npm.moment>2.29.4</version.org.webjars.npm.moment>
+    <version.org.webjars.npm.moment-timezone>0.5.43</version.org.webjars.npm.moment-timezone>
     <version.org.webjars.bower.bootstrap-daterangepicker>2.1.25</version.org.webjars.bower.bootstrap-daterangepicker>
     <version.org.webjars.bower.filesaver>1.3.3</version.org.webjars.bower.filesaver>
     <!-- Notice actually there exists a 1.3.3 version for jsPDF, but using this one

--- a/packages/serverless-workflow-diagram-editor/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -208,9 +208,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment</artifactId>
-                  <version>${version.org.webjars.bower.moment}</version>
+                  <version>${version.org.webjars.npm.moment}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment</outputDirectory>
@@ -229,9 +229,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment-timezone</artifactId>
-                  <version>${version.org.webjars.bower.moment-timezone}</version>
+                  <version>${version.org.webjars.npm.moment-timezone}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment-timezone</outputDirectory>
@@ -317,7 +317,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.bower.moment}/min/</directory>
+                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.npm.moment}/min/</directory>
                   <includes>
                     <include>moment-with-locales.min.js</include>
                   </includes>
@@ -335,7 +335,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment-timezone</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.bower.moment-timezone}/builds/</directory>
+                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.npm.moment-timezone}/builds/</directory>
                   <includes>
                     <include>moment-timezone-with-data-2012-2022.min.js</include>
                   </includes>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -166,8 +166,8 @@
     <!-- Properties from APPFORMER parent POM -->
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>
-    <version.org.webjars.bower.moment>2.29.4</version.org.webjars.bower.moment>
-    <version.org.webjars.bower.moment-timezone>0.5.34</version.org.webjars.bower.moment-timezone>
+    <version.org.webjars.npm.moment>2.29.4</version.org.webjars.npm.moment>
+    <version.org.webjars.npm.moment-timezone>0.5.43</version.org.webjars.npm.moment-timezone>
     <version.org.webjars.bower.bootstrap-daterangepicker>2.1.25</version.org.webjars.bower.bootstrap-daterangepicker>
     <version.org.webjars.bower.filesaver>1.3.3</version.org.webjars.bower.filesaver>
     <!-- Notice actually there exists a 1.3.3 version for jsPDF, but using this one

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -214,9 +214,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment</artifactId>
-                  <version>${version.org.webjars.bower.moment}</version>
+                  <version>${version.org.webjars.npm.moment}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment</outputDirectory>
@@ -235,9 +235,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.npm</groupId>
                   <artifactId>moment-timezone</artifactId>
-                  <version>${version.org.webjars.bower.moment-timezone}</version>
+                  <version>${version.org.webjars.npm.moment-timezone}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/moment-timezone</outputDirectory>
@@ -344,7 +344,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.bower.moment}/min/</directory>
+                  <directory>${project.build.directory}/moment/META-INF/resources/webjars/moment/${version.org.webjars.npm.moment}/min/</directory>
                   <includes>
                     <include>moment-with-locales.min.js</include>
                   </includes>
@@ -362,7 +362,7 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/moment-timezone</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.bower.moment-timezone}/builds/</directory>
+                  <directory>${project.build.directory}/moment-timezone/META-INF/resources/webjars/moment-timezone/${version.org.webjars.npm.moment-timezone}/builds/</directory>
                   <includes>
                     <include>moment-timezone-with-data-2012-2022.min.js</include>
                   </includes>


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/317

Upgrade versions of `moment-timezone` & `moment` webjars to fix vulnerabilities in `dashbuilder`, `serverless-workflow-diagram-editor` & `stunners-editors`.

- `moment-timezone`: WS-2022-0280 & WS-2022-0280
- `moment`: CVE-2022-31129, CVE-2017-18214 and CVE-2022-24785