### PR TITLE
KOGITO-9708: Fix Github list item locator

### DIFF
--- a/packages/chrome-extension-test-helper/src/framework/github-file-list/GitHubListPage.ts
+++ b/packages/chrome-extension-test-helper/src/framework/github-file-list/GitHubListPage.ts
@@ -27,7 +27,7 @@ export default class GitHubListPage extends Page {
   }
 
   public async getFile(name: string): Promise<GitHubListItem> {
-    const file: By = By.xpath(`//div[@title='${name}']`);
+    const file: By = By.xpath(`//td[@class='react-directory-row-name-cell-large-screen']//div[@title='${name}']`);
     await this.tools.by(file).wait(5000).untilPresent();
     return await this.tools.createPageFragment(GitHubListItem, await this.tools.by(file).getElement());
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9708

There were probably some Github pages changes which causes that Chrome extension tests started to fail.