### PR TITLE
kie-issues#216: DMN's Editor Boxed Expression Editor: It's not possible to delete a table row in Safari

### DIFF
--- a/packages/boxed-expression-component/src/contextMenu/Hooks.ts
+++ b/packages/boxed-expression-component/src/contextMenu/Hooks.ts
@@ -38,6 +38,9 @@ export function useCustomContextMenuHandler(domEventTargetRef: React.RefObject<H
   const hide = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
+      /* In SAFARI only, CTRL + click shortcut used to open the Menu, results in two distinct mouse events: "contextmenu" and “click“, in this order.
+         Considering this hide() function is currently bound with both event handlers, the second event (click) will suddenly close the menu. 
+         To prevent this, if ctrlKey is actually pressed, the event is ignored. */
       if (!isOpen || e.ctrlKey) {
         return;
       }

--- a/packages/boxed-expression-component/src/contextMenu/Hooks.ts
+++ b/packages/boxed-expression-component/src/contextMenu/Hooks.ts
@@ -38,7 +38,7 @@ export function useCustomContextMenuHandler(domEventTargetRef: React.RefObject<H
   const hide = useCallback(
     (e: MouseEvent) => {
       e.preventDefault();
-      if (!isOpen) {
+      if (!isOpen || e.ctrlKey) {
         return;
       }
 


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/216

The problem:
To simulate the Right Click using the trackpad and the keyboard, the shortcut CTRL+CLICK is used.
In Chrome-based browsers, that combination results in a single `contextmenu` event. In SAFARI, that generates 2 mouse events: `contextmenu` and `click`.
So, the first `contextmenu` opens the popup, while the second `click` event suddenly closes the popup, because of this [handler registration](https://github.com/kiegroup/kie-tools/pull/1778/files#diff-7af3f1ca21b3ed58a1c4f9788ef2e5fae0b7a6c41a8a13d99a6de708f40a3451L112). 
To fix that, if the `click` event is triggered together with a CTRL, the event is ignored. 


