### PR TITLE
KOGITO-9685: Fix dirty state on SWF combined editor

### DIFF
--- a/packages/serverless-logic-web-tools/src/editor/channel/SwfChannelComponent.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/channel/SwfChannelComponent.tsx
@@ -91,7 +91,11 @@ const RefForwardingSwfChannelComponent: ForwardRefRenderFunction<
   const apiImpl = useMemo(() => {
     const lsChannelApiImpl = new SwfLanguageServiceChannelApiImpl(languageService);
     const serviceCatalogChannelApiImpl = new SwfServiceCatalogChannelApiImpl(catalogStore);
-    return new SwfCombinedEditorChannelApiImpl(channelApiImpl, serviceCatalogChannelApiImpl, lsChannelApiImpl);
+    return new SwfCombinedEditorChannelApiImpl({
+      defaultApiImpl: channelApiImpl,
+      swfServiceCatalogApiImpl: serviceCatalogChannelApiImpl,
+      swfLanguageServiceChannelApiImpl: lsChannelApiImpl,
+    });
   }, [languageService, catalogStore, channelApiImpl]);
 
   const onNotificationClick = useCallback(

--- a/packages/serverless-workflow-combined-editor/dev-webapp/App.tsx
+++ b/packages/serverless-workflow-combined-editor/dev-webapp/App.tsx
@@ -21,7 +21,7 @@ import {
   EnvelopeMapping,
 } from "@kie-tools-core/editor/dist/api";
 import { EmbeddedEditorFile } from "@kie-tools-core/editor/dist/channel";
-import { EmbeddedEditor, useEditorRef } from "@kie-tools-core/editor/dist/embedded";
+import { EmbeddedEditor, useDirtyState, useEditorRef } from "@kie-tools-core/editor/dist/embedded";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { basename, extname } from "path";
 import * as React from "react";
@@ -35,6 +35,7 @@ export type ServerlessWorkflowType = "json" | "yml" | "yaml";
 export const App = () => {
   const { editor, editorRef } = useEditorRef();
   const [embeddedEditorFile, setEmbeddedEditorFile] = useState<EmbeddedEditorFile>();
+  const isDirty = useDirtyState(editor);
 
   const editorEnvelopeLocator = useMemo(
     () =>
@@ -117,6 +118,7 @@ export const App = () => {
               get={onGetContent}
               setTheme={onSetTheme}
               validate={onValidate}
+              isDirty={isDirty}
             />
           </PageSection>
           <PageSection padding={{ default: "noPadding" }} isFilled={true} hasOverflowScroll={false}>

--- a/packages/serverless-workflow-combined-editor/dev-webapp/HistoryButtons.scss
+++ b/packages/serverless-workflow-combined-editor/dev-webapp/HistoryButtons.scss
@@ -26,4 +26,8 @@
   &__theme-switch {
     padding-top: 5px;
   }
+
+  &__edited-indicator {
+    padding-top: 8px;
+  }
 }

--- a/packages/serverless-workflow-combined-editor/dev-webapp/HistoryButtons.tsx
+++ b/packages/serverless-workflow-combined-editor/dev-webapp/HistoryButtons.tsx
@@ -18,6 +18,7 @@ import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { Modal, ModalVariant } from "@patternfly/react-core/dist/js/components/Modal";
 import { Switch } from "@patternfly/react-core/dist/js/components/Switch";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import "./HistoryButtons.scss";
@@ -33,6 +34,7 @@ interface HistoryButtonsProps {
   get: () => Promise<string>;
   setTheme: (theme: Theme) => Promise<void>;
   validate: () => Promise<void>;
+  isDirty: boolean;
 }
 
 export const HistoryButtons = (props: HistoryButtonsProps) => {
@@ -71,6 +73,13 @@ export const HistoryButtons = (props: HistoryButtonsProps) => {
             }}
           />
         </SplitItem>
+        {props.isDirty && (
+          <SplitItem className="history-buttons__edited-indicator">
+            <TextContent>
+              <Text component={"small"}>{"(Edited)"}</Text>
+            </TextContent>
+          </SplitItem>
+        )}
       </Split>
       <hr className="history-buttons__divider" />
     </div>

--- a/packages/serverless-workflow-combined-editor/dev-webapp/envelope/ServerlessWorkflowCombinedEditorEnvelopeApp.ts
+++ b/packages/serverless-workflow-combined-editor/dev-webapp/envelope/ServerlessWorkflowCombinedEditorEnvelopeApp.ts
@@ -16,7 +16,7 @@
 
 import { init } from "@kie-tools-core/editor/dist/envelope";
 import { NoOpKeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dist/envelope";
-import { ServerlessWorkflowCombinedEditorFactory } from "../../src";
+import { ServerlessWorkflowCombinedEditorFactory } from "../../src/editor";
 
 init({
   container: document.getElementById("combined-envelope-app")!,

--- a/packages/serverless-workflow-combined-editor/src/channel/NoOpSwfServiceCatalogChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/channel/NoOpSwfServiceCatalogChannelApiImpl.ts
@@ -22,10 +22,6 @@ import {
 } from "@kie-tools/serverless-workflow-service-catalog/dist/api";
 
 export class NoOpSwfServiceCatalogChannelApiImpl implements SwfServiceCatalogChannelApi {
-  constructor() {
-    /* Empty on purpose */
-  }
-
   public kogitoSwfServiceCatalog_services(): SharedValueProvider<SwfServiceCatalogService[]> {
     return {
       defaultValue: [],

--- a/packages/serverless-workflow-combined-editor/src/channel/ServerlessWorkflowDiagramEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/channel/ServerlessWorkflowDiagramEditorChannelApiImpl.ts
@@ -34,64 +34,66 @@ import { ServerlessWorkflowTextEditorEnvelopeApi } from "@kie-tools/serverless-w
 
 export class ServerlessWorkflowDiagramEditorChannelApiImpl implements ServerlessWorkflowDiagramEditorChannelApi {
   constructor(
-    private readonly defaultApiImpl: KogitoEditorChannelApi,
-    private readonly textEditorEnvelopeApi?: MessageBusClientApi<ServerlessWorkflowTextEditorEnvelopeApi>
+    private readonly args: {
+      defaultApiImpl: KogitoEditorChannelApi;
+      textEditorEnvelopeApi?: MessageBusClientApi<ServerlessWorkflowTextEditorEnvelopeApi>;
+    }
   ) {}
 
   public kogitoEditor_contentRequest(): Promise<EditorContent> {
-    return this.defaultApiImpl.kogitoEditor_contentRequest();
+    return this.args.defaultApiImpl.kogitoEditor_contentRequest();
   }
 
   public kogitoEditor_ready(): void {
-    this.defaultApiImpl.kogitoEditor_ready();
+    this.args.defaultApiImpl.kogitoEditor_ready();
   }
 
   public kogitoEditor_setContentError(content: EditorContent): void {
-    this.defaultApiImpl.kogitoEditor_setContentError(content);
+    this.args.defaultApiImpl.kogitoEditor_setContentError(content);
   }
 
   public kogitoEditor_stateControlCommandUpdate(command: StateControlCommand) {
-    this.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
+    this.args.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
   }
 
   public kogitoI18n_getLocale(): Promise<string> {
-    return this.defaultApiImpl.kogitoI18n_getLocale();
+    return this.args.defaultApiImpl.kogitoI18n_getLocale();
   }
 
   public kogitoNotifications_createNotification(notification: Notification): void {
-    this.defaultApiImpl.kogitoNotifications_createNotification(notification);
+    this.args.defaultApiImpl.kogitoNotifications_createNotification(notification);
   }
 
   public kogitoNotifications_removeNotifications(path: string): void {
-    this.defaultApiImpl.kogitoNotifications_removeNotifications(path);
+    this.args.defaultApiImpl.kogitoNotifications_removeNotifications(path);
   }
 
   public kogitoNotifications_setNotifications(path: string, notifications: Notification[]): void {
-    this.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
+    this.args.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
   }
 
   public kogitoWorkspace_newEdit(edit: WorkspaceEdit): void {
-    this.defaultApiImpl.kogitoWorkspace_newEdit(edit);
+    this.args.defaultApiImpl.kogitoWorkspace_newEdit(edit);
   }
 
   public kogitoWorkspace_openFile(path: string): void {
-    this.defaultApiImpl.kogitoWorkspace_openFile(path);
+    this.args.defaultApiImpl.kogitoWorkspace_openFile(path);
   }
 
   public kogitoWorkspace_resourceContentRequest(request: ResourceContentRequest): Promise<ResourceContent | undefined> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
   }
 
   public kogitoWorkspace_resourceListRequest(request: ResourceListRequest): Promise<ResourcesList> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
   }
 
   public kogitoEditor_theme(): SharedValueProvider<EditorTheme> {
-    return this.defaultApiImpl.kogitoEditor_theme();
+    return this.args.defaultApiImpl.kogitoEditor_theme();
   }
 
   public kogitoSwfDiagramEditor__onNodeSelected(args: { nodeName: string; documentUri?: string }): void {
-    return this.textEditorEnvelopeApi?.notifications.kogitoSwfTextEditor__moveCursorToNode.send(args);
+    return this.args.textEditorEnvelopeApi?.notifications.kogitoSwfTextEditor__moveCursorToNode.send(args);
   }
 
   public kogitoSwfDiagramEditor__setContentSuccess(): void {

--- a/packages/serverless-workflow-combined-editor/src/channel/ServerlessWorkflowTextEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/channel/ServerlessWorkflowTextEditorChannelApiImpl.ts
@@ -40,62 +40,64 @@ import { CodeLens, CompletionItem, Position, Range } from "vscode-languageserver
 
 export class ServerlessWorkflowTextEditorChannelApiImpl implements ServerlessWorkflowTextEditorChannelApi {
   constructor(
-    private readonly defaultApiImpl: KogitoEditorChannelApi,
-    private readonly channelApi: MessageBusClientApi<ServerlessWorkflowTextEditorChannelApi>,
-    private readonly swfServiceCatalogApiImpl?: SwfServiceCatalogChannelApi,
-    private readonly diagramEditorEnvelopeApi?: MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>
+    private readonly args: {
+      defaultApiImpl: KogitoEditorChannelApi;
+      channelApi: MessageBusClientApi<ServerlessWorkflowTextEditorChannelApi>;
+      swfServiceCatalogApiImpl?: SwfServiceCatalogChannelApi;
+      diagramEditorEnvelopeApi?: MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>;
+    }
   ) {}
 
   public kogitoEditor_contentRequest(): Promise<EditorContent> {
-    return this.defaultApiImpl.kogitoEditor_contentRequest();
+    return this.args.defaultApiImpl.kogitoEditor_contentRequest();
   }
 
   public kogitoEditor_ready(): void {
-    this.defaultApiImpl.kogitoEditor_ready();
+    this.args.defaultApiImpl.kogitoEditor_ready();
   }
 
   public kogitoEditor_setContentError(content: EditorContent): void {
-    this.defaultApiImpl.kogitoEditor_setContentError(content);
+    this.args.defaultApiImpl.kogitoEditor_setContentError(content);
   }
 
   public kogitoEditor_stateControlCommandUpdate(command: StateControlCommand) {
-    this.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
+    this.args.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
   }
 
   public kogitoI18n_getLocale(): Promise<string> {
-    return this.defaultApiImpl.kogitoI18n_getLocale();
+    return this.args.defaultApiImpl.kogitoI18n_getLocale();
   }
 
   public kogitoNotifications_createNotification(notification: Notification): void {
-    this.defaultApiImpl.kogitoNotifications_createNotification(notification);
+    this.args.defaultApiImpl.kogitoNotifications_createNotification(notification);
   }
 
   public kogitoNotifications_removeNotifications(path: string): void {
-    this.defaultApiImpl.kogitoNotifications_removeNotifications(path);
+    this.args.defaultApiImpl.kogitoNotifications_removeNotifications(path);
   }
 
   public kogitoNotifications_setNotifications(path: string, notifications: Notification[]): void {
-    this.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
+    this.args.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
   }
 
   public kogitoWorkspace_newEdit(edit: WorkspaceEdit): void {
-    this.defaultApiImpl.kogitoWorkspace_newEdit(edit);
+    this.args.defaultApiImpl.kogitoWorkspace_newEdit(edit);
   }
 
   public kogitoWorkspace_openFile(path: string): void {
-    this.defaultApiImpl.kogitoWorkspace_openFile(path);
+    this.args.defaultApiImpl.kogitoWorkspace_openFile(path);
   }
 
   public kogitoWorkspace_resourceContentRequest(request: ResourceContentRequest): Promise<ResourceContent | undefined> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
   }
 
   public kogitoWorkspace_resourceListRequest(request: ResourceListRequest): Promise<ResourcesList> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
   }
 
   public kogitoEditor_theme(): SharedValueProvider<EditorTheme> {
-    return this.defaultApiImpl.kogitoEditor_theme();
+    return this.args.defaultApiImpl.kogitoEditor_theme();
   }
 
   public kogitoSwfServiceCatalog_serviceRegistriesSettings(): SharedValueProvider<SwfServiceRegistriesSettings> {
@@ -105,29 +107,29 @@ export class ServerlessWorkflowTextEditorChannelApiImpl implements ServerlessWor
   }
 
   public kogitoSwfServiceCatalog_services(): SharedValueProvider<SwfServiceCatalogService[]> {
-    return this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_services() ?? { defaultValue: [] };
+    return this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_services() ?? { defaultValue: [] };
   }
 
   public kogitoSwfServiceCatalog_refresh(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_refresh.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_refresh.send();
   }
 
   public kogitoSwfServiceCatalog_importFunctionFromCompletionItem(args: {
     containingService: SwfServiceCatalogService;
     documentUri: string;
   }): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_importFunctionFromCompletionItem.send(args);
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_importFunctionFromCompletionItem.send(args);
   }
 
   public kogitoSwfServiceCatalog_importEventFromCompletionItem(args: {
     containingService: SwfServiceCatalogService;
     documentUri: string;
   }): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_importEventFromCompletionItem.send(args);
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_importEventFromCompletionItem.send(args);
   }
 
   public kogitoSwfServiceCatalog_logInServiceRegistries(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_logInServiceRegistries.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_logInServiceRegistries.send();
   }
 
   public async kogitoSwfLanguageService__getCompletionItems(args: {
@@ -136,18 +138,18 @@ export class ServerlessWorkflowTextEditorChannelApiImpl implements ServerlessWor
     cursorPosition: Position;
     cursorWordRange: Range;
   }): Promise<CompletionItem[]> {
-    return this.channelApi.requests.kogitoSwfLanguageService__getCompletionItems(args);
+    return this.args.channelApi.requests.kogitoSwfLanguageService__getCompletionItems(args);
   }
 
   public async kogitoSwfLanguageService__getCodeLenses(args: { uri: string; content: string }): Promise<CodeLens[]> {
-    return this.channelApi.requests.kogitoSwfLanguageService__getCodeLenses(args);
+    return this.args.channelApi.requests.kogitoSwfLanguageService__getCodeLenses(args);
   }
 
   public kogitoSwfServiceCatalog_setupServiceRegistriesSettings(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_setupServiceRegistriesSettings.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_setupServiceRegistriesSettings.send();
   }
 
   public kogitoSwfTextEditor__onSelectionChanged(args: { nodeName: string }): void {
-    this.diagramEditorEnvelopeApi?.notifications.kogitoSwfDiagramEditor__highlightNode.send(args);
+    this.args.diagramEditorEnvelopeApi?.notifications.kogitoSwfDiagramEditor__highlightNode.send(args);
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/channel/SwfCombinedEditorChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/channel/SwfCombinedEditorChannelApiImpl.ts
@@ -41,78 +41,80 @@ import { SwfStaticEnvelopeContentProviderChannelApi } from "../api/SwfStaticEnve
 
 export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombinedEditorChannelApi {
   constructor(
-    private readonly defaultApiImpl: KogitoEditorChannelApi,
-    private readonly swfServiceCatalogApiImpl?: SwfServiceCatalogChannelApi,
-    private readonly swfLanguageServiceChannelApiImpl?: SwfLanguageServiceChannelApi,
-    private readonly swfPreviewOptionsChannelApiImpl?: SwfPreviewOptionsChannelApi,
-    private readonly swfStaticEnvelopeContentProviderChannelApi?: SwfStaticEnvelopeContentProviderChannelApi
+    private readonly args: {
+      defaultApiImpl: KogitoEditorChannelApi;
+      swfServiceCatalogApiImpl?: SwfServiceCatalogChannelApi;
+      swfLanguageServiceChannelApiImpl?: SwfLanguageServiceChannelApi;
+      swfPreviewOptionsChannelApiImpl?: SwfPreviewOptionsChannelApi;
+      swfStaticEnvelopeContentProviderChannelApi?: SwfStaticEnvelopeContentProviderChannelApi;
+    }
   ) {}
 
   public kogitoEditor_contentRequest(): Promise<EditorContent> {
-    return this.defaultApiImpl.kogitoEditor_contentRequest();
+    return this.args.defaultApiImpl.kogitoEditor_contentRequest();
   }
 
   public kogitoEditor_ready(): void {
-    this.defaultApiImpl.kogitoEditor_ready();
+    this.args.defaultApiImpl.kogitoEditor_ready();
   }
 
   public kogitoEditor_setContentError(content: EditorContent): void {
-    this.defaultApiImpl.kogitoEditor_setContentError(content);
+    this.args.defaultApiImpl.kogitoEditor_setContentError(content);
   }
 
   public kogitoEditor_stateControlCommandUpdate(command: StateControlCommand) {
-    this.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
+    this.args.defaultApiImpl.kogitoEditor_stateControlCommandUpdate(command);
   }
 
   public kogitoI18n_getLocale(): Promise<string> {
-    return this.defaultApiImpl.kogitoI18n_getLocale();
+    return this.args.defaultApiImpl.kogitoI18n_getLocale();
   }
 
   public kogitoNotifications_createNotification(notification: Notification): void {
-    this.defaultApiImpl.kogitoNotifications_createNotification(notification);
+    this.args.defaultApiImpl.kogitoNotifications_createNotification(notification);
   }
 
   public kogitoNotifications_removeNotifications(path: string): void {
-    this.defaultApiImpl.kogitoNotifications_removeNotifications(path);
+    this.args.defaultApiImpl.kogitoNotifications_removeNotifications(path);
   }
 
   public kogitoNotifications_setNotifications(path: string, notifications: Notification[]): void {
-    this.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
+    this.args.defaultApiImpl.kogitoNotifications_setNotifications(path, notifications);
   }
 
   public kogitoWorkspace_newEdit(edit: WorkspaceEdit): void {
-    this.defaultApiImpl.kogitoWorkspace_newEdit(edit);
+    this.args.defaultApiImpl.kogitoWorkspace_newEdit(edit);
   }
 
   public kogitoWorkspace_openFile(path: string): void {
-    this.defaultApiImpl.kogitoWorkspace_openFile(path);
+    this.args.defaultApiImpl.kogitoWorkspace_openFile(path);
   }
 
   public kogitoWorkspace_resourceContentRequest(request: ResourceContentRequest): Promise<ResourceContent | undefined> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceContentRequest(request);
   }
 
   public kogitoWorkspace_resourceListRequest(request: ResourceListRequest): Promise<ResourcesList> {
-    return this.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
+    return this.args.defaultApiImpl.kogitoWorkspace_resourceListRequest(request);
   }
 
   public kogitoEditor_theme(): SharedValueProvider<EditorTheme> {
-    return this.defaultApiImpl.kogitoEditor_theme();
+    return this.args.defaultApiImpl.kogitoEditor_theme();
   }
 
   public kogitoSwfServiceCatalog_services(): SharedValueProvider<SwfServiceCatalogService[]> {
-    return this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_services() ?? { defaultValue: [] };
+    return this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_services() ?? { defaultValue: [] };
   }
 
   public kogitoSwfServiceCatalog_refresh(): void {
-    this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_refresh();
+    this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_refresh();
   }
 
   public kogitoSwfServiceCatalog_importFunctionFromCompletionItem(args: {
     containingService: SwfServiceCatalogService;
     documentUri: string;
   }): void {
-    this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_importFunctionFromCompletionItem(args);
+    this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_importFunctionFromCompletionItem(args);
   }
 
   public async kogitoSwfLanguageService__getCompletionItems(args: {
@@ -121,32 +123,32 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
     cursorPosition: Position;
     cursorWordRange: Range;
   }): Promise<CompletionItem[]> {
-    return this.swfLanguageServiceChannelApiImpl?.kogitoSwfLanguageService__getCompletionItems(args) ?? [];
+    return this.args.swfLanguageServiceChannelApiImpl?.kogitoSwfLanguageService__getCompletionItems(args) ?? [];
   }
 
   public async kogitoSwfLanguageService__getCodeLenses(args: { uri: string; content: string }): Promise<CodeLens[]> {
-    return this.swfLanguageServiceChannelApiImpl?.kogitoSwfLanguageService__getCodeLenses(args) ?? [];
+    return this.args.swfLanguageServiceChannelApiImpl?.kogitoSwfLanguageService__getCodeLenses(args) ?? [];
   }
 
   public kogitoSwfServiceCatalog_serviceRegistriesSettings(): SharedValueProvider<SwfServiceRegistriesSettings> {
     return (
-      this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_serviceRegistriesSettings() ?? {
+      this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_serviceRegistriesSettings() ?? {
         defaultValue: { registries: [] },
       }
     );
   }
 
   public kogitoSwfServiceCatalog_logInServiceRegistries(): void {
-    this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_logInServiceRegistries();
+    this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_logInServiceRegistries();
   }
 
   public kogitoSwfServiceCatalog_setupServiceRegistriesSettings(): void {
-    this.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_setupServiceRegistriesSettings();
+    this.args.swfServiceCatalogApiImpl?.kogitoSwfServiceCatalog_setupServiceRegistriesSettings();
   }
 
   kogitoSwfPreviewOptions_get(): SharedValueProvider<SwfPreviewOptions> {
     return (
-      this.swfPreviewOptionsChannelApiImpl?.kogitoSwfPreviewOptions_get() ?? {
+      this.args.swfPreviewOptionsChannelApiImpl?.kogitoSwfPreviewOptions_get() ?? {
         defaultValue: { defaultWidth: "50%", editorMode: "full" },
       }
     );
@@ -154,7 +156,7 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
 
   public kogitoSwfGetDiagramEditorEnvelopeContent(): SharedValueProvider<string> {
     return (
-      this.swfStaticEnvelopeContentProviderChannelApi?.kogitoSwfGetDiagramEditorEnvelopeContent() ?? {
+      this.args.swfStaticEnvelopeContentProviderChannelApi?.kogitoSwfGetDiagramEditorEnvelopeContent() ?? {
         defaultValue: "",
       }
     );
@@ -162,7 +164,9 @@ export class SwfCombinedEditorChannelApiImpl implements ServerlessWorkflowCombin
 
   public kogitoSwfGetTextEditorEnvelopeContent(): SharedValueProvider<string> {
     return (
-      this.swfStaticEnvelopeContentProviderChannelApi?.kogitoSwfGetTextEditorEnvelopeContent() ?? { defaultValue: "" }
+      this.args.swfStaticEnvelopeContentProviderChannelApi?.kogitoSwfGetTextEditorEnvelopeContent() ?? {
+        defaultValue: "",
+      }
     );
   }
 

--- a/packages/serverless-workflow-combined-editor/src/channel/SwfServiceCatalogChannelApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/channel/SwfServiceCatalogChannelApiImpl.ts
@@ -23,46 +23,48 @@ import {
 
 export class SwfServiceCatalogChannelApiImpl implements SwfServiceCatalogChannelApi {
   constructor(
-    private readonly channelApi: MessageBusClientApi<SwfServiceCatalogChannelApi>,
-    private readonly services: SwfServiceCatalogService[],
-    private readonly serviceRegistriesSettings: SwfServiceRegistriesSettings
+    private readonly args: {
+      channelApi: MessageBusClientApi<SwfServiceCatalogChannelApi>;
+      services: SwfServiceCatalogService[];
+      serviceRegistriesSettings: SwfServiceRegistriesSettings;
+    }
   ) {}
 
   public kogitoSwfServiceCatalog_services(): SharedValueProvider<SwfServiceCatalogService[]> {
     return {
-      defaultValue: this.services,
+      defaultValue: this.args.services,
     };
   }
 
   public kogitoSwfServiceCatalog_serviceRegistriesSettings(): SharedValueProvider<SwfServiceRegistriesSettings> {
     return {
-      defaultValue: this.serviceRegistriesSettings,
+      defaultValue: this.args.serviceRegistriesSettings,
     };
   }
 
   public kogitoSwfServiceCatalog_refresh(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_refresh.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_refresh.send();
   }
 
   public kogitoSwfServiceCatalog_importFunctionFromCompletionItem(args: {
     containingService: SwfServiceCatalogService;
     documentUri: string;
   }): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_importFunctionFromCompletionItem.send(args);
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_importFunctionFromCompletionItem.send(args);
   }
 
   public kogitoSwfServiceCatalog_importEventFromCompletionItem(args: {
     containingService: SwfServiceCatalogService;
     documentUri: string;
   }): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_importEventFromCompletionItem.send(args);
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_importEventFromCompletionItem.send(args);
   }
 
   public kogitoSwfServiceCatalog_logInServiceRegistries(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_logInServiceRegistries.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_logInServiceRegistries.send();
   }
 
   public kogitoSwfServiceCatalog_setupServiceRegistriesSettings(): void {
-    this.channelApi.notifications.kogitoSwfServiceCatalog_setupServiceRegistriesSettings.send();
+    this.args.channelApi.notifications.kogitoSwfServiceCatalog_setupServiceRegistriesSettings.send();
   }
 }

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
@@ -55,6 +55,9 @@ export class ServerlessWorkflowCombinedEditorView implements ServerlessWorkflowC
         channelType={this.initArgs.channel}
         resourcesPathPrefix={this.initArgs.resourcesPathPrefix}
         onNewEdit={this.envelopeContext.channelApi.notifications.kogitoWorkspace_newEdit.send}
+        onStateControlCommandUpdate={
+          this.envelopeContext.channelApi.notifications.kogitoEditor_stateControlCommandUpdate.send
+        }
       />
     );
   }

--- a/packages/serverless-workflow-combined-editor/src/editor/hooks/useSwfDiagramEditorChannelApi.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/hooks/useSwfDiagramEditorChannelApi.tsx
@@ -49,7 +49,10 @@ export function useSwfDiagramEditorChannelApi(args: {
       args.channelApi &&
       channelApiImpl &&
       args.swfTextEditorEnvelopeApi &&
-      new ServerlessWorkflowDiagramEditorChannelApiImpl(channelApiImpl, args.swfTextEditorEnvelopeApi),
+      new ServerlessWorkflowDiagramEditorChannelApiImpl({
+        defaultApiImpl: channelApiImpl,
+        textEditorEnvelopeApi: args.swfTextEditorEnvelopeApi,
+      }),
     [args.channelApi, channelApiImpl, args.swfTextEditorEnvelopeApi]
   );
 

--- a/packages/serverless-workflow-combined-editor/src/editor/hooks/useSwfTextEditorChannelApi.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/hooks/useSwfTextEditorChannelApi.tsx
@@ -23,14 +23,17 @@ import { ServerlessWorkflowTextEditorChannelApi } from "@kie-tools/serverless-wo
 import { useMemo } from "react";
 import { SwfServiceCatalogChannelApiImpl } from "../../channel";
 import { ServerlessWorkflowTextEditorChannelApiImpl } from "../../channel/ServerlessWorkflowTextEditorChannelApiImpl";
+import { KogitoEditorChannelApi } from "@kie-tools-core/editor/dist/api";
 
-export function useSwfTextEditorChannelApi(args: {
+export interface UseSwfTextEditorChannelApiArgs {
+  apiOverrides: Partial<KogitoEditorChannelApi>;
   locale: string;
   channelApi?: MessageBusClientApi<ServerlessWorkflowTextEditorChannelApi>;
   embeddedEditorFile?: EmbeddedEditorFile;
-  onEditorReady: () => void;
   swfDiagramEditorEnvelopeApi?: MessageBusClientApi<ServerlessWorkflowDiagramEditorEnvelopeApi>;
-}) {
+}
+
+export function useSwfTextEditorChannelApi(args: UseSwfTextEditorChannelApiArgs) {
   const [services] = useSharedValue(args.channelApi?.shared.kogitoSwfServiceCatalog_services);
   const [serviceRegistriesSettings] = useSharedValue(
     args.channelApi?.shared.kogitoSwfServiceCatalog_serviceRegistriesSettings
@@ -44,9 +47,7 @@ export function useSwfTextEditorChannelApi(args: {
     () =>
       args.embeddedEditorFile &&
       new EmbeddedEditorChannelApiImpl(stateControl, args.embeddedEditorFile, args.locale, {
-        kogitoEditor_ready: () => {
-          args.onEditorReady();
-        },
+        ...args.apiOverrides,
       }),
     [args, stateControl]
   );
@@ -56,7 +57,7 @@ export function useSwfTextEditorChannelApi(args: {
       args.channelApi &&
       services &&
       serviceRegistriesSettings &&
-      new SwfServiceCatalogChannelApiImpl(args.channelApi, services, serviceRegistriesSettings),
+      new SwfServiceCatalogChannelApiImpl({ channelApi: args.channelApi, services, serviceRegistriesSettings }),
     [args.channelApi, serviceRegistriesSettings, services]
   );
 
@@ -64,13 +65,13 @@ export function useSwfTextEditorChannelApi(args: {
     () =>
       channelApiImpl &&
       args.channelApi &&
-      new ServerlessWorkflowTextEditorChannelApiImpl(
-        channelApiImpl,
-        args.channelApi,
-        swfServiceCatalogChannelApiImpl,
-        args.swfDiagramEditorEnvelopeApi
-      ),
-    [channelApiImpl, args.channelApi, args.swfDiagramEditorEnvelopeApi, swfServiceCatalogChannelApiImpl]
+      new ServerlessWorkflowTextEditorChannelApiImpl({
+        defaultApiImpl: channelApiImpl,
+        channelApi: args.channelApi,
+        swfServiceCatalogApiImpl: swfServiceCatalogChannelApiImpl,
+        diagramEditorEnvelopeApi: args.swfDiagramEditorEnvelopeApi,
+      }),
+    [channelApiImpl, args, swfServiceCatalogChannelApiImpl]
   );
 
   return {

--- a/packages/serverless-workflow-standalone-editor/src/common/Editor.ts
+++ b/packages/serverless-workflow-standalone-editor/src/common/Editor.ts
@@ -47,11 +47,9 @@ export const createEditor = (
 ): StandaloneEditorApi => {
   return {
     undo: () => {
-      stateControl.undo();
       return Promise.resolve(envelopeApi.notifications.kogitoEditor_editorUndo.send());
     },
     redo: () => {
-      stateControl.redo();
       return Promise.resolve(envelopeApi.notifications.kogitoEditor_editorRedo.send());
     },
     close: () => {

--- a/packages/serverless-workflow-text-editor/dev-webapp/App.tsx
+++ b/packages/serverless-workflow-text-editor/dev-webapp/App.tsx
@@ -21,7 +21,12 @@ import {
   EnvelopeMapping,
 } from "@kie-tools-core/editor/dist/api";
 import { EmbeddedEditorFile, StateControl } from "@kie-tools-core/editor/dist/channel";
-import { EmbeddedEditor, EmbeddedEditorChannelApiImpl, useEditorRef } from "@kie-tools-core/editor/dist/embedded";
+import {
+  EmbeddedEditor,
+  EmbeddedEditorChannelApiImpl,
+  useDirtyState,
+  useEditorRef,
+} from "@kie-tools-core/editor/dist/embedded";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { basename, extname } from "path";
@@ -44,6 +49,7 @@ export const App = () => {
   const [embeddedEditorFile, setEmbeddedEditorFile] = useState<EmbeddedEditorFile>();
   const downloadRef = useRef<HTMLAnchorElement>(null);
   const [isReady, setReady] = useState(false);
+  const isDirty = useDirtyState(editor);
 
   const stateControl = useMemo(() => new StateControl(), [embeddedEditorFile?.getFileContents]);
 
@@ -175,7 +181,7 @@ export const App = () => {
       {embeddedEditorFile && (
         <>
           <PageSection padding={{ default: "noPadding" }}>
-            <HistoryButtons undo={onUndo} redo={onRedo} download={onDownload} validate={onValidate} />
+            <HistoryButtons undo={onUndo} redo={onRedo} download={onDownload} validate={onValidate} isDirty={isDirty} />
           </PageSection>
           <PageSection padding={{ default: "noPadding" }} isFilled={true} hasOverflowScroll={false}>
             <div className="editor-container">

--- a/packages/serverless-workflow-text-editor/dev-webapp/HistoryButtons.scss
+++ b/packages/serverless-workflow-text-editor/dev-webapp/HistoryButtons.scss
@@ -26,4 +26,8 @@
   &__theme-switch {
     padding-top: 5px;
   }
+
+  &__edited-indicator {
+    padding-top: 8px;
+  }
 }

--- a/packages/serverless-workflow-text-editor/dev-webapp/HistoryButtons.tsx
+++ b/packages/serverless-workflow-text-editor/dev-webapp/HistoryButtons.tsx
@@ -16,6 +16,7 @@
 
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
+import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 import * as React from "react";
 import "./HistoryButtons.scss";
 
@@ -24,6 +25,7 @@ interface HistoryButtonsProps {
   redo: () => Promise<void>;
   download: () => Promise<void>;
   validate: () => Promise<void>;
+  isDirty: boolean;
 }
 
 export const HistoryButtons = (props: HistoryButtonsProps) => {
@@ -50,6 +52,13 @@ export const HistoryButtons = (props: HistoryButtonsProps) => {
             Download
           </Button>
         </SplitItem>
+        {props.isDirty && (
+          <SplitItem className="history-buttons__edited-indicator">
+            <TextContent>
+              <Text component={"small"}>{"(Edited)"}</Text>
+            </TextContent>
+          </SplitItem>
+        )}
       </Split>
       <hr className="history-buttons__divider" />
     </div>

--- a/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditorController.ts
+++ b/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditorController.ts
@@ -18,10 +18,6 @@ import { EditorTheme } from "@kie-tools-core/editor/dist/api";
 import { OperatingSystem } from "@kie-tools-core/operating-system";
 import { FileLanguage, SwfLanguageServiceCommandIds } from "@kie-tools/serverless-workflow-language-service/dist/api";
 import {
-  SwfJsonLanguageService,
-  SwfYamlLanguageService,
-} from "@kie-tools/serverless-workflow-language-service/dist/channel";
-import {
   getJsonStateNameFromOffset,
   getJsonStateNameOffset,
   getYamlStateNameFromOffset,
@@ -65,7 +61,7 @@ export class SwfTextEditorController implements SwfTextEditorApi {
 
   constructor(
     content: string,
-    private readonly onContentChange: (content: string, operation: SwfTextEditorOperation) => void,
+    private readonly onContentChange: (args: { content: string; operation: SwfTextEditorOperation }) => void,
     private readonly language: FileLanguage,
     private readonly operatingSystem: OperatingSystem | undefined,
     private readonly isReadOnly: boolean,
@@ -76,7 +72,7 @@ export class SwfTextEditorController implements SwfTextEditorApi {
     this.model.onDidChangeContent((event) => {
       if (!event.isUndoing && !event.isRedoing) {
         this.editor?.pushUndoStop();
-        onContentChange(this.model.getValue(), SwfTextEditorOperation.EDIT);
+        onContentChange({ content: this.model.getValue(), operation: SwfTextEditorOperation.EDIT });
       }
     });
 
@@ -127,16 +123,16 @@ export class SwfTextEditorController implements SwfTextEditorApi {
     });
 
     this.editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyZ, () => {
-      this.onContentChange(this.model.getValue(), SwfTextEditorOperation.UNDO);
+      this.onContentChange({ content: this.model.getValue(), operation: SwfTextEditorOperation.UNDO });
     });
 
     this.editor.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyZ, () => {
-      this.onContentChange(this.model.getValue(), SwfTextEditorOperation.REDO);
+      this.onContentChange({ content: this.model.getValue(), operation: SwfTextEditorOperation.REDO });
     });
 
     if (this.operatingSystem !== OperatingSystem.MACOS) {
       this.editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyY, () => {
-        this.onContentChange(this.model.getValue(), SwfTextEditorOperation.REDO);
+        this.onContentChange({ content: this.model.getValue(), operation: SwfTextEditorOperation.REDO });
       });
     }
 


### PR DESCRIPTION
Due to auto-save, the dirty state is not apparent on Serverless Logic Web Tools. However, other applications are having issues if the dirty state is needed to be shown somehow. This is because undo/redo operations are always being treated as a new edit, which confuses the state control. Besides fixing the issue, this PR also adds the dirty indicator in the dev-webapp as an example. Finally, I changed some class constructors to use an `args` object.

The first part of the video uses the buttons and the second part uses keyboard shortcuts for undoing/redoing on the dev-webapp of SWF combined editor.

https://github.com/kiegroup/kie-tools/assets/638737/c7cdb548-f994-4889-b1fe-0e4347c632ad

