### PR TITLE
KOGITO-9389: Add dashboards to operator deployment  on the cli (dashbuilder support)

### DIFF
--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/metadata"
 
 	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/common"
 	"github.com/ory/viper"
@@ -127,9 +128,15 @@ func runDeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err er
 		dir, err := os.Getwd()
 		cfg.SupportFileFolder = dir + "/specs"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get current directory: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
 		}
 	}
+	dir, err := os.Getwd()
+	cfg.DefaultDashboardsFolder = dir + "/" + metadata.DashboardsDefaultDirName
+	if err != nil {
+		return cfg, fmt.Errorf("❌ ERROR: failed to get default dashboards files folder: %w", err)
+	}
+
 	//setup manifest path
 	if err := setupConfigManifestPath(&cfg); err != nil {
 		return cfg, err

--- a/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
@@ -147,7 +147,7 @@ func generateManifests(cfg *DeployUndeployCmdConfig) error {
 		if err != nil {
 			return err
 		}
-		handler.AddResourceAt(filepath.Base(dashboardFile), "dashboards", specIO)
+		handler.AddResourceAt(filepath.Base(dashboardFile), metadata.DashboardsDefaultDirName, specIO)
 	}
 
 	_, err = handler.AsObjects()

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/convert.go
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/convert.go
@@ -182,6 +182,15 @@ func moveSWFFilesToQuarkusProject(cfg CreateQuarkusProjectConfig, rootFolder str
 				return fmt.Errorf("error moving directory %s: %w", oldPath, err)
 			}
 		}
+
+		// Move /dashboards directory to target
+		if file.IsDir() && file.Name() == metadata.DashboardsDefaultDirName {
+			oldPath := filepath.Join(rootFolder, file.Name())
+			newPath := filepath.Join(targetFolder, file.Name())
+			if err := os.Rename(oldPath, newPath); err != nil {
+				return fmt.Errorf("error moving directory %s: %w", oldPath, err)
+			}
+		}
 	}
 	return nil
 }

--- a/packages/kn-plugin-workflow/pkg/command/undeploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/undeploy.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/metadata"
 
 	"github.com/kiegroup/kie-tools/packages/kn-plugin-workflow/pkg/common"
 	"github.com/ory/viper"
@@ -125,6 +126,13 @@ func runUndeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err 
 			return cfg, fmt.Errorf("❌ ERROR: failed to get current directory: %w", err)
 		}
 	}
+
+	dir, err := os.Getwd()
+	cfg.DefaultDashboardsFolder = dir + "/" + metadata.DashboardsDefaultDirName
+	if err != nil {
+		return cfg, fmt.Errorf("❌ ERROR: failed to get default dashboards files folder: %w", err)
+	}
+
 	//setup manifest path
 	if err := setupConfigManifestPath(&cfg); err != nil {
 		return cfg, err

--- a/packages/kn-plugin-workflow/pkg/metadata/constants.go
+++ b/packages/kn-plugin-workflow/pkg/metadata/constants.go
@@ -47,6 +47,8 @@ const (
 	ManifestServiceFilesKind = "SonataFlow"
 
 	DockerInternalPort = "8080/tcp"
-	// The :z is to let docker know that the volume content can be shared between containers(SELinux)
+	// VolumeBindPath The :z is to let docker know that the volume content can be shared between containers(SELinux)
 	VolumeBindPath = "/home/kogito/serverless-workflow-project/src/main/resources:z"
+
+	DashboardsDefaultDirName = "dashboards"
 )


### PR DESCRIPTION
On this PR:

Serverless workflow projects containing dashboards, will be deployed on the operator:

├── application.properties
├── dashboards
│   ├── age2.dash.yml
│   └── products.dash.yaml
├── specs
│   ├── workflow-service-openapi.json
│   └── workflow-service-schema.json
├── workflow-minimal.svg
└── workflow-service.sw.json


./dashboards/ is the default directory for dashboards being loaded on dev UI:


<img width="1304" alt="Screenshot 2023-07-19 at 11 05 23 AM" src="https://github.com/kiegroup/kie-tools/assets/531351/1a729da3-74d2-4563-81c6-0a2a9df67b7b">
