### PR TITLE
NO-ISSUE: Temporarily disable `chrome-extensions-pack-kogito-kie-editors` integration tests

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/package.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/package.json
@@ -19,7 +19,7 @@
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "start": "webpack serve --env dev",
     "test": "run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --verbose --passWithNoTests\"",
-    "test:it": "run-script-if --ignore-errors \"$(build-env integrationTests.ignoreFailures)\" --bool \"$(build-env integrationTests.run)\" --then \"pnpm rimraf ./dist-it-tests\" \"pnpm start-server-and-test test:it:start https-get://localhost:$(build-env chromeExtension.dev.port) test:it:run\"",
+    "test:it": "run-script-if --ignore-errors \"$(build-env integrationTests.ignoreFailures)\" --bool false --then \"pnpm rimraf ./dist-it-tests\" \"pnpm start-server-and-test test:it:start https-get://localhost:$(build-env chromeExtension.dev.port) test:it:run\"",
     "test:it:run": "jest --runInBand -c ./jest.it.config.js",
     "test:it:start": "pnpm start"
   },


### PR DESCRIPTION
Since [1] our CI is breaking while performing the integration tests for `chrome-extensions-pack-kogito-kie-editors`. So while https://github.com/kiegroup/kie-issues/issues/247 is not fixed, we are disabling these tests.

[1] https://github.blog/changelog/2023-07-06-anonymous-users-have-access-to-new-code-view-and-navigation/