### PR TITLE
KOGITO-9257: Add a breadcrumb in the settings pages to go back to home page

### DIFF
--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFiles.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFiles.tsx
@@ -181,9 +181,7 @@ export function WorkspaceFiles(props: Props) {
               breadcrumb={
                 <Breadcrumb>
                   <BreadcrumbItem to={"#" + routes.recentModels.path({})}>Recent Models</BreadcrumbItem>
-                  <BreadcrumbItem to="#" isActive>
-                    {workspace.descriptor.name}
-                  </BreadcrumbItem>
+                  <BreadcrumbItem isActive>{workspace.descriptor.name}</BreadcrumbItem>
                 </Breadcrumb>
               }
             >

--- a/packages/serverless-logic-web-tools/src/settings/SettingsPageContainer.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/SettingsPageContainer.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/components/Breadcrumb";
+import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import * as React from "react";
+import { useEffect } from "react";
+import { setPageTitle } from "../PageTitle";
+import { routes } from "../navigation/Routes";
+import { SETTINGS_PAGE_SECTION_TITLE } from "./SettingsContext";
+
+export type SettingsPageContainerProps = {
+  pageTitle: string;
+  subtitle?: string | React.ReactNode;
+  children?: React.ReactNode;
+};
+
+export function SettingsPageContainer(props: SettingsPageContainerProps) {
+  const { pageTitle, subtitle, children } = props;
+
+  useEffect(() => {
+    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, pageTitle]);
+  }, [pageTitle]);
+
+  return (
+    <Page
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem to={"#" + routes.home.path({})}>Home</BreadcrumbItem>
+          <BreadcrumbItem to={"#" + routes.settings.home.path({})}>Settings</BreadcrumbItem>
+          <BreadcrumbItem isActive>{pageTitle}</BreadcrumbItem>
+        </Breadcrumb>
+      }
+    >
+      <PageSection variant={"light"}>
+        <TextContent>
+          <Text component={TextVariants.h1}>{pageTitle}</Text>
+          {subtitle && <Text component={TextVariants.p}>{subtitle}</Text>}
+        </TextContent>
+      </PageSection>
+
+      {children}
+    </Page>
+  );
+}

--- a/packages/serverless-logic-web-tools/src/settings/extendedServices/ExtendedServicesSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/extendedServices/ExtendedServicesSettings.tsx
@@ -22,21 +22,20 @@ import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-co
 import { ActionGroup, Form, FormAlert, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup, InputGroupText } from "@patternfly/react-core/dist/js/components/InputGroup";
 import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { AddCircleOIcon } from "@patternfly/react-icons/dist/js/icons/add-circle-o-icon";
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import HelpIcon from "@patternfly/react-icons/dist/js/icons/help-icon";
 import { TimesIcon } from "@patternfly/react-icons/dist/js/icons/times-icon";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
+import { useCallback, useContext, useMemo, useState } from "react";
 import { useExtendedServices } from "../../extendedServices/ExtendedServicesContext";
 import { ExtendedServicesStatus } from "../../extendedServices/ExtendedServicesStatus";
-import { setPageTitle } from "../../PageTitle";
 import { QuickStartIds } from "../../quickstarts-data";
 import { ExtendedServicesConfig, useSettings, useSettingsDispatch } from "../SettingsContext";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { SettingsPageProps } from "../types";
 
 const PAGE_TITLE = "Extended Services";
@@ -80,23 +79,17 @@ export function ExtendedServicesSettings(props: SettingsPageProps) {
     setIsModalOpen((prevIsModalOpen) => !prevIsModalOpen);
   }, []);
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"} isWidthLimited>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for proxying Serverless Logic Web Tools requests to OpenShift, thus
-            making it possible to deploy models.
-            <br /> All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Data you provide here is necessary for proxying Serverless Logic Web Tools requests to OpenShift, thus making
+          it possible to deploy models.
+          <br /> All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection isFilled>
         <PageSection variant={"light"}>
           {extendedServices.status === ExtendedServicesStatus.RUNNING ? (
@@ -291,6 +284,6 @@ export function ExtendedServicesSettings(props: SettingsPageProps) {
           </Form>
         </Modal>
       )}
-    </Page>
+    </SettingsPageContainer>
   );
 }

