### PR TITLE
NO-ISSUE: Remove Workspaces Shared Worker ping

### DIFF
--- a/packages/workspaces-git-fs/src/worker/WorkspacesSharedWorker.ts
+++ b/packages/workspaces-git-fs/src/worker/WorkspacesSharedWorker.ts
@@ -68,9 +68,6 @@ export class WorkspacesSharedWorker {
           kieToolsWorkspacesWorker_ready() {
             res();
           },
-          async kieToolsWorkspacesWorker_ping() {
-            return "pong";
-          },
         });
       };
     });

--- a/packages/workspaces-git-fs/src/worker/api/WorkspacesWorkerChannelApi.ts
+++ b/packages/workspaces-git-fs/src/worker/api/WorkspacesWorkerChannelApi.ts
@@ -16,5 +16,4 @@
 
 export interface WorkspacesWorkerChannelApi {
   kieToolsWorkspacesWorker_ready(): void;
-  kieToolsWorkspacesWorker_ping(): Promise<"pong">;
 }

--- a/packages/workspaces-git-fs/src/worker/setupWorkerConnection.ts
+++ b/packages/workspaces-git-fs/src/worker/setupWorkerConnection.ts
@@ -31,4 +31,8 @@ export function setupWorkerConnection(args: {
   args.port.addEventListener("message", (message) => bus.server.receive(message.data, args.apiImpl));
   args.port.start(); // Required when using addEventListener. Otherwise, called implicitly by onmessage setter.
   bus.clientApi.notifications.kieToolsWorkspacesWorker_ready.send();
+
+  args.fsFlushManager.subscribable.subscribe((flushes) => {
+    bus.shared.kieSandboxWorkspacesStorage_flushes.set(flushes);
+  });
 }

--- a/packages/workspaces-git-fs/src/worker/setupWorkerConnection.ts
+++ b/packages/workspaces-git-fs/src/worker/setupWorkerConnection.ts
@@ -31,24 +31,4 @@ export function setupWorkerConnection(args: {
   args.port.addEventListener("message", (message) => bus.server.receive(message.data, args.apiImpl));
   args.port.start(); // Required when using addEventListener. Otherwise, called implicitly by onmessage setter.
   bus.clientApi.notifications.kieToolsWorkspacesWorker_ready.send();
-
-  const flushManagerSubscription = args.fsFlushManager.subscribable.subscribe((flushes) => {
-    bus.shared.kieSandboxWorkspacesStorage_flushes.set(flushes);
-  });
-
-  const keepalive = setInterval(() => {
-    let ping: "ping" | "pong" = "ping";
-    bus.clientApi.requests.kieToolsWorkspacesWorker_ping().then((pong) => (ping = pong));
-    setTimeout(() => {
-      if (ping !== "pong") {
-        // This connection is no longer active, as the corresponding bus did not respond in 200ms. Tear it down.
-        console.log("Disconnecting from Workspaces Shared Worker");
-        args.port.close();
-        args.fsFlushManager.subscribable.unsubscribe(flushManagerSubscription);
-        clearInterval(keepalive);
-      } else {
-        console.debug("Connection is still alive.");
-      }
-    }, 200); // pong timeout
-  }, 60000); // interval for keepalive check
 }


### PR DESCRIPTION
The keep alive interval in the shared worker tries to ping the channel every 1 minute. If it doesn't receive a response, it disconnects. This behavior was causing the shared worker to disconnect when the channel was busy. One way to make the channel busy is to make and edit, create a file or change between files. If the shared worker tries to ping the channel at the same time, it will disconnect, and the user will need to refresh the browser page to restart the shared worker.

Changing the ping to a small value make it easier to replicate, the following video changes the ping from 60000ms to 1000ms.

https://github.com/kiegroup/kie-tools/assets/24302289/cec57d36-3314-43e0-ab73-892f1e10aa81

