### PR TITLE
KOGITO-9440: Add prerequisites for running IT tests of `kn-plugin-workflow`

### DIFF
--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -14,6 +14,11 @@ All the commands in this section should be performed in the monorepo root.
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Go `1.19.10` _(To install, follow these instructions: https://go.dev/doc/install)_
 
+#### Prerequisites for running integration tests
+
+- docker _(To install, follow these instructions: https://docs.docker.com/engine/install)_
+- podman _(To install, follow these instructions: https://podman.io/docs/installation)_
+
 ### Installing and linking dependencies
 
 The following command will install the `kn-plugin-workflow` dependencies and link it with any other monorepo


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-9440

The integration tests of `kn-plugin-workflow` require docker and podman to be installed. I am adding these prerequisites to the package. If someone builds the entire repo by `pnpm -r build:prod` with `KIE_TOOLS_BUILD__runIntegrationTests` set to `true`, these prerequisites are needed too. Should I add it to the root README too? @ederign 