### PR TITLE
KOGITO-9539 - remove of IsWidget and other GWT modules from InlineEditor

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -61,14 +61,6 @@
       <artifactId>kie-wb-common-stunner-core-common</artifactId>
     </dependency>
 
-    <!-- GWT. -->
-
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-user</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Uberfire & Errai. -->
     <dependency>
       <groupId>org.kie.kogito.stunner.serverless.editor</groupId>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControl.java
@@ -22,10 +22,8 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.touch.client.Point;
-import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.dom.DomGlobal;
-import elemental2.dom.HTMLElement;
-import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.Canvas;
@@ -86,7 +84,7 @@ public abstract class AbstractCanvasInlineTextEditorControl
     protected EditorSession session;
     private int EDIT_TEXTBOX_BOTTOM_PADDING = 10;
 
-    protected abstract FloatingView<IsWidget> getFloatingView();
+    protected abstract FloatingView<IsElement> getFloatingView();
 
     protected abstract TextEditorBox<AbstractCanvasHandler, Element> getTextEditorBox();
 
@@ -105,14 +103,10 @@ public abstract class AbstractCanvasInlineTextEditorControl
 
         getFloatingView()
                 .hide()
-                .add(wrapTextEditorBoxElement(getTextEditorBox().getElement()));
+                .add(getTextEditorBox());
 
         // if the user tries to scroll the editor must be closed
         setMouseWheelHandler();
-    }
-
-    protected IsWidget wrapTextEditorBoxElement(final HTMLElement element) {
-        return ElementWrapperWidget.getWidget(element);
     }
 
     @Override

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/CanvasInlineTextEditorControl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/CanvasInlineTextEditorControl.java
@@ -21,7 +21,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
 import org.kie.workbench.common.stunner.core.graph.Element;
