### PR TITLE
kie-issues#344: DMN Editor: Name and Data type popover menu visual misalignments in form labels

### DIFF
--- a/packages/boxed-expression-component/src/contextMenu/PopoverMenu/PopoverMenu.css
+++ b/packages/boxed-expression-component/src/contextMenu/PopoverMenu/PopoverMenu.css
@@ -22,6 +22,7 @@
 .popover-menu-selector .pf-c-title,
 .popover-menu-selector .pf-c-popover__content > .pf-c-button + * {
   padding: 0;
+  text-align: left;
 }
 .popover-menu-selector .pf-c-popover__content {
   padding-bottom: 16px;


### PR DESCRIPTION
This PR closes kiegroup/kie-issues#344


https://github.com/kiegroup/kie-tools/assets/8044780/693bcf52-1216-4f33-9300-dbe76d0d725a

