### PR TITLE
KOGITO-9248: Show create and import cards in RecentModels if there are no models

### DIFF
--- a/packages/serverless-logic-web-tools/src/homepage/overView/CreateOrImportModelGrid.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/overView/CreateOrImportModelGrid.tsx
@@ -16,53 +16,21 @@
 import React from "react";
 import { FileTypes } from "@kie-tools-core/workspaces-git-fs/dist/constants/ExtensionHelper";
 import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
-import { Card, CardBody } from "@patternfly/react-core/dist/js/components/Card";
-import { CardHeader, CardHeaderMain, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
+import { Card, CardBody, CardHeader, CardHeaderMain, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { Gallery } from "@patternfly/react-core/dist/js/layouts/Gallery";
 import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
-import { useCallback, useContext, useMemo } from "react";
-import { useHistory } from "react-router";
-import { useRoutes } from "../../navigation/Hooks";
-import { QueryParams } from "../../navigation/Routes";
-import { useQueryParam, useQueryParams } from "../../queryParams/QueryParamsContext";
+import { useContext, useMemo } from "react";
 import { ImportFromUrlCard } from "./ImportFromUrlCard";
 import { NewModelCard } from "./NewModelCard";
 import { UploadCard } from "./UploadCard";
 
 export function CreateOrImportModelGrid(props: { isNavOpen: boolean }) {
-  const routes = useRoutes();
-  const history = useHistory();
-  const expandedWorkspaceId = useQueryParam(QueryParams.EXPAND);
-  const queryParams = useQueryParams();
   const qsContext = useContext<QuickStartContextValues>(QuickStartContext);
 
   const force12Cols = useMemo(
     () => props.isNavOpen && !!qsContext.activeQuickStartID,
     [props.isNavOpen, qsContext.activeQuickStartID]
-  );
-
-  const closeExpandedWorkspace = useCallback(() => {
-    history.replace({
-      pathname: routes.home.path({}),
-      search: queryParams.without(QueryParams.EXPAND).toString(),
-    });
-  }, [history, routes, queryParams]);
-
-  const expandWorkspace = useCallback(
-    (workspaceId: string) => {
-      const expand = workspaceId !== expandedWorkspaceId ? workspaceId : undefined;
-      if (!expand) {
-        closeExpandedWorkspace();
-        return;
-      }
-
-      history.replace({
-        pathname: routes.home.path({}),
-        search: routes.home.queryString({ expand }),
-      });
-    },
-    [closeExpandedWorkspace, history, routes, expandedWorkspaceId]
   );
 
   return (
@@ -116,7 +84,7 @@ export function CreateOrImportModelGrid(props: { isNavOpen: boolean }) {
               style={{ height: "calc(100% - 32px)" }}
             >
               <ImportFromUrlCard />
-              <UploadCard expandWorkspace={expandWorkspace} />
+              <UploadCard />
             </Gallery>
           </CardBody>
         </Card>

--- a/packages/serverless-logic-web-tools/src/homepage/overView/CreateOrImportModelGrid.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/overView/CreateOrImportModelGrid.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react";
+import { FileTypes } from "@kie-tools-core/workspaces-git-fs/dist/constants/ExtensionHelper";
+import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
+import { Card, CardBody } from "@patternfly/react-core/dist/js/components/Card";
+import { CardHeader, CardHeaderMain, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
+import { Title } from "@patternfly/react-core/dist/js/components/Title";
+import { Gallery } from "@patternfly/react-core/dist/js/layouts/Gallery";
+import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
+import { useCallback, useContext, useMemo } from "react";
+import { useHistory } from "react-router";
+import { useRoutes } from "../../navigation/Hooks";
+import { QueryParams } from "../../navigation/Routes";
+import { useQueryParam, useQueryParams } from "../../queryParams/QueryParamsContext";
+import { ImportFromUrlCard } from "./ImportFromUrlCard";
+import { NewModelCard } from "./NewModelCard";
+import { UploadCard } from "./UploadCard";
+
+export function CreateOrImportModelGrid(props: { isNavOpen: boolean }) {
+  const routes = useRoutes();
+  const history = useHistory();
+  const expandedWorkspaceId = useQueryParam(QueryParams.EXPAND);
+  const queryParams = useQueryParams();
+  const qsContext = useContext<QuickStartContextValues>(QuickStartContext);
+
+  const force12Cols = useMemo(
+    () => props.isNavOpen && !!qsContext.activeQuickStartID,
+    [props.isNavOpen, qsContext.activeQuickStartID]
+  );
+
+  const closeExpandedWorkspace = useCallback(() => {
+    history.replace({
+      pathname: routes.home.path({}),
+      search: queryParams.without(QueryParams.EXPAND).toString(),
+    });
+  }, [history, routes, queryParams]);
+
+  const expandWorkspace = useCallback(
+    (workspaceId: string) => {
+      const expand = workspaceId !== expandedWorkspaceId ? workspaceId : undefined;
+      if (!expand) {
+        closeExpandedWorkspace();
+        return;
+      }
+
+      history.replace({
+        pathname: routes.home.path({}),
+        search: routes.home.queryString({ expand }),
+      });
+    },
+    [closeExpandedWorkspace, history, routes, expandedWorkspaceId]
+  );
+
+  return (
+    <Grid hasGutter>
+      <GridItem xl={12} xl2={force12Cols ? 12 : 6}>
+        <Card className="Dev-ui__card-size" style={{ height: "100%" }}>
+          <CardHeader>
+            <CardHeaderMain>
+              <CardTitle>
+                <Title headingLevel="h2">Create</Title>
+              </CardTitle>
+            </CardHeaderMain>
+          </CardHeader>
+          <CardBody>
+            <Grid>
+              <NewModelCard
+                title={"Workflow"}
+                jsonExtension={FileTypes.SW_JSON}
+                yamlExtension={FileTypes.SW_YAML}
+                description={"Define orchestration logic for services."}
+              />
+              <NewModelCard
+                title={"Decision"}
+                jsonExtension={FileTypes.YARD_JSON}
+                yamlExtension={FileTypes.YARD_YAML}
+                description={"Define decision logic for services."}
+              />
+              <NewModelCard
+                title={"Dashboard"}
+                yamlExtension={FileTypes.DASH_YAML}
+                description={"Define data visualization from data extracted from applications."}
+              />
+            </Grid>
+          </CardBody>
+        </Card>
+      </GridItem>
+      <GridItem xl={12} xl2={force12Cols ? 12 : 6}>
+        <Card className="Dev-ui__card-size" style={{ height: "100%" }}>
+          <CardHeader>
+            <CardHeaderMain>
+              <CardTitle>
+                <Title headingLevel="h2">Import</Title>
+              </CardTitle>
+            </CardHeaderMain>
+          </CardHeader>
+          <CardBody>
+            <Gallery
+              hasGutter={true}
+              // 16px is the "Gutter" width.
+              minWidths={{ sm: "calc(50% - 16px)", default: "100%" }}
+              style={{ height: "calc(100% - 32px)" }}
+            >
+              <ImportFromUrlCard />
+              <UploadCard expandWorkspace={expandWorkspace} />
+            </Gallery>
+          </CardBody>
+        </Card>
+      </GridItem>
+    </Grid>
+  );
+}

--- a/packages/serverless-logic-web-tools/src/homepage/overView/Overview.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/overView/Overview.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
 import { Button, ButtonVariant, Card } from "@patternfly/react-core/dist/js";
 import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
@@ -24,52 +23,14 @@ import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
 import { Stack, StackItem } from "@patternfly/react-core/dist/js/layouts/Stack";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/js/icons";
 import * as React from "react";
-import { useCallback, useContext, useEffect, useMemo } from "react";
-import { useHistory } from "react-router";
+import { useEffect } from "react";
 import { SERVERLESS_LOGIC_WEBTOOLS_DOCUMENTATION_URL } from "../../AppConstants";
-import { useRoutes } from "../../navigation/Hooks";
-import { QueryParams } from "../../navigation/Routes";
 import { setPageTitle } from "../../PageTitle";
-import { useQueryParam, useQueryParams } from "../../queryParams/QueryParamsContext";
 import { CreateOrImportModelGrid } from "./CreateOrImportModelGrid";
 
 const PAGE_TITLE = "Overview";
 
 export function Overview(props: { isNavOpen: boolean }) {
-  const routes = useRoutes();
-  const history = useHistory();
-  const expandedWorkspaceId = useQueryParam(QueryParams.EXPAND);
-  const queryParams = useQueryParams();
-  const qsContext = useContext<QuickStartContextValues>(QuickStartContext);
-
-  const force12Cols = useMemo(
-    () => props.isNavOpen && !!qsContext.activeQuickStartID,
-    [props.isNavOpen, qsContext.activeQuickStartID]
-  );
-
-  const closeExpandedWorkspace = useCallback(() => {
-    history.replace({
-      pathname: routes.home.path({}),
-      search: queryParams.without(QueryParams.EXPAND).toString(),
-    });
-  }, [history, routes, queryParams]);
-
-  const expandWorkspace = useCallback(
-    (workspaceId: string) => {
-      const expand = workspaceId !== expandedWorkspaceId ? workspaceId : undefined;
-      if (!expand) {
-        closeExpandedWorkspace();
-        return;
-      }
-
-      history.replace({
-        pathname: routes.home.path({}),
-        search: routes.home.queryString({ expand }),
-      });
-    },
-    [closeExpandedWorkspace, history, routes, expandedWorkspaceId]
-  );
-
   useEffect(() => {
     setPageTitle([PAGE_TITLE]);
   }, []);

--- a/packages/serverless-logic-web-tools/src/homepage/overView/Overview.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/overView/Overview.tsx
@@ -14,29 +14,24 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import { FileTypes } from "@kie-tools-core/workspaces-git-fs/dist/constants/ExtensionHelper";
-import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
-import { Gallery } from "@patternfly/react-core/dist/js/layouts/Gallery";
+import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
+import { Button, ButtonVariant, Card } from "@patternfly/react-core/dist/js";
+import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
-import { NewModelCard } from "./NewModelCard";
-import { Button, ButtonVariant, Card, CardBody } from "@patternfly/react-core/dist/js";
-import { ImportFromUrlCard } from "./ImportFromUrlCard";
-import { UploadCard } from "./UploadCard";
-import { useRoutes } from "../../navigation/Hooks";
-import { useHistory } from "react-router";
-import { useQueryParam, useQueryParams } from "../../queryParams/QueryParamsContext";
-import { QueryParams } from "../../navigation/Routes";
-import { useEffect, useCallback, useContext, useMemo } from "react";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
+import { Grid, GridItem } from "@patternfly/react-core/dist/js/layouts/Grid";
 import { Stack, StackItem } from "@patternfly/react-core/dist/js/layouts/Stack";
-import { CardHeader, CardHeaderMain, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
-import { List, ListItem } from "@patternfly/react-core/dist/js/components/List";
-import { QuickStartContext, QuickStartContextValues } from "@patternfly/quickstarts";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/js/icons";
+import * as React from "react";
+import { useCallback, useContext, useEffect, useMemo } from "react";
+import { useHistory } from "react-router";
 import { SERVERLESS_LOGIC_WEBTOOLS_DOCUMENTATION_URL } from "../../AppConstants";
+import { useRoutes } from "../../navigation/Hooks";
+import { QueryParams } from "../../navigation/Routes";
 import { setPageTitle } from "../../PageTitle";
+import { useQueryParam, useQueryParams } from "../../queryParams/QueryParamsContext";
+import { CreateOrImportModelGrid } from "./CreateOrImportModelGrid";
 
 const PAGE_TITLE = "Overview";
 
@@ -122,63 +117,9 @@ export function Overview(props: { isNavOpen: boolean }) {
           </StackItem>
         </Stack>
       </PageSection>
-      <PageSection className="appsrv-marketing--page-section--marketing" isWidthLimited>
-        <Grid hasGutter>
-          <GridItem xl={12} xl2={force12Cols ? 12 : 6}>
-            <Card className="Dev-ui__card-size" style={{ height: "100%" }}>
-              <CardHeader>
-                <CardHeaderMain>
-                  <CardTitle>
-                    <Title headingLevel="h2">Create</Title>
-                  </CardTitle>
-                </CardHeaderMain>
-              </CardHeader>
-              <CardBody>
-                <Grid>
-                  <NewModelCard
-                    title={"Workflow"}
-                    jsonExtension={FileTypes.SW_JSON}
-                    yamlExtension={FileTypes.SW_YAML}
-                    description={"Define orchestration logic for services."}
-                  />
-                  <NewModelCard
-                    title={"Decision"}
-                    jsonExtension={FileTypes.YARD_JSON}
-                    yamlExtension={FileTypes.YARD_YAML}
-                    description={"Define decision logic for services."}
-                  />
-                  <NewModelCard
-                    title={"Dashboard"}
-                    yamlExtension={FileTypes.DASH_YAML}
-                    description={"Define data visualization from data extracted from applications."}
-                  />
-                </Grid>
-              </CardBody>
-            </Card>
-          </GridItem>
-          <GridItem xl={12} xl2={force12Cols ? 12 : 6}>
-            <Card className="Dev-ui__card-size" style={{ height: "100%" }}>
-              <CardHeader>
-                <CardHeaderMain>
-                  <CardTitle>
-                    <Title headingLevel="h2">Import</Title>
-                  </CardTitle>
-                </CardHeaderMain>
-              </CardHeader>
-              <CardBody>
-                <Gallery
-                  hasGutter={true}
-                  // 16px is the "Gutter" width.
-                  minWidths={{ sm: "calc(50% - 16px)", default: "100%" }}
-                  style={{ height: "calc(100% - 32px)" }}
-                >
-                  <ImportFromUrlCard />
-                  <UploadCard expandWorkspace={expandWorkspace} />
-                </Gallery>
-              </CardBody>
-            </Card>
-          </GridItem>
-        </Grid>
+
+      <PageSection className="appsrv-marketing--page-section--marketing">
+        <CreateOrImportModelGrid isNavOpen={props.isNavOpen} />
       </PageSection>
 
       <PageSection isWidthLimited className="appsrv-marketing--page-section--marketing" variant="light">

--- a/packages/serverless-logic-web-tools/src/homepage/overView/UploadCard.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/overView/UploadCard.tsx
@@ -38,7 +38,7 @@ enum UploadType {
   DND,
 }
 
-export function UploadCard(props: { expandWorkspace: (workspaceId: string) => void }) {
+export function UploadCard() {
   const routes = useRoutes();
   const history = useHistory();
   const workspaces = useWorkspaces();
@@ -117,7 +117,7 @@ export function UploadCard(props: { expandWorkspace: (workspaceId: string) => vo
         });
 
         if (!suggestedFirstFile) {
-          return props.expandWorkspace(workspace.workspaceId);
+          return;
         }
 
         history.push({
@@ -131,7 +131,7 @@ export function UploadCard(props: { expandWorkspace: (workspaceId: string) => vo
         // setUploading(UploadType.NONE);
       }
     },
-    [props, workspaces, history, routes]
+    [workspaces, history, routes]
   );
 
   const { acceptedFiles, getRootProps, getInputProps, isDragActive, draggedFiles } = useDropzone({

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
@@ -36,10 +36,11 @@ import Fuse from "fuse.js";
 import { useAllWorkspacesWithFilesPromise } from "./hooks/useAllWorkspacesWithFilesPromise";
 import { WorkspaceKind } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceOrigin";
 import { GIT_DEFAULT_BRANCH } from "@kie-tools-core/workspaces-git-fs/dist/constants/GitConstants";
+import { CreateOrImportModelGrid } from "../overView/CreateOrImportModelGrid";
 
 const PAGE_TITLE = "Recent models";
 
-export function RecentModels() {
+export function RecentModels(props: { isNavOpen: boolean }) {
   const [selectedWorkspaceIds, setSelectedWorkspaceIds] = useState<WorkspaceDescriptor["workspaceId"][]>([]);
   const [deletingWorkspaceIds, setDeletingWorkspaceIds] = useState<WorkspaceDescriptor["workspaceId"][]>([]);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
@@ -263,61 +264,64 @@ export function RecentModels() {
         </PageSection>
 
         <PageSection isFilled aria-label="workspaces-table-section">
-          <PageSection variant={"light"} padding={{ default: "noPadding" }}>
-            {tableData.length > 0 && (
-              <>
-                <TableToolbar
-                  itemCount={filteredTableData.length}
-                  onDeleteActionButtonClick={onBulkConfirmDeleteModalOpen}
-                  onToggleAllElements={(checked) => onToggleAllElements(checked)}
-                  searchValue={searchValue}
-                  selectedElementsCount={selectedWorkspaceIds.length}
-                  setSearchValue={setSearchValue}
-                  page={page}
-                  perPage={perPage}
-                  perPageOptions={defaultPerPageOptions}
-                  setPage={setPage}
-                  setPerPage={setPerPage}
-                />
-                <WorkspacesTable
-                  page={page}
-                  perPage={perPage}
-                  onClearFilters={onClearFilters}
-                  onWsToggle={onWsToggle}
-                  selectedWorkspaceIds={selectedWorkspaceIds}
-                  tableData={filteredTableData}
-                  onDelete={onSingleConfirmDeleteModalOpen}
-                />
-                <TablePagination
-                  itemCount={filteredTableData.length}
-                  page={page}
-                  perPage={perPage}
-                  perPageOptions={defaultPerPageOptions}
-                  setPage={setPage}
-                  setPerPage={setPerPage}
-                  variant="bottom"
-                />
-              </>
-            )}
-            {tableData.length === 0 && (
-              <Bullseye>
-                <EmptyState>
-                  <EmptyStateIcon icon={CubesIcon} />
-                  <Title headingLevel="h4" size="lg">
-                    {`Nothing here`}
-                  </Title>
-                  <EmptyStateBody>
-                    <TextContent>
-                      <Text>
-                        Start by adding a <Link to={routes.home.path({})}>new model</Link> or{" "}
-                        <Link to={routes.sampleCatalog.path({})}>try a sample</Link>
-                      </Text>
-                    </TextContent>
-                  </EmptyStateBody>
-                </EmptyState>
-              </Bullseye>
-            )}
-          </PageSection>
+          {tableData.length > 0 && (
+            <PageSection variant={"light"} padding={{ default: "noPadding" }}>
+              <TableToolbar
+                itemCount={filteredTableData.length}
+                onDeleteActionButtonClick={onBulkConfirmDeleteModalOpen}
+                onToggleAllElements={(checked) => onToggleAllElements(checked)}
+                searchValue={searchValue}
+                selectedElementsCount={selectedWorkspaceIds.length}
+                setSearchValue={setSearchValue}
+                page={page}
+                perPage={perPage}
+                perPageOptions={defaultPerPageOptions}
+                setPage={setPage}
+                setPerPage={setPerPage}
+              />
+              <WorkspacesTable
+                page={page}
+                perPage={perPage}
+                onClearFilters={onClearFilters}
+                onWsToggle={onWsToggle}
+                selectedWorkspaceIds={selectedWorkspaceIds}
+                tableData={filteredTableData}
+                onDelete={onSingleConfirmDeleteModalOpen}
+              />
+              <TablePagination
+                itemCount={filteredTableData.length}
+                page={page}
+                perPage={perPage}
+                perPageOptions={defaultPerPageOptions}
+                setPage={setPage}
+                setPerPage={setPerPage}
+                variant="bottom"
+              />
+            </PageSection>
+          )}
+          {tableData.length === 0 && (
+            <>
+              <PageSection variant={"light"} padding={{ default: "noPadding" }}>
+                <Bullseye>
+                  <EmptyState>
+                    <EmptyStateIcon icon={CubesIcon} />
+                    <Title headingLevel="h4" size="lg">
+                      {`Nothing here`}
+                    </Title>
+                    <EmptyStateBody>
+                      <TextContent>
+                        <Text>
+                          Start by adding a model or <Link to={routes.sampleCatalog.path({})}>try a sample</Link>
+                        </Text>
+                      </TextContent>
+                    </EmptyStateBody>
+                  </EmptyState>
+                </Bullseye>
+              </PageSection>
+              <br />
+              <CreateOrImportModelGrid isNavOpen={props.isNavOpen} />
+            </>
+          )}
         </PageSection>
       </Page>
       <ConfirmDeleteModal

--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/RecentModels.tsx
@@ -299,7 +299,7 @@ export function RecentModels(props: { isNavOpen: boolean }) {
               />
             </PageSection>
           )}
-          {tableData.length === 0 && (
+          {workspacesWithFilesPromise.data && tableData.length === 0 && (
             <>
               <PageSection variant={"light"} padding={{ default: "noPadding" }}>
                 <Bullseye>

--- a/packages/serverless-logic-web-tools/src/homepage/routes/HomePageRoutes.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/routes/HomePageRoutes.tsx
@@ -63,7 +63,7 @@ export function HomePageRoutes(props: { isNavOpen: boolean }) {
         <Overview isNavOpen={props.isNavOpen} />
       </Route>
       <Route path={routes.recentModels.path({})}>
-        <RecentModels />
+        <RecentModels isNavOpen={props.isNavOpen} />
       </Route>
       <Route path={routes.workspaceWithFiles.path({ workspaceId: ":workspaceId" })}>
         {({ match }) => <WorkspaceFiles workspaceId={match!.params.workspaceId!} />}

--- a/packages/serverless-logic-web-tools/src/navigation/Routes.ts
+++ b/packages/serverless-logic-web-tools/src/navigation/Routes.ts
@@ -21,7 +21,6 @@ export enum QueryParams {
   SETTINGS = "settings",
   URL = "url",
   BRANCH = "branch",
-  EXPAND = "expand",
   REMOVE_REMOTE = "removeRemote",
   RENAME_WORKSPACE = "renameWorkspace",
   SAMPLE_ID = "sampleId",
@@ -112,9 +111,7 @@ export function newQueryParamsImpl<Q extends string>(queryString: string): Query
 }
 
 export const routes = {
-  home: new Route<{
-    queryParams: QueryParams.EXPAND;
-  }>(() => `/`),
+  home: new Route<{}>(() => `/`),
 
   newModel: new Route<{
     pathParams: PathParams.EXTENSION;


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9248

**Description**
If you go to Recent Models and it is empty there is no way to create or redirect to a place where you can create model, import sample or use a model from the catalog.


![KOGITO-9248](https://github.com/kiegroup/kie-tools/assets/17780574/82d1c342-25a9-49cd-8f76-dfaa7283efdc)
