### PR TITLE
kie-issues#365: Top-left cell data is getting lost after Cutting and Pasting to the DMN Editor's Boxed Expression Editor

### DIFF
--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -612,10 +612,9 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
           for (let c = startColumn; c <= endColumn; c++) {
             clipboardMatrix[r - startRow][c - startColumn] = [...(refs.current?.get(r)?.get(c) ?? [])]
               ?.flatMap((ref) => {
-                const value = ref.getValue ? [ref.getValue()] : [];
-                console.log("R: " + r + " C: " + " value:" + value);
+                const cellValue = ref.getValue ? [ref.getValue()] : [];
                 ref.setValue?.(CELL_EMPTY_VALUE);
-                return value;
+                return cellValue;
               })
               .join(""); // What to do? Only one ref should be yielding the content. See https://github.com/kiegroup/kie-issues/issues/170
           }

--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -588,7 +588,6 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
         for (let r = startRow; r <= endRow; r++) {
           clipboardMatrix[r - startRow] ??= [];
           for (let c = startColumn; c <= endColumn; c++) {
-            clipboardMatrix[r - startRow] ??= [];
             clipboardMatrix[r - startRow][c - startColumn] = [...(refs.current?.get(r)?.get(c) ?? [])]
               ?.flatMap((ref) => (ref.getValue ? [ref.getValue()] : []))
               .join(""); // FIXME: What to do? Only one ref should be yielding the content. See https://github.com/kiegroup/kie-issues/issues/170
@@ -611,11 +610,12 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
         for (let r = startRow; r <= endRow; r++) {
           clipboardMatrix[r - startRow] ??= [];
           for (let c = startColumn; c <= endColumn; c++) {
-            clipboardMatrix[r - startRow] ??= [];
             clipboardMatrix[r - startRow][c - startColumn] = [...(refs.current?.get(r)?.get(c) ?? [])]
               ?.flatMap((ref) => {
+                const value = ref.getValue ? [ref.getValue()] : [];
+                console.log("R: " + r + " C: " + " value:" + value);
                 ref.setValue?.(CELL_EMPTY_VALUE);
-                return ref.getValue ? [ref.getValue()] : [];
+                return value;
               })
               .join(""); // What to do? Only one ref should be yielding the content. See https://github.com/kiegroup/kie-issues/issues/170
           }


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/365

The fix consists of storing the "cut" cell value before setting it with an empty value. Can't explain why the bug occurs for the first selected cell only. 

I removed lines 591 and 614 because duplicates of 589 and 612; It seems to me these are useless statements.