### PR TITLE
kie-issues#334: Upgrade DMN Dev deployment base image to `ubi8/openjdk-11:1.16`

### DIFF
--- a/packages/dmn-dev-deployment-base-image/Containerfile
+++ b/packages/dmn-dev-deployment-base-image/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.15
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.16
 
 ARG QUARKUS_PLATFORM_VERSION
 ARG KOGITO_RUNTIME_VERSION


### PR DESCRIPTION
Upgrading to most recent release of ubi8/openjdk-11 image:  https://catalog.redhat.com/software/containers/ubi8/openjdk-11

