### PR TITLE
kie-issues#338: kie-tools - make sure maven.config contains single argument per line

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -56,7 +56,8 @@ runs:
         echo "STEP: Setup default Maven args"
         cd ${{ inputs.working_dir }}
         pnpm -r exec 'bash' '-c' 'mkdir .mvn'
-        pnpm -r exec 'bash' '-c' 'echo -B -ntp > .mvn/maven.config'
+        pnpm -r exec 'bash' '-c' 'echo -B > .mvn/maven.config'
+        pnpm -r exec 'bash' '-c' 'echo -ntp >> .mvn/maven.config'
         pnpm -r exec 'bash' '-c' 'echo -Xmx2g > .mvn/jvm.config'
 
     - name: "Install Fluxbox (Ubuntu only)"

--- a/packages/maven-config-setup-helper/index.js
+++ b/packages/maven-config-setup-helper/index.js
@@ -46,7 +46,7 @@ module.exports = {
       .map((l) => l.trim())
       .join("\n");
 
-    const newMavenConfigString = `${originalMvnConfigString.trim()} ${trimmedMavenConfigString.trim()}`.trim();
+    const newMavenConfigString = `${originalMvnConfigString.trim()}\n${trimmedMavenConfigString.trim()}`.trim();
     console.info(`[maven-config-setup-helper] Writing '${MVN_CONFIG_FILE_PATH}'...`);
     console.info(newMavenConfigString);
     fs.writeFileSync(MVN_CONFIG_FILE_PATH, newMavenConfigString);


### PR DESCRIPTION
Closes kiegroup/kie-issues#338

Making sure each arg inside maven.config is on a separate line as required in Maven 3.9, as per https://issues.apache.org/jira/browse/MNG-7684

Notes:
* EDIT: ~`Setup default Maven args` in setup-env/action.yml used to overwrite maven.config contents because of using `>` for writing into file, switched to `>>` in consecutive writes, keeping `>` in first one.~ Fixing the PR, didn't notice the second write is into jvm.config
* maven-config-setup-helper/index.js was appending original and new args using space, turned to newline as a separator.