### PR TITLE
NO-ISSUE: Bump `guava` to `32.0.1`

### DIFF
--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -258,7 +258,7 @@
     <!-- Third party Libraries -->
     <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.guava>32.0.1-jre</version.com.google.guava>
+    <version.com.google.guava>30.1-jre</version.com.google.guava>
     <version.gwt.nio>1.1</version.gwt.nio>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -258,7 +258,7 @@
     <!-- Third party Libraries -->
     <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.guava>30.1-jre</version.com.google.guava>
+    <version.com.google.guava>32.0.1-jre</version.com.google.guava>
     <version.gwt.nio>1.1</version.gwt.nio>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -266,7 +266,7 @@
     <!-- Third party Libraries -->
     <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.guava>30.1-jre</version.com.google.guava>
+    <version.com.google.guava>32.0.1-jre</version.com.google.guava>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
     <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>


### PR DESCRIPTION
Current version is affected by CVE-2023-2976

Not applicable in the SWF code, as it requires GWT 2.10 (because of [nanoTime](https://github.com/gwtproject/gwt/commit/595bc258f227c047e18b5301cef063eee0305b3c ) not emulated in versions < 2.10).