### PR TITLE
kie-issues#180: On DMN Editor's Boxed Expression Editor, when resizing Context/Invocation entry info cells, minWidths are getting messy

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -50,7 +50,7 @@ import { ContextEntryExpressionCell } from "./ContextEntryExpressionCell";
 import { ContextEntryInfoCell } from "./ContextEntryInfoCell";
 import "./ContextExpression.css";
 import { ContextResultExpressionCell } from "./ContextResultExpressionCell";
-import { getExpressionTotalMinimalWidth } from "../../resizing/WidthMaths";
+import { getExpressionTotalMinWidth } from "../../resizing/WidthMaths";
 
 const CONTEXT_ENTRY_DEFAULT_DATA_TYPE = DmnBuiltInDataType.Undefined;
 
@@ -95,11 +95,11 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
     useNestedExpressionContainerWithNestedExpressions(
       useMemo(() => {
         const entriesWidths = contextExpression.contextEntries.map((e) =>
-          getExpressionTotalMinimalWidth(0, e.entryExpression)
+          getExpressionTotalMinWidth(0, e.entryExpression)
         );
-        const resultWidth = getExpressionTotalMinimalWidth(0, contextExpression.result);
+        const resultWidth = getExpressionTotalMinWidth(0, contextExpression.result);
 
-        const biggestWidth = Math.max(...entriesWidths, resultWidth);
+        const maxNestedExpressionMinWidth = Math.max(...entriesWidths, resultWidth, CONTEXT_ENTRY_EXPRESSION_MIN_WIDTH);
 
         return {
           nestedExpressions: [
@@ -109,12 +109,12 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
           fixedColumnActualWidth: entryInfoWidth,
           fixedColumnResizingWidth: entryInfoResizingWidth,
           fixedColumnMinWidth: CONTEXT_ENTRY_INFO_MIN_WIDTH,
-          nestedExpressionMinWidth: biggestWidth > 0 ? biggestWidth : CONTEXT_ENTRY_EXPRESSION_MIN_WIDTH,
+          nestedExpressionMinWidth: maxNestedExpressionMinWidth,
           extraWidth: CONTEXT_EXPRESSION_EXTRA_WIDTH,
           expression: contextExpression,
           flexibleColumnIndex: 2,
         };
-      }, [contextExpression, entryInfoResizingWidth, entryInfoWidth, getExpressionTotalMinimalWidth])
+      }, [contextExpression, entryInfoResizingWidth, entryInfoWidth])
     );
 
   /// //////////////////////////////////////////////////////

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -50,6 +50,7 @@ import { ContextEntryExpressionCell } from "./ContextEntryExpressionCell";
 import { ContextEntryInfoCell } from "./ContextEntryInfoCell";
 import "./ContextExpression.css";
 import { ContextResultExpressionCell } from "./ContextResultExpressionCell";
+import { getExpressionTotalMinimalWidth } from "../../resizing/WidthMaths";
 
 const CONTEXT_ENTRY_DEFAULT_DATA_TYPE = DmnBuiltInDataType.Undefined;
 
@@ -93,6 +94,13 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
   const { nestedExpressionContainerValue, onColumnResizingWidthChange: onColumnResizingWidthChange2 } =
     useNestedExpressionContainerWithNestedExpressions(
       useMemo(() => {
+        const entriesWidths = contextExpression.contextEntries.map((e) =>
+          getExpressionTotalMinimalWidth(0, e.entryExpression)
+        );
+        const resultWidth = getExpressionTotalMinimalWidth(0, contextExpression.result);
+
+        const biggestWidth = Math.max(...entriesWidths, resultWidth);
+
         return {
           nestedExpressions: [
             ...contextExpression.contextEntries.map((e) => e.entryExpression),
@@ -101,12 +109,12 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
           fixedColumnActualWidth: entryInfoWidth,
           fixedColumnResizingWidth: entryInfoResizingWidth,
           fixedColumnMinWidth: CONTEXT_ENTRY_INFO_MIN_WIDTH,
-          nestedExpressionMinWidth: CONTEXT_ENTRY_EXPRESSION_MIN_WIDTH,
+          nestedExpressionMinWidth: biggestWidth > 0 ? biggestWidth : CONTEXT_ENTRY_EXPRESSION_MIN_WIDTH,
           extraWidth: CONTEXT_EXPRESSION_EXTRA_WIDTH,
           expression: contextExpression,
           flexibleColumnIndex: 2,
         };
-      }, [contextExpression, entryInfoResizingWidth, entryInfoWidth])
+      }, [contextExpression, entryInfoResizingWidth, entryInfoWidth, getExpressionTotalMinimalWidth])
     );
 
   /// //////////////////////////////////////////////////////

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -46,6 +46,7 @@ import { ArgumentEntryExpressionCell } from "./ArgumentEntryExpressionCell";
 import { ContextEntryInfoCell } from "../ContextExpression";
 import "./InvocationExpression.css";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
