### PR TITLE
NO-ISSUE: Add DMN 1.5 specification files to `packages/dmn-marshaller`

### DIFF
--- a/packages/dmn-marshaller/package.json
+++ b/packages/dmn-marshaller/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "build:codegen": "pnpm build:codegen:dmn10 && pnpm build:codegen:dmn11 && pnpm build:codegen:dmn12 && pnpm build:codegen:dmn13 && pnpm build:codegen:dmn14 && pnpm build:codegen:dmn15 &&pnpm build:codegen:kie10",
+    "build:codegen": "pnpm build:codegen:dmn10 && pnpm build:codegen:dmn11 && pnpm build:codegen:dmn12 && pnpm build:codegen:dmn13 && pnpm build:codegen:dmn14 && pnpm build:codegen:dmn15 && pnpm build:codegen:kie10",
     "build:codegen:dmn10": "xml-parser-ts-codegen ./src/schemas/dmn-1_0/dmn3.xsd Definitions",
     "build:codegen:dmn11": "xml-parser-ts-codegen ./src/schemas/dmn-1_1/dmn.xsd definitions",
     "build:codegen:dmn12": "xml-parser-ts-codegen ./src/schemas/dmn-1_2/DMN12.xsd definitions",

--- a/packages/dmn-marshaller/package.json
+++ b/packages/dmn-marshaller/package.json
@@ -19,12 +19,13 @@
     "src"
   ],
   "scripts": {
-    "build:codegen": "pnpm build:codegen:dmn10 && pnpm build:codegen:dmn11 && pnpm build:codegen:dmn12 && pnpm build:codegen:dmn13 && pnpm build:codegen:dmn14 && pnpm build:codegen:kie10",
+    "build:codegen": "pnpm build:codegen:dmn10 && pnpm build:codegen:dmn11 && pnpm build:codegen:dmn12 && pnpm build:codegen:dmn13 && pnpm build:codegen:dmn14 && pnpm build:codegen:dmn15 &&pnpm build:codegen:kie10",
     "build:codegen:dmn10": "xml-parser-ts-codegen ./src/schemas/dmn-1_0/dmn3.xsd Definitions",
     "build:codegen:dmn11": "xml-parser-ts-codegen ./src/schemas/dmn-1_1/dmn.xsd definitions",
     "build:codegen:dmn12": "xml-parser-ts-codegen ./src/schemas/dmn-1_2/DMN12.xsd definitions",
     "build:codegen:dmn13": "xml-parser-ts-codegen ./src/schemas/dmn-1_3/DMN13.xsd definitions",
     "build:codegen:dmn14": "xml-parser-ts-codegen ./src/schemas/dmn-1_4/DMN14.xsd definitions",
+    "build:codegen:dmn15": "xml-parser-ts-codegen ./src/schemas/dmn-1_5/DMN15.xsd definitions",
     "build:codegen:kie10": "xml-parser-ts-codegen ./src/schemas/kie-1_0/KIE.xsd ComponentsWidthsExtension",
     "build:dev": "rimraf dist && pnpm build:codegen && tsc -p tsconfig.json",
     "build:prod": "pnpm lint && rimraf dist &&  pnpm build:codegen && tsc -p tsconfig.json && pnpm test",

--- a/packages/dmn-marshaller/src/index.ts
+++ b/packages/dmn-marshaller/src/index.ts
@@ -50,8 +50,16 @@ import {
   root as dmn14root,
   ns as dmn14ns,
 } from "./schemas/dmn-1_4/ts-gen/meta";
+import {
+  subs as dmn15subs,
+  elements as dmn15elements,
+  meta as dmn15meta,
+  root as dmn15root,
+  ns as dmn15ns,
+} from "./schemas/dmn-1_5/ts-gen/meta";
 // import { dmn3__tDefinitions as DMN10__tDefinitions } from "./schemas/dmn-1_0/ts-gen/types";
 // import { dmn__tDefinitions as DMN11__tDefinitions } from "./schemas/dmn-1_1/ts-gen/types";
+import { DMN15__tDefinitions } from "./schemas/dmn-1_5/ts-gen/types";
 import { DMN14__tDefinitions } from "./schemas/dmn-1_4/ts-gen/types";
 import { DMN13__tDefinitions } from "./schemas/dmn-1_3/ts-gen/types";
 import { DMN12__tDefinitions } from "./schemas/dmn-1_2/ts-gen/types";
@@ -63,11 +71,11 @@ type DmnMarshaller = {
   instanceNs: Map<string, string>;
   root: { element: string; type: string };
   meta: Meta;
-  version: "1.0" | "1.1" | "1.2" | "1.3" | "1.4";
+  version: "1.0" | "1.1" | "1.2" | "1.3" | "1.4" | "1.5";
 };
 
 export type DmnDefinitions = {
-  definitions: DMN14__tDefinitions; // Keeping the latest version for now, as the other should be retro-compatible with it.
+  definitions: DMN15__tDefinitions; // Keeping the latest version for now, as the other should be retro-compatible with it.
 };
 
 // FIXME: Tiago --> DMN 1.1 doesn't seem to have diagram types, which is too much of a deal breaker... What to do?
@@ -169,6 +177,23 @@ export function getMarshaller(xml: string): DmnMarshaller {
       meta: dmn14meta,
       parser: { parse: () => p.parse({ xml, domdoc, instanceNs }).json },
       builder: { build: (json: { definitions: DMN14__tDefinitions }) => p.build({ json, instanceNs }) },
+    };
+  } else if (instanceNs.get(dmn15ns.get("")!) !== undefined) {
+    const p = getParser<{ definitions: DMN15__tDefinitions }>({
+      ns: dmn15ns,
+      meta: dmn15meta,
+      subs: dmn15subs,
+      elements: dmn15elements,
+      root: dmn15root,
+    });
+
+    return {
+      instanceNs,
+      version: "1.5",
+      root: dmn15root,
+      meta: dmn15meta,
+      parser: { parse: () => p.parse({ xml, domdoc, instanceNs }).json },
+      builder: { build: (json: { definitions: DMN15__tDefinitions }) => p.build({ json, instanceNs }) },
     };
   } else {
     throw new Error(

--- a/packages/dmn-marshaller/src/kie-extensions.ts
+++ b/packages/dmn-marshaller/src/kie-extensions.ts
@@ -15,14 +15,16 @@
  */
 
 import { Namespaced, mergeMetas } from "@kie-tools/xml-parser-ts";
-import "./schemas/dmn-1_4/ts-gen/types";
-import "./schemas/dmn-1_3/ts-gen/types";
+
+import { meta as dmn12meta, ns as dmn12ns } from "./schemas/dmn-1_2/ts-gen/meta";
 import "./schemas/dmn-1_2/ts-gen/types";
-import { ns as dmn12ns, meta as dmn12meta } from "./schemas/dmn-1_2/ts-gen/meta";
-import { ns as dmn13ns, meta as dmn13meta } from "./schemas/dmn-1_3/ts-gen/meta";
-import { ns as dmn14ns, meta as dmn14meta } from "./schemas/dmn-1_4/ts-gen/meta";
-import { ns as dmn15ns, meta as dmn15meta } from "./schemas/dmn-1_5/ts-gen/meta";
-import { ns as kie10ns, meta as kie10meta } from "./schemas/kie-1_0/ts-gen/meta";
+import { meta as dmn13meta, ns as dmn13ns } from "./schemas/dmn-1_3/ts-gen/meta";
+import "./schemas/dmn-1_3/ts-gen/types";
+import { meta as dmn14meta, ns as dmn14ns } from "./schemas/dmn-1_4/ts-gen/meta";
+import "./schemas/dmn-1_4/ts-gen/types";
+import { meta as dmn15meta, ns as dmn15ns } from "./schemas/dmn-1_5/ts-gen/meta";
+import "./schemas/dmn-1_5/ts-gen/types";
+import { meta as kie10meta, ns as kie10ns } from "./schemas/kie-1_0/ts-gen/meta";
 import { KIE__tAttachment, KIE__tComponentsWidthsExtension } from "./schemas/kie-1_0/ts-gen/types";
 
 export const KIE_NS = "kie:";

--- a/packages/dmn-marshaller/src/kie-extensions.ts
+++ b/packages/dmn-marshaller/src/kie-extensions.ts
@@ -21,6 +21,7 @@ import "./schemas/dmn-1_2/ts-gen/types";
 import { ns as dmn12ns, meta as dmn12meta } from "./schemas/dmn-1_2/ts-gen/meta";
 import { ns as dmn13ns, meta as dmn13meta } from "./schemas/dmn-1_3/ts-gen/meta";
 import { ns as dmn14ns, meta as dmn14meta } from "./schemas/dmn-1_4/ts-gen/meta";
+import { ns as dmn15ns, meta as dmn15meta } from "./schemas/dmn-1_5/ts-gen/meta";
 import { ns as kie10ns, meta as kie10meta } from "./schemas/kie-1_0/ts-gen/meta";
 import { KIE__tAttachment, KIE__tComponentsWidthsExtension } from "./schemas/kie-1_0/ts-gen/types";
 
@@ -114,6 +115,37 @@ dmn14ns.set(kie10ns.get("")!, KIE_NS);
 };
 
 (dmn14meta["DMN14__tKnowledgeSource__extensionElements"] as any)["kie:attachment"] = {
+  type: "KIE__tAttachment",
+  isArray: true,
+  isOptional: true,
+};
+
+///////////////////////////
+///       DMN 1.5       ///
+///////////////////////////
+
+declare module "./schemas/dmn-1_5/ts-gen/types" {
+  export interface DMNDI15__DMNDiagram__extension {
+    "kie:ComponentsWidthsExtension"?: Namespaced<KIE, KIE__tComponentsWidthsExtension>;
+  }
+
+  export interface DMN15__tKnowledgeSource__extensionElements {
+    "kie:attachment"?: Namespaced<KIE, KIE__tAttachment>[];
+  }
+}
+
+dmn15ns.set(KIE_NS, kie10ns.get("")!);
+dmn15ns.set(kie10ns.get("")!, KIE_NS);
+
+(dmn15meta as any) = mergeMetas(dmn15meta, [[KIE_NS, kie10meta]]);
+
+(dmn15meta["DMNDI15__DMNDiagram__extension"] as any)["kie:ComponentsWidthsExtension"] = {
+  type: "KIE__tComponentsWidthsExtension",
+  isArray: true,
+  isOptional: true,
+};
+
+(dmn15meta["DMN15__tKnowledgeSource__extensionElements"] as any)["kie:attachment"] = {
   type: "KIE__tAttachment",
   isArray: true,
   isOptional: true,

--- a/packages/dmn-marshaller/src/schemas/dmn-1_5/DC.xsd
+++ b/packages/dmn-marshaller/src/schemas/dmn-1_5/DC.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DC/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+	<xsd:element name="Color" type="dc:Color"/>
+	<xsd:element name="Point" type="dc:Point"/>
+	<xsd:element name="Bounds" type="dc:Bounds"/>
+	<xsd:element name="Dimension" type="dc:Dimension"/>
+
+	<xsd:complexType name="Color">
+		<xsd:annotation>
+			<xsd:documentation>Color is a data type that represents a color value in the RGB format.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="red" type="dc:rgb" use="required"/>
+		<xsd:attribute name="green" type="dc:rgb" use="required"/>
+		<xsd:attribute name="blue" type="dc:rgb" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="rgb">
+		<xsd:restriction base="xsd:int">
+			<xsd:minInclusive value="0"/>
+			<xsd:maxInclusive value="255"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="Point">
+		<xsd:annotation>
+			<xsd:documentation>A Point specifies an location in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Dimension">
+		<xsd:annotation>
+			<xsd:documentation>Dimension specifies two lengths (width and height) along the x and y axes in some x-y coordinate system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Bounds">
+	   <xsd:annotation>
+			<xsd:documentation>Bounds specifies a rectangular area in some x-y coordinate system that is defined by a location (x and y) and a size (width and height).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="x" type="xsd:double" use="required"/>
+		<xsd:attribute name="y" type="xsd:double" use="required"/>
+		<xsd:attribute name="width" type="xsd:double" use="required"/>
+		<xsd:attribute name="height" type="xsd:double" use="required"/>
+	</xsd:complexType>
+
+	<xsd:simpleType name="AlignmentKind">
+		<xsd:annotation>
+			<xsd:documentation>AlignmentKind enumerates the possible options for alignment for layout purposes.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="start"/>
+			<xsd:enumeration value="end"/>
+			<xsd:enumeration value="center"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="KnownColor">
+		<xsd:annotation>
+			<xsd:documentation>KnownColor is an enumeration of 17 known colors.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="maroon">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="red">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF0000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="orange">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFA500</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="yellow">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="olive">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="purple">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #800080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="fuchsia">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FF00FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="white">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #FFFFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="lime">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FF00</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="green">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="navy">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="blue">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #0000FF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="aqua">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #00FFFF</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="teal">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #008080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="black">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #000000</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="silver">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #C0C0C0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="gray">
+				<xsd:annotation>
+					<xsd:documentation>a color with a value of #808080</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/packages/dmn-marshaller/src/schemas/dmn-1_5/DI.xsd
+++ b/packages/dmn-marshaller/src/schemas/dmn-1_5/DI.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="http://www.omg.org/spec/DMN/20180521/DI/"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>The Diagram Interchange (DI) package enables interchange of graphical information that language users have control over, such as position of nodes and line routing points. Language specifications specialize elements of DI to define diagram interchange elements for a language.</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="Style" type="di:Style">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DiagramElement" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>DiagramElement is the abstract super type of all elements in diagrams, including diagrams themselves. When contained in a diagram, diagram elements are laid out relative to the diagram's origin.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element ref="di:Style" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>an optional locally-owned style for this diagram element.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="sharedStyle" type="xsd:IDREF">
+			<xsd:annotation>
+				<xsd:documentation>a reference to an optional shared style element for this diagram element.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="Diagram" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">			
+				<xsd:attribute name="name" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the name of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="documentation" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>the documentation of the diagram.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="resolution" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>the resolution of the diagram expressed in user units per inch.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Shape" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>the optional bounds of the shape relative to the origin of its nesting plane.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Edge" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element name="waypoint" type="dc:Point" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>an optional list of points relative to the origin of the nesting diagram that specifies the connected line segments of the edge</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="Style" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Style contains formatting properties that affect the appearance or style of diagram elements, including diagram themselves.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/packages/dmn-marshaller/src/schemas/dmn-1_5/DMN15.xsd
+++ b/packages/dmn-marshaller/src/schemas/dmn-1_5/DMN15.xsd
@@ -1,0 +1,592 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+	xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+	targetNamespace="https://www.omg.org/spec/DMN/20230324/MODEL/">
+
+	<xsd:import namespace="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+	            schemaLocation="DMNDI15.xsd">
+		<xsd:annotation>
+			<xsd:documentation>
+				Include the DMN Diagram Interchange (DI) schema
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:import>
+
+	<xsd:element name="DMNElement" type="tDMNElement" abstract="true"/>
+	<xsd:complexType name="tDMNElement">
+		<xsd:sequence>
+			<xsd:element name="description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="extensionElements" minOccurs="0" maxOccurs="1">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="label" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	<xsd:element name="namedElement" type="tNamedElement" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tNamedElement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tDMNElementReference">
+		<xsd:attribute name="href" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+	<xsd:element name="definitions" type="tDefinitions" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="itemDefinition" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="drgElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="elementCollection" type="tElementCollection" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="businessContextElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dmndi:DMNDI" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20230324/FEEL/"/>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="https://www.omg.org/spec/DMN/20230324/FEEL/"/>
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="exporter" type="xsd:string" use="optional"/>
+				<xsd:attribute name="exporterVersion" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="import" type="tImport" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tImport">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="elementCollection" type="tElementCollection" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tElementCollection">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:sequence>
+					<xsd:element name="drgElement" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="drgElement" type="tDRGElement" abstract="true" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tDRGElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decision" type="tDecision" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tDecision">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="question" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="allowedAnswers" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+					<xsd:element name="informationRequirement" type="tInformationRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supportedObjective" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="impactedPerformanceIndicator" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionMaker" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwner" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingProcess" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="usingTask" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- decisionLogic -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessContextElement" type="tBusinessContextElement" abstract="true"/>
+	<xsd:complexType name="tBusinessContextElement">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="performanceIndicator" type="tPerformanceIndicator" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tPerformanceIndicator">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="impactingDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="organizationUnit" type="tOrganizationUnit" substitutionGroup="businessContextElement"/>
+	<xsd:complexType name="tOrganizationUnit">
+		<xsd:complexContent>
+			<xsd:extension base="tBusinessContextElement">
+				<xsd:sequence>
+					<xsd:element name="decisionMade" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="decisionOwned" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocable" type="tInvocable" abstract="true" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInvocable">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="businessKnowledgeModel" type="tBusinessKnowledgeModel" substitutionGroup="invocable"/>
+	<xsd:complexType name="tBusinessKnowledgeModel">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="encapsulatedLogic" type="tFunctionDefinition" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="inputData" type="tInputData" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tInputData">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeSource" type="tKnowledgeSource" substitutionGroup="drgElement"/>
+	<xsd:complexType name="tKnowledgeSource">
+		<xsd:complexContent>
+			<xsd:extension base="tDRGElement">
+				<xsd:sequence>
+					<xsd:element name="authorityRequirement" type="tAuthorityRequirement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="type" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="owner" type="tDMNElementReference" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="locationURI" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="informationRequirement" type="tInformationRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tInformationRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+						<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					</xsd:choice>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="knowledgeRequirement" type="tKnowledgeRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tKnowledgeRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="requiredKnowledge" type="tDMNElementReference" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="authorityRequirement" type="tAuthorityRequirement" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tAuthorityRequirement">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:choice minOccurs="1" maxOccurs="1">
+					<xsd:element name="requiredDecision" type="tDMNElementReference"/>
+					<xsd:element name="requiredInput" type="tDMNElementReference"/>
+					<xsd:element name="requiredAuthority" type="tDMNElementReference"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="expression" type="tExpression" abstract="true"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:attribute name="typeRef" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element name="typeRef" type="xsd:string"/>
+						<xsd:element name="allowedValues" type="tUnaryTests" minOccurs="0"/>
+						<xsd:element name="typeConstraint" type="tUnaryTests" minOccurs="0"/>
+					</xsd:sequence>
+					<xsd:element name="itemComponent" type="tItemDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="functionItem" type="tFunctionItem" minOccurs="0" maxOccurs="1"/>
+				</xsd:choice>
+				<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionItem" type="tFunctionItem" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tFunctionItem">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="parameters" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="outputTypeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="literalExpression" type="tLiteralExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tLiteralExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:element name="text" type="xsd:string"/>
+					<xsd:element name="importedValues" type="tImportedValues"/>
+				</xsd:choice>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="invocation" type="tInvocation" substitutionGroup="expression"/>
+	<xsd:complexType name="tInvocation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- calledFunction -->
+					<xsd:element ref="expression" minOccurs="0"/>
+					<xsd:element name="binding" type="tBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tBinding">
+		<xsd:sequence>
+			<xsd:element name="parameter" type="tInformationItem" minOccurs="1" maxOccurs="1"/>
+			<!-- bindingFormula -->
+			<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="informationItem" type="tInformationItem" substitutionGroup="namedElement"/>
+	<xsd:complexType name="tInformationItem">
+		<xsd:complexContent>
+			<xsd:extension base="tNamedElement">
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionTable" type="tDecisionTable" substitutionGroup="expression"/>
+	<xsd:complexType name="tDecisionTable">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="input" type="tInputClause" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="output" type="tOutputClause" maxOccurs="unbounded"/>
+					<xsd:element name="annotation" type="tRuleAnnotationClause"  minOccurs="0" maxOccurs="unbounded"/>
+					<!-- NB: when the hit policy is FIRST or RULE ORDER, the ordering of the rules is significant and MUST be preserved -->
+					<xsd:element name="rule" type="tDecisionRule" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="hitPolicy" type="tHitPolicy" use="optional" default="UNIQUE"/>
+				<xsd:attribute name="aggregation" type="tBuiltinAggregator" use="optional"/>
+				<xsd:attribute name="preferredOrientation" type="tDecisionTableOrientation" use="optional" default="Rule-as-Row"/>
+				<xsd:attribute name="outputLabel" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tInputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputExpression" type="tLiteralExpression"/>
+					<xsd:element name="inputValues" type="tUnaryTests" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tOutputClause">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="outputValues" type="tUnaryTests" minOccurs="0"/>
+					<xsd:element name="defaultOutputEntry" type="tLiteralExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="typeRef" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotationClause">
+		<xsd:attribute name="name" type="xsd:string"/>
+	</xsd:complexType>
+	<xsd:complexType name="tDecisionRule">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="inputEntry" type="tUnaryTests" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputEntry" type="tLiteralExpression" maxOccurs="unbounded"/>
+					<xsd:element name="annotationEntry" type="tRuleAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tRuleAnnotation">
+		<xsd:sequence>
+			<xsd:element name="text" type="xsd:string" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:simpleType name="tHitPolicy">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="UNIQUE"/>
+			<xsd:enumeration value="FIRST"/>
+			<xsd:enumeration value="PRIORITY"/>
+			<xsd:enumeration value="ANY"/>
+			<xsd:enumeration value="COLLECT"/>
+			<xsd:enumeration value="RULE ORDER"/>
+			<xsd:enumeration value="OUTPUT ORDER"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tBuiltinAggregator">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="SUM"/>
+			<xsd:enumeration value="COUNT"/>
+			<xsd:enumeration value="MIN"/>
+			<xsd:enumeration value="MAX"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="tDecisionTableOrientation">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Rule-as-Row"/>
+			<xsd:enumeration value="Rule-as-Column"/>
+			<xsd:enumeration value="CrossTable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="tImportedValues">
+		<xsd:complexContent>
+			<xsd:extension base="tImport">
+				<xsd:sequence>
+					<xsd:element name="importedElement" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="artifact" type="tArtifact" abstract="true" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tArtifact">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="group" type="tGroup" substitutionGroup="artifact"/>
+	<xsd:complexType name="tGroup">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="tDMNElementReference"/>
+					<xsd:element name="targetRef" type="tDMNElementReference"/>
+				</xsd:sequence>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="context" type="tContext" substitutionGroup="expression"/>
+	<xsd:complexType name="tContext">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element ref="contextEntry" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="contextEntry" type="tContextEntry" substitutionGroup="DMNElement"/>
+	<xsd:complexType name="tContextEntry">
+		<xsd:complexContent>
+			<xsd:extension base="tDMNElement">
+				<xsd:sequence>
+					<xsd:element name="variable" type="tInformationItem" minOccurs="0" maxOccurs="1"/>
+					<!-- value -->
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="functionDefinition" type="tFunctionDefinition" substitutionGroup="expression"/>
+	<xsd:complexType name="tFunctionDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="formalParameter" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- body -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="kind" type="tFunctionKind" default="FEEL"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="tFunctionKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="FEEL"/>
+			<xsd:enumeration value="Java"/>
+			<xsd:enumeration value="PMML"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="relation" type="tRelation" substitutionGroup="expression"/>
+	<xsd:complexType name="tRelation">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="column" type="tInformationItem" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="row" type="tList" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="list" type="tList" substitutionGroup="expression"/>
+	<xsd:complexType name="tList">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<!-- element -->
+					<xsd:element ref="expression" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tUnaryTests">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="text" type="xsd:string"/>
+				</xsd:sequence>
+				<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="decisionService" type="tDecisionService" substitutionGroup="invocable"/>
+	<xsd:complexType name="tDecisionService">
+		<xsd:complexContent>
+			<xsd:extension base="tInvocable">
+				<xsd:sequence>
+					<xsd:element name="outputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="encapsulatedDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputDecision" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputData" type="tDMNElementReference" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tChildExpression">
+		<xsd:sequence>
+			<xsd:element ref="expression"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="tTypedChildExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tChildExpression">
+				<xsd:attribute name="typeRef" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="tIterator">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="in" type="tTypedChildExpression"/>
+				</xsd:sequence>
+				<xsd:attribute name="iteratorVariable" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="for" type="tFor" substitutionGroup="expression"/>
+	<xsd:complexType name="tFor">
+		<xsd:complexContent>
+			<xsd:extension base="tIterator">
+				<xsd:sequence>
+					<xsd:element name="return" type="tChildExpression"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="every" type="tQuantified" substitutionGroup="expression"/>
+	<xsd:element name="some" type="tQuantified" substitutionGroup="expression"/>
+	<xsd:complexType name="tQuantified">
+		<xsd:complexContent>
+			<xsd:extension base="tIterator">
+				<xsd:sequence>
+					<xsd:element name="satisfies" type="tChildExpression"/>	
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="conditional" type="tConditional" substitutionGroup="expression"/>
+	<xsd:complexType name="tConditional">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="if" type="tChildExpression"/>
+					<xsd:element name="then" type="tChildExpression"/>
+					<xsd:element name="else" type="tChildExpression"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="filter" type="tFilter" substitutionGroup="expression"/>
+	<xsd:complexType name="tFilter">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:sequence>
+					<xsd:element name="in" type="tChildExpression"/>
+					<xsd:element name="match" type="tChildExpression"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/packages/dmn-marshaller/src/schemas/dmn-1_5/DMNDI15.xsd
+++ b/packages/dmn-marshaller/src/schemas/dmn-1_5/DMNDI15.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+            xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+            xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+            targetNamespace="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DC/"
+	            schemaLocation="DC.xsd"/>
+	<xsd:import namespace="http://www.omg.org/spec/DMN/20180521/DI/"
+	            schemaLocation="DI.xsd"/>
+
+	<xsd:element name="DMNDI" type="dmndi:DMNDI"/>
+	<xsd:element name="DMNDiagram" type="dmndi:DMNDiagram"/>
+	<xsd:element name="DMNDiagramElement" type="di:DiagramElement">
+		<xsd:annotation>
+			<xsd:documentation>This element should never be instantiated directly, but rather concrete implementation should. It is placed there only to be referred in the sequence</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="DMNShape" type="dmndi:DMNShape" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNEdge" type="dmndi:DMNEdge" substitutionGroup="dmndi:DMNDiagramElement"/>
+	<xsd:element name="DMNStyle" type="dmndi:DMNStyle" substitutionGroup="di:Style"/>
+	<xsd:element name="DMNLabel" type="dmndi:DMNLabel"/>
+	<xsd:element name="DMNDecisionServiceDividerLine" type="dmndi:DMNDecisionServiceDividerLine"/>
+
+	<xsd:complexType name="DMNDI">
+		<xsd:sequence>
+			<xsd:element ref="dmndi:DMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="dmndi:DMNStyle" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element name="Size" type="dc:Dimension" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDiagramElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="useAlternativeInputDataShape" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="dmndi:DMNDecisionServiceDividerLine" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="isListedInputData" type="xsd:boolean" use="optional"/>
+				<xsd:attribute name="isCollapsed" type="xsd:boolean" use="optional" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+		<xsd:complexType name="DMNDecisionServiceDividerLine">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge">
+				<xsd:sequence>
+					<xsd:element ref="dmndi:DMNLabel" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="dmnElementRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="sourceElement" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="targetElement" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape">
+				<xsd:sequence>
+					<xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="DMNStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element name="FillColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="StrokeColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="FontColor" type="dc:Color" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="fontFamily" type="xsd:string"/>
+				<xsd:attribute name="fontSize" type="xsd:double"/>
+				<xsd:attribute name="fontItalic" type="xsd:boolean"/>
+				<xsd:attribute name="fontBold" type="xsd:boolean"/>
+				<xsd:attribute name="fontUnderline" type="xsd:boolean"/>
+				<xsd:attribute name="fontStrikeThrough" type="xsd:boolean"/>
+				<xsd:attribute name="labelHorizontalAlignement" type="dc:AlignmentKind"/>
+				<xsd:attribute name="labelVerticalAlignment" type="dc:AlignmentKind"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
With these files, `dmn-marshaller` can now parse and build DMN 1.5 files.

Two notable differences between DMN 1.4 and DMN 1.5 are:
1. The optional new InputData shape. (See https://issues.omg.org/issues/spec/DMN/fixed#issue-48580)
2. The deprecation of `allowedValues` in favor of `typeConstraint` (See https://issues.omg.org/issues/spec/DMN/fixed#issue-49990)

More changes are going to be necessary for supporting scientific number notation.