--- a/packages/serverless-logic-web-tools/src/settings/featurePreview/FeaturePreviewSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/featurePreview/FeaturePreviewSettings.tsx
@@ -17,12 +17,10 @@
 import React from "react";
 import { Checkbox } from "@patternfly/react-core/dist/js/components/Checkbox";
 import { Form } from "@patternfly/react-core/dist/js/components/Form";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { useCallback, useEffect, useState } from "react";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
-import { setPageTitle } from "../../PageTitle";
 import { useSettings, useSettingsDispatch } from "../SettingsContext";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { saveConfigCookie } from "./FeaturePreviewConfig";
 
 const PAGE_TITLE = "Feature Preview";
@@ -46,22 +44,16 @@ export function FeaturePreviewSettings() {
     [config]
   );
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"} isWidthLimited>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for configuring the preview of features that are not fully supported yet.
-            <br /> All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Data you provide here is necessary for configuring the preview of features that are not fully supported yet.
+          <br /> All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection>
         <PageSection variant={"light"}>
           <Form>
@@ -75,6 +67,6 @@ export function FeaturePreviewSettings() {
           </Form>
         </PageSection>
       </PageSection>
-    </Page>
+    </SettingsPageContainer>
   );
 }

--- a/packages/serverless-logic-web-tools/src/settings/github/GitHubSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/github/GitHubSettings.tsx
@@ -104,7 +104,6 @@ export function GitHubSettings(props: SettingsPageProps) {
       pageTitle={PAGE_TITLE}
       subtitle={
         <>
-          {" "}
           Data you provide here is necessary for creating repositories containing models you design, and syncing changes
           with GitHub.
           <br />

--- a/packages/serverless-logic-web-tools/src/settings/github/GitHubSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/github/GitHubSettings.tsx
@@ -15,28 +15,27 @@
  */
 
 import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
-import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { Form, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup } from "@patternfly/react-core/dist/js/components/InputGroup";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Spinner } from "@patternfly/react-core/dist/js/components/Spinner";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { AddCircleOIcon } from "@patternfly/react-icons/dist/js/icons/add-circle-o-icon";
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/js/icons/external-link-alt-icon";
 import { GithubIcon } from "@patternfly/react-icons/dist/js/icons/github-icon";
-import * as React from "react";
-import { useEffect, useCallback, useContext, useMemo, useRef, useState } from "react";
+import React from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import { makeCookieName } from "../../cookies";
 import { QuickStartIds } from "../../quickstarts-data";
 import { AuthStatus, useSettings, useSettingsDispatch } from "../../settings/SettingsContext";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { SettingsPageProps } from "../types";
-import { setPageTitle } from "../../PageTitle";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
 
 const PAGE_TITLE = "GitHub";
 export const GITHUB_OAUTH_TOKEN_SIZE = 40;
@@ -100,24 +99,19 @@ export function GitHubSettings(props: SettingsPageProps) {
     setPotentialGitHubToken(undefined);
   }, [settingsDispatch.github.authService]);
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"}>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for creating repositories containing models you design, and syncing
-            changes with GitHub.
-            <br />
-            All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          {" "}
+          Data you provide here is necessary for creating repositories containing models you design, and syncing changes
+          with GitHub.
+          <br />
+          All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection isFilled>
         <PageSection variant={"light"}>
           {settings.github.authStatus === AuthStatus.TOKEN_EXPIRED && (
@@ -248,7 +242,7 @@ export function GitHubSettings(props: SettingsPageProps) {
           </Form>
         </Modal>
       )}
-    </Page>
+    </SettingsPageContainer>
   );
 }
 

