### PR TITLE
kie-issues#342: specify target origin on postMessage

### DIFF
--- a/packages/editor/src/embedded/embedded/EmbeddedEditor.tsx
+++ b/packages/editor/src/embedded/embedded/EmbeddedEditor.tsx
@@ -103,7 +103,10 @@ const RefForwardingEmbeddedEditor: React.ForwardRefRenderFunction<EmbeddedEditor
 
   const envelopeServer = useMemo(() => {
     return new EnvelopeServer<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>(
-      { postMessage: (message) => iframeRef.current?.contentWindow?.postMessage(message, "*") },
+      {
+        postMessage: (message) =>
+          iframeRef.current?.contentWindow?.postMessage(message, props.editorEnvelopeLocator.targetOrigin),
+      },
       props.editorEnvelopeLocator.targetOrigin,
       (self) =>
         self.envelopeApi.requests.kogitoEditor_initRequest(

--- a/packages/envelope-bus/src/api/index.ts
+++ b/packages/envelope-bus/src/api/index.ts
@@ -128,5 +128,5 @@ export enum EnvelopeBusMessageDirectSender {
 }
 
 export interface EnvelopeBus {
-  postMessage<D, T>(message: EnvelopeBusMessage<D, T>, targetOrigin?: string, _?: any): void;
+  postMessage<D, T>(message: EnvelopeBusMessage<D, T>, targetOrigin: string, _?: any): void;
 }

--- a/packages/envelope-bus/src/channel/EnvelopeServer.ts
+++ b/packages/envelope-bus/src/channel/EnvelopeServer.ts
@@ -57,11 +57,14 @@ export class EnvelopeServer<
     public readonly type: EnvelopeServerType = EnvelopeServerType.REMOTE,
     public readonly manager = new EnvelopeBusMessageManager<ApiToProvide, ApiToConsume>(
       (message) =>
-        bus.postMessage({
-          ...message,
-          targetEnvelopeId: type === EnvelopeServerType.LOCAL ? this.id : undefined,
-          directSender: EnvelopeBusMessageDirectSender.ENVELOPE_SERVER,
-        }),
+        bus.postMessage(
+          {
+            ...message,
+            targetEnvelopeId: type === EnvelopeServerType.LOCAL ? this.id : undefined,
+            directSender: EnvelopeBusMessageDirectSender.ENVELOPE_SERVER,
+          },
+          origin
+        ),
       "EnvelopeServer"
     )
   ) {

--- a/packages/envelope/src/embedded/EmbeddedEnvelopeFactory.tsx
+++ b/packages/envelope/src/embedded/EmbeddedEnvelopeFactory.tsx
@@ -70,9 +70,9 @@ export function RefForwardingEmbeddedEnvelope<
     () => ({
       postMessage<D, T>(message: EnvelopeBusMessage<D, T>) {
         if (props.config.containerType === ContainerType.DIV) {
-          window.postMessage(message, "*");
+          window.postMessage(message, props.origin);
         } else {
-          iframeRef.current?.contentWindow?.postMessage(message, "*");
+          iframeRef.current?.contentWindow?.postMessage(message, props.origin);
         }
       },
     }),

--- a/packages/online-editor/src/envelope/BpmnEditorEnvelopeApp.ts
+++ b/packages/online-editor/src/envelope/BpmnEditorEnvelopeApp.ts
@@ -20,6 +20,6 @@ import * as EditorEnvelope from "@kie-tools-core/editor/dist/envelope";
 
 EditorEnvelope.initCustom<BpmnEditor, BpmnEditorEnvelopeApi, BpmnEditorChannelApi>({
   container: document.getElementById("envelope-app")!,
-  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, "*", _) },
+  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, targetOrigin, _) },
   apiImplFactory: { create: (args) => new BpmnEditorEnvelopeApiImpl(args, { shouldLoadResourcesDynamically: true }) },
 });

--- a/packages/online-editor/src/envelope/DmnEditorEnvelopeApp.ts
+++ b/packages/online-editor/src/envelope/DmnEditorEnvelopeApp.ts
@@ -20,6 +20,6 @@ import * as EditorEnvelope from "@kie-tools-core/editor/dist/envelope";
 
 EditorEnvelope.initCustom<DmnEditor, DmnEditorEnvelopeApi, DmnEditorChannelApi>({
   container: document.getElementById("envelope-app")!,
-  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, "*", _) },
+  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, targetOrigin, _) },
   apiImplFactory: { create: (args) => new DmnEditorEnvelopeApiImpl(args, { shouldLoadResourcesDynamically: true }) },
 });

--- a/packages/online-editor/src/envelope/PMMLEditorEnvelopeApp.ts
+++ b/packages/online-editor/src/envelope/PMMLEditorEnvelopeApp.ts
@@ -19,6 +19,6 @@ import * as EditorEnvelope from "@kie-tools-core/editor/dist/envelope";
 
 EditorEnvelope.init({
   container: document.getElementById("envelope-app")!,
-  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, "*", _) },
+  bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, targetOrigin, _) },
   editorFactory: new PMMLEditorFactory(),
 });


### PR DESCRIPTION
Issue: kiegroup/kie-issues#342

Replacing asterisk in postMessage calls using component properties.