### PR TITLE
NO-ISSUE: Fix relative path parser for files without name

### DIFF
--- a/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
+++ b/packages/workspaces-git-fs/src/relativePath/WorkspaceFileRelativePathParser.ts
@@ -16,14 +16,24 @@
 import { basename, extname, parse } from "path";
 import { isOfKind } from "../constants/ExtensionHelper";
 
-export function parseWorkspaceFileRelativePath(relativePath: string) {
+export interface ParsedWorkspaceFileRelativePath {
+  relativePathWithoutExtension: string;
+  relativeDirPath: string;
+  extension: string;
+  nameWithoutExtension: string;
+  name: string;
+}
+
+export function parseWorkspaceFileRelativePath(relativePath: string): ParsedWorkspaceFileRelativePath {
   const extension = extractExtension(relativePath);
+  const extensionIndex = relativePath.lastIndexOf("." + extension);
+  const name = basename(relativePath);
   return {
-    relativePathWithoutExtension: relativePath.substring(0, relativePath.lastIndexOf("." + extension)) || relativePath,
+    relativePathWithoutExtension: extensionIndex !== -1 ? relativePath.substring(0, extensionIndex) : relativePath,
     relativeDirPath: parse(relativePath).dir,
     extension: extension,
-    nameWithoutExtension: basename(relativePath, `.${extension}`),
-    name: basename(relativePath),
+    nameWithoutExtension: name !== `.${extension}` ? basename(relativePath, `.${extension}`) : "",
+    name,
   };
 }
 

--- a/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
+++ b/packages/workspaces-git-fs/tests/relativePath/WorkspaceFileRelativePathParser.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { extractExtension } from "../../src/relativePath/WorkspaceFileRelativePathParser";
+import {
+  ParsedWorkspaceFileRelativePath,
+  extractExtension,
+  parseWorkspaceFileRelativePath,
+} from "../../src/relativePath/WorkspaceFileRelativePathParser";
 
 describe("WorkspaceFileRelativePathParser :: extractExtension", () => {
   it.each([
@@ -39,4 +43,214 @@ describe("WorkspaceFileRelativePathParser :: extractExtension", () => {
   ])("should extract extension properly for %p", (relativePath: string, extension: string) => {
     expect(extractExtension(relativePath)).toBe(extension);
   });
+});
+
+describe("WorkspaceFileRelativePathParser :: parseWorkspaceFileRelativePath", () => {
+  it.each([
+    [
+      "foo.yaml",
+      {
+        relativePathWithoutExtension: "foo",
+        relativeDirPath: "",
+        extension: "yaml",
+        nameWithoutExtension: "foo",
+        name: "foo.yaml",
+      },
+    ],
+    [
+      "foo.yml",
+      {
+        relativePathWithoutExtension: "foo",
+        relativeDirPath: "",
+        extension: "yml",
+        nameWithoutExtension: "foo",
+        name: "foo.yml",
+      },
+    ],
+    [
+      "foo.json",
+      {
+        relativePathWithoutExtension: "foo",
+        relativeDirPath: "",
+        extension: "json",
+        nameWithoutExtension: "foo",
+        name: "foo.json",
+      },
+    ],
+    [
+      ".gitignore",
+      {
+        relativePathWithoutExtension: "",
+        relativeDirPath: "",
+        extension: "gitignore",
+        nameWithoutExtension: "",
+        name: ".gitignore",
+      },
+    ],
+    [
+      ".gitignore.gitignore",
+      {
+        relativePathWithoutExtension: ".gitignore",
+        relativeDirPath: "",
+        extension: "gitignore",
+        nameWithoutExtension: ".gitignore",
+        name: ".gitignore.gitignore",
+      },
+    ],
+    [
+      "noExtension",
+      {
+        relativePathWithoutExtension: "noExtension",
+        relativeDirPath: "",
+        extension: "",
+        nameWithoutExtension: "noExtension",
+        name: "noExtension",
+      },
+    ],
+    [
+      "bar.sw.yml",
+      {
+        relativePathWithoutExtension: "bar",
+        relativeDirPath: "",
+        extension: "sw.yml",
+        nameWithoutExtension: "bar",
+        name: "bar.sw.yml",
+      },
+    ],
+    [
+      "bar.yard.yml",
+      {
+        relativePathWithoutExtension: "bar",
+        relativeDirPath: "",
+        extension: "yard.yml",
+        nameWithoutExtension: "bar",
+        name: "bar.yard.yml",
+      },
+    ],
+    [
+      "bar.yard.yaml.yard.yaml",
+      {
+        relativePathWithoutExtension: "bar.yard.yaml",
+        relativeDirPath: "",
+        extension: "yard.yaml",
+        nameWithoutExtension: "bar.yard.yaml",
+        name: "bar.yard.yaml.yard.yaml",
+      },
+    ],
+    [
+      "bar.dash.yml",
+      {
+        relativePathWithoutExtension: "bar",
+        relativeDirPath: "",
+        extension: "dash.yml",
+        nameWithoutExtension: "bar",
+        name: "bar.dash.yml",
+      },
+    ],
+    [
+      "a/b/c/foo.json",
+      {
+        relativePathWithoutExtension: "a/b/c/foo",
+        relativeDirPath: "a/b/c",
+        extension: "json",
+        nameWithoutExtension: "foo",
+        name: "foo.json",
+      },
+    ],
+    [
+      "a/b/c/.gitignore",
+      {
+        relativePathWithoutExtension: "a/b/c/",
+        relativeDirPath: "a/b/c",
+        extension: "gitignore",
+        nameWithoutExtension: "",
+        name: ".gitignore",
+      },
+    ],
+    [
+      "a/b/c/.gitignore.gitignore",
+      {
+        relativePathWithoutExtension: "a/b/c/.gitignore",
+        relativeDirPath: "a/b/c",
+        extension: "gitignore",
+        nameWithoutExtension: ".gitignore",
+        name: ".gitignore.gitignore",
+      },
+    ],
+    [
+      "a/b/c/noExtension",
+      {
+        relativePathWithoutExtension: "a/b/c/noExtension",
+        relativeDirPath: "a/b/c",
+        extension: "",
+        nameWithoutExtension: "noExtension",
+        name: "noExtension",
+      },
+    ],
+    [
+      "a/b/c/bar.sw.json",
+      {
+        relativePathWithoutExtension: "a/b/c/bar",
+        relativeDirPath: "a/b/c",
+        extension: "sw.json",
+        nameWithoutExtension: "bar",
+        name: "bar.sw.json",
+      },
+    ],
+    [
+      "asd.dmn.dmn",
+      {
+        relativePathWithoutExtension: "asd.dmn",
+        relativeDirPath: "",
+        extension: "dmn",
+        nameWithoutExtension: "asd.dmn",
+        name: "asd.dmn.dmn",
+      },
+    ],
+    [
+      "a/b/c'asd.DMn",
+      {
+        relativePathWithoutExtension: "a/b/c'asd",
+        relativeDirPath: "a/b",
+        extension: "DMn",
+        nameWithoutExtension: "c'asd",
+        name: "c'asd.DMn",
+      },
+    ],
+    [
+      "foo.bpmN2",
+      {
+        relativePathWithoutExtension: "foo",
+        relativeDirPath: "",
+        extension: "bpmN2",
+        nameWithoutExtension: "foo",
+        name: "foo.bpmN2",
+      },
+    ],
+    [
+      "pmml.pmml",
+      {
+        relativePathWithoutExtension: "pmml",
+        relativeDirPath: "",
+        extension: "pmml",
+        nameWithoutExtension: "pmml",
+        name: "pmml.pmml",
+      },
+    ],
+    [
+      "TEST.BPMN",
+      {
+        relativePathWithoutExtension: "TEST",
+        relativeDirPath: "",
+        extension: "BPMN",
+        nameWithoutExtension: "TEST",
+        name: "TEST.BPMN",
+      },
+    ],
+  ])(
+    "should parse workspace file relative path properly for %p",
+    (relativePath: string, expectedResult: ParsedWorkspaceFileRelativePath) => {
+      expect(parseWorkspaceFileRelativePath(relativePath)).toStrictEqual(expectedResult);
+    }
+  );
 });


### PR DESCRIPTION
Without this fix: 
- if you have `relativePath=".gitignore"`
```
{
      relativePathWithoutExtension: '.gitignore',
      relativeDirPath: '',
      extension: 'gitignore',
      nameWithoutExtension: '',
      name: '.gitignore'
}
```
- if you have `relativePath="a/b/c/.gitignore"`
```
{
      relativePathWithoutExtension: 'a/b/c/',
      relativeDirPath: 'a/b/c',
      extension: 'gitignore',
      nameWithoutExtension: '.gitignore',
      name: '.gitignore'
}
```

The fix standardizes the way we treat `extractExtension` for all scenarios.