--- a/packages/serverless-logic-web-tools/src/settings/openshift/OpenShiftSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/openshift/OpenShiftSettings.tsx
@@ -20,20 +20,19 @@ import { Alert } from "@patternfly/react-core/dist/js/components/Alert";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import { AddCircleOIcon } from "@patternfly/react-icons/dist/js/icons/add-circle-o-icon";
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
-import { useCallback, useEffect, useState, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
 import { useExtendedServices } from "../../extendedServices/ExtendedServicesContext";
 import { ExtendedServicesStatus } from "../../extendedServices/ExtendedServicesStatus";
 import { routes } from "../../navigation/Routes";
 import { OpenShiftInstanceStatus } from "../../openshift/OpenShiftInstanceStatus";
-import { setPageTitle } from "../../PageTitle";
 import { obfuscate } from "../github/GitHubSettings";
 import { useSettings, useSettingsDispatch } from "../SettingsContext";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { SettingsPageProps } from "../types";
 import { saveConfigCookie } from "./OpenShiftSettingsConfig";
 import { OpenShiftSettingsSimpleConfig } from "./OpenShiftSettingsSimpleConfig";
@@ -66,23 +65,17 @@ export function OpenShiftSettings(props: SettingsPageProps) {
     [settings.openshift.isDevModeEnabled]
   );
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"} isWidthLimited>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for deploying models you design to your OpenShift instance.
-            <br />
-            All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Data you provide here is necessary for deploying models you design to your OpenShift instance.
+          <br />
+          All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection>
         {extendedServices.status !== ExtendedServicesStatus.RUNNING && (
           <>
@@ -164,6 +157,6 @@ export function OpenShiftSettings(props: SettingsPageProps) {
           <OpenShiftSettingsSimpleConfig />
         </Modal>
       )}
-    </Page>
+    </SettingsPageContainer>
   );
 }

--- a/packages/serverless-logic-web-tools/src/settings/serviceAccount/ServiceAccountSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/serviceAccount/ServiceAccountSettings.tsx
@@ -22,25 +22,24 @@ import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-co
 import { ActionGroup, Form, FormAlert, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup, InputGroupText } from "@patternfly/react-core/dist/js/components/InputGroup";
 import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { AddCircleOIcon } from "@patternfly/react-icons/dist/js/icons/add-circle-o-icon";
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import HelpIcon from "@patternfly/react-icons/dist/js/icons/help-icon";
 import { TimesIcon } from "@patternfly/react-icons/dist/js/icons/times-icon";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
 import { useExtendedServices } from "../../extendedServices/ExtendedServicesContext";
 import { ExtendedServicesStatus } from "../../extendedServices/ExtendedServicesStatus";
 import { routes } from "../../navigation/Routes";
-import { setPageTitle } from "../../PageTitle";
 import { QuickStartIds } from "../../quickstarts-data";
 import { useSettings, useSettingsDispatch } from "../SettingsContext";
 import { SettingsPageProps } from "../types";
 import { EMPTY_CONFIG, isServiceAccountConfigValid, resetConfigCookie, saveConfigCookie } from "./ServiceAccountConfig";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 
 const PAGE_TITLE = "Service Account";
 
@@ -99,22 +98,16 @@ export function ServiceAccountSettings(props: SettingsPageProps) {
     saveConfigCookie(config);
   }, [config, settingsDispatch.serviceAccount]);
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"} isWidthLimited>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for uploading Open API specs associated with models you design to your
-            Service Registry instance. All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Data you provide here is necessary for uploading Open API specs associated with models you design to your
+          Service Registry instance. All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection>
         {extendedServices.status !== ExtendedServicesStatus.RUNNING && (
           <>
@@ -309,7 +302,7 @@ export function ServiceAccountSettings(props: SettingsPageProps) {
           </Form>
         </Modal>
       )}
-    </Page>
+    </SettingsPageContainer>
   );
 }
 