@@ -32,11 +32,11 @@ import org.kie.workbench.common.stunner.core.graph.Element;
 public class CanvasInlineTextEditorControl
         extends AbstractCanvasInlineTextEditorControl {
 
-    private final FloatingView<IsWidget> floatingView;
+    private final FloatingView<IsElement> floatingView;
     private final TextEditorBox<AbstractCanvasHandler, Element> textEditorBox;
 
     @Inject
-    public CanvasInlineTextEditorControl(final FloatingView<IsWidget> floatingView,
+    public CanvasInlineTextEditorControl(final FloatingView<IsElement> floatingView,
                                          final @InlineTextEditorBox TextEditorBox<AbstractCanvasHandler, Element> textEditorBox) {
         this.floatingView = floatingView;
         this.textEditorBox = textEditorBox;
@@ -60,7 +60,7 @@ public class CanvasInlineTextEditorControl
     }
 
     @Override
-    protected FloatingView<IsWidget> getFloatingView() {
+    protected FloatingView<IsElement> getFloatingView() {
         return floatingView;
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/FloatingWidgetView.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/FloatingWidgetView.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
+
+import java.util.Objects;
+
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.user.client.Timer;
+import elemental2.dom.CSSProperties;
+import elemental2.dom.DomGlobal;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.kie.workbench.common.stunner.core.client.components.views.FloatingView;
+import org.uberfire.mvp.Command;
+
+/**
+ * Floating view implementation for generic J2CL Widgets.
+ */
+@Dependent
+public class FloatingWidgetView implements FloatingView<IsElement> {
+
+    private double ox;
+    private double oy;
+    private double x;
+    private double y;
+    private boolean attached;
+    private Timer timer;
+    private int timeout = 800;
+    private boolean visible;
+    private Command hideCallback;
+    private final FlowPanel panel = new FlowPanel();
+
+    public FloatingWidgetView() {
+        this.attached = false;
+        this.ox = 0;
+        this.oy = 0;
+        this.visible = false;
+        this.hideCallback = () -> {
+        };
+    }
+
+    @Override
+    public void add(final IsElement item) {
+        panel.add(item);
+    }
+
+    @Override
+    public FloatingView<IsElement> setOffsetX(final double ox) {
+        this.ox = ox;
+        reposition();
+        return this;
+    }
+
+    @Override
+    public FloatingView<IsElement> setOffsetY(final double oy) {
+        this.oy = oy;
+        reposition();
+        return this;
+    }
+
+    @Override
+    public FloatingWidgetView setX(final double x) {
+        this.x = x;
+        reposition();
+        return this;
+    }
+
+    @Override
+    public FloatingWidgetView setY(final double y) {
+        this.y = y;
+        reposition();
+        return this;
+    }
+
+    @Override
+    public FloatingWidgetView setTimeOut(final int timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    @Override
+    public FloatingView<IsElement> clearTimeOut() {
+        setTimeOut(-1);
+        return this;
+    }
+
+    @Override
+    public FloatingView<IsElement> setHideCallback(final Command hideCallback) {
+        Objects.requireNonNull(hideCallback, "Parameter named 'hideCallback' should be not null!");
+        this.hideCallback = hideCallback;
+        return this;
+    }
+
+    @Override
+    public void clear() {
+        panel.clear();
+    }
+
+    @Override
+    public FloatingWidgetView show() {
+        if (!isVisible()) {
+            visible = true;
+            attach();
+            startTimeout();
+            reposition();
+            doShow();
+        }
+        return this;
+    }
+
+    @Override
+    public FloatingWidgetView hide() {
+        if (isVisible()) {
+            this.visible = false;
+            stopTimeout();
+            doHide();
+        }
+        return this;
+    }
+
+    protected void doShow() {
+        panel.getElement().style.display = "inline";
+    }
+
+    protected void doHide() {
+        panel.getElement().style.display = "none";
+        hideCallback.execute();
+    }
+
+    private void attach() {
+        if (!attached) {
+            DomGlobal.document.body.appendChild(panel.getElement());
+            panel.getElement().style.position = "fixed";
+            panel.getElement().style.zIndex = CSSProperties.ZIndexUnionType.of(Integer.MAX_VALUE);
+            doHide();
+            attached = true;
+        }
+    }
+
+    @Override
+    public void destroy() {
+        stopTimeout();
+        detach();
+        timer = null;
+        hideCallback = null;
+    }
+
+    private void detach() {
+        if (attached) {
+            DomGlobal.document.body.removeChild(panel.getElement());
+            attached = false;
+        }
+    }
+
+    private void reposition() {
+        panel.getElement().style.left = (ox + x) + "px";
+        panel.getElement().style.top = (oy + y) + "px";
+    }
+
+    private boolean isVisible() {
+        return visible;
+    }
+
+    public void startTimeout() {
+        if (timeout > 0 &&
+                (null == timer || !timer.isRunning())) {
+            timer = new Timer() {
+                @Override
+                public void run() {
+                    FloatingWidgetView.this.hide();
+                }
+            };
+            timer.schedule(timeout);
+        }
+    }
+
+    public void stopTimeout() {
+        if (null != timer && timer.isRunning()) {
+            timer.cancel();
+        }
+    }
+
+    protected FlowPanel getPanel() {
+        return panel;
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/FlowPanel.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/FlowPanel.java
@@ -1,0 +1,39 @@
+package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+
+public class FlowPanel implements IsElement {
+
+    private final Map<IsElement, HTMLElement> children = new HashMap<>();
+
+    private final HTMLDivElement root = (HTMLDivElement) DomGlobal.document.createElement("div");
+
+    public void add(IsElement element) {
+        HTMLElement child = element.getElement();
+        children.put(element, child);
+        root.appendChild(child);
+    }
+
+    public void remove(IsElement element) {
+        HTMLElement child = children.remove(element);
+        if (child != null) {
+            root.removeChild(child);
+        }
+    }
+
+    public void clear() {
+        children.forEach((element, htmlElement) -> root.removeChild(htmlElement));
+        children.clear();
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return root;
+    }
+}

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/TextEditorBox.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/TextEditorBox.java
@@ -16,7 +16,7 @@
 
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
-import org.jboss.errai.common.client.api.IsElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.command.RequiresCommandManager;
 import org.kie.workbench.common.stunner.core.graph.Element;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/test/java/org/kie/workbench/common/stunner/core/client/canvas/controls/inlineeditor/AbstractCanvasInlineTextEditorControlTest.java
@@ -16,8 +16,8 @@
 package org.kie.workbench.common.stunner.core.client.canvas.controls.inlineeditor;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,7 +60,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -92,16 +91,13 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
     private static final String POSITION_OUTSIDE = "OUTSIDE";
 
     @Mock
-    protected FloatingView<IsWidget> floatingView;
+    protected FloatingView<IsElement> floatingView;
 
     @Mock
     protected TextEditorBox<AbstractCanvasHandler, Element> textEditorBox;
 
     @Mock
     protected HTMLElement textEditBoxElement;
-
-    @Mock
-    protected IsWidget textEditBoxWidget;
 
     @Mock
     protected EditorSession session;
@@ -201,7 +197,6 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
             return null;
         }).when(control).scheduleDeferredCommand(any(Scheduler.ScheduledCommand.class));
 
-        doReturn(textEditBoxWidget).when(control).wrapTextEditorBoxElement(eq(textEditBoxElement));
         doAnswer(i -> abstractCanvas).when(control).getAbstractCanvas();
         doAnswer(i -> hasTitle).when(control).getHasTitle();
         doNothing().when(control).setMouseWheelHandler();
@@ -277,7 +272,7 @@ public abstract class AbstractCanvasInlineTextEditorControlTest<C extends Abstra
         verify(textEditorBox).initialize(eq(canvasHandler),
                                          any(Command.class));
         verify(floatingView).hide();
-        verify(floatingView).add(textEditBoxWidget);
+        verify(floatingView).add(textEditorBox);
     }
 
     @Test


### PR DESCRIPTION
Hello @romartin, @treblereel, @LuboTerifaj,

I removed GWT dependency from `serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common` module. The only affected component is `CanvasInlineTextEditorControl` which appears on edit mode, so to test that all still works you need to use our test app with Edit mode On and just try to rename any State node.

As discussed on the meeting I created two addition widgets/panels instead of fixing the global one to make progress in chunks. Both of them should be removed (unified) at the end of KOGITO-9539.

* `FloatingWidgetView`
* `FlowPanel`

I will add it to the Jira issue description.

Thank you!