### PR TITLE
kie-issues#183: Dead keys (E.g., ˜ˆ´¨) are not triggering edit mode correctly on BeeTable cells

### DIFF
--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableEditableCellContent.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableEditableCellContent.tsx
@@ -207,7 +207,7 @@ function isEditModeTriggeringKey(e: React.KeyboardEvent) {
     return false;
   }
 
-  return /^[\d\w ()[\]{},.\-_'"/?<>+\\|]$/.test(e.key);
+  return /^[\s\S]$/.test(e.key);
 }
 
 function calculateCellHeight(value: string) {


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/183

With this change:
- any character, even non latin alphabet, triggers edit mode
- whitespace character triggers edit mdoe
- TAB still works as navigation key and finish edit mode key