### PR TITLE
NO-ISSUE: Hide Apache server version on kie-sandbox-image

### DIFF
--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -23,6 +23,8 @@ RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.53-11.el9
   && sed -i -e 's/#ServerName www.example.com:80/ServerName 127.0.0.1:8080/' /etc/httpd/conf/httpd.conf \
   && sed -i -e "/ServerName 127.0.0.1:8080/aHeader set Content-Security-Policy \"frame-ancestors 'self';\"" /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/Options Indexes FollowSymLinks/Options -Indexes +FollowSymLinks/' /etc/httpd/conf/httpd.conf \
+  && sed -i '$ a ServerTokens Prod' /etc/httpd/conf/httpd.conf \
+  && sed -i '$ a ServerSignature Off' /etc/httpd/conf/httpd.conf \
   && mkdir /kie-sandbox \
   && mv -t /kie-sandbox /tmp/entrypoint.sh /tmp/image-env-to-json-standalone /tmp/EnvJson.schema.json \
   && chgrp -R 0 /var/log/httpd /var/run/httpd /var/www/html /kie-sandbox \


### PR DESCRIPTION
This PR adds two configs to the httpd.conf file with the objective to remove the Apache server version on HTTP requests.