### PR TITLE
KOGITO-9733: Fix broken QEMU (homebrew) on MacOS GH Actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -75,7 +75,18 @@ runs:
         brew untap homebrew/core homebrew/cask
         brew update
         brew install docker docker-compose
-        brew reinstall -f --force-bottle qemu
+        cat >entitlements.xml <<EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>com.apple.security.hypervisor</key>
+            <true/>
+        </dict>
+        </plist>
+        EOF
+
+        codesign --sign - --entitlements entitlements.xml --force /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
         mkdir -p ~/.docker/cli-plugins
         ln -sfn $(brew --prefix)/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
         brew install docker-Buildx


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9733

The GitHub Actions check on MacOS started to fail on the environment setup. The issue is described in https://github.com/lima-vm/lima/issues/1742 and the third fix mentioned works here.

This is the second time there is an issue with that. First, it was fixed in https://github.com/kiegroup/kie-tools/pull/1905