### PR TITLE
KOGITO-9424: No popup in the recent models filesAdd Tooltip to WorkspacesTableRow

### DIFF
--- a/packages/serverless-logic-web-tools/src/homepage/recentModels/WorkspacesTableRow.tsx
+++ b/packages/serverless-logic-web-tools/src/homepage/recentModels/WorkspacesTableRow.tsx
@@ -31,6 +31,7 @@ import "../../table/Table.css";
 import { FileLabel } from "../../workspace/components/FileLabel";
 import { WorkspaceLabel } from "../../workspace/components/WorkspaceLabel";
 import { columnNames, WorkspacesTableRowData } from "./WorkspacesTable";
+import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 
 export type WorkspacesTableRowProps = {
   rowIndex: TdSelectType["rowIndex"];
@@ -125,7 +126,10 @@ export function WorkspacesTableRow(props: WorkspacesTableRowProps) {
           {linkTo ? (
             <>
               {isWsFolder ? <FolderIcon /> : <TaskIcon />}
-              &nbsp;&nbsp;&nbsp;<Link to={linkTo}>{descriptor.name}</Link>
+              &nbsp;&nbsp;&nbsp;
+              <Tooltip content={isWsFolder ? descriptor.name : editableFiles[0].relativePath}>
+                <Link to={linkTo}>{descriptor.name}</Link>
+              </Tooltip>
             </>
           ) : (
             descriptor.name


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9424

**Description**
Move mouse cursor over the file in the Recent models files -> No pop up.
Move mouse cursor over the file in a directory -> Pop up is displayed (file.sw.json)

[KOGITO-9424.webm](https://github.com/kiegroup/kie-tools/assets/17780574/69591a24-c5f6-48a9-9017-f479772c51a1)
