### PR TITLE
KOGITO-9332: Title name is shortened when it contains sequence of letters i,j or l

### DIFF
--- a/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
@@ -272,7 +272,12 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
                           aria-label={"EmbeddedEditorFile name"}
                           headingLevel={"h3"}
                           size={"2xl"}
-                          style={{ fontWeight: "bold" }}
+                          style={
+                            {
+                              letterSpacing: "0.3px",
+                              fontWeight: "bold",
+                            } /* margin here is to avoid truncation of names like "iiiiiiiii" KOGITO-9332 */
+                          }
                         >
                           {displayName}
                         </Title>

--- a/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/FileSwitcher.tsx
@@ -274,9 +274,9 @@ export function FileSwitcher(props: { workspace: ActiveWorkspace; workspaceFile:
                           size={"2xl"}
                           style={
                             {
-                              letterSpacing: "0.3px",
+                              letterSpacing: "0.2px",
                               fontWeight: "bold",
-                            } /* margin here is to avoid truncation of names like "iiiiiiiii" KOGITO-9332 */
+                            } /* letterSpacing is to avoid truncation of names like "iiiiiiiii" KOGITO-9332 */
                           }
                         >
                           {displayName}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9332

**Description**

When a file is renamed to name which contains sequence of letters i,j or l, the name is shortened and three dots are added at the end.

**Note**
The width of the input is determined by a hidden h3 placed under the input. 
To fix this issue, I incremented the letter-spacing of the h3. 
**Downside**: the file name is graphically slightly moved to the right.  

[KOGITO-9332.webm](https://github.com/kiegroup/kie-tools/assets/17780574/8e75b323-f150-4532-8ece-c41a65e89abf)
