### PR TITLE
kie-issues#321: Change the default user to non-root on KIE Sandbox, Extended Services, and Git CORS Proxy images

### DIFF
--- a/packages/git-cors-proxy-image/Containerfile
+++ b/packages/git-cors-proxy-image/Containerfile
@@ -14,16 +14,16 @@
 
 FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:1-51
 
-USER root
+USER 1000
 
-COPY dist-dev/git-cors-proxy /tmp/git-cors-proxy
+COPY --chown=1000:1000 --chmod=777 dist-dev/git-cors-proxy /tmp/git-cors-proxy
 
-RUN mkdir /kie-sandbox \
-  && mv /tmp/git-cors-proxy /kie-sandbox \
-  && chgrp -R 0 /kie-sandbox \
-  && chmod -R g=u /kie-sandbox \
-  && npm install --production --silent --prefix /kie-sandbox/git-cors-proxy
+RUN mkdir -p -m 777 $HOME/kie-sandbox \
+  && mv /tmp/git-cors-proxy $HOME/kie-sandbox \
+  && chgrp -R 0 $HOME/kie-sandbox \
+  && chmod -R g=u $HOME/kie-sandbox \
+  && npm install --production --silent --prefix $HOME/kie-sandbox/git-cors-proxy
 
 EXPOSE 8080
 
-CMD [ "/kie-sandbox/git-cors-proxy/bin.js", "start", "-p", "8080" ]
+CMD $HOME/kie-sandbox/git-cors-proxy/bin.js start -p 8080

--- a/packages/kie-sandbox-extended-services-image/Containerfile
+++ b/packages/kie-sandbox-extended-services-image/Containerfile
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
-RUN mkdir -m 775 -p /kie-sandbox /root/.cache /.cache
+RUN microdnf install shadow-utils -y \
+  && groupadd extended-services-user \
+  && useradd --create-home --shell /bin/bash extended-services-user -g extended-services-user \
+  && mkdir /home/extended-services-user/.cache \
+  && chown extended-services-user /home/extended-services-user/.cache
 
-COPY dist-dev/kie_sandbox_extended_services_headless /kie-sandbox/kie_sandbox_extended_services_headless
+COPY --chown=extended-services-user:extended-services-user dist-dev/kie_sandbox_extended_services_headless /home/extended-services-user/kie-sandbox/kie_sandbox_extended_services_headless
 
 EXPOSE 21345
 
-CMD [ "/kie-sandbox/kie_sandbox_extended_services_headless" ]
+USER extended-services-user
+
+CMD /home/extended-services-user/kie-sandbox/kie_sandbox_extended_services_headless

--- a/packages/kie-sandbox-extended-services-image/Containerfile
+++ b/packages/kie-sandbox-extended-services-image/Containerfile
@@ -16,14 +16,14 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 RUN microdnf install shadow-utils -y \
   && groupadd extended-services-user \
-  && useradd --create-home --shell /bin/bash extended-services-user -g extended-services-user \
-  && mkdir /home/extended-services-user/.cache \
-  && chown extended-services-user /home/extended-services-user/.cache
+  && useradd --create-home extended-services-user -g extended-services-user \
+  && mkdir -m 775 -p /kie-sandbox /root/.cache /home/extended-services-user/.cache \
+  && chown extended-services-user:extended-services-user /home/extended-services-user/.cache
 
-COPY --chown=extended-services-user:extended-services-user dist-dev/kie_sandbox_extended_services_headless /home/extended-services-user/kie-sandbox/kie_sandbox_extended_services_headless
+COPY dist-dev/kie_sandbox_extended_services_headless /kie-sandbox/kie_sandbox_extended_services_headless
 
 EXPOSE 21345
 
 USER extended-services-user
 
-CMD /home/extended-services-user/kie-sandbox/kie_sandbox_extended_services_headless
+CMD [ "/kie-sandbox/kie_sandbox_extended_services_headless" ]

--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -32,4 +32,6 @@ RUN if [ -f /var/www/html/env.json ]; then chmod a+w /var/www/html/env.json; fi
 
 EXPOSE 8080
 
+USER 1000
+
 ENTRYPOINT [ "/kie-sandbox/entrypoint.sh" ]

--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 COPY entrypoint.sh dist-dev/image-env-to-json-standalone dist-dev/EnvJson.schema.json /tmp/
 


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/321

Changed users to non-root on Containerfiles for `git-cors-proxy-image`, `kie-sandbox-image`, and `kie-sandbox-extended-services-image`.
When possible, the user selection was made at the beginning of the Containerfile, in other cases, the user was changed right before the CMD or ENTRYPOINT.

This was tested on docker, locally, and deployed to OpenShift (https://kie-sandbox-route-thiago-lugli-dev.apps.sandbox-m2.ll9k.p1.openshiftapps.com <- This pod will probably go down automatically in 12 hours)