### PR TITLE
kie-tools#1698: Add Edge as compatible browser for KIE Sandbox

### DIFF
--- a/packages/online-editor/src/workspace/startupBlockers/IncompatibleBrowser.tsx
+++ b/packages/online-editor/src/workspace/startupBlockers/IncompatibleBrowser.tsx
@@ -29,6 +29,7 @@ export const LATEST_VERSION_COMPATIBLE_WITH_LFS = "0.23.0";
 const hasNecessaryApis = window["SharedWorker"] && window["BroadcastChannel"];
 const isCompatibleBrowser = Bowser.getParser(window.navigator.userAgent).satisfies({
   chrome: ">4",
+  edge: ">=79",
   safari: ">=16",
   mobile: {
     safari: ">=16",
@@ -61,6 +62,7 @@ export function Component() {
           <Text component={TextVariants.p}>Compatible browsers are:</Text>
           <List>
             <ListItem>Chrome</ListItem>
+            <ListItem>Edge</ListItem>
             <ListItem>Safari 16 or newer</ListItem>
           </List>
         </TextContent>


### PR DESCRIPTION
Related to kie-tools#1698.

<img width="1536" alt="Screenshot 2023-06-09 at 14 23 42" src="https://github.com/kiegroup/kie-tools/assets/16005046/6c6f2d4e-1ec5-455f-8423-58c5e798f5ec">

Edge (since version 79) is a chronium based browser, therefore we can safely add it as supported browser.

