### PR TITLE
kie-issues#375: DMN Editor: Context Menu is empty in List expression header

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
@@ -86,6 +86,15 @@ export function ListExpression(listExpression: ListExpressionDefinition & { isNe
           { name: i18n.rowOperations.delete, type: BeeTableOperation.RowDelete },
         ],
       },
+      {
+        group: _.upperCase(i18n.terms.selection),
+        items: [
+          { name: i18n.terms.copy, type: BeeTableOperation.SelectionCopy },
+          { name: i18n.terms.cut, type: BeeTableOperation.SelectionCut },
+          { name: i18n.terms.paste, type: BeeTableOperation.SelectionPaste },
+          { name: i18n.terms.reset, type: BeeTableOperation.SelectionReset },
+        ],
+      },
     ],
     [i18n]
   );


### PR DESCRIPTION
Closes: kiegroup/kie-issues#375

### before
![image](https://github.com/kiegroup/kie-tools/assets/8044780/af6b2718-ca70-417a-9203-a78b8f962e6a)

### after
![Screenshot 2023-06-29 113411](https://github.com/kiegroup/kie-tools/assets/8044780/fdbd9972-3af3-4cc7-8926-885cbcfe3b98)
