### PR TITLE
kie-issues#319: On the DMN Editor, Expression properties are not correctly persisted

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "eslint.options": {
     "configFile": "packages/eslint/.eslintrc.js"
-  }
+  },
+  "WhiteSource Advise.Diff.BaseBranch": "main"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "eslint.options": {
     "configFile": "packages/eslint/.eslintrc.js"
-  },
-  "WhiteSource Advise.Diff.BaseBranch": "main"
+  }
 }

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -296,19 +296,13 @@ export function DecisionTableExpression(
           switch (groupType) {
             case DecisionTableColumnType.InputClause:
               const newInputEntries = [...newRules[u.rowIndex].inputEntries];
-              newInputEntries[u.columnIndex] = {
-                id: generateUuid(),
-                content: u.value,
-              };
+              newInputEntries[u.columnIndex].content = u.value;
               newRules[u.rowIndex].inputEntries = newInputEntries;
               n.rules = newRules;
               break;
             case DecisionTableColumnType.OutputClause:
               const newOutputEntries = [...newRules[u.rowIndex].outputEntries];
-              newOutputEntries[u.columnIndex - (prev.input?.length ?? 0)] = {
-                id: generateUuid(),
-                content: u.value,
-              };
+              newOutputEntries[u.columnIndex - (prev.input?.length ?? 0)].content = u.value;
               newRules[u.rowIndex].outputEntries = newOutputEntries;
               n.rules = newRules;
               break;

--- a/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
@@ -163,7 +163,7 @@ export function RelationExpression(relationExpression: RelationExpressionDefinit
           const newRows = [...(n.rows ?? [])];
 
           const newCells = [...newRows[u.rowIndex].cells];
-          newCells[u.columnIndex] = { id: generateUuid(), content: u.value };
+          newCells[u.columnIndex].content = u.value;
 
           newRows[u.rowIndex] = {
             ...newRows[u.rowIndex],

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -640,7 +640,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         return modelName -> {
             final EntryInfo[] parametersFromModel = pmmlDocumentMetadataProvider.getPMMLDocumentModelParameterNames(documentName, modelName)
                     .stream()
-                    .map(parameter -> new EntryInfo(new Id().getValue(), parameter, BuiltInType.ANY.getName()))
+                    .map(parameter -> new EntryInfo(new Id().getValue(), parameter, BuiltInType.ANY.getName(), null))
                     .toArray(EntryInfo[]::new);
             return new ModelsFromDocument(modelName, parametersFromModel);
         };

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/Cell.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/Cell.java
@@ -22,10 +22,13 @@ public class Cell {
 
     public final String id;
     public final String content;
+    public final String description;
+    public final String expressionLanguage;
 
-    public Cell(final String id,
-                     final String content) {
+    public Cell(final String id, final String content, String description, String expressionLanguage) {
         this.id = id;
         this.content = content;
+        this.description = description;
+        this.expressionLanguage = expressionLanguage;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/Column.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/Column.java
@@ -24,12 +24,14 @@ public class Column {
     public final String id;
     public final String name;
     public final String dataType;
+    public final String description;
     public final Double width;
 
-    public Column(final String id, final String name, final String dataType, final Double width) {
+    public Column(final String id, final String name, final String dataType, String description, final Double width) {
         this.id = id;
         this.name = name;
         this.dataType = dataType;
+        this.description = description;
         this.width = width;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/EntryInfo.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/EntryInfo.java
@@ -20,13 +20,16 @@ import jsinterop.annotations.JsType;
 
 @JsType
 public class EntryInfo {
-    public final String id;
-    public final String name;
-    public final String dataType;
 
-    public EntryInfo(final String id, final String name, final String dataType) {
+    public final String id;
+    public final String dataType;
+    public final String description;
+    public final String name;
+
+    public EntryInfo(final String id, final String name, final String dataType, String description) {
         this.id = id;
         this.name = name;
         this.dataType = dataType;
+        this.description = description;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/InputClauseProps.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/InputClauseProps.java
@@ -18,14 +18,17 @@ package org.kie.workbench.common.dmn.client.editors.expressions.jsinterop.props;
 public class InputClauseProps extends Clause {
 
     public final String idLiteralExpression;
+    public final String description;
 
     public InputClauseProps(final String id,
-                       final String name,
-                       final String dataType,
-                       final Double width,
-                       final ClauseUnaryTests unaryTests,
-                       final String idLiteralExpression) {
+                            final String name,
+                            final String dataType,
+                            final Double width,
+                            final ClauseUnaryTests unaryTests,
+                            final String idLiteralExpression,
+                            final String description) {
         super(id, name, dataType, width, unaryTests);
         this.idLiteralExpression = idLiteralExpression;
+        this.description = description;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/LiteralProps.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/LiteralProps.java
@@ -22,12 +22,17 @@ import static org.kie.workbench.common.dmn.client.editors.expressions.types.Expr
 
 @JsType
 public class LiteralProps extends ExpressionProps {
+
     public final String content;
+    public final String description;
+    public final String expressionLanguage;
     public final Double width;
 
-    public LiteralProps(final String id, final String name, final String dataType, final String content, final Double width) {
+    public LiteralProps(final String id, final String name, final String dataType, final String content, String description, String expressionLanguage, final Double width) {
         super(id, name, dataType, LITERAL_EXPRESSION.getText());
         this.content = content;
+        this.description = description;
+        this.expressionLanguage = expressionLanguage;
         this.width = width;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/OutputClauseProps.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/OutputClauseProps.java
@@ -23,14 +23,17 @@ public class OutputClauseProps extends Clause {
      * for the decision table, which is also an instance of LiteralExpression
      */
     public final ExpressionProps defaultOutputValue;
+    public final String description;
 
     public OutputClauseProps(final String id,
                              final String name,
                              final String dataType,
                              final Double width,
                              final ClauseUnaryTests unaryTests,
-                             final ExpressionProps defaultOutputValue) {
+                             final ExpressionProps defaultOutputValue,
+                             final String description) {
         super(id, name, dataType, width, unaryTests);
         this.defaultOutputValue = defaultOutputValue;
+        this.description = description;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/RuleEntry.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/props/RuleEntry.java
@@ -23,10 +23,13 @@ public class RuleEntry {
 
     public final String id;
     public final String content;
+    public final String description;
+    public final String expressionLanguage;
 
-    public RuleEntry(final String id,
-                     final String content) {
+    public RuleEntry(final String id, final String content, final String description, final String expressionLanguage) {
         this.id = id;
         this.content = content;
+        this.description = description;
+        this.expressionLanguage = expressionLanguage;
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -553,7 +553,7 @@ public class ExpressionEditorViewImplTest {
 
     @Test
     public void testUpdateExpressionLiteralProps() {
-        final LiteralProps props = new LiteralProps("", "", ExpressionType.LITERAL_EXPRESSION.getText(), null, 0d);
+        final LiteralProps props = new LiteralProps("", "", ExpressionType.LITERAL_EXPRESSION.getText(), null, "", "", 0d);
 
         doNothing().when(view).executeUndoableExpressionCommand(any());
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionModelFillerTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionModelFillerTest.java
@@ -70,10 +70,12 @@ public class ExpressionModelFillerTest {
     public static final String DATA_TYPE = BuiltInType.UNDEFINED.asQName().getLocalPart();
     private static final String ENTRY_INFO_NAME = "Entry Info";
     private static final String ENTRY_INFO_DATA_TYPE = BuiltInType.STRING.asQName().getLocalPart();
+    private static final String ENTRY_INFO_DESCRIPTION = "This is an entry info";
     private static final String ENTRY_EXPRESSION_CONTENT = "content";
+    private static final String ENTRY_EXPRESSION_DESCRIPTION = "This is a content";
+    private static final String ENTRY_EXPRESSION_EXPRESSION_LANGUAGE = "expLan";
     private static final Double ENTRY_INFO_WIDTH = 200d;
     private static final Double ENTRY_EXPRESSION_WIDTH = 350d;
-
     private static final Double EMPTY_EXPRESSION_WIDTH = 190d;
     private static final Double PARAMETERS_WIDTH = 450d;
     private static final String PARAM_ID = "param-id";
@@ -84,8 +86,10 @@ public class ExpressionModelFillerTest {
     public void testFillLiteralExpression() {
         final LiteralExpression literalExpression = new LiteralExpression();
         final String content = "content";
+        final String description = "desc";
+        final String expressionLanguage = "eL";
         final double width = 100d;
-        final LiteralProps literalProps = new LiteralProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, content, width);
+        final LiteralProps literalProps = new LiteralProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, content, description, expressionLanguage, width);
 
         ExpressionModelFiller.fillLiteralExpression(literalExpression, literalProps);
 
@@ -98,6 +102,10 @@ public class ExpressionModelFillerTest {
         assertThat(literalExpression.getComponentWidths())
                 .isNotEmpty()
                 .first().isEqualTo(width);
+        assertThat(literalExpression.getDescription().getValue())
+                .isNotNull().isEqualTo(description);
+        assertThat(literalExpression.getExpressionLanguage().getValue())
+                .isNotNull().isEqualTo(expressionLanguage);
     }
 
     @Test
@@ -106,7 +114,7 @@ public class ExpressionModelFillerTest {
         final ContextEntryProps[] contextEntries = new ContextEntryProps[]{
                 buildContextEntryProps()
         };
-        final ExpressionProps result = new LiteralProps("result-id", "Result Expression", BuiltInType.DATE.asQName().getLocalPart(), "", null);
+        final ExpressionProps result = new LiteralProps("result-id", "Result Expression", BuiltInType.DATE.asQName().getLocalPart(), "", "", "", null);
         final ContextProps contextProps = new ContextProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, contextEntries, result, ENTRY_INFO_WIDTH, ENTRY_EXPRESSION_WIDTH);
 
         ExpressionModelFiller.fillContextExpression(contextExpression, contextProps, qName -> qName);
@@ -121,9 +129,12 @@ public class ExpressionModelFillerTest {
                     assertThat(contextEntry).extracting(ContextEntry::getVariable).isNotNull();
                     assertThat(contextEntry).extracting(entry -> entry.getVariable().getValue().getValue()).isEqualTo(ENTRY_INFO_NAME);
                     assertThat(contextEntry).extracting(entry -> entry.getVariable().getTypeRef().getLocalPart()).isEqualTo(ENTRY_INFO_DATA_TYPE);
+                    assertThat(contextEntry).extracting(entry -> entry.getVariable().getDescription().getValue()).isEqualTo(ENTRY_INFO_DESCRIPTION);
                     assertThat(contextEntry).extracting(ContextEntry::getExpression)
                             .isNotNull()
                             .isExactlyInstanceOf(LiteralExpression.class);
+                    assertThat(contextEntry).extracting(entry -> entry.getExpression().getDescription().getValue()).isEqualTo(ENTRY_EXPRESSION_DESCRIPTION);
+                    assertThat(contextEntry).extracting(entry -> ((LiteralExpression) entry.getExpression()).getExpressionLanguage().getValue()).isEqualTo(ENTRY_EXPRESSION_EXPRESSION_LANGUAGE);
                 });
 
         assertThat(contextExpression.getContextEntry())
@@ -145,15 +156,17 @@ public class ExpressionModelFillerTest {
         final String firstColumnName = "Column Name";
         final String firstColumnDataType = BuiltInType.BOOLEAN.asQName().getLocalPart();
         final double firstColumnWidth = 200d;
+        final String firstColumnDescription = "1st";
         final String secondColumnId = "Another Column Name";
         final String secondColumnName = "Another Column Name";
         final String secondColumnDataType = BuiltInType.DATE.asQName().getLocalPart();
         final double secondColumnWidth = 315d;
-        final Cell firstCell = new Cell("firstCellId", "first cell");
-        final Cell secondCell = new Cell("secondCellId", "second cell");
-        final Cell thirdCell = new Cell("thirdCellId", "third cell");
-        final Cell fourthCell = new Cell("fourthCellId", "fourth cell");
-        final Column[] columns = new Column[]{new Column(firstColumnId, firstColumnName, firstColumnDataType, firstColumnWidth), new Column(secondColumnId, secondColumnName, secondColumnDataType, secondColumnWidth)};
+        final String secondColumnDescription = "2nd";
+        final Cell firstCell = new Cell("firstCellId", "first cell", "", "");
+        final Cell secondCell = new Cell("secondCellId", "second cell", "", "");
+        final Cell thirdCell = new Cell("thirdCellId", "third cell", "", "");
+        final Cell fourthCell = new Cell("fourthCellId", "fourth cell", "", "");
+        final Column[] columns = new Column[]{new Column(firstColumnId, firstColumnName, firstColumnDataType, firstColumnDescription, firstColumnWidth), new Column(secondColumnId, secondColumnName, secondColumnDataType, secondColumnDescription, secondColumnWidth)};
         final Row[] rows = new Row[]{new Row("first-row", new Cell[]{firstCell, secondCell}), new Row("second-id", new Cell[]{thirdCell, fourthCell})};
         final RelationProps relationProps = new RelationProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, columns, rows);
 
@@ -165,10 +178,10 @@ public class ExpressionModelFillerTest {
                 .hasSize(2);
         assertThat(relationExpression.getColumn())
                 .first()
-                .satisfies(checkRelationColumn(firstColumnName, firstColumnDataType));
+                .satisfies(checkRelationColumn(firstColumnName, firstColumnDataType, firstColumnDescription));
         assertThat(relationExpression.getColumn())
                 .last()
-                .satisfies(checkRelationColumn(secondColumnName, secondColumnDataType));
+                .satisfies(checkRelationColumn(secondColumnName, secondColumnDataType, secondColumnDescription));
 
         assertThat(relationExpression.getRow())
                 .isNotNull()
@@ -187,8 +200,7 @@ public class ExpressionModelFillerTest {
     public void testFillListExpression() {
         final List listExpression = new List();
         final String nestedContent = "nested content";
-        final ExpressionProps[] items = new ExpressionProps[]{new LiteralProps("nested-literal", "Nested Literal Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), nestedContent, null)};
-        final Double width = 600d;
+        final ExpressionProps[] items = new ExpressionProps[]{new LiteralProps("nested-literal", "Nested Literal Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), nestedContent, "", "", null)};
         final ListProps listProps = new ListProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, items);
 
         ExpressionModelFiller.fillListExpression(listExpression, listProps, qName -> qName);
@@ -242,7 +254,7 @@ public class ExpressionModelFillerTest {
         final FunctionDefinition functionExpression = new FunctionDefinition();
         final String documentName = "document name";
         final String modelName = "model name";
-        final PmmlFunctionProps functionProps = new PmmlFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE)}, PARAMETERS_WIDTH, documentName, modelName, "document-id", "model-id");
+        final PmmlFunctionProps functionProps = new PmmlFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE, null)}, PARAMETERS_WIDTH, documentName, modelName, "document-id", "model-id");
 
         ExpressionModelFiller.fillFunctionExpression(functionExpression, functionProps, qName -> qName);
 
@@ -257,7 +269,7 @@ public class ExpressionModelFillerTest {
         final FunctionDefinition functionExpression = new FunctionDefinition();
         final String className = "class name";
         final String methodName = "method name";
-        final JavaFunctionProps functionProps = new JavaFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE)}, PARAMETERS_WIDTH, className, methodName, "class-id", "method-id");
+        final JavaFunctionProps functionProps = new JavaFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE, null)}, PARAMETERS_WIDTH, className, methodName, "class-id", "method-id");
 
         ExpressionModelFiller.fillFunctionExpression(functionExpression, functionProps, qName -> qName);
 
@@ -271,8 +283,10 @@ public class ExpressionModelFillerTest {
     public void testFillFeelFunctionExpression() {
         final FunctionDefinition functionExpression = new FunctionDefinition();
         final String nestedContent = "Nested Content";
-        final FeelFunctionProps functionProps = new FeelFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE)}, PARAMETERS_WIDTH,
-                                                                      new LiteralProps("nested-literal", "Nested Literal Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), nestedContent, null));
+        final String literalDescription = "Nested Description";
+        final String literalExpressionLanguage = "Nested Literal Expression";
+        final FeelFunctionProps functionProps = new FeelFunctionProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, new EntryInfo[]{new EntryInfo(PARAM_ID, PARAM_NAME, PARAM_DATA_TYPE, null)}, PARAMETERS_WIDTH,
+                                                                      new LiteralProps("nested-literal", "Nested Literal Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), nestedContent, literalDescription, literalExpressionLanguage, null));
 
         ExpressionModelFiller.fillFunctionExpression(functionExpression, functionProps, qName -> qName);
 
@@ -283,6 +297,8 @@ public class ExpressionModelFillerTest {
                 .isNotNull()
                 .isExactlyInstanceOf(LiteralExpression.class);
         assertThat(((LiteralExpression) functionExpression.getExpression()).getText().getValue()).isEqualTo(nestedContent);
+        assertThat(functionExpression.getExpression().getDescription().getValue()).isEqualTo(literalDescription);
+        assertThat(((LiteralExpression) functionExpression.getExpression()).getExpressionLanguage().getValue()).isEqualTo(literalExpressionLanguage);
     }
 
     @Test
@@ -295,24 +311,28 @@ public class ExpressionModelFillerTest {
         final String inputLiteralExpressionId = "Input le id";
         final String inputColumn = "Input column";
         final String inputDataType = BuiltInType.DATE_TIME.asQName().getLocalPart();
+        final String inputDescription = "First Input";
         final double inputWidth = 123d;
         final String inputId2 = "Input id2";
         final String inputLiteralExpressionId2 = "Input le id2";
         final String inputColumn2 = "Input column 2";
         final String inputDataType2 = "tCustom";
+        final String inputDescription2 = "Second Input";
         final double inputWidth2 = 234d;
         final String inputClauseUnaryTestsId = "icud id";
         final String inputClauseUnaryTestsText = "text";
         final String inputClauseUnaryTestsConstraintType = "enumeration";
         final ClauseUnaryTests inputClauseUnaryTest = new ClauseUnaryTests(inputClauseUnaryTestsId, inputClauseUnaryTestsText, inputClauseUnaryTestsConstraintType);
-        final InputClauseProps[] input = new InputClauseProps[]{new InputClauseProps(inputId, inputColumn, inputDataType, inputWidth, inputClauseUnaryTest, inputLiteralExpressionId), new InputClauseProps(inputId2, inputColumn2, inputDataType2, inputWidth2, null, inputLiteralExpressionId2)};
+        final InputClauseProps[] input = new InputClauseProps[]{new InputClauseProps(inputId, inputColumn, inputDataType, inputWidth, inputClauseUnaryTest, inputLiteralExpressionId, inputDescription), new InputClauseProps(inputId2, inputColumn2, inputDataType2, inputWidth2, null, inputLiteralExpressionId2, inputDescription2)};
         final String outputId = "Output id";
         final String outputColumn = "Output column";
         final String outputDataType = BuiltInType.STRING.asQName().getLocalPart();
+        final String outputDescription = "First description";
         final double outputWidth = 223d;
         final String outputId2 = "Output id2";
         final String outputColumn2 = "Output column 2";
         final String outputDataType2 = "tTest";
+        final String outputDescription2 = "Second description";
         final double outputWidth2 = 432d;
         final String outputClauseUnaryTestsId = "ocud id";
         final String outputClauseUnaryTestsText = "";
@@ -320,12 +340,14 @@ public class ExpressionModelFillerTest {
         final ClauseUnaryTests outputClauseUnaryTest = new ClauseUnaryTests(outputClauseUnaryTestsId, outputClauseUnaryTestsText, outputClauseUnaryTestsConstraintType);
         final String defaultOutputValueId = "dovID";
         final String defaultOutputValueContent = "Default-Test";
-        final LiteralProps defaultOutputValue = new LiteralProps(defaultOutputValueId, null, BuiltInType.UNDEFINED.asQName().getLocalPart(), defaultOutputValueContent, null);
-        final OutputClauseProps[] output = new OutputClauseProps[]{new OutputClauseProps(outputId, outputColumn, outputDataType, outputWidth, outputClauseUnaryTest, defaultOutputValue), new OutputClauseProps(outputId2, outputColumn2, outputDataType2, outputWidth2, null, null)};
+        final LiteralProps defaultOutputValue = new LiteralProps(defaultOutputValueId, null, BuiltInType.UNDEFINED.asQName().getLocalPart(), defaultOutputValueContent, null, null, null);
+        final OutputClauseProps[] output = new OutputClauseProps[]{new OutputClauseProps(outputId, outputColumn, outputDataType, outputWidth, outputClauseUnaryTest, defaultOutputValue, outputDescription), new OutputClauseProps(outputId2, outputColumn2, outputDataType2, outputWidth2, null, null, outputDescription2)};
         final String inputValue = "input value";
+        final String inputDesc = "input description";
         final String outputValue = "output value";
+        final String outputDesc = "output description";
         final String annotationValue = "annotation value";
-        DecisionTableRule[] rules = new DecisionTableRule[]{new DecisionTableRule("rule-1", new RuleEntry[]{new RuleEntry("someId", inputValue)}, new RuleEntry[]{new RuleEntry("anotherId", outputValue)}, new String[]{annotationValue})};
+        DecisionTableRule[] rules = new DecisionTableRule[]{new DecisionTableRule("rule-1", new RuleEntry[]{new RuleEntry("someId", inputValue, inputDesc, "")}, new RuleEntry[]{new RuleEntry("anotherId", outputValue, outputDesc, "")}, new String[]{annotationValue})};
         final DecisionTableProps decisionTableProps = new DecisionTableProps(EXPRESSION_ID, EXPRESSION_NAME, DATA_TYPE, HitPolicy.COLLECT.value(), BuiltinAggregator.MAX.getCode(), annotations, input, output, rules);
 
         ExpressionModelFiller.fillDecisionTableExpression(decisionTableExpression, decisionTableProps, qName -> qName);
@@ -343,9 +365,9 @@ public class ExpressionModelFillerTest {
                 .satisfies(inputRef -> {
                     assertThat(inputRef).extracting(InputClause::getInputExpression).isNotNull();
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getText().getValue()).isEqualTo(inputColumn);
+                    assertThat(inputRef).extracting(inputClause -> inputClause.getDescription().getValue()).isEqualTo(inputDescription);
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getTypeRef().getLocalPart()).isEqualTo(inputDataType);
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getId().getValue()).isEqualTo(inputLiteralExpressionId);
-
                     assertThat(inputRef).extracting(InputClause::getInputValues).extracting(inputClauseUnaryTests -> inputClauseUnaryTests.getId().getValue()).isEqualTo(inputClauseUnaryTestsId);
                     assertThat(inputRef).extracting(InputClause::getInputValues).extracting(inputClauseUnaryTests -> inputClauseUnaryTests.getText().getValue()).isEqualTo(inputClauseUnaryTestsText);
                     assertThat(inputRef).extracting(InputClause::getInputValues).extracting(inputClauseUnaryTests -> inputClauseUnaryTests.getConstraintType().value()).isEqualTo(inputClauseUnaryTestsConstraintType);
@@ -354,6 +376,7 @@ public class ExpressionModelFillerTest {
                 .satisfies(inputRef -> {
                     assertThat(inputRef).extracting(InputClause::getInputExpression).isNotNull();
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getText().getValue()).isEqualTo(inputColumn2);
+                    assertThat(inputRef).extracting(inputClause -> inputClause.getDescription().getValue()).isEqualTo(inputDescription2);
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getTypeRef().getLocalPart()).isEqualTo(inputDataType2);
                     assertThat(inputRef).extracting(inputClause -> inputClause.getInputExpression().getId().getValue()).isEqualTo(inputLiteralExpressionId2);
 
@@ -365,6 +388,7 @@ public class ExpressionModelFillerTest {
                 .satisfies(outputRef -> {
                     assertThat(outputRef).extracting(OutputClause::getName).isEqualTo(outputColumn);
                     assertThat(outputRef).extracting(outputClause -> outputClause.getTypeRef().getLocalPart()).isEqualTo(outputDataType);
+                    assertThat(outputRef).extracting(outputClause -> outputClause.getDescription().getValue()).isEqualTo(outputDescription);
                     assertThat(outputRef).extracting(OutputClause::getOutputValues).extracting(outputClauseUnaryTests -> outputClauseUnaryTests.getId().getValue()).isEqualTo(outputClauseUnaryTestsId);
                     assertThat(outputRef).extracting(OutputClause::getOutputValues).extracting(outputClauseUnaryTests -> outputClauseUnaryTests.getText().getValue()).isEqualTo(outputClauseUnaryTestsText);
                     assertThat(outputRef).extracting(OutputClause::getOutputValues).extracting(outputClauseUnaryTests -> outputClauseUnaryTests.getConstraintType().value()).isEqualTo(outputClauseUnaryTestsConstraintType);
@@ -375,6 +399,7 @@ public class ExpressionModelFillerTest {
                 .satisfies(outputRef -> {
                     assertThat(outputRef).extracting(OutputClause::getName).isEqualTo(outputColumn2);
                     assertThat(outputRef).extracting(outputClause -> outputClause.getTypeRef().getLocalPart()).isEqualTo(outputDataType2);
+                    assertThat(outputRef).extracting(outputClause -> outputClause.getDescription().getValue()).isEqualTo(outputDescription2);
                 });
 
         assertThat(decisionTableExpression.getRule())
@@ -395,7 +420,7 @@ public class ExpressionModelFillerTest {
     }
 
     private ContextEntryProps buildContextEntryProps() {
-        return new ContextEntryProps(new EntryInfo("entry-info-id", ENTRY_INFO_NAME, ENTRY_INFO_DATA_TYPE), new LiteralProps("nested-literal", "Nested Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), ENTRY_EXPRESSION_CONTENT, null));
+        return new ContextEntryProps(new EntryInfo("entry-info-id", ENTRY_INFO_NAME, ENTRY_INFO_DATA_TYPE, ENTRY_INFO_DESCRIPTION), new LiteralProps("nested-literal", "Nested Expression", BuiltInType.UNDEFINED.asQName().getLocalPart(), ENTRY_EXPRESSION_CONTENT, ENTRY_EXPRESSION_DESCRIPTION, ENTRY_EXPRESSION_EXPRESSION_LANGUAGE, null));
     }
 
     private void assertEntryWidths(final Collection<Double> componentWidths) {
@@ -415,10 +440,11 @@ public class ExpressionModelFillerTest {
         };
     }
 
-    private Consumer<InformationItem> checkRelationColumn(final String columnName, final String columnDataType) {
+    private Consumer<InformationItem> checkRelationColumn(final String columnName, final String columnDataType, final String columnDescription) {
         return param -> {
             assertThat(param).extracting(HasName::getValue).isNotNull();
             assertThat(param).extracting(informationItem -> informationItem.getValue().getValue()).isEqualTo(columnName);
+            assertThat(param).extracting(informationItem -> informationItem.getDescription().getValue()).isEqualTo(columnDescription);
             assertThat(param).extracting(informationItem -> informationItem.getTypeRef().getLocalPart()).isEqualTo(columnDataType);
         };
     }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionPropsFillerTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionPropsFillerTest.java
@@ -38,6 +38,7 @@ import org.kie.workbench.common.dmn.api.definition.model.Relation;
 import org.kie.workbench.common.dmn.api.definition.model.RuleAnnotationClause;
 import org.kie.workbench.common.dmn.api.definition.model.RuleAnnotationClauseText;
 import org.kie.workbench.common.dmn.api.definition.model.UnaryTests;
+import org.kie.workbench.common.dmn.api.property.dmn.Description;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.QName;
@@ -106,12 +107,14 @@ public class ExpressionPropsFillerTest {
         final Relation relationExpression = new Relation();
         final String firstColumnId = "First Column id";
         final String firstColumnName = "First Column";
+        final String firstColumnDescription = "First Description";
         final QName firstColumnDataType = BuiltInType.BOOLEAN.asQName();
-        relationExpression.getColumn().add(new InformationItem(new Id(firstColumnId), null, new Name(firstColumnName), firstColumnDataType));
+        relationExpression.getColumn().add(new InformationItem(new Id(firstColumnId), new Description(firstColumnDescription), new Name(firstColumnName), firstColumnDataType));
         final String secondColumnId = "Second Column id";
         final String secondColumnName = "Second Column";
+        final String secondColumnDescription = "Second Description";
         final QName secondColumnDataType = BuiltInType.NUMBER.asQName();
-        relationExpression.getColumn().add(new InformationItem(new Id(secondColumnId), null, new Name(secondColumnName), secondColumnDataType));
+        relationExpression.getColumn().add(new InformationItem(new Id(secondColumnId), new Description(secondColumnDescription), new Name(secondColumnName), secondColumnDataType));
         final String firstCellValue = "first cell value";
         final String secondCellValue = "second cell value";
         relationExpression.getRow().add(buildListWithTwoLiteralExpressions(firstCellValue, secondCellValue));
@@ -127,9 +130,11 @@ public class ExpressionPropsFillerTest {
         assertThat(((RelationProps) expressionProps).columns[0].name).isEqualTo(firstColumnName);
         assertThat(((RelationProps) expressionProps).columns[0].dataType).isEqualTo(firstColumnDataType.getLocalPart());
         assertThat(((RelationProps) expressionProps).columns[0].width).isEqualTo(relationExpression.getComponentWidths().get(1));
+        assertThat(((RelationProps) expressionProps).columns[0].description).isEqualTo(firstColumnDescription);
         assertThat(((RelationProps) expressionProps).columns[1].name).isEqualTo(secondColumnName);
         assertThat(((RelationProps) expressionProps).columns[1].dataType).isEqualTo(secondColumnDataType.getLocalPart());
         assertThat(((RelationProps) expressionProps).columns[1].width).isEqualTo(relationExpression.getComponentWidths().get(2));
+        assertThat(((RelationProps) expressionProps).columns[1].description).isEqualTo(secondColumnDescription);
         assertThat(((RelationProps) expressionProps).rows)
                 .isNotNull()
                 .hasSize(1);


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/319

Persistence issues fixed in this PR:
- Every time you change the content of a **Decision Table** or **Relation** expression, the cell ID changes. The fix consists to update the content only on `cellUpdate` methods.
- **Description** and **Expression Language** properties are not persisted in most scenarios. As the updates from the React component act like a function (eg. The expression status in GWT is CLEAN and restored from the JSON sent by the React Component) I added the Description and Expression Language data in the JSON shared between GWT <--> REACT

https://github.com/kiegroup/kie-tools/assets/16005046/ea0b0503-339a-4822-98d1-a7e02fb74f04