### PR TITLE
KOGITO-9282: Reflect changes from other tabs in Recent Models page

### DIFF
--- a/packages/serverless-logic-web-tools/regex/index.ts
+++ b/packages/serverless-logic-web-tools/regex/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
@@ -15,7 +15,6 @@
  */
 
 import { PromiseStateWrapper } from "@kie-tools-core/react-hooks/dist/PromiseState";
-import { useController } from "@kie-tools-core/react-hooks/dist/useController";
 import { useWorkspaces } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { useWorkspaceDescriptorsPromise } from "@kie-tools-core/workspaces-git-fs/dist/hooks/WorkspacesHooks";
 import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
@@ -228,7 +227,7 @@ export function RecentModels() {
                         onWsToggle={onWsToggle}
                         searchValue={searchValue}
                         selectedWorkspaceIds={selectedWorkspaceIds}
-                        workspaceDescriptors={workspaceDescriptors}
+                        workspaceIds={workspaceDescriptors.map((d) => d.workspaceId)}
                         onWsDelete={onWorkspaceDelete}
                       />
                       <TablePagination

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/hooks/useActiveWorkspacesPromise.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/hooks/useActiveWorkspacesPromise.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Holder } from "@kie-tools-core/react-hooks/dist/Holder";
+import { usePromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
+import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancelableEffect";
+import { useWorkspaces } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
+import { ActiveWorkspace } from "@kie-tools-core/workspaces-git-fs/dist/model/ActiveWorkspace";
+import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";
+import { WORKSPACES_BROADCAST_CHANNEL } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspacesBroadcastEvents";
+import { useCallback } from "react";
+
+export function useActiveWorkspacesPromise(workspaceIds: WorkspaceDescriptor["workspaceId"][]) {
+  const workspaces = useWorkspaces();
+  const [activeWorkspacesPromise, setActiveWorkspacesPromise] = usePromiseState<ActiveWorkspace[]>();
+
+  const refresh = useCallback(
+    async (canceled: Holder<boolean>) => {
+      try {
+        const activeWorkspaces = await Promise.all(
+          workspaceIds.map(async (workspaceId) => {
+            const descriptor = await workspaces.getWorkspace({ workspaceId });
+            const files = await workspaces.getFiles({ workspaceId });
+            return { descriptor, files };
+          })
+        );
+        if (canceled.get()) {
+          return;
+        }
+
+        setActiveWorkspacesPromise({ data: activeWorkspaces });
+      } catch (error) {
+        setActiveWorkspacesPromise({ error: "Can't load data from workspaces" });
+        console.error(error);
+        return;
+      }
+    },
+    [setActiveWorkspacesPromise, workspaceIds, workspaces]
+  );
+
+  useCancelableEffect(
+    useCallback(
+      ({ canceled }) => {
+        refresh(canceled);
+      },
+      [refresh]
+    )
+  );
+
+  useCancelableEffect(
+    useCallback(
+      ({ canceled }) => {
+        const workspacesBroadcastChannel = new BroadcastChannel(WORKSPACES_BROADCAST_CHANNEL);
+        workspacesBroadcastChannel.onmessage = ({ data }) => {
+          console.debug(`EVENT::WORKSPACES: ${JSON.stringify(data)}`);
+          return refresh(canceled);
+        };
+
+        const workspaceBroadcastChannels = workspaceIds.map((workspaceId) => {
+          const bc = new BroadcastChannel(workspaceId);
+          bc.onmessage = ({ data }) => {
+            console.debug(`EVENT::WORKSPACE: ${JSON.stringify(data)}`);
+            return refresh(canceled);
+          };
+          return bc;
+        });
+
+        return () => {
+          workspacesBroadcastChannel.close();
+          workspaceBroadcastChannels.forEach((bc) => bc.close());
+        };
+      },
+      [workspaceIds, refresh]
+    )
+  );
+
+  return activeWorkspacesPromise;
+}

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTable.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTable.tsx
@@ -27,6 +27,7 @@ import { useCallback, useMemo, useState } from "react";
 import { isEditable } from "../../../extension";
 import { WorkspaceFilesTableRow } from "./WorkspaceFilesTableRow";
 import { TablePaginationProps, TableRowEmptyState } from "../../../table";
+import { escapeRegExp } from "../../../../regex";
 
 export const columnNames = {
   name: "Name",
@@ -76,7 +77,7 @@ export function WorkspaceFilesTable(props: WorkspaceFilesTableProps) {
   );
 
   const filteredTableData = useMemo<WorkspaceFilesTableRowData[]>(() => {
-    const searchRegex = new RegExp(searchValue, "i");
+    const searchRegex = new RegExp(escapeRegExp(searchValue), "i");
     return searchValue ? tableData.filter((e) => e.name.search(searchRegex) >= 0) : tableData;
   }, [searchValue, tableData]);
 

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTableRow.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTableRow.tsx
@@ -25,6 +25,7 @@ import { routes } from "../../../navigation/Routes";
 import "../../../table/Table.css";
 import { FileLabel } from "../../../workspace/components/FileLabel";
 import { columnNames, WorkspaceFilesTableRowData } from "./WorkspaceFilesTable";
+import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 
 export const workspacesTableRowErrorContent = "Error obtaining workspace information";
 
@@ -97,7 +98,10 @@ export function WorkspaceFilesTableRow(props: WorkspaceFilesTableRowProps) {
         />
         <Td dataLabel={columnNames.name}>
           <TaskIcon />
-          &nbsp;&nbsp;&nbsp;<Link to={linkTo}>{name}</Link>
+          &nbsp;&nbsp;&nbsp;
+          <Tooltip content={fileDescriptor.relativePath}>
+            <Link to={linkTo}>{name}</Link>
+          </Tooltip>
         </Td>
         <Td dataLabel={columnNames.type}>
           <FileLabel extension={extension} />

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTableRow.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFilesTableRow.tsx
@@ -19,7 +19,7 @@ import { BanIcon, CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons"
 import { TaskIcon } from "@patternfly/react-icons/dist/js/icons/task-icon";
 import { ActionsColumn, Td, Tr } from "@patternfly/react-table/dist/esm";
 import { TdSelectType } from "@patternfly/react-table/dist/esm/components/Table/base";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { routes } from "../../../navigation/Routes";
 import "../../../table/Table.css";
@@ -50,6 +50,7 @@ export type WorkspaceFilesTableRowProps = {
 export function WorkspaceFilesTableRow(props: WorkspaceFilesTableRowProps) {
   const { isSelected, rowIndex, totalFilesCount } = props;
   const { name, extension, isEditable, fileDescriptor } = props.rowData;
+  const downloadRef = useRef<HTMLAnchorElement>(null);
   const workspaces = useWorkspaces();
   const history = useHistory();
 
@@ -67,41 +68,59 @@ export function WorkspaceFilesTableRow(props: WorkspaceFilesTableRowProps) {
     if (totalFilesCount > 1) {
       await workspaces.deleteFile({ file: fileDescriptor });
     } else {
-      workspaces.deleteWorkspace({ workspaceId: fileDescriptor.workspaceId });
+      await workspaces.deleteWorkspace({ workspaceId: fileDescriptor.workspaceId });
       history.push({ pathname: routes.recentModels.path({}) });
     }
     props.onDelete(fileDescriptor);
   }, [fileDescriptor, history, workspaces, totalFilesCount, props]);
 
+  const onDownload = useCallback(async () => {
+    if (!downloadRef.current) {
+      return;
+    }
+    const content = await fileDescriptor.getFileContentsAsString();
+    const fileBlob = new Blob([content], { type: "text/plain" });
+    downloadRef.current.download = `${fileDescriptor.name}`;
+    downloadRef.current.href = URL.createObjectURL(fileBlob);
+    downloadRef.current.click();
+  }, [fileDescriptor]);
+
   return (
-    <Tr key={name}>
-      <Td
-        select={{
-          rowIndex,
-          onSelect: (_event, checked) => props.onToggle(checked),
-          isSelected,
-        }}
-      />
-      <Td dataLabel={columnNames.name}>
-        <TaskIcon />
-        &nbsp;&nbsp;&nbsp;<Link to={linkTo}>{name}</Link>
-      </Td>
-      <Td dataLabel={columnNames.type}>
-        <FileLabel extension={extension} />
-      </Td>
-      <Td dataLabel={columnNames.isEditable}>
-        {isEditable ? <CheckCircleIcon className="success-icon"></CheckCircleIcon> : <BanIcon></BanIcon>}
-      </Td>
-      <Td isActionCell>
-        <ActionsColumn
-          items={[
-            {
-              title: "Delete",
-              onClick: onDelete,
-            },
-          ]}
+    <>
+      <Tr key={fileDescriptor.relativePath}>
+        <Td
+          select={{
+            rowIndex,
+            onSelect: (_event, checked) => props.onToggle(checked),
+            isSelected,
+          }}
         />
-      </Td>
-    </Tr>
+        <Td dataLabel={columnNames.name}>
+          <TaskIcon />
+          &nbsp;&nbsp;&nbsp;<Link to={linkTo}>{name}</Link>
+        </Td>
+        <Td dataLabel={columnNames.type}>
+          <FileLabel extension={extension} />
+        </Td>
+        <Td dataLabel={columnNames.isEditable}>
+          {isEditable ? <CheckCircleIcon className="success-icon"></CheckCircleIcon> : <BanIcon></BanIcon>}
+        </Td>
+        <Td isActionCell>
+          <ActionsColumn
+            items={[
+              {
+                title: "Delete",
+                onClick: onDelete,
+              },
+              {
+                title: "Download",
+                onClick: onDownload,
+              },
+            ]}
+          />
+        </Td>
+      </Tr>
+      <a ref={downloadRef} />
+    </>
   );
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9282

https://github.com/kiegroup/kie-tools/assets/638737/de365070-f088-4d6b-ac93-99f4a8b135e3

Also in this PR
- Add the ability to download files right from the tables
- Show the relative path in a tooltip in the Files table
- Escape values in the search filters
- Improve error mechanism for workspace items