### PR TITLE
kie-issues#318: Data Type for Invocation and Decision Table merged output columns is not updated

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -338,6 +338,10 @@ export function DecisionTableExpression(
           if (u.column.depth === 0 && u.column.groupType === DecisionTableColumnType.OutputClause) {
             n.name = u.name;
             n.dataType = u.dataType;
+            // Single output column is merged with the aggregator column and should have the same datatype
+            if (n.output?.length === 1) {
+              n.output[0].dataType = u.dataType;
+            }
             continue;
           }
 

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -181,6 +181,12 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
               name: u.name,
             },
           }));
+        } else {
+          setExpression((prev: InvocationExpressionDefinition) => ({
+            ...prev,
+            dataType: u.dataType,
+            name: u.name,
+          }));
         }
       }
     },


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/318

For decision tables, this is the same behavior of the old BEE:
1. You have a single output column and you change the data type
2. You add another output column
3. The first output column will remains with the same output data type

The video bellow also shows the Invocation expression:

https://github.com/kiegroup/kie-tools/assets/7305741/64e9bad6-612d-4f75-bc58-d4a5d4bcb373

Another scenario:
1. You have multiple output columns, each one with one type
2. You remove all output columns except one
3. The DataType will be the data type of the last output column removed


https://github.com/kiegroup/kie-tools/assets/7305741/024e1cd3-2ee4-462f-a404-abfae42fb5a2

