### PR TITLE
kie-issues#322: Upgrade kie-tools base images

### DIFF
--- a/packages/kie-sandbox-extended-services-image/Containerfile
+++ b/packages/kie-sandbox-extended-services-image/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 RUN mkdir -m 775 -p /kie-sandbox /root/.cache /.cache
 

--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 COPY entrypoint.sh dist-dev/image-env-to-json-standalone dist-dev/EnvJson.schema.json /tmp/
 


### PR DESCRIPTION
kiegroup/kie-issues#322
As per the reported issue upgrading base images in Containerfile of
* kie-sandbox-image
* kie-sandbox-extended-services-image

the following were already up to date:
* git-cors-proxy-image
* dmn-dev-deployment-base-image