--- a/packages/serverless-logic-web-tools/src/settings/serviceAccount/ServiceAccountSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/serviceAccount/ServiceAccountSettings.tsx
@@ -104,7 +104,9 @@ export function ServiceAccountSettings(props: SettingsPageProps) {
       subtitle={
         <>
           Data you provide here is necessary for uploading Open API specs associated with models you design to your
-          Service Registry instance. All information is locally stored in your browser and never shared with anyone.
+          Service Registry instance.
+          <br />
+          All information is locally stored in your browser and never shared with anyone.
         </>
       }
     >

--- a/packages/serverless-logic-web-tools/src/settings/serviceRegistry/ServiceRegistrySettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/serviceRegistry/ServiceRegistrySettings.tsx
@@ -22,7 +22,7 @@ import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-co
 import { ActionGroup, Form, FormAlert, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup, InputGroupText } from "@patternfly/react-core/dist/js/components/InputGroup";
 import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
@@ -30,15 +30,14 @@ import { AddCircleOIcon } from "@patternfly/react-icons/dist/js/icons/add-circle
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import HelpIcon from "@patternfly/react-icons/dist/js/icons/help-icon";
 import { TimesIcon } from "@patternfly/react-icons/dist/js/icons/times-icon";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
 import { useExtendedServices } from "../../extendedServices/ExtendedServicesContext";
 import { ExtendedServicesStatus } from "../../extendedServices/ExtendedServicesStatus";
 import { routes } from "../../navigation/Routes";
-import { setPageTitle } from "../../PageTitle";
 import { QuickStartIds } from "../../quickstarts-data";
 import { useSettings, useSettingsDispatch } from "../SettingsContext";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { SettingsPageProps } from "../types";
 import {
   EMPTY_CONFIG,
@@ -98,22 +97,16 @@ export function ServiceRegistrySettings(props: SettingsPageProps) {
     saveConfigCookie(config);
   }, [config, settingsDispatch.serviceRegistry]);
 
-  useEffect(() => {
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
-  }, []);
-
   return (
-    <Page>
-      <PageSection variant={"light"} isWidthLimited>
-        <TextContent>
-          <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-          <Text component={TextVariants.p}>
-            Data you provide here is necessary for uploading specs associated with models you design to your Service
-            Registry instance. All information is locally stored in your browser and never shared with anyone.
-          </Text>
-        </TextContent>
-      </PageSection>
-
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Data you provide here is necessary for uploading specs associated with models you design to your Service
+          Registry instance. All information is locally stored in your browser and never shared with anyone.
+        </>
+      }
+    >
       <PageSection>
         {!isExtendedServicesRunning && (
           <>
@@ -320,6 +313,6 @@ export function ServiceRegistrySettings(props: SettingsPageProps) {
           </Form>
         </Modal>
       )}
-    </Page>
+    </SettingsPageContainer>
   );
 }

