### PR TITLE
KOGITO-9295: Wrong selection counter when deleting a file in another tab

### DIFF
--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
@@ -194,6 +194,14 @@ export function RecentModels() {
     setPageTitle([PAGE_TITLE]);
   }, []);
 
+  useEffect(() => {
+    if (workspaceDescriptorsPromise.data) {
+      setSelectedWorkspaceIds((selectedIds) =>
+        selectedIds.filter((id) => workspaceDescriptorsPromise.data.some((element) => element.workspaceId === id))
+      );
+    }
+  }, [workspaceDescriptorsPromise]);
+
   return (
     <PromiseStateWrapper
       promise={workspaceDescriptorsPromise}

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFiles.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/workspaceFiles/WorkspaceFiles.tsx
@@ -170,7 +170,13 @@ export function WorkspaceFiles(props: Props) {
   }, [searchValue]);
 
   useEffect(() => {
-    setSelectedWorkspaceFiles([]);
+    if (workspacePromise.data?.files) {
+      setSelectedWorkspaceFiles((selectedFiles) =>
+        selectedFiles.filter((sFile) =>
+          workspacePromise.data.files.some((wFile) => wFile.relativePath === sFile.relativePath)
+        )
+      );
+    }
   }, [workspacePromise]);
 
   return (


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-9295

**Steps to Reproduce:**
- Open Recent Models
- Select some workspaces, e.g. 4
- The counter shows "4 selected"
- Open Recent Models in another tab
- Delete one of the selected workspaces
- Go back to the first tab
- There are 3 selected items but the counter still shows "4 selected"


[KOGITO-9295.webm](https://github.com/kiegroup/kie-tools/assets/17780574/004bc90e-7513-4a08-85a7-bd35b4bdf7db)
