### PR TITLE
kie-issues#346: DMN Editor: Enable `Duplicate` operation just for DecisionTable and Relation expressions

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -198,7 +198,6 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
           { name: i18n.rowOperations.insertAbove, type: BeeTableOperation.RowInsertAbove },
           { name: i18n.rowOperations.insertBelow, type: BeeTableOperation.RowInsertBelow },
           { name: i18n.rowOperations.delete, type: BeeTableOperation.RowDelete },
-          { name: i18n.rowOperations.duplicate, type: BeeTableOperation.RowDuplicate },
         ],
       },
       {
@@ -332,7 +331,6 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
                 ? [BeeTableOperation.RowDelete]
                 : []), // do not delete <result>
               BeeTableOperation.RowReset,
-              ...(rowIndex !== contextExpression.contextEntries.length ? [BeeTableOperation.RowDuplicate] : []), // do not duplicate <result>
             ]
           : []),
       ];

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -233,7 +233,6 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
           { name: i18n.rowOperations.insertAbove, type: BeeTableOperation.RowInsertAbove },
           { name: i18n.rowOperations.insertBelow, type: BeeTableOperation.RowInsertBelow },
           { name: i18n.rowOperations.delete, type: BeeTableOperation.RowDelete },
-          { name: i18n.rowOperations.duplicate, type: BeeTableOperation.RowDuplicate },
         ],
       },
       {
@@ -332,7 +331,6 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
               BeeTableOperation.RowInsertBelow,
               ...(beeTableRows.length > 1 ? [BeeTableOperation.RowDelete] : []),
               BeeTableOperation.RowReset,
-              BeeTableOperation.RowDuplicate,
             ]
           : []),
       ];

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
@@ -83,7 +83,6 @@ export function ListExpression(listExpression: ListExpressionDefinition & { isNe
           { name: i18n.rowOperations.insertAbove, type: BeeTableOperation.RowInsertAbove },
           { name: i18n.rowOperations.insertBelow, type: BeeTableOperation.RowInsertBelow },
           { name: i18n.rowOperations.delete, type: BeeTableOperation.RowDelete },
-          { name: i18n.rowOperations.duplicate, type: BeeTableOperation.RowDuplicate },
         ],
       },
     ],
@@ -198,7 +197,6 @@ export function ListExpression(listExpression: ListExpressionDefinition & { isNe
               BeeTableOperation.RowInsertBelow,
               ...(beeTableRows.length > 1 ? [BeeTableOperation.RowDelete] : []),
               BeeTableOperation.RowReset,
-              BeeTableOperation.RowDuplicate,
             ]
           : []),
       ];

--- a/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
@@ -342,7 +342,7 @@ export function RelationExpression(relationExpression: RelationExpressionDefinit
               BeeTableOperation.RowInsertBelow,
               ...(beeTableRows.length > 1 ? [BeeTableOperation.RowDelete] : []),
               BeeTableOperation.RowReset,
-              BeeTableOperation.RowDuplicate,
+              // BeeTableOperation.RowDuplicate, https://github.com/kiegroup/kie-issues/issues/347
             ]
           : []),
       ];


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/346

This is follow-up PR for #1652 .

We found out, 'Duplicate' operation as not suitable for expressions, where rows consists of complex expressions, other than literal cells.