+import { getExpressionTotalMinimalWidth } from "../../resizing/WidthMaths";
 
 type ROWTYPE = ContextExpressionDefinitionEntry;
 
@@ -81,17 +82,23 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
   const { nestedExpressionContainerValue, onColumnResizingWidthChange: onColumnResizingWidthChange2 } =
     useNestedExpressionContainerWithNestedExpressions(
       useMemo(() => {
+        const entriesWidths = invocationExpression.bindingEntries.map((e) =>
+          getExpressionTotalMinimalWidth(0, e.entryExpression)
+        );
+
+        const biggestWidth = Math.max(...entriesWidths);
+
         return {
           nestedExpressions: invocationExpression.bindingEntries?.map((e) => e.entryExpression) ?? [],
           fixedColumnActualWidth: parametersWidth,
           fixedColumnResizingWidth: parametersResizingWidth,
           fixedColumnMinWidth: INVOCATION_PARAMETER_MIN_WIDTH,
-          nestedExpressionMinWidth: INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH,
+          nestedExpressionMinWidth: biggestWidth > 0 ? biggestWidth : INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH,
           extraWidth: INVOCATION_EXTRA_WIDTH,
           expression: invocationExpression,
           flexibleColumnIndex: 2,
         };
-      }, [parametersWidth, parametersResizingWidth, invocationExpression])
+      }, [parametersWidth, parametersResizingWidth, invocationExpression, getExpressionTotalMinimalWidth])
     );
 
   /// //////////////////////////////////////////////////////

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -46,7 +46,7 @@ import { ArgumentEntryExpressionCell } from "./ArgumentEntryExpressionCell";
 import { ContextEntryInfoCell } from "../ContextExpression";
 import "./InvocationExpression.css";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
-import { getExpressionTotalMinimalWidth } from "../../resizing/WidthMaths";
+import { getExpressionTotalMinWidth } from "../../resizing/WidthMaths";
 
 type ROWTYPE = ContextExpressionDefinitionEntry;
 
@@ -83,22 +83,22 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
     useNestedExpressionContainerWithNestedExpressions(
       useMemo(() => {
         const entriesWidths = invocationExpression.bindingEntries.map((e) =>
-          getExpressionTotalMinimalWidth(0, e.entryExpression)
+          getExpressionTotalMinWidth(0, e.entryExpression)
         );
 
-        const biggestWidth = Math.max(...entriesWidths);
+        const maxNestedExpressionWidth = Math.max(...entriesWidths, INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH);
 
         return {
           nestedExpressions: invocationExpression.bindingEntries?.map((e) => e.entryExpression) ?? [],
           fixedColumnActualWidth: parametersWidth,
           fixedColumnResizingWidth: parametersResizingWidth,
           fixedColumnMinWidth: INVOCATION_PARAMETER_MIN_WIDTH,
-          nestedExpressionMinWidth: biggestWidth > 0 ? biggestWidth : INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH,
+          nestedExpressionMinWidth: maxNestedExpressionWidth,
           extraWidth: INVOCATION_EXTRA_WIDTH,
           expression: invocationExpression,
           flexibleColumnIndex: 2,
         };
-      }, [parametersWidth, parametersResizingWidth, invocationExpression, getExpressionTotalMinimalWidth])
+      }, [parametersWidth, parametersResizingWidth, invocationExpression])
     );
 
   /// //////////////////////////////////////////////////////

--- a/packages/boxed-expression-component/src/resizing/WidthMaths.ts
+++ b/packages/boxed-expression-component/src/resizing/WidthMaths.ts
@@ -1,10 +1,5 @@
 import { ExpressionDefinitionLogicType } from "../api";