--- a/packages/serverless-logic-web-tools/src/settings/serviceRegistry/ServiceRegistrySettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/serviceRegistry/ServiceRegistrySettings.tsx
@@ -103,7 +103,9 @@ export function ServiceRegistrySettings(props: SettingsPageProps) {
       subtitle={
         <>
           Data you provide here is necessary for uploading specs associated with models you design to your Service
-          Registry instance. All information is locally stored in your browser and never shared with anyone.
+          Registry instance.
+          <br />
+          All information is locally stored in your browser and never shared with anyone.
         </>
       }
     >

--- a/packages/serverless-logic-web-tools/src/settings/storage/StorageSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/storage/StorageSettings.tsx
@@ -18,17 +18,15 @@ import React from "react";
 import { Alert, AlertActionCloseButton, Button } from "@patternfly/react-core/dist/js";
 import { Checkbox } from "@patternfly/react-core/dist/js/components/Checkbox";
 import { Form } from "@patternfly/react-core/dist/js/components/Form";
-import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
-import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
+import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { useCallback, useEffect, useState } from "react";
-import { APP_NAME } from "../../AppConstants";
-import { routes } from "../../navigation/Routes";
-import { setPageTitle } from "../../PageTitle";
-import { SETTINGS_PAGE_SECTION_TITLE } from "../SettingsContext";
-import { isBrowserChromiumBased } from "../../workspace/startupBlockers/SupportedBrowsers";
 import { useHistory } from "react-router";
 import { useGlobalAlert } from "../../alerts/GlobalAlertsContext";
+import { APP_NAME } from "../../AppConstants";
+import { routes } from "../../navigation/Routes";
 import { ConfirmDeleteModal } from "../../table";
+import { isBrowserChromiumBased } from "../../workspace/startupBlockers/SupportedBrowsers";
+import { SettingsPageContainer } from "../SettingsPageContainer";
 import { useStorage } from "./useStorage";
 
 const PAGE_TITLE = "Storage";
@@ -74,71 +72,66 @@ export function StorageSettings() {
     if (!isBrowserChromiumBased()) {
       history.replace(routes.settings.home.path({}));
     }
-    setPageTitle([SETTINGS_PAGE_SECTION_TITLE, PAGE_TITLE]);
   }, [history]);
 
   return (
-    <>
-      <Page>
-        <PageSection variant={"light"} isWidthLimited>
-          <TextContent>
-            <Text component={TextVariants.h1}>{PAGE_TITLE}</Text>
-            <Text component={TextVariants.p}>
-              Here, you have the ability to completely erase all stored data in your browser.
+    <SettingsPageContainer
+      pageTitle={PAGE_TITLE}
+      subtitle={
+        <>
+          Here, you have the ability to completely erase all stored data in your browser.
+          <br />
+          Safely delete your cookies, modules, settings and all information locally stored in your browser, giving a
+          fresh start to {APP_NAME}.
+        </>
+      }
+    >
+      <PageSection>
+        <PageSection variant={"light"}>
+          <Form>
+            <Checkbox
+              id="delete-indexedDB"
+              label="Storage"
+              description={"Delete all databases. You will lose all your modules and workspaces."}
+              isChecked
+              isDisabled
+            />
+            <Alert
+              variant="warning"
+              isInline
+              title="By selecting the cookies and local storage, all your saved settings will be permanently erased."
+            >
               <br />
-              Safely delete your cookies, modules, settings and all information locally stored in your browser, giving a
-              fresh start to {APP_NAME}.
-            </Text>
-          </TextContent>
-        </PageSection>
-
-        <PageSection>
-          <PageSection variant={"light"}>
-            <Form>
               <Checkbox
-                id="delete-indexedDB"
-                label="Storage"
-                description={"Delete all databases. You will lose all your modules and workspaces."}
-                isChecked
-                isDisabled
+                id="delete-cookies"
+                label="Cookies"
+                description={"Delete all cookies."}
+                isChecked={isDeleteCookiesChecked}
+                onChange={setDeleteCookiesChecked}
               />
-              <Alert
-                variant="warning"
-                isInline
-                title="By selecting the cookies and local storage, all your saved settings will be permanently erased."
-              >
-                <br />
-                <Checkbox
-                  id="delete-cookies"
-                  label="Cookies"
-                  description={"Delete all cookies."}
-                  isChecked={isDeleteCookiesChecked}
-                  onChange={setDeleteCookiesChecked}
-                />
-                <br />
-                <Checkbox
-                  id="delete-localStorage"
-                  label="LocalStorage"
-                  description={"Delete all localStorage information."}
-                  isChecked={isDeleteLocalStorageChecked}
-                  onChange={setDeleteLocalStorageChecked}
-                />
-              </Alert>
-            </Form>
-            <br />
-            <Button variant="danger" onClick={toggleConfirmModal}>
-              Delete data
-            </Button>
-          </PageSection>
+              <br />
+              <Checkbox
+                id="delete-localStorage"
+                label="LocalStorage"
+                description={"Delete all localStorage information."}
+                isChecked={isDeleteLocalStorageChecked}
+                onChange={setDeleteLocalStorageChecked}
+              />
+            </Alert>
+          </Form>
+          <br />
+          <Button variant="danger" onClick={toggleConfirmModal}>
+            Delete data
+          </Button>
         </PageSection>
-        <ConfirmDeleteModal
-          isOpen={isConfirmDeleteModalOpen}
-          onClose={toggleConfirmModal}
-          onDelete={onConfirmDeleteModalDelete}
-          elementsTypeName="data"
-          deleteMessage="All stored information will be permanently deleted and you will be redirected to the Overview page."
-        />
-      </Page>
-    </>
+      </PageSection>
+      <ConfirmDeleteModal
+        isOpen={isConfirmDeleteModalOpen}
+        onClose={toggleConfirmModal}
+        onDelete={onConfirmDeleteModalDelete}
+        elementsTypeName="data"
+        deleteMessage="All stored information will be permanently deleted and you will be redirected to the Overview page."
+      />
+    </SettingsPageContainer>
   );
 }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-9257

**Description**
Currently, the only way how to get from settings is to click the main logo.
It might be confusing for the users to get back to the main navigation.

[KOGITO-9257.webm](https://github.com/kiegroup/kie-tools/assets/17780574/c596db60-9b36-4e2d-9019-ad467d95e634)
