### PR TITLE
NO-ISSUE: Switch cors-proxy dependency (maintain original isomorphic-git package-lock dependencies)

### DIFF
--- a/packages/git-cors-proxy-image/package.json
+++ b/packages/git-cors-proxy-image/package.json
@@ -19,15 +19,15 @@
     "build:prod:win32": "echo \"Build not supported on Windows\"",
     "cleanup": "rimraf dist-dev && mkdir dist-dev",
     "copy:git-cors-proxy-package": "run-script-os",
-    "copy:git-cors-proxy-package:linux:darwin": "cp -R ./node_modules/@pefernan/cors-proxy/ dist-dev/git-cors-proxy",
+    "copy:git-cors-proxy-package:linux:darwin": "cp -R ./node_modules/@thiagoelg/cors-proxy/ dist-dev/git-cors-proxy",
     "copy:git-cors-proxy-package:win32": "echo \"Copy git-cors-proxy package not supported on Windows\"",
     "docker:build": "run-script-if --bool $([ $(command -v docker) ] && echo true || echo false) --then \"docker build $(echo $(build-env gitCorsProxy.image.buildTags) | xargs printf -- \"-t $(build-env gitCorsProxy.image.registry)/$(build-env gitCorsProxy.image.account)/$(build-env gitCorsProxy.image.name):%s\n\" | xargs echo) . -f Containerfile\" --else \"echo Docker not found, skipping image build.\"",
     "podman:build": "run-script-if --bool $([ $(command -v podman) ] && echo true || echo false) --then \"podman build $(echo $(build-env gitCorsProxy.image.buildTags) | xargs printf -- \"-t $(build-env gitCorsProxy.image.registry)/$(build-env gitCorsProxy.image.account)/$(build-env gitCorsProxy.image.name):%s\n\" | xargs echo) -f Containerfile\" --else \"echo Podman not found, skipping image build.\"",
-    "start": "cd ./node_modules/@pefernan/cors-proxy && pnpm start -p 8080"
+    "start": "cd ./node_modules/@thiagoelg/cors-proxy && pnpm start -p 8080"
   },
   "devDependencies": {
     "@kie-tools/root-env": "workspace:*",
-    "@pefernan/cors-proxy": "^0.0.3",
+    "@thiagoelg/cors-proxy": "^0.0.1",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3904,9 +3904,9 @@ importers:
       "@kie-tools/root-env":
         specifier: workspace:*
         version: link:../root-env
-      "@pefernan/cors-proxy":
-        specifier: ^0.0.3
-        version: 0.0.3
+      "@thiagoelg/cors-proxy":
+        specifier: ^0.0.1
+        version: 0.0.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -14404,22 +14404,6 @@ packages:
     resolution:
       { integrity: sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q== }
 
-  /@pefernan/cors-proxy@0.0.3:
-    resolution:
-      { integrity: sha512-gEb0hRRYnOEvLpl1oQj2NWQBtSphFETdW0emXrMKPX5HTo8Q9DERXnmlOHE4alo54KG2nEM7l9WKAdmzJInZpQ== }
-    hasBin: true
-    dependencies:
-      cross-env: 5.2.1
-      daemonize-process: 1.0.9
-      micro: 9.3.4
-      micro-cors: 0.1.1
-      minimisted: 2.0.1
-      node-fetch: 2.6.11
-      tree-kill: 1.2.2
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /@pnpm/build-modules@9.3.5(@pnpm/logger@4.0.0):
     resolution:
       { integrity: sha512-R2Lvw7EcXFXdyMuohWK4JIew255hge484OLl7mButULJ6/PPvgjs1ph6nT+pROcdaxic/yVVVuVvd6WPlyE1oA== }
@@ -15844,6 +15828,22 @@ packages:
       "@babel/runtime": 7.16.7
       "@testing-library/dom": 7.31.0
       react: 17.0.2
+    dev: true
+
+  /@thiagoelg/cors-proxy@0.0.1:
+    resolution:
+      { integrity: sha512-bWuahxgmL4D7GgcaoI7YygUzwD1/tx3F7c7OzNhinQM8A+VYdmu2M+2RuronAfCDTsEmumMqFSZoF3FD/p58kQ== }
+    hasBin: true
+    dependencies:
+      cross-env: 5.2.1
+      daemonize-process: 1.0.9
+      micro: 9.3.4
+      micro-cors: 0.1.1
+      minimisted: 2.0.1
+      node-fetch: 2.6.11
+      tree-kill: 1.2.2
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@tootallnate/once@1.1.2:
@@ -28612,7 +28612,7 @@ packages:
       chalk: 4.1.2
       fs-extra: 9.1.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.6.7
+      node-fetch: 2.6.11
       progress: 2.0.3
       semver: 7.3.8
       tar-fs: 2.1.1


### PR DESCRIPTION
Previous version (`@pefernan/cors-proxy@0.0.3`) had deleted the entire `package-lock.json` file, causing all dependencies to be upgraded, which broke the app.

This new version (`@thiagoelg/cors-proxy@0.0.1`) only upgraded what had CVEs, so we're keeping the app stable and upgrade only what was necessary.