### PR TITLE
KOGITO-9394: Add confirm dialog after deleting a file from its menu

### DIFF
--- a/packages/serverless-logic-web-tools/it-tests/e2e/RecentModel.cy.ts
+++ b/packages/serverless-logic-web-tools/it-tests/e2e/RecentModel.cy.ts
@@ -61,6 +61,10 @@ describe("Serverless Logic Web Tools - Recent model test", () => {
     cy.ouia({ ouiaId: "kebab-sm" }).click();
     cy.ouia({ ouiaId: "delete-file-button" }).click();
 
+    // confirm deletion in the modal
+    cy.ouia({ ouiaId: "confirm-delete-checkbox" }).click();
+    cy.ouia({ ouiaId: "confirm-delete-button" }).click();
+
     // check the file is deleted (recent section is emtpy)
     cy.goToSidebarLink({ ouiaId: "recent-models-nav" });
     cy.get(".pf-l-bullseye").should("contain.text", "Nothing here");

--- a/packages/serverless-logic-web-tools/src/table/ConfirmDeleteModal.tsx
+++ b/packages/serverless-logic-web-tools/src/table/ConfirmDeleteModal.tsx
@@ -57,7 +57,14 @@ export function ConfirmDeleteModal(props: ConfirmDeleteModalProps) {
         aria-describedby="modal-custom-icon-description"
         actions={[
           dataLoaded ? (
-            <Button key="confirm" variant="danger" onClick={onDelete} isDisabled={!isDeleteCheck} aria-label="Delete">
+            <Button
+              key="confirm"
+              variant="danger"
+              onClick={onDelete}
+              isDisabled={!isDeleteCheck}
+              aria-label="Delete"
+              ouiaId="confirm-delete-button"
+            >
               Delete {elementsTypeName}
             </Button>
           ) : (
@@ -78,6 +85,7 @@ export function ConfirmDeleteModal(props: ConfirmDeleteModalProps) {
           isChecked={isDeleteCheck}
           onChange={onDeleteCheckChange}
           aria-label="Confirm checkbox delete model"
+          ouiaId="confirm-delete-checkbox"
         />
       </Modal>
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-9394

**Description**
Recent models table already contains confirm dialogs after deleting a single file, multiple files or workspaces. The last way how to delete a file is from its own menu. There is currently no dialog and the file is immediately deleted.

![KOGITO-9394](https://github.com/kiegroup/kie-tools/assets/17780574/5d8c2ad6-84a2-40ba-b169-c084275f960d)
