### PR TITLE
KOGITO-9583: SWF diagram editor is not opened when opening workflow while another is open

### DIFF
--- a/packages/serverless-workflow-vscode-extension/src/extension/setupDiagramEditorCompanionTab.ts
+++ b/packages/serverless-workflow-vscode-extension/src/extension/setupDiagramEditorCompanionTab.ts
@@ -76,6 +76,9 @@ export async function setupDiagramEditorCompanionTab(args: {
   args.context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async (textEditor) => {
       if (args.kieEditorsStore.activeEditor) {
+        args.kieEditorsStore.openEditors.forEach((kieEditor) => {
+          kieEditor.close();
+        });
         return;
       }
 


### PR DESCRIPTION
This has to be verified on the newest version of VS Code.