### PR TITLE
NO-ISSUE: Bump up the Golang version 1.20.7

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -40,10 +40,10 @@ runs:
         java-version: 11
         distribution: "zulu"
 
-    - name: "Set up GOLANG 1.20.5"
+    - name: "Set up GOLANG 1.20.7"
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20.5"
+        go-version: "1.20.7"
 
     - name: "Set up Maven"
       uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f #v4.5

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start building the KIE Tools project, you're going to need:
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Maven `3.8.6`
 - Java `11`
-- Go `1.20.5` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.20.7` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 > **ℹ️ NOTE:** Some packages will require that `make` is available as well.
 

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -12,7 +12,7 @@ All the commands in this section should be performed in the monorepo root.
 
 - Node `>= 18.14.0` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
 - pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
-- Go `1.20.5` _(To install, follow these instructions: https://go.dev/doc/install)_
+- Go `1.20.7` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 #### Prerequisites for running integration tests
 


### PR DESCRIPTION
This change was suggested as go1.20.7 (released 2023-08-01) includes a security fix to the crypto/tls package, as well as bug fixes to the assembler and the compiler. See: https://github.com/golang/go/issues?q=milestone%3AGo1.20.7+label%3ACherryPickApproved