### PR TITLE
NO-ISSUE: Add Content Security Policy header to `httpd` server

### DIFF
--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -20,6 +20,7 @@ RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.53-11.el9
   && microdnf --disableplugin=subscription-manager clean all \
   && sed -i -e 's/Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/#ServerName www.example.com:80/ServerName 127.0.0.1:8080/' /etc/httpd/conf/httpd.conf \
+  && sed -i -e "/ServerName 127.0.0.1:8080/aHeader set Content-Security-Policy \"frame-ancestors 'self';\"" /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/Options Indexes FollowSymLinks/Options -Indexes +FollowSymLinks/' /etc/httpd/conf/httpd.conf \
   && mkdir /kie-sandbox \
   && mv -t /kie-sandbox /tmp/entrypoint.sh /tmp/image-env-to-json-standalone /tmp/EnvJson.schema.json \


### PR DESCRIPTION
## On this PR
Add the Content Security Policy header to the `httpd` server to avoid a Clickjacking attack, where it's possible to embed kie-sandbox into a frame.

## Example
### HTML
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>
<body>
    <p>clickjacking</p>
    <!-- <iframe src="<sandbox url>" width="1000px" height="1000px"></iframe> -->
</body>
</html>
```


### Without Content Security Policy
<img width="1068" alt="Screenshot 2023-06-15 at 19 27 39" src="https://github.com/kiegroup/kie-tools/assets/24302289/d5526301-f6fe-4c41-85bb-0eee2ba97983">

### With Content Security Policy
<img width="1068" alt="Screenshot 2023-06-15 at 19 27 24" src="https://github.com/kiegroup/kie-tools/assets/24302289/89599740-54cd-4b4e-adf6-f932e375a248">
