### PR TITLE
kie-issues#332: KIE Sandbox's logo not showing and sometimes breaking the header entirely on Safari

### DIFF
--- a/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
+++ b/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
@@ -47,9 +47,7 @@ export function OnlineEditorPage(props: { children?: React.ReactNode; onKeyDown?
                   onClick={() => history.push({ pathname: routes.home.path({}) })}
                   style={{ textDecoration: "none" }}
                 >
-                  <Brand src={routes.static.images.appLogoReverse.path({})} alt={"Logo"} heights={{ default: "38px" }}>
-                    <source srcSet={routes.static.images.appLogoReverse.path({})} />
-                  </Brand>
+                  <img alt={"Logo"} src={routes.static.images.appLogoReverse.path({})} style={{ height: "38px" }} />
                 </MastheadBrand>
                 <AboutButton />
               </Flex>


### PR DESCRIPTION
## issue
Closes https://github.com/kiegroup/kie-issues/issues/332

## On this PR
This PR Removes the Patternfly `Brand` component. Safari is stretching the SVG width to 100vw because it's inside a flex component [1]. The Pattenfly `MaterBrand`  adds a `div` with `display: inline-flex`, and `Brand` was adding a new one. Inside the `Brand` `div` was two tags, `source` and `img` triggering the bug. Keeping just one tag inside the flex component solves the issue.

## Video

https://github.com/kiegroup/kie-tools/assets/24302289/f84d7510-f0a0-4705-8e4d-5db68254df5f



[1] https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
