### PR TITLE
NO-ISSUE: Add JSON Schema draft-4 to DMN validators on DMN Dev deployment form webapp

### DIFF
--- a/packages/form-dmn/src/DmnValidator.ts
+++ b/packages/form-dmn/src/DmnValidator.ts
@@ -20,10 +20,10 @@ import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from 
 import { DmnFormJsonSchemaBridge } from "./uniforms";
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
+import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
 
 export class DmnValidator extends Validator {
   private dmnRunnerAjv = new DmnRunnerAjv();
-  private readonly SCHEMA_DRAFT4 = "http://json-schema.org/draft-04/schema#";
 
   constructor(i18n: DmnFormI18n) {
     super(i18n);
@@ -58,7 +58,8 @@ export class DmnValidator extends Validator {
   }
 
   public getBridge(formSchema: ExtendedServicesDmnJsonSchema): DmnFormJsonSchemaBridge {
-    const validator = this.createValidator(formSchema);
-    return new DmnFormJsonSchemaBridge(formSchema, validator, this.i18n as DmnFormI18n);
+    const formDraft4 = { ...formSchema, $schema: SCHEMA_DRAFT4 };
+    const validator = this.createValidator(formDraft4);
+    return new DmnFormJsonSchemaBridge(formDraft4, validator, this.i18n as DmnFormI18n);
   }
 }

--- a/packages/form/src/FormHook.tsx
+++ b/packages/form/src/FormHook.tsx
@@ -139,6 +139,7 @@ export function useForm<Input extends Record<string, any>, Schema extends Record
 
       setFormStatus(FormStatus.WITHOUT_ERROR);
     } catch (err) {
+      console.error(err);
       setFormStatus(FormStatus.VALIDATOR_ERROR);
     }
   }, [setFormInputs, formSchema, formValidator, entryPath, removeRequired]);

--- a/packages/unitables-dmn/src/DmnUnitablesValidator.ts
+++ b/packages/unitables-dmn/src/DmnUnitablesValidator.ts
@@ -20,6 +20,7 @@ import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from 
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 import { UnitablesValidator } from "@kie-tools/unitables/dist/UnitablesValidator";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
+import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
 
 export class DmnUnitablesValidator extends UnitablesValidator {
   protected readonly dmnRunnerAjv = new DmnRunnerAjv();
@@ -55,7 +56,8 @@ export class DmnUnitablesValidator extends UnitablesValidator {
   }
 
   public getBridge(formSchema: ExtendedServicesDmnJsonSchema): DmnUnitablesJsonSchemaBridge {
-    const validator = this.createValidator(formSchema);
-    return new DmnUnitablesJsonSchemaBridge(formSchema, validator, this.i18n);
+    const formDraft4 = { ...formSchema, $schema: SCHEMA_DRAFT4 };
+    const validator = this.createValidator(formDraft4);
+    return new DmnUnitablesJsonSchemaBridge(formDraft4, validator, this.i18n);
   }
 }


### PR DESCRIPTION
The https://github.com/kiegroup/kie-tools/pull/1666 removed the JSON Schema draft 4 addition in the DMN Validators, as the online-editor were adding it, causing the `dmn-dev-deployment-form-webapp` to break. This PR adds back the JSON Schema draft 4.