### PR TITLE
[0.31.0] KOGITO-9480: Temporary fix accessing the root path does not redirect to `index.html`

### DIFF
--- a/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
+++ b/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
@@ -67,7 +67,7 @@ export function OpenShiftDeploymentDropdownItem(props: Props) {
     window.open(
       props.deployment.devMode
         ? endpoints.swfDevUi
-        : // Temporay fix to KOGITO-9480
+        : // Temporary fix to KOGITO-9480
           `${endpoints.base}/index.html`,
       "_blank"
     );

--- a/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
+++ b/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
@@ -64,7 +64,13 @@ export function OpenShiftDeploymentDropdownItem(props: Props) {
 
   const onDeploymentClicked = useCallback(() => {
     const endpoints = buildEndpoints(props.deployment.routeUrl);
-    window.open(props.deployment.devMode ? endpoints.swfDevUi : endpoints.base, "_blank");
+    window.open(
+      props.deployment.devMode
+        ? endpoints.swfDevUi
+        : // Temporay fix to KOGITO-9480
+          `${endpoints.base}/index.html`,
+      "_blank"
+    );
   }, [props.deployment.devMode, props.deployment.routeUrl]);
 
   const onRestoreClicked = useCallback(async () => {


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9480

**Description:**
When the dependency `kogito-addons-quarkus-knative-eventing` is present, accessing the root path does not redirect to `index.html`, unless the user changes the `mp.messaging.incoming.kogito_incoming_stream.path` prop to something different than "/".

**Fix:**
As a temporary fix now the user is redirected to "/index.html" of the deployment