### PR TITLE
NO-ISSUE: Load docker built images to podman local registry on daily-dev GitHub action

### DIFF
--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       KIE_SANDBOX_EXTENDED_SERVICES_VERSION: "0.0.0"
       KIE_TOOLS_BUILD__buildContainerImages: ${{ matrix.os != 'windows-latest' }}
@@ -140,7 +140,7 @@ jobs:
           SERVERLESS_LOGIC_WEB_TOOLS__buildInfo: "${{ steps.version.outputs.version }} (daily-dev) @ ${{ github.sha }}"
         run: |
           cd kie-tools
-          pnpm -r -F @kie-tools/git-cors-proxy-image... -F @kie-tools/kie-sandbox-extended-services-image... build:prod
+          pnpm -r build:prod
 
       - name: "Upload Serverless Workflow VS Code Extension - KIE (Ubuntu only)"
         if: runner.os == 'Linux'

--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     env:
       KIE_SANDBOX_EXTENDED_SERVICES_VERSION: "0.0.0"
       KIE_TOOLS_BUILD__buildContainerImages: ${{ matrix.os != 'windows-latest' }}
@@ -140,7 +140,7 @@ jobs:
           SERVERLESS_LOGIC_WEB_TOOLS__buildInfo: "${{ steps.version.outputs.version }} (daily-dev) @ ${{ github.sha }}"
         run: |
           cd kie-tools
-          pnpm -r build:prod
+          pnpm -r -F @kie-tools/git-cors-proxy-image... -F @kie-tools/kie-sandbox-extended-services-image... build:prod
 
       - name: "Upload Serverless Workflow VS Code Extension - KIE (Ubuntu only)"
         if: runner.os == 'Linux'
@@ -176,6 +176,10 @@ jobs:
         with:
           name: swf-chrome-extension
           path: kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${{ steps.version.outputs.version }}.zip
+
+      - name: "Load docker built images to podman local registry"
+        if: runner.os == 'Linux'
+        run: docker images --format docker-daemon:{{.Repository}}:{{.Tag}} | grep -e '${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }}' -e '${{ env.GIT_CORS_PROXY__imageName }}' -e '${{ env.KIE_SANDBOX__imageName }}' | grep -v '<none>' | xargs podman pull
 
       - name: "Push dmn-dev-deployment-base-image to quay.io (Ubuntu only)"
         if: runner.os == 'Linux' && github.event_name != 'pull_request'
@@ -225,6 +229,7 @@ jobs:
         run: |
           cd kie-tools
           docker image ls -q --filter reference=${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount }}/${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }} | xargs docker rmi
+          podman image ls -q --filter reference=${{ env.KIE_SANDBOX_EXTENDED_SERVICES__imageName }} | xargs podman rmi
           rm -rf ${{ env.TMPDIR }}/*
           pnpm -F kie-sandbox-extended-services-image cleanup
           cd -
@@ -258,6 +263,7 @@ jobs:
         run: |
           cd kie-tools
           docker image ls -q --filter reference=${{ env.GIT_CORS_PROXY__imageRegistry }}/${{ env.GIT_CORS_PROXY__imageAccount }}/${{ env.GIT_CORS_PROXY__imageName }} | xargs docker rmi
+          podman image ls -q --filter reference=${{ env.GIT_CORS_PROXY__imageName }} | xargs podman rmi
           rm -rf ${{ env.TMPDIR }}/*
           pnpm -F git-cors-proxy-image cleanup
           cd -
@@ -298,6 +304,7 @@ jobs:
         run: |
           cd kie-tools
           docker image ls -q --filter reference=${{ env.KIE_SANDBOX__imageRegistry }}/${{ env.KIE_SANDBOX__imageAccount }}/${{ env.KIE_SANDBOX__imageName }} | xargs docker rmi
+          podman image ls -q --filter reference=${{ env.KIE_SANDBOX__imageName }} | xargs podman rmi
           rm -rf ${{ env.TMPDIR }}/*
           pnpm -F kie-sandbox-image cleanup
           cd -


### PR DESCRIPTION
Even though `redhat-actions/push-to-registry` says it supports loading images from docker while pushing [1], the way podman tries to load these images is incompatible with how docker provides them.
Podman tries to pull images by `podman pull docker-daemon:<image-name>:<image-tag>`, but docker can only reference images by their full name, like `<image-registry>/<image-account>/<image-name>:<image-tag>`, resulting in podman not finding these images on the docker local registry.

This PR adds a new step to the daily-dev action, manually loading images that were built with docker to the podman local registry.
On the cleanup step those images are deleted from both registries.

[1] https://github.com/redhat-actions/push-to-registry#note-about-images-built-with-docker