### PR TITLE
NO-ISSUE: Temporarily disable `serverless-logic-web-tools-swf-dev-mode-image` build due to lack of space

### DIFF
--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/package.json
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build:dev": "echo Nothing to do",
-    "build:prod": "pnpm cleanup && run-script-os",
+    "build:prod": "echo Temporarily disabled",
     "build:prod:darwin": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy:assets\" \"pnpm image:docker:build\"",
     "build:prod:linux": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy:assets\" \"pnpm image:podman:build\"",
     "build:prod:win32": "echo \"Build not supported on Windows\"",


### PR DESCRIPTION
After daily-dev and staging builds complained about lack of space, now CI Full Build is failing for the same reason.
Since `serverless-logic-web-tools-swf-dev-mode-image` is our largest image, I am temporarily disabling its build until we improve the CI Build, and also to unblock PRs. Ideally, container images and their used resources must be clean up right after their successful build on CI Build.