-import {
-  ContextExpressionDefinition,
-  ExpressionDefinition,
-  FunctionExpressionDefinitionKind,
-  InvocationExpressionDefinition,
-} from "../api/ExpressionDefinition";
+import { ExpressionDefinition, FunctionExpressionDefinitionKind } from "../api/ExpressionDefinition";
 import { ResizingWidth } from "./ResizingWidthsContext";
 import {
   BEE_TABLE_ROW_INDEX_COLUMN_WIDTH,
@@ -118,27 +113,22 @@ export function getExpressionMinWidth(expression?: ExpressionDefinition): number
  *
  * This function returns maximal sum found in all `expression`'s nested expressions.
  */
-export function getExpressionTotalMinimalWidth(currentWidth: number, expression: ExpressionDefinition): number {
+export function getExpressionTotalMinWidth(currentWidth: number, expression: ExpressionDefinition): number {
   if (expression.logicType === ExpressionDefinitionLogicType.Context) {
-    // it is a Context, we need to go trough entries and result row
-    const c = expression as ContextExpressionDefinition;
-    const width = currentWidth + (c.entryInfoWidth ?? 0);
-    const contextEntriesMaxWidth = c.contextEntries.reduce((maxWidth, currentExpression) => {
-      return Math.max(maxWidth, getExpressionTotalMinimalWidth(width, currentExpression.entryExpression));
+    const width = currentWidth + (expression.entryInfoWidth ?? 0);
+    const contextEntriesMaxWidth = expression.contextEntries.reduce((maxWidth, currentExpression) => {
+      return Math.max(maxWidth, getExpressionTotalMinWidth(width, currentExpression.entryExpression));
     }, width);
-    const resultWidth = getExpressionTotalMinimalWidth(width, c.result);
+    const resultWidth = getExpressionTotalMinWidth(width, expression.result);
     return Math.max(contextEntriesMaxWidth, resultWidth);
   } else if (expression.logicType === ExpressionDefinitionLogicType.Invocation) {
-    // it is an Invocation, we need to go trough entries
-    const i = expression as InvocationExpressionDefinition;
-    const width = currentWidth + (i.entryInfoWidth ?? 0);
-    return i.bindingEntries.reduce((maxWidth, currentExpression) => {
-      return Math.max(maxWidth, getExpressionTotalMinimalWidth(width, currentExpression.entryExpression));
+    const width = currentWidth + (expression.entryInfoWidth ?? 0);
+    return expression.bindingEntries.reduce((maxWidth, currentExpression) => {
+      return Math.max(maxWidth, getExpressionTotalMinWidth(width, currentExpression.entryExpression));
     }, width);
   } else {
     // it is an expression without entryInfoWidth
-    const width = currentWidth + getExpressionMinWidth(expression);
-    return width;
+    return currentWidth + getExpressionMinWidth(expression);
   }
 }
 

--- a/packages/boxed-expression-component/src/resizing/WidthMaths.ts
+++ b/packages/boxed-expression-component/src/resizing/WidthMaths.ts
@@ -114,8 +114,9 @@ export function getExpressionMinWidth(expression?: ExpressionDefinition): number
 }
 
 /**
- * This function gous recursively trough all `expression` nested expressions and sum either `entryInfoWidth` or default minimal width, returned by `getExpressionMinWidth`, if it is last nested expression in the chain.
- * This function returns maximal sum found bewteen all `expression` nested expressions
+ * This function goes recursively through all `expression`'s nested expressions and sums either `entryInfoWidth` or default minimal width, returned by `getExpressionMinWidth`, if it is the last nested expression in the chain.
+ *
+ * This function returns maximal sum found in all `expression`'s nested expressions.
  */
 export function getExpressionTotalMinimalWidth(currentWidth: number, expression: ExpressionDefinition): number {
   if (expression.logicType === ExpressionDefinitionLogicType.Context) {


### PR DESCRIPTION
Closes kiegroup/kie-issues#180

![Screenshot 2023-07-11 154657](https://github.com/kiegroup/kie-tools/assets/8044780/a73aed09-a96e-4c19-a74c-004eab5039b8)


So we update the logic for minimal expression width, `getExpressionTotalMinimalWidth`, to return a value highlighted with red color in the attached picture. The computed value is a sum of:
- `A` `entry info` width 
- `CC` `entry info` width
- `BBB` `entry info` width
- `default minimal width` of literal expression, as literal expression is actual expression of `BBB`