### PR TITLE
KOGITO-9384: [Dashbuilder] Keep order and ignore empty in Join datasets

### DIFF
--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetReadyCallbackAdapter.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetReadyCallbackAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataset.client;
+
+import org.dashbuilder.common.client.error.ClientRuntimeError;
+import org.dashbuilder.dataset.DataSet;
+
+/**
+ * Used then users do not want to implement all methods from DataSetReadyCallback 
+ *
+ */
+public class DataSetReadyCallbackAdapter implements DataSetReadyCallback {
+
+    @Override
+    public void callback(DataSet dataSet) {
+        // empty
+
+    }
+
+    @Override
+    public void notFound() {
+        // empty
+
+    }
+
+    @Override
+    public boolean onError(ClientRuntimeError error) {
+        // empty
+        return false;
+    }
+
+}

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
@@ -15,7 +15,6 @@
  */
 package org.dashbuilder.client.services;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
@@ -16,6 +16,7 @@
 package org.dashbuilder.client.services;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -47,8 +48,8 @@ public class JoinDataSetsService {
 
     public void joinDataSets(List<String> uuids, DataSetLookup lookup, DataSetReadyCallback listener) {
         var joinedDataSet = DataSetFactory.newEmptyDataSet();
-        var missingDatasets = new ArrayList<String>(uuids);
         var onError = new AtomicBoolean(false);
+        var dataSetsMap = new HashMap<String, DataSet>();
 
         joinedDataSet.setUUID(lookup.getDataSetUUID());
         for (var uuid : uuids) {
@@ -60,9 +61,12 @@ public class JoinDataSetsService {
                     if (onError.get()) {
                         return;
                     }
-                    missingDatasets.remove(uuid);
-                    join(joinedDataSet, dataSet);
-                    if (missingDatasets.isEmpty()) {
+                    dataSetsMap.put(uuid, dataSet);
+                    if (dataSetsMap.size() == uuids.size()) {
+                        uuids.stream()
+                                .map(dataSetsMap::get)
+                                .filter(ds -> !isEmpty(ds))
+                                .forEach(ds -> join(joinedDataSet, ds));
                         manager.registerDataSet(joinedDataSet);
                         var result = manager.lookupDataSet(lookup);
                         manager.removeDataSet(lookup.getDataSetUUID());
@@ -139,6 +143,10 @@ public class JoinDataSetsService {
         dataSet.getColumns().forEach((cl -> joinedDataSet.addColumn(cl.getId(), cl.getColumnType())));
         joinedDataSet.addColumn(DATASET_COLUMN, ColumnType.LABEL);
 
+    }
+
+    private boolean isEmpty(DataSet dataSet) {
+        return dataSet.getRowCount() == 0 && (dataSet.getColumns() == null || dataSet.getColumns().isEmpty());
     }
 
 }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/services/JoinDataSetsServiceTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/services/JoinDataSetsServiceTest.java
@@ -25,6 +25,7 @@ import org.dashbuilder.dataset.DataSetFactory;
 import org.dashbuilder.dataset.DataSetLookupFactory;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
+import org.dashbuilder.dataset.client.DataSetReadyCallbackAdapter;
 import org.dashbuilder.dataset.def.DataSetDefFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class JoinDataSetsServiceTest {
         joinService.join(result, d2);
         verifyDataSet(result);
     }
-    
+
     @Test
     public void testJoinSingleDataSet() {
         var result = DataSetFactory.newEmptyDataSet();
@@ -126,18 +127,7 @@ public class JoinDataSetsServiceTest {
                 .column(JoinDataSetsService.DATASET_COLUMN)
                 .buildLookup();
 
-        joinService.joinDataSets(List.of(DS1_UUID, DS2_UUID), lookup, new DataSetReadyCallback() {
-
-            @Override
-            public boolean onError(ClientRuntimeError error) {
-                // should not be called
-                return false;
-            }
-
-            @Override
-            public void notFound() {
-                // should not be called
-            }
+        joinService.joinDataSets(List.of(DS1_UUID, DS2_UUID), lookup, new DataSetReadyCallbackAdapter() {
 
             @Override
             public void callback(DataSet result) {
@@ -152,6 +142,56 @@ public class JoinDataSetsServiceTest {
 
         ds1DatasetCallbackCaptor.getValue().callback(d1);
         ds2DatasetCallbackCaptor.getValue().callback(d2);
+    }
+
+    @Test
+    public void testJoinDatasetsKeepOrder() {
+        var lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(RESULT_UUID)
+                .column(C1_ID)
+                .column(C2_ID)
+                .column(JoinDataSetsService.DATASET_COLUMN)
+                .buildLookup();
+
+        joinService.joinDataSets(List.of(DS2_UUID, DS1_UUID), lookup, new DataSetReadyCallbackAdapter() {
+
+            @Override
+            public void callback(DataSet result) {
+                assertEquals(List.of("ds2", "ds2", "ds1", "ds1"),
+                        result.getColumnById(JoinDataSetsService.DATASET_COLUMN).getValues());
+            }
+
+        });
+        verify(externalDataSetClientProvider).fetchAndRegister(eq(DS1_UUID), any(), ds1DatasetCallbackCaptor.capture());
+        verify(externalDataSetClientProvider).fetchAndRegister(eq(DS2_UUID), any(), ds2DatasetCallbackCaptor.capture());
+
+        ds1DatasetCallbackCaptor.getValue().callback(d1);
+        ds2DatasetCallbackCaptor.getValue().callback(d2);
+    }
+
+    @Test
+    public void testJoinDatasetsIgnoringEmpty() {
+        var lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .dataset(RESULT_UUID)
+                .column(C1_ID)
+                .column(C2_ID)
+                .column(JoinDataSetsService.DATASET_COLUMN)
+                .buildLookup();
+
+
+        joinService.joinDataSets(List.of(DS1_UUID, DS2_UUID), lookup, new DataSetReadyCallbackAdapter() {
+
+            @Override
+            public void callback(DataSet result) {
+                verifyDataSetD1(result);
+            }
+
+        });
+        verify(externalDataSetClientProvider).fetchAndRegister(eq(DS1_UUID), any(), ds1DatasetCallbackCaptor.capture());
+        verify(externalDataSetClientProvider).fetchAndRegister(eq(DS2_UUID), any(), ds2DatasetCallbackCaptor.capture());
+
+        ds1DatasetCallbackCaptor.getValue().callback(d1);
+        ds2DatasetCallbackCaptor.getValue().callback(DataSetFactory.newEmptyDataSet());
     }
 
     @Test
@@ -190,6 +230,16 @@ public class JoinDataSetsServiceTest {
 
         verify(datasetReadyCallback, times(1)).onError(any());
         verify(datasetReadyCallback, times(0)).callback(any());
+    }
+
+    private void verifyDataSetD1(DataSet result) {
+        assertEquals(List.of("D1_C1_R1", "D1_C1_R2"),
+                result.getColumnById(C1_ID).getValues());
+        assertEquals(List.of("D1_C2_R1", "D1_C2_R2"),
+                result.getColumnById(C2_ID).getValues());
+        assertEquals(List.of("ds1", "ds1"),
+                result.getColumnById(JoinDataSetsService.DATASET_COLUMN).getValues());
+        assertEquals(2, result.getRowCount());
     }
 
     private void verifyDataSet(DataSet result) {


### PR DESCRIPTION
When using Join datasets we noticed two main problems:

* The result order may change, which impacts the legends in series (the color will change according to the order)
* Some datasets may be empty and added later

This is a  fix for these two problems.