### PR TITLE
NO-ISSUE: Excluding`dist/tests` folder when unpacking folder of `Patternfly`, in order to don't import vulnerable deps (`moment-2.14.1`)

### DIFF
--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -178,6 +178,7 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/patternfly</outputDirectory>
+                  <excludes>META-INF/resources/webjars/patternfly/${version.org.webjars.bower.org.patternfly}/dist/tests/</excludes>
                 </artifactItem>
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>


### PR DESCRIPTION
The last MEND scan still complains about an old `moment` dependency with a CVE, already fixed in https://github.com/kiegroup/kie-tools/pull/1715

<img width="1412" alt="Screenshot 2023-06-22 at 10 09 33" src="https://github.com/kiegroup/kie-tools/assets/16005046/86ffa02d-185c-4f79-8897-5683ddaf765e">

This is another case. Basically, the dependency is directly imported by a Patternfly HTML file, used for test/dev purposes. 

<img width="1184" alt="Screenshot 2023-06-22 at 10 13 20" src="https://github.com/kiegroup/kie-tools/assets/16005046/b2a7f90e-59e1-4017-a2c0-32d23892c0cb">


Considering the scope of that (and all) HTML files, we can safely exclude the "tests" folder of the unpacked Patternfly dependency, in order to don't have those HTML files at all
