### PR TITLE
KOGITO-9499: Support POST for Dashbuilder external DataSets

### DIFF
--- a/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
+++ b/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
@@ -222,15 +222,25 @@ export const DASHBUILDER_SCHEMA = {
           description: "The max of rows cached by the dataset or with accumulated datasets. Default is 1000.",
           type: "integer",
         },
+        method: {
+          description: "HTTP Method used by the the dataset request. By default it is GET",
+          type: "string",
+        },
         accumulate: {
           description: "If true then previous calls to the dataset are kept in memory and not discarded.",
           type: "boolean",
         },
         headers: {
+          description: "HTTP headers sent with the request.",
           $ref: "#/definitions/DatasetHeaders",
         },
         query: {
+          description: "Query parameters added to the dataset URL.",
           $ref: "#/definitions/DatasetQuery",
+        },
+        form: {
+          description: "Form parameters sent when the HTTP method is POST.",
+          $ref: "#/definitions/DatasetForm",
         },
       },
       oneOf: [
@@ -294,6 +304,7 @@ export const DASHBUILDER_SCHEMA = {
     },
     typeEnum: {
       type: "string",
+      description: "For datasets that are reading data from Prometheus query response",
       enum: ["prometheus"],
       additionalProperties: false,
       title: "typeEnum",
@@ -302,6 +313,7 @@ export const DASHBUILDER_SCHEMA = {
       type: "object",
       properties: {
         id: {
+          description: "An unique ID for the column",
           type: "string",
         },
         type: {
@@ -313,6 +325,7 @@ export const DASHBUILDER_SCHEMA = {
     },
     DataSetLookup: {
       type: "object",
+      description: "Selects a dataset part to be displayed by this component",
       properties: {
         uuid: {
           description: "The dataset uuid.",
@@ -358,45 +371,18 @@ export const DASHBUILDER_SCHEMA = {
           type: ["boolean"],
         },
         listening: {
+          description: "Enable this so this component can be filtered by others",
           type: ["boolean"],
         },
         notification: {
+          description: "Enable this so this component can filter others",
           type: ["boolean"],
         },
         selfapply: {
+          description: "Enable this so this component can self apply the filter",
           type: ["boolean"],
         },
       },
-      oneOf: [
-        {
-          properties: {
-            notification: {
-              type: "boolean",
-            },
-            listening: {
-              type: "boolean",
-            },
-          },
-          required: ["notification"],
-          not: {
-            required: ["listening"],
-          },
-        },
-        {
-          properties: {
-            notification: {
-              type: "boolean",
-            },
-            listening: {
-              type: "boolean",
-            },
-          },
-          required: ["listening"],
-          not: {
-            required: ["notification"],
-          },
-        },
-      ],
       title: "SettingsFilter",
     },
     SettingsColumn: {
@@ -780,10 +766,16 @@ export const DASHBUILDER_SCHEMA = {
       description: "Additional query parameter sent to a dataset HTTP Request",
       additionalProperties: {},
     },
+    DatasetForm: {
+      type: "object",
+      description: "Form Parameters used in the request body when the HTTP method is POST",
+      additionalProperties: {},
+    },
     DisplayerSettings: {
       type: "object",
       properties: {
         lookup: {
+          description: "Configures the source of data for this displayer",
           $ref: "#/definitions/DataSetLookup",
         },
         filter: {

--- a/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
+++ b/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
@@ -782,6 +782,10 @@ export const DASHBUILDER_SCHEMA = {
           description: "Configures the source of data for this displayer",
           $ref: "#/definitions/DataSetLookup",
         },
+        dataSet: {
+          description: "A local dataset declaration which should be a string with a JSON array",
+          type: "string",
+        },
         filter: {
           $ref: "#/definitions/SettingsFilter",
         },

--- a/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
+++ b/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
@@ -222,6 +222,10 @@ export const DASHBUILDER_SCHEMA = {
           description: "The max of rows cached by the dataset or with accumulated datasets. Default is 1000.",
           type: "integer",
         },
+        path: {
+          description: "Additional path added to the dataset URL",
+          type: "string",
+        },
         method: {
           description: "HTTP Method used by the the dataset request. By default it is GET",
           type: "string",

--- a/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
+++ b/packages/dashbuilder-language-service/src/assets/schemas/dashbuilder.ts
@@ -1069,7 +1069,6 @@ export const DASHBUILDER_SCHEMA = {
           },
         },
       ],
-      required: ["lookup"],
       title: "DisplayerSettings",
     },
     SettingsExternal: {

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/ExternalDataSetParserProvider.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/ExternalDataSetParserProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataset.client;
+
+import org.dashbuilder.dataset.json.ExternalDataSetJSONParser;
+
+public interface ExternalDataSetParserProvider {
+
+    ExternalDataSetJSONParser get();
+
+}

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-editor/src/main/java/org/dashbuilder/client/editor/DisplayerDragComponent.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-editor/src/main/java/org/dashbuilder/client/editor/DisplayerDragComponent.java
@@ -17,10 +17,12 @@ package org.dashbuilder.client.editor;
 
 import java.util.Optional;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.dashbuilder.dataset.client.ExternalDataSetParserProvider;
 import org.dashbuilder.displayer.DisplayerSettings;
 import org.dashbuilder.displayer.DisplayerSubType;
 import org.dashbuilder.displayer.DisplayerType;
@@ -36,6 +38,8 @@ import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.client.api.LayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.api.RenderingContext;
 
+import static org.dashbuilder.common.client.StringUtils.isBlank;
+
 @Dependent
 public class DisplayerDragComponent implements LayoutDragComponent {
 
@@ -43,25 +47,32 @@ public class DisplayerDragComponent implements LayoutDragComponent {
     DisplayerViewer viewer;
     PlaceManager placeManager;
     PerspectiveCoordinator perspectiveCoordinator;
-    DisplayerSettingsJSONMarshaller marshaller;
     GlobalDisplayerSettings globalDisplayerSettings;
 
     @Inject
     DisplayerErrorWidget displayError;
 
     @Inject
+    ExternalDataSetParserProvider dataSetParserProvider;
+
+    @Inject
     public DisplayerDragComponent(SyncBeanManager beanManager,
-            DisplayerViewer viewer,
-            PlaceManager placeManager,
-            PerspectiveCoordinator perspectiveCoordinator,
-            GlobalDisplayerSettings globalDisplayerSettings) {
+                                  DisplayerViewer viewer,
+                                  PlaceManager placeManager,
+                                  PerspectiveCoordinator perspectiveCoordinator,
+                                  GlobalDisplayerSettings globalDisplayerSettings) {
 
         this.beanManager = beanManager;
         this.viewer = viewer;
         this.placeManager = placeManager;
         this.perspectiveCoordinator = perspectiveCoordinator;
         this.globalDisplayerSettings = globalDisplayerSettings;
-        this.marshaller = DisplayerSettingsJSONMarshaller.get();
+    }
+
+    @PostConstruct
+    public void init() {
+        // use the client side implementation
+        DisplayerSettingsJSONMarshaller.get().setDataSetJsonParser(dataSetParserProvider.get());
     }
 
     public DisplayerType getDisplayerType() {
@@ -118,9 +129,17 @@ public class DisplayerDragComponent implements LayoutDragComponent {
         if (settings != null) {
             var displayerSettings = (DisplayerSettings) settings;
             globalDisplayerSettings.apply(displayerSettings);
+            if (isDataMissing(displayerSettings)) {
+                displayerSettings.setError("A displayer must have a dataset 'uuid' in 'lookup' or an inline dataSet.");
+            }
             return Optional.of(displayerSettings);
         }
 
         return Optional.empty();
+    }
+
+    private boolean isDataMissing(DisplayerSettings displayerSettings) {
+        var lookup = displayerSettings.getDataSetLookup();
+        return (lookup == null || isBlank(lookup.getDataSetUUID())) && displayerSettings.getDataSet() == null;
     }
 }

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -39,6 +39,7 @@ import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.DataSetLookup;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
+import org.dashbuilder.dataset.client.ExternalDataSetParserProvider;
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
 import org.dashbuilder.dataset.def.HttpMethod;
 import org.jboss.resteasy.util.HttpResponseCodes;

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import com.google.gwt.dev.util.HttpHeaders;
 import elemental2.core.Global;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.FormData;
 import elemental2.dom.Headers;
 import elemental2.dom.RequestInit;
 import elemental2.dom.Response;
@@ -39,6 +40,7 @@ import org.dashbuilder.dataset.DataSetLookup;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
+import org.dashbuilder.dataset.def.HttpMethod;
 import org.jboss.resteasy.util.HttpResponseCodes;
 
 import static org.dashbuilder.common.client.StringUtils.isBlank;
@@ -152,6 +154,15 @@ public class ExternalDataSetClientProvider {
 
         if (def.getQuery() != null) {
             def.getQuery().forEach(url.searchParams::set);
+        }
+        if (def.getMethod() != null) {
+            req.setMethod(def.getMethod().name());
+        }
+
+        if (def.getMethod() == HttpMethod.POST && def.getForm() != null && !def.getForm().isEmpty()) {
+            var form = new FormData();
+            def.getForm().forEach(form::set);
+            req.setBody(form);
         }
 
         DomGlobal.fetch(url.toString(), req).then((Response response) -> {

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -170,11 +170,10 @@ public class ExternalDataSetClientProvider {
             def.getForm().forEach(form::set);
             req.setBody(form);
         }
-
-        DomGlobal.fetch(url.toString(), req).then((Response response) -> {
+        final var finalUrl = url.toString();
+        DomGlobal.fetch(finalUrl, req).then((Response response) -> {
             var contentType = response.headers.get(HttpHeaders.CONTENT_TYPE);
-            var mimeType = SupportedMimeType.byMimeTypeOrUrl(contentType, def.getUrl())
-                    .orElse(DEFAULT_TYPE);
+            var mimeType = SupportedMimeType.byMimeTypeOrUrl(contentType, finalUrl).orElse(DEFAULT_TYPE);
             return response.text().then(responseText -> {
                 if (response.status == HttpResponseCodes.SC_OK) {
                     return register(def, callback, responseText, mimeType);

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetClientProvider.java
@@ -146,6 +146,11 @@ public class ExternalDataSetClientProvider {
             // relative URLs
             url = new URL(def.getUrl(), DomGlobal.location.href);
         }
+
+        if (!isBlank(def.getPath())) {
+            url = new URL(def.getPath(), url);
+        }
+
         if (def.getHeaders() != null) {
             var headers = new Headers();
             def.getHeaders().forEach(headers::append);
@@ -203,8 +208,14 @@ public class ExternalDataSetClientProvider {
         DataSet dataSet = null;
         var content = contentType.tranformer.apply(responseText);
 
-        if (def.getType() != null && isBlank(def.getExpression())) {
-            def.setExpression(def.getType().getExpression());
+        if (def.getType() != null) {
+            var type = def.getType();
+            try {
+                content = applyExpression(type.getExpression(), content);
+            } catch (Exception e) {
+                callback.onError(new ClientRuntimeError("Error evaluating type \"" + type + "\" expression", e));
+                return null;
+            }
         }
 
         if (!isBlank(def.getExpression())) {

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetParserProviderImpl.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/external/ExternalDataSetParserProviderImpl.java
@@ -20,10 +20,11 @@ import javax.enterprise.context.ApplicationScoped;
 
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
+import org.dashbuilder.dataset.client.ExternalDataSetParserProvider;
 import org.dashbuilder.dataset.json.ExternalDataSetJSONParser;
 
 @ApplicationScoped
-public class ExternalDataSetParserProvider {
+public class ExternalDataSetParserProviderImpl implements ExternalDataSetParserProvider {
 
     ExternalDataSetJSONParser parser;
 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/main/java/org/dashbuilder/client/services/JoinDataSetsService.java
@@ -24,7 +24,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.dashbuilder.client.external.ExternalDataSetClientProvider;
-import org.dashbuilder.client.external.ExternalDataSetParserProvider;
 import org.dashbuilder.common.client.error.ClientRuntimeError;
 import org.dashbuilder.dataset.ColumnType;
 import org.dashbuilder.dataset.DataColumn;
@@ -34,6 +33,7 @@ import org.dashbuilder.dataset.DataSetLookup;
 import org.dashbuilder.dataset.DataSetLookupFactory;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
+import org.dashbuilder.dataset.client.ExternalDataSetParserProvider;
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
 
 import static org.dashbuilder.common.client.StringUtils.isBlank;

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/services/JoinDataSetsServiceTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/src/test/java/org/dashbuilder/client/services/JoinDataSetsServiceTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.client.external.ExternalDataSetClientProvider;
-import org.dashbuilder.client.external.ExternalDataSetParserProvider;
 import org.dashbuilder.common.client.error.ClientRuntimeError;
 import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.DataSetFactory;
@@ -27,6 +26,7 @@ import org.dashbuilder.dataset.DataSetLookupFactory;
 import org.dashbuilder.dataset.client.ClientDataSetManager;
 import org.dashbuilder.dataset.client.DataSetReadyCallback;
 import org.dashbuilder.dataset.client.DataSetReadyCallbackAdapter;
+import org.dashbuilder.dataset.client.ExternalDataSetParserProvider;
 import org.dashbuilder.dataset.def.DataSetDefFactory;
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
 import org.junit.Before;

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/main/java/org/dashbuilder/shared/marshalling/GlobalSettingsJSONMarshaller.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/main/java/org/dashbuilder/shared/marshalling/GlobalSettingsJSONMarshaller.java
@@ -15,6 +15,7 @@
  */
 package org.dashbuilder.shared.marshalling;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import org.dashbuilder.dataprovider.DataSetProviderType;
@@ -32,7 +33,7 @@ public class GlobalSettingsJSONMarshaller {
     private static final String MODE = "mode";
     private static final String DATASET = "dataset";
     private static final String ALLOW_URL_PROPERTIES = "allowUrlProperties";
-    private static final Mode DEFAULT_MODE = Mode.LIGHT;    
+    private static final Mode DEFAULT_MODE = Mode.LIGHT;
 
     private static GlobalSettingsJSONMarshaller instance;
 
@@ -58,22 +59,23 @@ public class GlobalSettingsJSONMarshaller {
         if (json != null) {
             mode = retrieveMode(json);
             allowUrlProperties = retrieveAllowUrlProperties(json);
-            var displayerSettingsObj = json.getObject(LayoutTemplateJSONMarshaller.SETTINGS);
+            var displayerSettingsObj = json.getObject(Arrays.asList(LayoutTemplateJSONMarshaller.SETTINGS,
+                    LayoutTemplateJSONMarshaller.DISPLAYER));
             try {
                 displayerSettings = DisplayerSettingsJSONMarshaller.get().fromJsonObject(displayerSettingsObj, false);
             } catch (Exception e) {
-                // ignore settings and use a empty global settings                
+                displayerSettings.setError("Error on global dataset declaration: " + e.getMessage());
             }
-            
+
             var datasetDefJson = json.getObject(DATASET);
             try {
-                DataSetDefJSONMarshaller marshaller = new DataSetDefJSONMarshaller(DataSetProviderType.EXTERNAL);
+                var marshaller = new DataSetDefJSONMarshaller(DataSetProviderType.EXTERNAL);
                 dataSetDef = (ExternalDataSetDef) marshaller.fromJsonObj(datasetDefJson);
-                
-            }  catch (Exception e) {
+
+            } catch (Exception e) {
                 // ignore def and use empty global settings
             }
-            
+
         }
 
         displayerSettings.setMode(mode);

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/main/java/org/dashbuilder/shared/marshalling/LayoutTemplateJSONMarshaller.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/main/java/org/dashbuilder/shared/marshalling/LayoutTemplateJSONMarshaller.java
@@ -243,9 +243,8 @@ public class LayoutTemplateJSONMarshaller {
                 .getCssProperties()));
         if (settings != null) {
             try {
-                component.setSettings(DisplayerSettingsJSONMarshaller.get().fromJsonObject(settings));
+                component.setSettings(DisplayerSettingsJSONMarshaller.get().fromJsonObject(settings, false));
             } catch (Exception e) {
-                // just log the error and let displayers handle missing configuration
                 LOGGER.warn("Error reading component settings", e);
                 var _displayer = new DisplayerSettings();
                 _displayer.setError(e.getMessage());

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
@@ -85,7 +85,8 @@ public class RuntimeModelJSONMarshallerTest {
             "      \"dynamic\": false,\n" + 
             "      \"url\": \"http://acme.com\",\n" +
             "      \"accumulate\": false,\n" +
-            "      \"method\": \"GET\"\n" +
+            "      \"method\": \"GET\",\n" +
+            "      \"path\": \"\"\n" +
             "    }\n" + 
             "  ],\n" + 
             "  \"properties\": {\n" + 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
@@ -84,7 +84,8 @@ public class RuntimeModelJSONMarshallerTest {
             "      \"refreshAlways\": false,\n" + 
             "      \"dynamic\": false,\n" + 
             "      \"url\": \"http://acme.com\",\n" +
-            "      \"accumulate\": false\n" +
+            "      \"accumulate\": false,\n" +
+            "      \"method\": \"GET\"\n" +
             "    }\n" + 
             "  ],\n" + 
             "  \"properties\": {\n" + 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-shared/src/test/java/org/dashbuilder/shared/marshalling/RuntimeModelJSONMarshallerTest.java
@@ -31,67 +31,81 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class RuntimeModelJSONMarshallerTest {
-    
-    private String GLOBAL_DATASET = "{\n" + 
-            "  \"global\": {\n" + 
-            "    \"dataset\": {\n" + 
-            "      \"content\": \"[[\\\"Global\\\"]]\"\n" + 
-            "    }\n" + 
-            "  },\n" + 
-            "  \"datasets\": [\n" + 
-            "    {\n" + 
-            "      \"uuid\": \"a\"\n" + 
-            "    },\n" + 
-            "    {\n" + 
-            "      \"uuid\": \"b\"\n" + 
-            "    }\n" + 
-            "  ],\n" + 
-            "  \"pages\": [\n" + 
-            "    {\n" + 
-            "      \"name\": null\n" + 
-            "    }\n" + 
-            "  ]\n" + 
+
+    private String GLOBAL_DATASET = "{\n" +
+            "  \"global\": {\n" +
+            "    \"dataset\": {\n" +
+            "      \"content\": \"[[\\\"Global\\\"]]\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"datasets\": [\n" +
+            "    {\n" +
+            "      \"uuid\": \"a\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"uuid\": \"b\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"pages\": [\n" +
+            "    {\n" +
+            "      \"name\": null\n" +
+            "    }\n" +
+            "  ]\n" +
             "}";
 
-    private String RUNTIME_MODEL_JSON = "{\n" + 
-            "  \"lastModified\": 123,\n" + 
-            "  \"navTree\": {\n" + 
-            "    \"root_items\": [\n" + 
-            "      {\n" + 
-            "        \"id\": \"TestId\",\n" + 
-            "        \"type\": \"ITEM\",\n" + 
-            "        \"name\": \"TestItem\",\n" + 
-            "        \"description\": \"Item Description\",\n" + 
-            "        \"modifiable\": false\n" + 
-            "      }\n" + 
-            "    ]\n" + 
-            "  },\n" + 
-            "  \"layoutTemplates\": [\n" + 
-            "    {\n" + 
-            "      \"style\": \"FLUID\",\n" + 
-            "      \"name\": \"My Template\"\n" + 
-            "    }\n" + 
-            "  ],\n" + 
-            "  \"datasets\": [\n" + 
-            "    {\n" + 
-            "      \"uuid\": \"123\",\n" + 
-            "      \"provider\": \"External\",\n" + 
-            "      \"isPublic\": true,\n" + 
-            "      \"cacheEnabled\": true,\n" + 
-            "      \"cacheMaxRows\": 1000,\n" + 
-            "      \"pushEnabled\": false,\n" + 
-            "      \"pushMaxSize\": 1024,\n" + 
-            "      \"refreshAlways\": false,\n" + 
-            "      \"dynamic\": false,\n" + 
+    private String SINGLE_GLOBAL_DATASET = "{\n" +
+            "  \"global\": {\n" +
+            "    \"dataset\": {\n" +
+            "      \"uuid\": \"a\",\n" +
+            "      \"content\": \"[[\\\"Global\\\"]]\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"pages\": [\n" +
+            "    {\n" +
+            "      \"name\": null\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    private String RUNTIME_MODEL_JSON = "{\n" +
+            "  \"lastModified\": 123,\n" +
+            "  \"navTree\": {\n" +
+            "    \"root_items\": [\n" +
+            "      {\n" +
+            "        \"id\": \"TestId\",\n" +
+            "        \"type\": \"ITEM\",\n" +
+            "        \"name\": \"TestItem\",\n" +
+            "        \"description\": \"Item Description\",\n" +
+            "        \"modifiable\": false\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"layoutTemplates\": [\n" +
+            "    {\n" +
+            "      \"style\": \"FLUID\",\n" +
+            "      \"name\": \"My Template\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"datasets\": [\n" +
+            "    {\n" +
+            "      \"uuid\": \"123\",\n" +
+            "      \"provider\": \"External\",\n" +
+            "      \"isPublic\": true,\n" +
+            "      \"cacheEnabled\": true,\n" +
+            "      \"cacheMaxRows\": 1000,\n" +
+            "      \"pushEnabled\": false,\n" +
+            "      \"pushMaxSize\": 1024,\n" +
+            "      \"refreshAlways\": false,\n" +
+            "      \"dynamic\": false,\n" +
             "      \"url\": \"http://acme.com\",\n" +
             "      \"accumulate\": false,\n" +
             "      \"method\": \"GET\",\n" +
             "      \"path\": \"\"\n" +
-            "    }\n" + 
-            "  ],\n" + 
-            "  \"properties\": {\n" + 
-            "    \"TEST\": \"VALUE\"\n" + 
-            "  }\n" + 
+            "    }\n" +
+            "  ],\n" +
+            "  \"properties\": {\n" +
+            "    \"TEST\": \"VALUE\"\n" +
+            "  }\n" +
             "}";
 
     RuntimeModelJSONMarshaller marshaller;
@@ -100,7 +114,7 @@ public class RuntimeModelJSONMarshallerTest {
     public void setup() {
         marshaller = RuntimeModelJSONMarshaller.get();
     }
-    
+
     @Test
     public void globalDataSetTest() {
         var model = marshaller.fromJson(GLOBAL_DATASET);
@@ -112,6 +126,16 @@ public class RuntimeModelJSONMarshallerTest {
         assertEquals("[[\"Global\"]]", b.getContent());
         assertEquals("a", a.getUUID());
         assertEquals("b", b.getUUID());
+    }
+
+    @Test
+    public void globalSingleDataSetTest() {
+        var model = marshaller.fromJson(SINGLE_GLOBAL_DATASET);
+        var datasets = model.getClientDataSets();
+        var a = model.getClientDataSets().get(0);
+        assertEquals(1, datasets.size());
+        assertEquals("[[\"Global\"]]", a.getContent());
+        assertEquals("a", a.getUUID());
     }
 
     @Test
@@ -142,7 +166,7 @@ public class RuntimeModelJSONMarshallerTest {
         var model = marshaller.fromJson(RUNTIME_MODEL_JSON);
         checkModel(model);
     }
-    
+
     @Test
     public void fromJsonTestWithPagesTest() {
         var model = marshaller.fromJson(RUNTIME_MODEL_JSON.replaceAll("layoutTemplates", "pages"));

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/GlobalDisplayerSettings.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/GlobalDisplayerSettings.java
@@ -30,13 +30,16 @@ public interface GlobalDisplayerSettings {
         getSettings().ifPresent(globalSettings -> {
             var globalLookup = globalSettings.getDataSetLookup();
             var lookup = settings.getDataSetLookup();
-            var globalColumnsSettings = globalSettings.getColumnSettingsList();
             // Copy Settings
             globalSettings.getSettingsFlatMap().forEach((k, v) -> {
                 if (!settings.getSettingsFlatMap().containsKey(k)) {
                     settings.setDisplayerSetting(k, v);
                 }
             });
+
+            if (globalSettings.getDataSet() != null && settings.getDataSet() == null) {
+                settings.setDataSet(globalSettings.getDataSet());
+            }
 
             // Copy Lookup
             if (globalLookup != null) {

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/GlobalDisplayerSettings.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/GlobalDisplayerSettings.java
@@ -18,6 +18,8 @@ package org.dashbuilder.displayer;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import org.dashbuilder.dataset.DataSetOp;
+
 public interface GlobalDisplayerSettings {
 
     void setDisplayerSettings(DisplayerSettings settings);
@@ -55,8 +57,11 @@ public interface GlobalDisplayerSettings {
                     if (lookup.getNumberOfRows() == -1) {
                         lookup.setNumberOfRows(globalLookup.getNumberOfRows());
                     }
-                    // Operations can't be overriden
-                    globalLookup.getOperationList().forEach(lookup::addOperation);
+                    // Operations can't be overriden, but the global operation should come first
+                    var globalOperations = new ArrayList<DataSetOp>(globalLookup.getOperationList());
+                    lookup.getOperationList().forEach(globalOperations::add);
+                    lookup.getOperationList().clear();
+                    globalOperations.forEach(lookup::addOperation);
                 }
             }
 

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/json/DisplayerSettingsJSONMarshaller.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/json/DisplayerSettingsJSONMarshaller.java
@@ -17,14 +17,15 @@ package org.dashbuilder.displayer.json;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.DataSetLookup;
-import org.dashbuilder.dataset.json.DataSetJSONMarshaller;
 import org.dashbuilder.dataset.json.DataSetLookupJSONMarshaller;
+import org.dashbuilder.dataset.json.ExternalDataSetJSONParser;
 import org.dashbuilder.displayer.ColumnSettings;
 import org.dashbuilder.displayer.DisplayerSettings;
 import org.dashbuilder.displayer.DisplayerType;
@@ -55,17 +56,17 @@ public class DisplayerSettingsJSONMarshaller {
         return SINGLETON;
     }
 
-    private DataSetJSONMarshaller dataSetJsonMarshaller;
+    private ExternalDataSetJSONParser dataSetJsonParser;
     private DataSetLookupJSONMarshaller dataSetLookupJsonMarshaller;
 
     public DisplayerSettingsJSONMarshaller() {
-        this(DataSetJSONMarshaller.get(), DataSetLookupJSONMarshaller.get());
+        this(DataSetLookupJSONMarshaller.get(), new ExternalDataSetJSONParser(s -> new Date(Long.parseLong(s))));
     }
 
-    public DisplayerSettingsJSONMarshaller(DataSetJSONMarshaller dataSetJsonMarshaller,
-                                           DataSetLookupJSONMarshaller dataSetLookupJsonMarshaller) {
-        this.dataSetJsonMarshaller = dataSetJsonMarshaller;
+    public DisplayerSettingsJSONMarshaller(DataSetLookupJSONMarshaller dataSetLookupJsonMarshaller,
+                                           ExternalDataSetJSONParser externalDataSetJSONParser) {
         this.dataSetLookupJsonMarshaller = dataSetLookupJsonMarshaller;
+        dataSetJsonParser = externalDataSetJSONParser;
     }
 
     public DisplayerSettings fromJsonString(String jsonString) {
@@ -98,7 +99,8 @@ public class DisplayerSettingsJSONMarshaller {
 
         if (jsonObject == null ||
             jsonObject.getType() != JsonType.OBJECT) {
-            throw new IllegalArgumentException("Displayer Settings is not using a valid object");
+            // returns an empty displayer
+            return ds;
         }
 
         // UUID
@@ -116,10 +118,10 @@ public class DisplayerSettingsJSONMarshaller {
                 DATASET_LOOKUP_PREFIX.toUpperCase(),
                 "datasetLookup",
                 "lookup");
-        var data = jsonObject.getObject(DATASET_PREFIX);
+        var data = jsonObject.getString(DATASET_PREFIX);
         var lookup = dataSetLookupJsonMarshaller.fromJson(jsonObject.getObject(lookupNames));
         if (data != null) {
-            var dataSet = dataSetJsonMarshaller.fromJson(data);
+            var dataSet = dataSetJsonParser.parseDataSet(data);
             ds.setDataSet(dataSet);
 
             // Remove from the json input so that it doesn't end up in the settings map.
@@ -180,7 +182,7 @@ public class DisplayerSettingsJSONMarshaller {
         DataSetLookup dataSetLookup = displayerSettings.getDataSetLookup();
         DataSet dataSet = displayerSettings.getDataSet();
         if (dataSet != null) {
-            json.put(DATASET_PREFIX, dataSetJsonMarshaller.toJson(dataSet));
+            json.put(DATASET_PREFIX, dataSetJsonParser.toJsonArray(dataSet));
         } else if (dataSetLookup != null) {
             json.put(DATASET_LOOKUP_PREFIX, dataSetLookupJsonMarshaller.toJson(dataSetLookup));
         } else {
@@ -194,6 +196,10 @@ public class DisplayerSettingsJSONMarshaller {
         }
 
         return json;
+    }
+
+    public void setDataSetJsonParser(ExternalDataSetJSONParser dataSetJsonParser) {
+        this.dataSetJsonParser = dataSetJsonParser;
     }
 
     private void setNodeValue(JsonObject node, String path, String value) {

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/test/java/org/dashbuilder/displayer/GlobalDisplayerSettingsTest.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/test/java/org/dashbuilder/displayer/GlobalDisplayerSettingsTest.java
@@ -18,6 +18,8 @@ package org.dashbuilder.displayer;
 import java.util.Optional;
 
 import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetOpType;
+import org.dashbuilder.dataset.filter.DataSetFilter;
 import org.dashbuilder.dataset.sort.DataSetSort;
 import org.junit.Test;
 
@@ -143,16 +145,37 @@ public class GlobalDisplayerSettingsTest {
     }
 
     @Test
+    public void testLookupOpOrder() {
+        var globalSettings = new DisplayerSettings();
+        var settings = new DisplayerSettings();
+
+        var userLookup = new DataSetLookup(null);
+        userLookup.addOperation(new DataSetFilter());
+        settings.setDataSetLookup(userLookup);
+
+        var globalLookup = new DataSetLookup("GLOBAL UUID");
+        globalLookup.addOperation(new DataSetSort());
+        globalSettings.setDataSetLookup(globalLookup);
+
+        globalDisplayerSettings.setDisplayerSettings(globalSettings);
+        globalDisplayerSettings.apply(settings);
+
+        assertEquals(globalLookup.getDataSetUUID(), settings.getDataSetLookup().getDataSetUUID());
+        assertEquals(DataSetOpType.SORT, settings.getDataSetLookup().getOperation(0).getType());
+        assertEquals(DataSetOpType.FILTER, settings.getDataSetLookup().getOperation(1).getType());
+    }
+
+    @Test
     public void testGlobalColumnsSettings() {
         var globalSettings = new DisplayerSettings();
         var settings = new DisplayerSettings();
-        var userSettingsColumnId= "user columns";
-        var globalSettingsColumnId= "global column";
+        var userSettingsColumnId = "user columns";
+        var globalSettingsColumnId = "global column";
         settings.getColumnSettingsList().add(new ColumnSettings(userSettingsColumnId));
         globalSettings.getColumnSettingsList().add(new ColumnSettings(globalSettingsColumnId));
         globalDisplayerSettings.setDisplayerSettings(globalSettings);
         globalDisplayerSettings.apply(settings);
-        
+
         assertEquals(2, settings.getColumnSettingsList().size());
         assertEquals(globalSettingsColumnId, settings.getColumnSettingsList().get(0).getColumnId());
         assertEquals(userSettingsColumnId, settings.getColumnSettingsList().get(1).getColumnId());

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
@@ -38,9 +38,13 @@ public class ExternalDataSetDef extends DataSetDef {
 
     private Map<String, String> query = new HashMap<>();
 
+    private Map<String, String> form = new HashMap<>();
+
     private boolean accumulate;
 
     private ExternalServiceType type;
+
+    private HttpMethod method = HttpMethod.GET;
 
     private Collection<String> join;
 
@@ -119,7 +123,23 @@ public class ExternalDataSetDef extends DataSetDef {
     public Map<String, String> getQuery() {
         return query;
     }
-    
+
+    public Map<String, String> getForm() {
+        return form;
+    }
+
+    public void setForm(Map<String, String> form) {
+        this.form = form;
+    }
+
+    public void setMethod(HttpMethod method) {
+        this.method = method;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
     public void validate() {
         super.validate();
         if (isBlank(url) && isBlank(content) && (join == null || join.isEmpty())) {
@@ -139,6 +159,8 @@ public class ExternalDataSetDef extends DataSetDef {
         def.setType(getType());
         def.setJoin(getJoin());
         def.setQuery(getQuery());
+        def.setForm(getForm());
+        def.setMethod(getMethod());
         return def;
     }
 
@@ -159,7 +181,9 @@ public class ExternalDataSetDef extends DataSetDef {
                Objects.equals(accumulate, other.accumulate) &&
                Objects.equals(type, other.type) &&
                Objects.equals(join, other.join) &&
-               Objects.equals(query, other.query);
+               Objects.equals(query, other.query) &&
+               Objects.equals(form, other.form) &&
+               Objects.equals(method, other.method);
     }
 
     public String toString() {
@@ -175,9 +199,11 @@ public class ExternalDataSetDef extends DataSetDef {
         out.append("Content=").append(content).append("\n");
         out.append("Headers=").append(headers).append("\n");
         out.append("Accumulate=").append(accumulate).append("\n");
-        out.append("Type=").append(type);
-        out.append("Join=").append(join);
-        out.append("Query=").append(query);
+        out.append("Type=").append(type).append("\n");
+        out.append("Join=").append(join).append("\n");
+        out.append("Query=").append(query).append("\n");
+        out.append("Form=").append(form).append("\n");
+        out.append("Method=").append(method);
         return out.toString();
     }
 
@@ -192,7 +218,9 @@ public class ExternalDataSetDef extends DataSetDef {
                 accumulate,
                 type,
                 join,
-                query);
+                query,
+                form,
+                method);
     }
 
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/ExternalDataSetDef.java
@@ -46,6 +46,8 @@ public class ExternalDataSetDef extends DataSetDef {
 
     private HttpMethod method = HttpMethod.GET;
 
+    private String path = "";
+
     private Collection<String> join;
 
     public ExternalDataSetDef() {
@@ -140,6 +142,14 @@ public class ExternalDataSetDef extends DataSetDef {
         return method;
     }
 
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
     public void validate() {
         super.validate();
         if (isBlank(url) && isBlank(content) && (join == null || join.isEmpty())) {
@@ -161,6 +171,7 @@ public class ExternalDataSetDef extends DataSetDef {
         def.setQuery(getQuery());
         def.setForm(getForm());
         def.setMethod(getMethod());
+        def.setPath(getPath());
         return def;
     }
 
@@ -183,7 +194,8 @@ public class ExternalDataSetDef extends DataSetDef {
                Objects.equals(join, other.join) &&
                Objects.equals(query, other.query) &&
                Objects.equals(form, other.form) &&
-               Objects.equals(method, other.method);
+               Objects.equals(method, other.method) &&
+               Objects.equals(path, other.path);
     }
 
     public String toString() {
@@ -203,7 +215,8 @@ public class ExternalDataSetDef extends DataSetDef {
         out.append("Join=").append(join).append("\n");
         out.append("Query=").append(query).append("\n");
         out.append("Form=").append(form).append("\n");
-        out.append("Method=").append(method);
+        out.append("Method=").append(method).append("\n");
+        out.append("Path=").append(path);
         return out.toString();
     }
 
@@ -220,7 +233,8 @@ public class ExternalDataSetDef extends DataSetDef {
                 join,
                 query,
                 form,
-                method);
+                method,
+                path);
     }
 
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/HttpMethod.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/HttpMethod.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataset.def;
+
+/**
+ * Support HTTP Methods for external datasets. Other methods are usually not used, hence ommited here.
+ *
+ */
+public enum HttpMethod {
+
+    POST("POST"),
+    GET("GET"),
+    HEAD("HEAD");
+
+    private HttpMethod(String method) {
+        this.method = method;
+    }
+
+    private String method;
+
+    public String getMethod() {
+        return method;
+    }
+
+    public static HttpMethod byName(String type) {
+        if (type != null) {
+            for (var t : HttpMethod.values()) {
+                if (t.name().equalsIgnoreCase(type)) {
+                    return t;
+                }
+            }
+        }
+        return GET;
+    }
+}

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.dashbuilder.dataset.def.ExternalDataSetDef;
 import org.dashbuilder.dataset.def.ExternalServiceType;
+import org.dashbuilder.dataset.def.HttpMethod;
 import org.dashbuilder.json.Json;
 import org.dashbuilder.json.JsonObject;
 
@@ -39,6 +40,8 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
     public static final String ACCUMULATE = "accumulate";
     public static final String TYPE = "type";
     public static final String JOIN = "join";
+    public static final String FORM = "form";
+    public static final String METHOD = "method";
 
     @Override
     public void fromJson(ExternalDataSetDef def, JsonObject json) {
@@ -47,9 +50,11 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         var content = json.getString(CONTENT);
         var expression = json.getString(EXPRESSION);
         var headers = json.getObject(HEADERS);
+        var form = json.getObject(FORM);
         var query = json.getObject(QUERY);
         var accumulate = json.getBoolean(ACCUMULATE);
         var type = json.getString(TYPE);
+        var method = json.getString(METHOD);
         var join = json.getArray(JOIN);
 
         if (!isBlank(url)) {
@@ -64,6 +69,10 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
             def.setExpression(expression);
         }
 
+        if (!isBlank(method)) {
+            def.setMethod(HttpMethod.byName(method));
+        }
+
         if (headers != null) {
             var headersMap = getMap(headers);
             def.setHeaders(headersMap);
@@ -72,6 +81,11 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         if (query != null) {
             var queryMap = getMap(query);
             def.setQuery(queryMap);
+        }
+
+        if (form != null) {
+            var formMap = getMap(form);
+            def.setForm(formMap);
         }
 
         if (!isBlank(type)) {
@@ -101,16 +115,23 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
             json.put(TYPE, def.getType().name());
         }
 
+        if (def.getMethod() != null) {
+            json.put(METHOD, def.getMethod().name());
+        }
+
         if (def.getHeaders() != null) {
-            var headers = Json.createObject();
-            def.getHeaders().forEach((k, v) -> headers.set(k, Json.create(v)));
+            var headers = mapToObject(def.getHeaders());
             json.set(HEADERS, headers);
         }
 
         if (def.getQuery() != null) {
-            var query = Json.createObject();
-            def.getQuery().forEach((k, v) -> query.set(k, Json.create(v)));
+            var query = mapToObject(def.getQuery());
             json.set(QUERY, query);
+        }
+
+        if (def.getForm() != null) {
+            var form = mapToObject(def.getForm());
+            json.set(FORM, form);
         }
 
         if (def.getJoin() != null) {
@@ -120,6 +141,12 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
             }
             json.set(JOIN, join);
         }
+    }
+
+    private JsonObject mapToObject(Map<String, String> map) {
+        var object = Json.createObject();
+        map.forEach((k, v) -> object.set(k, Json.create(v)));
+        return object;
     }
 
     private Map<String, String> getMap(JsonObject map) {

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/json/ExternalDefJSONMarshaller.java
@@ -42,6 +42,7 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
     public static final String JOIN = "join";
     public static final String FORM = "form";
     public static final String METHOD = "method";
+    public static final String PATH = "path";
 
     @Override
     public void fromJson(ExternalDataSetDef def, JsonObject json) {
@@ -54,6 +55,7 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
         var query = json.getObject(QUERY);
         var accumulate = json.getBoolean(ACCUMULATE);
         var type = json.getString(TYPE);
+        var path = json.getString(PATH);
         var method = json.getString(METHOD);
         var join = json.getArray(JOIN);
 
@@ -71,6 +73,10 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
 
         if (!isBlank(method)) {
             def.setMethod(HttpMethod.byName(method));
+        }
+
+        if (!isBlank(path)) {
+            def.setPath(path);
         }
 
         if (headers != null) {
@@ -117,6 +123,10 @@ public class ExternalDefJSONMarshaller implements DataSetDefJSONMarshallerExt<Ex
 
         if (def.getMethod() != null) {
             json.put(METHOD, def.getMethod().name());
+        }
+
+        if (def.getPath() != null) {
+            json.put(PATH, def.getPath());
         }
 
         if (def.getHeaders() != null) {


### PR DESCRIPTION
Adds support for POST method in datasets. Here's a sample:

```
datasets:
  - uuid: pop
    url: /datasets/population.json
    method: "POST"
    form:
        formKey: FormValue
pages:
  - components:
      - settings:
          lookup:
            uuid: pop
```

This PR also includes:

* Support for `path` in datasets;
* Support for inline `dataSet` in displayers
* Fix for global lookup - now global displayer global lookup is respected
* Support a single global dataset only no datasets are declared.