### PR TITLE
kie-issues#382: [DMN Editor] Superfluous newline in multi-cell copy/paste

### DIFF
--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -122,7 +122,8 @@ export enum BeeTableSelectionPosition {
   Right = "right",
 }
 
-const CLIPBOARD_ROW_SEPARATOR = "\n";
+const TEXT_TO_CLIPBOARD_ROW_SEPARATOR = "\n";
+const CLIPBOARD_TO_TEXT_ROW_SEPARATOR = /\r?\n/;
 const CLIPBOARD_COLUMN_SEPARATOR = "\t";
 
 const NEUTRAL_SELECTION = {
@@ -261,7 +262,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
     }
 
     const clipboardMatrix = clipboardValue
-      .split(CLIPBOARD_ROW_SEPARATOR)
+      .split(CLIPBOARD_TO_TEXT_ROW_SEPARATOR)
       .map((r) => r.split(CLIPBOARD_COLUMN_SEPARATOR));
 
     const { startRow, endRow, startColumn, endColumn } = getSelectionIterationBoundaries(selectionRef.current);
@@ -596,7 +597,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
 
         const clipboardValue = clipboardMatrix
           .map((r) => r.join(CLIPBOARD_COLUMN_SEPARATOR))
-          .join(CLIPBOARD_ROW_SEPARATOR);
+          .join(TEXT_TO_CLIPBOARD_ROW_SEPARATOR);
         navigator.clipboard.writeText(clipboardValue);
       },
       cut: () => {
@@ -622,7 +623,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
 
         const clipboardValue = clipboardMatrix
           .map((row) => row.join(CLIPBOARD_COLUMN_SEPARATOR))
-          .join(CLIPBOARD_ROW_SEPARATOR);
+          .join(TEXT_TO_CLIPBOARD_ROW_SEPARATOR);
 
         navigator.clipboard.writeText(clipboardValue);
       },


### PR DESCRIPTION
Closes: https://github.com/kiegroup/kie-issues/issues/382

The web Clipboard API we use for copy and paste feature in boxed expression editor, doesn't allow to adjust formatting/encoding of strings, see:
- https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText
- https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText

For some reason, even we write text into clipboard containing only `\n` new line characters, it is changed to `\r\n` during reading text from the clipboard.

### Writing to the clipboard / copy operation
![Screenshot 2023-07-12 110904](https://github.com/kiegroup/kie-tools/assets/8044780/afcdb1a3-0ebf-4a17-9f63-0f75cbfc67c7)

### Reading from the clipboard / paste operation
![Screenshot 2023-07-12 111950](https://github.com/kiegroup/kie-tools/assets/8044780/d8179089-8f73-47ee-b6d1-41b8a7005f94)


Please compare `clipboardValue` in the screenshots above. You can see there the difference of `\n` vs `\r\n`