### PR TITLE
KOGITO-9585: Resume executing all it tests

### DIFF
--- a/packages/kn-plugin-workflow/it-tests/quarkus_run_test.go
+++ b/packages/kn-plugin-workflow/it-tests/quarkus_run_test.go
@@ -55,7 +55,7 @@ var cfgTestInputQuarkusRun_Success = []cfgTestInputQuarkusRun{
 func transformQuarkusRunCmdCfgToArgs(cfg quarkus.RunCmdConfig) []string {
 	args := []string{"run"}
 	if !cfg.OpenDevUI {
-		args = append(args, "--open-dev-ui=", "false")
+		args = append(args, "--open-dev-ui=false")
 	}
 	if cfg.PortMapping != "" {
 		args = append(args, "--port", cfg.PortMapping)
@@ -74,7 +74,6 @@ func getRunQuarkusProjectPort(t *testing.T, config cfgTestInputQuarkusRun) strin
 }
 
 func TestQuarkusRunCommand(t *testing.T) {
-	t.Skip("Skipping test because of `quarkus run` not working properly. Probably related to https://issues.redhat.com/browse/KOGITO-9449")
 	for testIndex, test := range cfgTestInputQuarkusRun_Success {
 		t.Run(fmt.Sprintf("Test quarkus run project success index: %d", testIndex), func(t *testing.T) {
 			defer CleanUpAndChdirTemp(t)

--- a/packages/kn-plugin-workflow/it-tests/run_test.go
+++ b/packages/kn-plugin-workflow/it-tests/run_test.go
@@ -48,7 +48,7 @@ var cfgTestInputRun_Success = []cfgTestInputRun{
 func transformRunCmdCfgToArgs(cfg command.RunCmdConfig) []string {
 	args := []string{"run"}
 	if !cfg.OpenDevUI {
-		args = append(args, "--open-dev-ui=", "false")
+		args = append(args, "--open-dev-ui=false")
 	}
 	if cfg.PortMapping != "" {
 		args = append(args, "--port", cfg.PortMapping)
@@ -67,8 +67,6 @@ func getRunProjectPort(t *testing.T, config cfgTestInputRun) string {
 }
 
 func TestRunCommand(t *testing.T) {
-	//testPrintCmdOutput = true
-	t.Skip("Skipping test because of `run` not working properly on osx")
 	for testIndex, test := range cfgTestInputRun_Success {
 		t.Run(fmt.Sprintf("Test run project success index: %d", testIndex), func(t *testing.T) {
 			defer CleanUpAndChdirTemp(t)


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9585

The `quarkus run` integration test is fixed by #1910 and by updating the `--open-dev-ui=false` flag in tests. The `run` integration test is fixed just by the flag.

Both the disabled tests work fine on virtualized MacOS Monterey (only the timeouts are too tight for a slow, virtualized MacOS). Please let me know @ederign if you still have issues with your native MacOS. 