### PR TITLE
kie-issues#380: Replace the patternfly webjar in stunner-editors

### DIFF
--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -178,6 +178,7 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/patternfly</outputDirectory>
+                  <includes>META-INF/resources/webjars/patternfly/${version.org.webjars.bower.org.patternfly}/dist/</includes>
                   <excludes>META-INF/resources/webjars/patternfly/${version.org.webjars.bower.org.patternfly}/dist/tests/</excludes>
                 </artifactItem>
               </artifactItems>
@@ -307,12 +308,6 @@
               <resources>
                 <resource>
                   <directory>${project.build.directory}/patternfly/META-INF/resources/webjars/patternfly/${version.org.webjars.bower.org.patternfly}/dist</directory>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                  <excludes>
-                    <exclude>tests/**</exclude>
-                  </excludes>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/380

This PR filters the assets unpacked from the `patternfly` webjar to avoid the to avoid the following vulnerabilities:

- `CVE-2022-24785`, `WS-2016-0075`, `CVE-2017-18214` & `CVE-2022-31129`: `moment.js@2.14.1` brought on package tests (via cdnjs links).
- `CVE-2018-17567`: `jekyll.gem` which is brought by the original patternfly build.