### PR TITLE
NO-ISSUE: Bump up the Golang version 1.19.10

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -33,10 +33,10 @@ runs:
         java-version: 11
         distribution: "zulu"
 
-    - name: "Set up GOLANG 1.19.8"
+    - name: "Set up GOLANG 1.19.10"
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.8"
+        go-version: "1.19.10"
 
     - name: "Set up Maven"
       uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f #v4.5

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start building the KIE Tools project, you're going to need:
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Maven `3.8.6`
 - Java `11`
-- Go `1.19.8` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.19.10` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 > **ℹ️ NOTE:** Some packages will require that `make` is available as well.
 

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -12,7 +12,7 @@ All the commands in this section should be performed in the monorepo root.
 
 - Node `>= 18.14.0` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
-- Go `1.19.8` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.19.10` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 ### Installing and linking dependencies
 


### PR DESCRIPTION
The https://github.com/kiegroup/kie-tools/pull/1762 bumped the Golang version to 1.19.8 to solve some CVEs, but new ones were found in 1.19.8 and 1.19.9. [1]

This PR bumps to 1.19.10 to avoid any CVE.

[1] https://nvd.nist.gov/vuln/search/results?form_type=Basic&results_type=overview&query=golang&search_type=all&isCpeNameSearch=false