### PR TITLE
kie-issues#373: DMN's Decision Table: Changing the column data type doens't work after changing Decision node type

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -224,7 +224,8 @@ export function DecisionTableExpression(
           decisionTableExpression.output?.length == 1
             ? decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME
             : outputClause.name,
-        dataType: outputClause.dataType,
+        dataType:
+          decisionTableExpression.output?.length == 1 ? decisionTableExpression.dataType : outputClause.dataType,
         width: outputClause.width ?? DECISION_TABLE_OUTPUT_MIN_WIDTH,
         setWidth: setOutputColumnWidth(outputIndex),
         minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/373

In the case of a single output column, the column should take the type form the root expression type.