### PR TITLE
kie-issues#323: Fix CVE-2023-34104 vulnerabilitie in kie-tools

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,7 +27,7 @@
     "@kie-tools-core/notifications": "workspace:*",
     "@kie-tools-core/workspace": "workspace:*",
     "axios": "^0.27.2",
-    "fast-xml-parser": "^4.1.2",
+    "fast-xml-parser": "^4.2.4",
     "portfinder": "^1.0.32",
     "semver": "^7.3.5",
     "sinon": "^11.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,8 +661,8 @@ importers:
         specifier: ^0.27.2
         version: 0.27.2
       fast-xml-parser:
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^4.2.4
+        version: 4.2.4
       portfinder:
         specifier: ^1.0.32
         version: 1.0.32
@@ -9126,8 +9126,8 @@ importers:
   scripts/check-junit-report-results:
     dependencies:
       fast-xml-parser:
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^4.2.4
+        version: 4.2.4
     devDependencies:
       "@babel/core":
         specifier: ^7.16.0
@@ -17652,7 +17652,7 @@ packages:
     engines: { node: ">= 6" }
     dependencies:
       glob: 7.2.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       lazystream: 1.0.0
       lodash.defaults: 4.2.0
       lodash.difference: 4.5.0
@@ -20825,7 +20825,7 @@ packages:
       decompress-tarbz2: 4.1.1
       decompress-targz: 4.1.1
       decompress-unzip: 4.0.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
@@ -21378,7 +21378,7 @@ packages:
       { integrity: sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw== }
     engines: { node: ">=10.13.0" }
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       tapable: 2.2.0
     dev: true
 
@@ -22548,9 +22548,9 @@ packages:
       { integrity: sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig== }
     dev: false
 
-  /fast-xml-parser@4.1.2:
+  /fast-xml-parser@4.2.4:
     resolution:
-      { integrity: sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg== }
+      { integrity: sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ== }
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -27439,7 +27439,7 @@ packages:
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       npmlog: 6.0.0
@@ -33444,7 +33444,7 @@ packages:
     engines: { node: ">=10.13.0" }
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /wbuf@1.7.3:
@@ -33570,7 +33570,7 @@ packages:
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
       express: 4.18.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       html-entities: 2.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.13)
       ipaddr.js: 2.0.1
@@ -33844,7 +33844,7 @@ packages:
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
       loader-runner: 4.2.0
       mime-types: 2.1.34

--- a/scripts/check-junit-report-results/package.json
+++ b/scripts/check-junit-report-results/package.json
@@ -7,7 +7,7 @@
     "install": "jest --silent --verbose --passWithNoTests"
   },
   "dependencies": {
-    "fast-xml-parser": "^4.1.2"
+    "fast-xml-parser": "^4.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/323

Upgrading `fast-xml-parser@^4.1.2` to `fast-xml-parser@^4.2.4`.

