### PR TITLE
KOGITO-9279: Enable JSON schemas for forms on Dev Mode

### DIFF
--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
@@ -64,9 +64,9 @@
       </dependency>
 
       <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>quarkus-kogito-bom</artifactId>
-        <version>${quarkus.platform.version}</version>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-bom</artifactId>
+        <version>1.39.0.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
@@ -31,10 +31,11 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <kogito.bom.version>1.39.0.Final</kogito.bom.version>
+    <kogito.bom.version>1.40.0.Final</kogito.bom.version>
     <io.swagger.parser.v3.swagger-parser-v3.version>2.1.12</io.swagger.parser.v3.swagger-parser-v3.version>
     <org.apache.commons.commons-compress.version>1.22</org.apache.commons.commons-compress.version>
     <com.github.erosb.everit-json-schema.version>1.14.2</com.github.erosb.everit-json-schema.version>
+    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>
 
   <repositories>
@@ -127,12 +128,6 @@
       <groupId>com.github.erosb</groupId>
       <artifactId>everit-json-schema</artifactId>
       <version>${com.github.erosb.everit-json-schema.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -143,12 +138,6 @@
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser-v3</artifactId>
       <version>${io.swagger.parser.v3.swagger-parser-v3.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -180,6 +169,16 @@
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
@@ -31,12 +31,13 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
-    <io.swagger.parser.v3-swagger-parser-v3-version>2.1.12</io.swagger.parser.v3-swagger-parser-v3-version>
-    <org.apache.commons-commons-compress-version>1.22</org.apache.commons-commons-compress-version>
-    <com.networknt-json-schema-validator>1.0.83</com.networknt-json-schema-validator>
+    <kogito.bom.version>1.39.0.Final</kogito.bom.version>
+    <io.swagger.parser.v3.swagger-parser-v3.version>2.1.12</io.swagger.parser.v3.swagger-parser-v3.version>
+    <org.apache.commons.commons-compress.version>1.22</org.apache.commons.commons-compress.version>
+    <com.github.erosb.everit-json-schema.version>1.14.2</com.github.erosb.everit-json-schema.version>
   </properties>
 
-   <repositories>
+  <repositories>
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
@@ -64,9 +65,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-bom</artifactId>
-        <version>1.39.0.Final</version>
+        <groupId>${kogito.bom.group-id}</groupId>
+        <artifactId>${kogito.bom.artifact-id}</artifactId>
+        <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -119,19 +120,35 @@
       <artifactId>kogito-addons-quarkus-source-files</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>${org.apache.commons-commons-compress-version}</version>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-jobs-service-embedded</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.networknt</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>${com.networknt-json-schema-validator}</version>
+      <groupId>com.github.erosb</groupId>
+      <artifactId>everit-json-schema</artifactId>
+      <version>${com.github.erosb.everit-json-schema.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${org.apache.commons.commons-compress.version}</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser-v3</artifactId>
-      <version>${io.swagger.parser.v3-swagger-parser-v3-version}</version>
+      <version>${io.swagger.parser.v3.swagger-parser-v3.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/pom.xml
@@ -33,6 +33,7 @@
     <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
     <io.swagger.parser.v3-swagger-parser-v3-version>2.1.12</io.swagger.parser.v3-swagger-parser-v3-version>
     <org.apache.commons-commons-compress-version>1.22</org.apache.commons-commons-compress-version>
+    <com.networknt-json-schema-validator>1.0.83</com.networknt-json-schema-validator>
   </properties>
 
    <repositories>
@@ -121,6 +122,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>${org.apache.commons-commons-compress-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>${com.networknt-json-schema-validator}</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/model/FileType.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/model/FileType.java
@@ -19,6 +19,7 @@ package org.kie.kogito.model;
 public enum FileType {
     SERVERLESS_WORKFLOW,
     APPLICATION_PROPERTIES,
-    SPEC,
+    JSON,
+    YAML,
     UNKNOWN
 }

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.api;
+package org.kie.kogito.validation;
 
 import java.nio.file.Path;
 
+import com.networknt.schema.JsonSchemaFactory;
+import org.kie.kogito.api.FileValidation;
 import org.kie.kogito.model.FileValidationResult;
 
-public interface FileValidation {
+public class JsonSchemaValidation implements FileValidation {
 
-    FileValidationResult validate(Path path);
+    @Override
+    public FileValidationResult validate(final Path path) {
+        final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance();
+        try {
+            schemaFactory.getSchema(path.toFile().toURI());
+            return FileValidationResult.createValidResult(path);
+        } catch (Exception e) {
+            return FileValidationResult.createInvalidResult(path, "Cannot validate JSON file as JSON Schema");
+        }
+    }
 }

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
@@ -29,7 +29,6 @@ public class JsonSchemaValidation implements FileValidation {
 
     @Override
     public FileValidationResult validate(final Path path) {
-
         try {
             FileInputStream schemaStream = new FileInputStream(path.toFile());
             JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream));

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/JsonSchemaValidation.java
@@ -16,9 +16,12 @@
 
 package org.kie.kogito.validation;
 
+import java.io.FileInputStream;
 import java.nio.file.Path;
 
-import com.networknt.schema.JsonSchemaFactory;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 import org.kie.kogito.api.FileValidation;
 import org.kie.kogito.model.FileValidationResult;
 
@@ -26,9 +29,11 @@ public class JsonSchemaValidation implements FileValidation {
 
     @Override
     public FileValidationResult validate(final Path path) {
-        final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance();
+
         try {
-            schemaFactory.getSchema(path.toFile().toURI());
+            FileInputStream schemaStream = new FileInputStream(path.toFile());
+            JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream));
+            SchemaLoader.load(rawSchema);
             return FileValidationResult.createValidResult(path);
         } catch (Exception e) {
             return FileValidationResult.createInvalidResult(path, "Cannot validate JSON file as JSON Schema");

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/OpenApiValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/OpenApiValidation.java
@@ -29,7 +29,7 @@ public class OpenApiValidation implements FileValidation {
     private final OpenAPIV3Parser parser = new OpenAPIV3Parser();
 
     @Override
-    public FileValidationResult isValid(final Path path) {
+    public FileValidationResult validate(final Path path) {
         try {
             final SwaggerParseResult result = parser.readLocation(path.toAbsolutePath().toString(), null, null);
             if (result.getMessages() != null && result.getMessages().size() > 0) {

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/PropertiesValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/PropertiesValidation.java
@@ -33,6 +33,13 @@ public class PropertiesValidation implements FileValidation {
             try (var inputStream = Files.newInputStream(path)) {
                 properties.load(inputStream);
             }
+            for (String key : properties.stringPropertyNames()) {
+                final String value = properties.getProperty(key);
+
+                if (key.isEmpty() || value.isEmpty()) {
+                    return FileValidationResult.createInvalidResult(path, "Key or value cannot be empty");
+                }
+            }
             return FileValidationResult.createValidResult(path);
         } catch (IOException e) {
             return FileValidationResult.createInvalidResult(path, e.getMessage());

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/PropertiesValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/PropertiesValidation.java
@@ -27,7 +27,7 @@ import org.kie.kogito.model.FileValidationResult;
 public class PropertiesValidation implements FileValidation {
 
     @Override
-    public FileValidationResult isValid(final Path path) {
+    public FileValidationResult validate(final Path path) {
         try {
             final Properties properties = new Properties();
             try (var inputStream = Files.newInputStream(path)) {

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/ServerlessWorkflowValidation.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/java/org/kie/kogito/validation/ServerlessWorkflowValidation.java
@@ -32,7 +32,7 @@ import org.kie.kogito.serverless.workflow.utils.WorkflowFormat;
 public class ServerlessWorkflowValidation implements FileValidation {
 
     @Override
-    public FileValidationResult isValid(final Path path) {
+    public FileValidationResult validate(final Path path) {
         try {
             final WorkflowFormat format = resolveFormat(path);
 

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
@@ -6,6 +6,10 @@ quarkus.http.enable-compression=true
 quarkus.http.port=8080
 quarkus.devservices.enabled=false
 
+quarkus.log.category."org.kie.kogito.jobs".level=ERROR
+quarkus.log.category."io.zonky".level=ERROR
+quarkus.log.category."org.flywaydb.".level=ERROR
+
 kogito.dev-ui.url=${KOGITO_DEV_UI_URL:http://localhost:8080}
 kogito.data-index.url=${KOGITO_DATA_INDEX_URL:http://localhost:8080}
 

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.http.cors.origins=*
 quarkus.http.host=0.0.0.0
 quarkus.http.enable-compression=true
 quarkus.http.port=8080
+quarkus.devservices.enabled=false
 
 kogito.dev-ui.url=${KOGITO_DEV_UI_URL:http://localhost:8080}
 kogito.data-index.url=${KOGITO_DATA_INDEX_URL:http://localhost:8080}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/TestConstants.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/TestConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito;
+
+public interface TestConstants {
+
+    String ASSETS_FOLDER = "src/test/resources/assets/";
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/service/FileServiceTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/service/FileServiceTest.java
@@ -92,9 +92,9 @@ public class FileServiceTest {
                               Map.entry(tempFolder.resolve("model.sw.yaml"), FileType.SERVERLESS_WORKFLOW),
                               Map.entry(tempFolder.resolve("model.sw.yml"), FileType.SERVERLESS_WORKFLOW),
                               Map.entry(tempFolder.resolve("application.properties"), FileType.APPLICATION_PROPERTIES),
-                              Map.entry(tempFolder.resolve("specs/api.yaml"), FileType.SPEC),
-                              Map.entry(tempFolder.resolve("api.json"), FileType.SPEC),
-                              Map.entry(tempFolder.resolve("api/spec.yml"), FileType.SPEC));
+                              Map.entry(tempFolder.resolve("specs/api.yaml"), FileType.YAML),
+                              Map.entry(tempFolder.resolve("api.json"), FileType.JSON),
+                              Map.entry(tempFolder.resolve("api/spec.yml"), FileType.YAML));
 
         for (var entry : pathFileTypeMap.entrySet()) {
             FileType actualType = fileService.getFileType(entry.getKey());

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/service/FileServiceTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/service/FileServiceTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/BaseValidationTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/BaseValidationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.validation;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.TestConstants;
+import org.kie.kogito.api.FileValidation;
+import org.kie.kogito.model.FileValidationResult;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseValidationTest {
+
+    protected final FileValidation validator;
+    private final String basicValidFileName;
+    private final String basicInvalidFileName;
+
+    protected BaseValidationTest(FileValidation validator, String basicValidFileName, String basicInvalidFileName) {
+        this.validator = validator;
+        this.basicValidFileName = basicValidFileName;
+        this.basicInvalidFileName = basicInvalidFileName;
+    }
+
+    @Test
+    void testBasicValidFile() {
+        final Path filePath = Path.of(TestConstants.ASSETS_FOLDER + this.basicValidFileName);
+        final FileValidationResult result = validator.validate(filePath);
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void testBasicInvalidFile() {
+        final Path filePath = Path.of(TestConstants.ASSETS_FOLDER + this.basicInvalidFileName);
+        final FileValidationResult result = validator.validate(filePath);
+        assertFalse(result.isValid());
+    }
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/JsonSchemaValidationTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/JsonSchemaValidationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.validation;
+
+public class JsonSchemaValidationTest extends BaseValidationTest {
+
+    public JsonSchemaValidationTest() {
+        super(new JsonSchemaValidation(), "valid-jsonschema.json", "invalid-jsonschema.json");
+    }
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/OpenApiValidationTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/OpenApiValidationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.validation;
+
+public class OpenApiValidationTest extends BaseValidationTest {
+
+    public OpenApiValidationTest() {
+        super(new OpenApiValidation(), "valid-openapi.yaml", "invalid-openapi.yaml");
+    }
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/PropertiesValidationTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/PropertiesValidationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.validation;
+
+public class PropertiesValidationTest extends BaseValidationTest {
+
+    public PropertiesValidationTest() {
+        super(new PropertiesValidation(), "valid.properties", "invalid.properties");
+    }
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/ServerlessWorkflowValidationTest.java
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/java/org/kie/kogito/validation/ServerlessWorkflowValidationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.validation;
+
+public class ServerlessWorkflowValidationTest extends BaseValidationTest {
+
+    public ServerlessWorkflowValidationTest() {
+        super(new ServerlessWorkflowValidation(), "valid.sw.json", "invalid.sw.json");
+    }
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid-jsonschema.json
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid-jsonschema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-999/schema#",
+  "type": "objec",
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 3
+    },
+    "age": {
+      "type": "int"
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid-openapi.yaml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid-openapi.yaml
@@ -1,0 +1,33 @@
+---
+openapi: 3.0.3
+info:
+  title: Score Service
+  version: 1.0.0
+servers:
+  - url: localhost:8080
+paths:
+  "/scores":
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                format: int64
+                type: integer
+    post:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScoreResult"
+components:
+  schemas:
+    ScoreResult:
+      type: object
+      properties:
+        result:
+          type: boolean

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid.properties
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid.properties
@@ -1,0 +1,5 @@
+key1=value1
+key2=value2
+noValue
+=noKey
+key3=value3

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid.sw.json
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/invalid.sw.json
@@ -1,0 +1,9 @@
+{
+  "id": "Workflow unique identifier",
+  "version": "0.1",
+  "name": "Workflow name",
+  "description": "Workflow description",
+  "functions": [],
+  "events": [],
+  "states": []
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid-jsonschema.json
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid-jsonschema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid-openapi.yaml
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid-openapi.yaml
@@ -1,0 +1,35 @@
+---
+openapi: 3.0.3
+info:
+  title: Score Service
+  version: 1.0.0
+servers:
+  - url: localhost:8080
+paths:
+  "/scores":
+    get:
+      operationId: countWinners
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                format: int64
+                type: integer
+    post:
+      operationId: isWinner
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScoreResult"
+components:
+  schemas:
+    ScoreResult:
+      type: object
+      properties:
+        result:
+          type: boolean

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid.properties
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid.properties
@@ -1,0 +1,3 @@
+key1=value1
+key2=value2
+key3=value3

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid.sw.json
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/test/resources/assets/valid.sw.json
@@ -1,0 +1,68 @@
+{
+  "id": "jsongreet",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Greeting workflow",
+  "description": "JSON based greeting workflow",
+  "start": "ChooseOnLanguage",
+  "functions": [
+    {
+      "name": "greetFunction",
+      "type": "custom",
+      "operation": "sysout"
+    }
+  ],
+  "states": [
+    {
+      "name": "ChooseOnLanguage",
+      "type": "switch",
+      "dataConditions": [
+        {
+          "condition": "${ .language == \"English\" }",
+          "transition": "GreetInEnglish"
+        },
+        {
+          "condition": "${ .language == \"Spanish\" }",
+          "transition": "GreetInSpanish"
+        }
+      ],
+      "defaultCondition": {
+        "transition": "GreetInEnglish"
+      }
+    },
+    {
+      "name": "GreetInEnglish",
+      "type": "inject",
+      "data": {
+        "greeting": "Hello from JSON Workflow, "
+      },
+      "transition": "GreetPerson"
+    },
+    {
+      "name": "GreetInSpanish",
+      "type": "inject",
+      "data": {
+        "greeting": "Saludos desde JSON Workflow, "
+      },
+      "transition": "GreetPerson"
+    },
+    {
+      "name": "GreetPerson",
+      "type": "operation",
+      "actions": [
+        {
+          "name": "greetAction",
+          "functionRef": {
+            "refName": "greetFunction",
+            "arguments": {
+              "message": ".greeting+.name"
+            }
+          }
+        }
+      ],
+      "end": {
+        "terminate": true
+      }
+    }
+  ]
+}

--- a/packages/serverless-logic-web-tools/src/openshift/swfDevMode/DevModeContext.tsx
+++ b/packages/serverless-logic-web-tools/src/openshift/swfDevMode/DevModeContext.tsx
@@ -207,6 +207,7 @@ export function DevModeContextProvider(props: React.PropsWithChildren<{}>) {
       }
 
       try {
+        const swfFileDirPath = args.targetSwfFile.relativeDirPath;
         const filesToUpload = [args.targetSwfFile];
 
         const applicationPropertiesFile = args.allFiles.find((f) => isApplicationProperties(f.relativePath));
@@ -215,13 +216,22 @@ export function DevModeContextProvider(props: React.PropsWithChildren<{}>) {
         }
 
         const supportingFiles = args.allFiles.filter((f) =>
-          isSupportingFileForDevMode({ path: f.relativePath, targetFolder: args.targetSwfFile.relativeDirPath })
+          isSupportingFileForDevMode({ path: f.relativePath, targetFolder: swfFileDirPath })
         );
         if (supportingFiles.length > 0) {
           filesToUpload.push(...supportingFiles);
         }
 
-        const zipBlob = await zipFiles(filesToUpload);
+        const cleanedUpFilesToUpload = filesToUpload.map(
+          (f) =>
+            new WorkspaceFile({
+              workspaceId: f.workspaceId,
+              getFileContents: f.getFileContents,
+              relativePath: f.relativePath.replace(swfFileDirPath, ""),
+            })
+        );
+
+        const zipBlob = await zipFiles(cleanedUpFilesToUpload);
 
         const formData = new FormData();
         formData.append(ZIP_FILE_PART_KEY, zipBlob, ZIP_FILE_NAME);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9279

After some fixes introduced in Kogito Runtimes `1.40.0.Final`, we are able to use forms specified in the `dataInputSchema` property.

https://github.com/kiegroup/kie-tools/assets/638737/bea2ae0d-d3b0-4220-99bb-2488b1f4bdb5

Also in this PR:
- Use Kogito Runtimes `1.40.0.Final`
- Create specific tests for validators
- Suppress some database logs that are not ERROR

Known issue: https://issues.redhat.com/browse/KOGITO-9415