### PR TITLE
NO-ISSUE: Minor fixes in the DMN Runner with Included Models

### DIFF
--- a/packages/dmn-language-service/src/index.ts
+++ b/packages/dmn-language-service/src/index.ts
@@ -43,7 +43,7 @@ export class DmnLanguageService {
 
   constructor(
     private readonly args: {
-      getDmnImportedModel: (importedModelRelativePath: string) => Promise<DmnLanguageServiceImportedModel>;
+      getDmnImportedModel: (importedModelRelativePath: string) => Promise<DmnLanguageServiceImportedModel | undefined>;
     }
   ) {}
 

--- a/packages/dmn-runner/src/jsonSchema.ts
+++ b/packages/dmn-runner/src/jsonSchema.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import { JSON_SCHEMA_INPUT_SET_PATH, RECURSION_KEYWORD, RECURSION_REF_KEYWORD, X_DMN_TYPE_KEYWORD } from "./constants";
 import { ValidateFunction } from "./ajv";
 import {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -748,8 +748,8 @@ export function DmnRunnerExtendedServicesError() {
           <p>An error has happened while trying to show your inputs</p>
           <br />
           <p>
-            If you're using included models, please check if they still exist in project. If you have deleted one file
-            that was included, please remove all its entry in the "Included Models" tab.
+            If your DMN file has included models, please check if they still exist.
+            If you have deleted a file that was being used as an included model, please remove its reference in the "Included Models" tab.
           </p>
         </EmptyStateBody>
       </EmptyState>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -749,7 +749,7 @@ export function DmnRunnerExtendedServicesError() {
           <br />
           <p>
             If your DMN file has included models, please check if they still exist. If you have deleted a file that was
-            being used as an included model, please remove its reference in the "Included Models" tab.
+            being used as an included model, please remove its reference in the Included Models tab.
           </p>
         </EmptyStateBody>
       </EmptyState>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -746,6 +746,11 @@ export function DmnRunnerExtendedServicesError() {
         </TextContent>
         <EmptyStateBody>
           <p>An error has happened while trying to show your inputs</p>
+          <br />
+          <p>
+            If you're using included models, please check if they still exist in project. If you have deleted one file
+            that was included, please remove all its entry in the "Included Models" tab.
+          </p>
         </EmptyStateBody>
       </EmptyState>
     </div>

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -748,8 +748,8 @@ export function DmnRunnerExtendedServicesError() {
           <p>An error has happened while trying to show your inputs</p>
           <br />
           <p>
-            If your DMN file has included models, please check if they still exist.
-            If you have deleted a file that was being used as an included model, please remove its reference in the "Included Models" tab.
+            If your DMN file has included models, please check if they still exist. If you have deleted a file that was
+            being used as an included model, please remove its reference in the "Included Models" tab.
           </p>
         </EmptyStateBody>
       </EmptyState>

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -333,12 +333,17 @@ export function EditorPage(props: Props) {
 
     return new DmnLanguageService({
       getDmnImportedModel: async (importedModelRelativePath: string) => {
-        const fileContent = await workspaces.getFileContent({
-          workspaceId: workspaceFilePromise.data?.workspaceFile.workspaceId,
-          relativePath: importedModelRelativePath,
-        });
+        try {
+          const fileContent = await workspaces.getFileContent({
+            workspaceId: workspaceFilePromise.data?.workspaceFile.workspaceId,
+            relativePath: importedModelRelativePath,
+          });
 
-        return { content: decoder.decode(fileContent), relativePath: importedModelRelativePath };
+          return { content: decoder.decode(fileContent), relativePath: importedModelRelativePath };
+        } catch (err) {
+          console.debug("ERROR: DmnLanguageService.getImportedModel: ", err);
+          return undefined;
+        }
       },
     });
   }, [workspaces, workspaceFilePromise.data?.workspaceFile]);

--- a/packages/online-editor/src/extendedServices/ExtendedServicesClient.ts
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesClient.ts
@@ -97,14 +97,15 @@ export class ExtendedServicesClient {
       throw new Error(`${response.status} ${response.statusText}`);
     }
 
-    // The input set property associated with the mainURI is InputSetX, where X is a number not always 1.
-    // So replace all occurrences InputSetX -> InputSet to keep compatibility with the current DmnForm.
+    // The input set property associated with the mainURI can be InputSetX or nsYInputSetX, where X and Y are a number.
+    // So replace all occurrences InputSetX/nsYInputSetX -> InputSet to keep compatibility with the current DmnForm.
     const json = await response.json();
-    const refIndex = json["$ref"].replace("#/definitions/InputSet", "");
+    const inputSet = json["$ref"].replace("#/definitions/", "");
+    const outputSet = inputSet.replace("InputSet", "OutputSet");
     return JSON.parse(
       JSON.stringify(json)
-        .replace(new RegExp(`InputSet${refIndex}`, "g"), "InputSet")
-        .replace(new RegExp(`OutputSet${refIndex}`, "g"), "OutputSet")
+        .replace(new RegExp(`${inputSet}`, "g"), "InputSet")
+        .replace(new RegExp(`${outputSet}`, "g"), "OutputSet")
     );
   }
 


### PR DESCRIPTION
## On this PR
 - Fix DMN Runner breaking after deleting the file that is included in another DMN;
 - Improved the error message to guide the user to remove any reference of a deleted file in the "Included Models" section if this is the case;
 - Add the case where the DMN JSON Schema comes with `nsYInputSetX` instead of `InputSetX`; This case happens when the target DMN has included models with types or nodes with the same name.