### PR TITLE
NO-ISSUE: Stop using Nodesource for `git-cors-proxy-image`, using nvm instead

### DIFF
--- a/packages/git-cors-proxy-image/Containerfile
+++ b/packages/git-cors-proxy-image/Containerfile
@@ -14,8 +14,9 @@
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
-ENV HOME=/home/kie-sandbox
-ENV NVM_DIR=$HOME/.nvm
+ENV HOME          /home/kie-sandbox
+ENV NVM_DIR       $HOME/.nvm
+ENV NODE_VERSION  v20.3.1
 
 RUN mkdir $HOME \
   && chgrp -R 0 $HOME \
@@ -23,7 +24,10 @@ RUN mkdir $HOME \
   && chown -R 1000:0 $HOME \
   && microdnf install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \
-  && . ~/.nvm/nvm.sh && nvm install 20.3.1
+  && /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION"
+
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
+ENV PATH      $NODE_PATH:$PATH
 
 COPY --chown=1000:0 dist-dev/git-cors-proxy $HOME/git-cors-proxy
 
@@ -31,8 +35,8 @@ EXPOSE 8080
 
 WORKDIR $HOME/git-cors-proxy
 
+RUN npm install --cache $HOME/.cache --production && chmod -R 775 .
+
 USER 1000
 
-RUN . ~/.nvm/nvm.sh && npm install --cache $HOME/.cache --production && chmod -R 775 .
-
-CMD . ~/.nvm/nvm.sh && ./bin.js start -p 8080
+CMD ./bin.js start -p 8080

--- a/packages/git-cors-proxy-image/Containerfile
+++ b/packages/git-cors-proxy-image/Containerfile
@@ -15,23 +15,24 @@
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 ENV HOME=/home/kie-sandbox
+ENV NVM_DIR=$HOME/.nvm
 
 RUN mkdir $HOME \
   && chgrp -R 0 $HOME \
   && chmod -R g=u $HOME \
   && chown -R 1000:0 $HOME \
-  && curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - \
-  && microdnf install nodejs-2:20.3.1-1nodesource.x86_64 -y \
-  && microdnf clean all
+  && microdnf install -y tar gzip \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \
+  && . ~/.nvm/nvm.sh && nvm install 20.3.1
 
 COPY --chown=1000:0 dist-dev/git-cors-proxy $HOME/git-cors-proxy
 
 EXPOSE 8080
 
-USER 1000
-
 WORKDIR $HOME/git-cors-proxy
 
-RUN npm install --cache $HOME/.cache --production && chmod -R 775 .
+USER 1000
 
-CMD ./bin.js start -p 8080
+RUN . ~/.nvm/nvm.sh && npm install --cache $HOME/.cache --production && chmod -R 775 .
+
+CMD . ~/.nvm/nvm.sh && ./bin.js start -p 8080

--- a/packages/git-cors-proxy-image/Containerfile
+++ b/packages/git-cors-proxy-image/Containerfile
@@ -21,7 +21,7 @@ RUN mkdir $HOME \
   && chgrp -R 0 $HOME \
   && chmod -R g=u $HOME \
   && chown -R 1000:0 $HOME \
-  && microdnf install -y tar gzip \
+  && microdnf install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \
   && . ~/.nvm/nvm.sh && nvm install 20.3.1
 

--- a/packages/image-builder/src/bin.ts
+++ b/packages/image-builder/src/bin.ts
@@ -99,7 +99,6 @@ CLI tool to help building container images using build variables and different e
         default: false,
         describe: "Push the image to the registry",
         type: "boolean",
-        nargs: 1,
       },
       containerfile: {
         alias: "f",


### PR DESCRIPTION
Nodesource repositories appear to be intermittent during builds i.e. https://github.com/kiegroup/kie-tools/actions/runs/5546816247

There's an issue to track this problem, but no solution yet: https://github.com/nodesource/distributions/issues/1585

For now, switching to using nvm to install NodeJS 20 on ubi9.