### PR TITLE
KOGITO-9422: Uploading second non editable file will cause error

### DIFF
--- a/packages/workspaces-git-fs/src/worker/WorkspacesWorkerApiImpl.ts
+++ b/packages/workspaces-git-fs/src/worker/WorkspacesWorkerApiImpl.ts
@@ -214,7 +214,7 @@ export class WorkspacesWorkerApiImpl implements WorkspacesWorkerApi {
       async ({ fs, broadcaster }) => {
         for (let i = 0; i < this.MAX_NEW_FILE_INDEX_ATTEMPTS; i++) {
           const index = i === 0 ? "" : `-${i}`;
-          const fileName = `${args.name}${index}.${args.extension}`;
+          const fileName = `${args.name}${index}${args.extension ? "." : ""}${args.extension}`;
           const relativePath = join(args.destinationDirRelativePath, fileName);
           if (
             await this.args.services.workspaceService.existsFile({ fs, workspaceId: args.workspaceId, relativePath })


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9422

**Steps to Reproduce:**
- Upload a data file "data1"
- File is opened and it is not possible to edit it.
- Click New File -> Upload...
- Select file "data2"
- File is opened and it is not possible to edit it.
- Go back to workspace files
- Try to open "data2" file.
- Error is displayed.

**Description:**
If you upload a data file which is non editable, it will create a workspace. If you upload a second not editable file to the workspace, error is displayed: "File 'dataFile' not found in Workspace".

**Note:**
The issue was caused by always concatenating "." in the filename even if there was no extension, resulting in a filename called "data2." in the storage.

[KOGITO-9422.webm](https://github.com/kiegroup/kie-tools/assets/17780574/87eb8b3e-de49-4c7a-b735-d6b21d38beba)

