### PR TITLE
kie-issues#328: Fix CVE-2021-23353, CVE-2020-7691 & CVE-2020-7690 (jspdf@1.2.6) in kie-tools

### DIFF
--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -173,7 +173,7 @@
     <!-- Notice actually there exists a 1.3.3 version for jsPDF, but using this one
         produces a conflict with the UF ace js plugin once trying to create a new jsPDF
         instance.-->
-    <version.org.webjars.bower.jspdf>1.2.61</version.org.webjars.bower.jspdf>
+    <version.org.webjars.bowergithub.mrrio.jspdf>2.3.1</version.org.webjars.bowergithub.mrrio.jspdf>
     <version.org.webjars.bowergithub.gliffy.canvas2svg>0.1</version.org.webjars.bowergithub.gliffy.canvas2svg>
     <version.org.webjars.bower.mustachejs>3.0.1</version.org.webjars.bower.mustachejs>
     <version.org.webjars.bower.jqueryui>1.12.1</version.org.webjars.bower.jqueryui>

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -169,9 +169,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.webjars.bower</groupId>
+                  <groupId>org.webjars.bowergithub.mrrio</groupId>
                   <artifactId>jspdf</artifactId>
-                  <version>${version.org.webjars.bower.jspdf}</version>
+                  <version>${version.org.webjars.bowergithub.mrrio.jspdf}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jspdf</outputDirectory>
@@ -263,9 +263,9 @@
               <outputDirectory>${project.build.outputDirectory}/org/uberfire/ext/editor/commons/client/file/exports/js</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/jspdf/META-INF/resources/webjars/jspdf/${version.org.webjars.bower.jspdf}/dist/</directory>
+                  <directory>${project.build.directory}/jspdf/META-INF/resources/webjars/jspdf/dist/</directory>
                   <includes>
-                    <include>jspdf.min.js</include>
+                    <include>jspdf.umd.min.js</include>
                   </includes>
                 </resource>
               </resources>

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportResources.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportResources.java
@@ -32,7 +32,7 @@ public interface FileExportResources extends ClientBundle {
     TextResource fileSaver();
 
     // The jsPDF js.
-    @Source("js/jspdf.min.js")
+    @Source("js/jspdf.umd.min.js")
     TextResource jsPdf();
 
     @Source("js/canvas2svg.js")

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
@@ -69,10 +69,10 @@ public class FileExportScriptInjector {
     private String getJsPdfSource() {
         final String jsPdfScript = FileExportResources.INSTANCE.jsPdf().getText();
         final String jsPdfNsObject = buildNamespaceObject(NS + "JsPdf");
-        return jsPdfNsObject + " = function(settings) {" + "\n" +
-                jsPdfScript + "\n" +
-                "var saveAs = " + NS + "JsFileSaver.saveAs; " +
-                "return new jsPDF(settings);};";
+
+        return jsPdfScript + "\n" +
+                jsPdfNsObject + " = function(settings) {" + "\n" +
+                "return new window.jspdf.jsPDF(settings);};";
     }
 
     private String getC2SSource() {

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsPdf.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsPdf.java
@@ -23,7 +23,7 @@ import jsinterop.annotations.JsType;
 
 /**
  * Provides the JsInterop API for jsPdf.
- * Provided by the webjar <code>org.webjars.bower.jspdf</code>.
+ * Provided by the webjar <code>org.webjars.bowergithub.mrrio.jspdf</code>.
  * @see <a href="https://github.com/MrRio/jsPDF">jsPDF.js</a>
  */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
@@ -60,11 +60,10 @@ public class FileExportScriptInjectorTest {
                              " = function(blob, fileName, disableAutoBOM) {\n" +
                              "fileSaver\n" +
                              "return saveAs(blob, fileName, disableAutoBOM);};\n" +
+                             "jsPdf\n" +
                              jsPdfNsObject +
                              " = function(settings) {\n" +
-                             "jsPdf\n" +
-                             "var saveAs = " + NS + "JsFileSaver.saveAs; " +
-                             "return new jsPDF(settings);};" + "\n" +
+                             "return new window.jspdf.jsPDF(settings);};" + "\n" +
                              c2sNsObject + "\n",
                      script);
     }


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/328

Upgrades `jspdf` version to fix the `CVE-2021-23353`, `CVE-2020-7691` & `CVE-2020-7690` vulnerabilities.