### PR TITLE
kie-issues#488: Upgrade `pnpm` from `7.x.x` to `8.x.x` on `kie-tools`

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: "Setup pnpm"
       uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
       with:
-        version: 7.26.3
+        version: 8.7.0
 
     - name: "Setup Node"
       uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains tooling applications and libraries for KIE projects.
 To start building the KIE Tools project, you're going to need:
 
 - Node `18` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
-- pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
+- pnpm `8.7.0` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Maven `3.8.6`
 - Java `11`
 - Go `1.20.7` _(To install, follow these instructions: https://go.dev/doc/install)_

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bootstrap": "pnpm bootstrap:root && pnpm bootstrap:packages",
     "bootstrap:packages": "kie-tools--bootstrap",
-    "bootstrap:root": "pnpm install --use-lockfile-v6 --workspace-root --strict-peer-dependencies=false -F kie-tools-root...",
+    "bootstrap:root": "pnpm install --workspace-root --strict-peer-dependencies=false -F kie-tools-root...",
     "format": "prettier --write . '**/*.xml' '!./packages/uniforms-patternfly/src/cjs' '!./packages/uniforms-patternfly/src/esm'",
     "format:check": "prettier --check . '**/*.xml' '!./packages/uniforms-patternfly/src/cjs' '!./packages/uniforms-patternfly/src/esm'",
     "prepare": "husky install",
@@ -34,7 +34,7 @@
   },
   "engines": {
     "node": ">=18",
-    "pnpm": "7.26.3"
+    "pnpm": "8.7.0"
   },
   "pnpm": {
     "packageExtensions": {

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -11,7 +11,7 @@ All the commands in this section should be performed in the monorepo root.
 ### Prerequisites
 
 - Node `>= 18.14.0` _(To install, follow these instructions: https://nodejs.org/en/download/package-manager/)_
-- pnpm `7.26.3` _(To install, follow these instructions: https://pnpm.io/installation)_
+- pnpm `8.7.0` _(To install, follow these instructions: https://pnpm.io/installation)_
 - Go `1.20.7` _(To install, follow these instructions: https://go.dev/doc/install)_
 
 #### Prerequisites for running integration tests

--- a/scripts/bootstrap/bootstrap.js
+++ b/scripts/bootstrap/bootstrap.js
@@ -31,7 +31,7 @@ const execOpts = { stdio: "inherit" };
 
 console.info("\n\n[bootstrap] Installing packages dependencies...");
 execSync(
-  `pnpm install --use-lockfile-v6 --strict-peer-dependencies=false -F !kie-tools-root... ${pnpmFilterStringForInstalling}`,
+  `pnpm install --strict-peer-dependencies=false -F !kie-tools-root... ${pnpmFilterStringForInstalling}`,
   execOpts
 );
 


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/488

`pnpm` updated to `8.7.0` version.

No changes are required for the lock file.

`--use-lockfile-v6` removed as that is the default in v8.x --> https://github.com/pnpm/pnpm/releases/tag/v8.0.0

