### PR TITLE
NO-ISSUE: Proposal to prevent errors when an API is unsupported

### DIFF
--- a/packages/envelope-bus/src/common/EnvelopeBusMessageManager.ts
+++ b/packages/envelope-bus/src/common/EnvelopeBusMessageManager.ts
@@ -304,6 +304,7 @@ export class EnvelopeBusMessageManager<
           response = api.apply(apiImpl, request.data);
         } else {
           console.warn(`API '${String(request.type)}' was not found. Request will be ignored.`);
+          return;
         }
       } catch (err) {
         console.error(err);

--- a/packages/envelope-bus/src/common/EnvelopeBusMessageManager.ts
+++ b/packages/envelope-bus/src/common/EnvelopeBusMessageManager.ts
@@ -299,7 +299,12 @@ export class EnvelopeBusMessageManager<
 
       let response;
       try {
-        response = apiImpl[request.type].apply(apiImpl, request.data);
+        const api = apiImpl[request.type];
+        if (api !== undefined) {
+          response = api.apply(apiImpl, request.data);
+        } else {
+          console.warn(`API '${String(request.type)}' was not found. Request will be ignored.`);
+        }
       } catch (err) {
         console.error(err);
         this.respond(request, undefined, err);


### PR DESCRIPTION
This problem manifests itself with the `CombinedEditor`. 

Messages are sent to the `CombinedEnvelope` envelope relating to the `TextEditor` API. The messages are sent to both the `DiagramEditor` and `TextEditor` however fail in the `DiagramEditor` as the `TextEditor` API is not implemented.

An alternative could be to stub the missing `TextEditor` API for the `DiagramEditor`.

This seemed the safest option.

The Combined Editor in `serverless-logic-web-tools` uses a custom channel for both nested editors.

This channel exposes the same API to both, that includes the `TextEditor` API.

https://github.com/kiegroup/kie-tools/blob/main/packages/serverless-logic-web-tools/src/editor/WebToolsEmbeddedEditor.tsx#L141

https://github.com/kiegroup/kie-tools/blob/main/packages/serverless-logic-web-tools/src/editor/channel/SwfChannelComponent.tsx#L91-L95