### PR TITLE
KOGITO-9508: Create new Splunk Search Dataset type for Dashbuilder

### DIFF
--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
@@ -35,7 +35,7 @@ public enum ExternalServiceType {
             ")"),
     SPLUNK("{\n" +
             "    \"columns\": $.fields.name.({\"id\": $, \"type\": \"LABEL\"} ),\n" +
-            "    \"values\": $map($.results, function($r) { $.fields.name.( $join($lookup($r, $), \",\")) } )\n" +
+            "    \"values\": $map($.results, function($r) { $.fields.name.( $join($lookup($r, $) ? $lookup($r, $) : \"\", \",\")) } )\n" +
             "}");
 
     private ExternalServiceType(String expression) {

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
@@ -32,7 +32,11 @@ public enum ExternalServiceType {
             "            resultType = \"vector\" ?  result.[ value[0] * 1000, value[1],  metric.* ]\n" +
             "        )\n" +
             "    }\n" +
-            ")");
+            ")"),
+    SPLUNK("{\n" +
+            "  \"columns\": $.fields.name.({\"id\": $} ),\n" +
+            "  \"values\": $map($.results, function($r) { $.fields.name.( $lookup($r, $)) } )\n" +
+            "}");
 
     private ExternalServiceType(String expression) {
         this.expression = expression;

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalServiceType.java
@@ -34,8 +34,8 @@ public enum ExternalServiceType {
             "    }\n" +
             ")"),
     SPLUNK("{\n" +
-            "  \"columns\": $.fields.name.({\"id\": $} ),\n" +
-            "  \"values\": $map($.results, function($r) { $.fields.name.( $lookup($r, $)) } )\n" +
+            "    \"columns\": $.fields.name.({\"id\": $, \"type\": \"LABEL\"} ),\n" +
+            "    \"values\": $map($.results, function($r) { $.fields.name.( $join($lookup($r, $), \",\")) } )\n" +
             "}");
 
     private ExternalServiceType(String expression) {


### PR DESCRIPTION
With this change users will be able to consume splunk search results using the following declaration:

```
datasets:
    - uuid: search
      # point here to the search URL (using REST API and JSON response)
      url: http://127.0.0.1:3001/hosts_uptime
      # This expression will be internal in a next Dashbuilder release
      type: splunk
pages:
    - components:
          - settings:
                lookup:
                    uuid: search
```