### PR TITLE
kie-issues#348: DMN Editor: Function header context menus are empty

### DIFF
--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
@@ -102,6 +102,10 @@ export function FeelFunctionExpression({
   const beeTableOperationConfig = useMemo<BeeTableOperationConfig>(() => {
     return [
       {
+        group: _.upperCase(i18n.terms.selection),
+        items: [{ name: i18n.terms.copy, type: BeeTableOperation.SelectionCopy }],
+      },
+      {
         group: _.upperCase(i18n.function),
         items: [{ name: i18n.rowOperations.reset, type: BeeTableOperation.RowReset }],
       },

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -151,6 +151,10 @@ export function JavaFunctionExpression({
   const beeTableOperationConfig = useMemo<BeeTableOperationConfig>(() => {
     return [
       {
+        group: _.upperCase(i18n.terms.selection),
+        items: [{ name: i18n.terms.copy, type: BeeTableOperation.SelectionCopy }],
+      },
+      {
         group: _.upperCase(i18n.function),
         items: [{ name: i18n.rowOperations.reset, type: BeeTableOperation.RowReset }],
       },

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
@@ -130,6 +130,10 @@ export function PmmlFunctionExpression({
   const beeTableOperationConfig = useMemo<BeeTableOperationConfig>(() => {
     return [
       {
+        group: _.upperCase(i18n.terms.selection),
+        items: [{ name: i18n.terms.copy, type: BeeTableOperation.SelectionCopy }],
+      },
+      {
         group: _.upperCase(i18n.function),
         items: [{ name: i18n.rowOperations.reset, type: BeeTableOperation.RowReset }],
       },


### PR DESCRIPTION
Closes kiegroup/kie-issues#348
Each function cell should offer 'Copy' as available operation in context menu

