### PR TITLE
KOGITO-9724: Move selectFromContentAssist to SwfTextEditor class

### DIFF
--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
@@ -34,6 +34,7 @@ export default class SwfTextEditor extends TextEditor {
 
   /**
    * Selects a value from the content assist.
+   *
    * @param value The value to be selected.
    */
   public async selectFromContentAssist(value: string): Promise<void> {

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
@@ -21,11 +21,21 @@ import { sleep } from "@kie-tools/vscode-extension-common-test-helpers";
 import { expect } from "chai";
 import { TextEditor } from "vscode-extension-tester";
 
+/**
+ * Helper class which represents Serverless Workflow text editor.
+ */
 export default class SwfTextEditor extends TextEditor {
+  /**
+   * The class constuctor.
+   */
   constructor() {
     super();
   }
 
+  /**
+   * Selects a value from the content assist.
+   * @param value The value to be selected.
+   */
   public async selectFromContentAssist(value: string): Promise<void> {
     try {
       const contentAssist = await this.toggleContentAssist(true);

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
@@ -1,0 +1,23 @@
+import { sleep } from "@kie-tools/vscode-extension-common-test-helpers";
+import { expect } from "chai";
+import { TextEditor } from "vscode-extension-tester";
+
+export default class SwfTextEditor extends TextEditor {
+  constructor() {
+    super();
+  }
+
+  public async selectFromContentAssist(value: string): Promise<void> {
+    try {
+      const contentAssist = await this.toggleContentAssist(true);
+      const item = await contentAssist?.getItem(value);
+      await sleep(1000);
+      expect(await item?.getLabel()).contain(value);
+      await item?.click();
+    } catch (e) {
+      throw new Error(
+        `The ContentAssist menu is not available or it was not possible to select the element '${value}'!`
+      );
+    }
+  }
+}

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { sleep } from "@kie-tools/vscode-extension-common-test-helpers";
 import { expect } from "chai";
 import { TextEditor } from "vscode-extension-tester";

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditor.ts
@@ -25,9 +25,6 @@ import { TextEditor } from "vscode-extension-tester";
  * Helper class which represents Serverless Workflow text editor.
  */
 export default class SwfTextEditor extends TextEditor {
-  /**
-   * The class constuctor.
-   */
   constructor() {
     super();
   }

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
@@ -28,6 +28,10 @@ import SwfTextEditor from "./SwfTextEditor";
 export default class SwfTextEditorTestHelper {
   constructor(private readonly webview: WebView) {}
 
+  /**
+   * Creates and returns Serverless Workflow text editor.
+   * @returns Serverless Workflow text editor.
+   */
   public async getSwfTextEditor(): Promise<SwfTextEditor> {
     return Promise.resolve(new SwfTextEditor());
   }

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
@@ -30,6 +30,7 @@ export default class SwfTextEditorTestHelper {
 
   /**
    * Creates and returns Serverless Workflow text editor.
+   *
    * @returns Serverless Workflow text editor.
    */
   public async getSwfTextEditor(): Promise<SwfTextEditor> {

--- a/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/helpers/swf/SwfTextEditorTestHelper.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-import { TextEditor, WebView } from "vscode-extension-tester";
+import { WebView } from "vscode-extension-tester";
+import SwfTextEditor from "./SwfTextEditor";
 
 /**
  * Helper class to easen work with swf text editor.
@@ -27,7 +28,7 @@ import { TextEditor, WebView } from "vscode-extension-tester";
 export default class SwfTextEditorTestHelper {
   constructor(private readonly webview: WebView) {}
 
-  public async getSwfTextEditor(): Promise<TextEditor> {
-    return Promise.resolve(new TextEditor());
+  public async getSwfTextEditor(): Promise<SwfTextEditor> {
+    return Promise.resolve(new SwfTextEditor());
   }
 }

--- a/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-autocompletion.test.ts
@@ -22,8 +22,8 @@ require("./serverless-workflow-editor-extension-smoke.test");
 import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
-import { Key, TextEditor } from "vscode-extension-tester";
-import { VSCodeTestHelper, sleep } from "@kie-tools/vscode-extension-common-test-helpers";
+import { Key } from "vscode-extension-tester";
+import { VSCodeTestHelper } from "@kie-tools/vscode-extension-common-test-helpers";
 import SwfEditorTestHelper from "./helpers/swf/SwfEditorTestHelper";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
@@ -81,16 +81,16 @@ describe("Serverless workflow editor - autocompletion tests", () => {
       await textEditor.toggleContentAssist(false);
 
       // add function from specs directory
-      await selectFromContentAssist(textEditor, "functions");
+      await textEditor.selectFromContentAssist("functions");
       await textEditor.typeText(": ");
-      await selectFromContentAssist(textEditor, "[]");
-      await selectFromContentAssist(textEditor, "specs»api.yaml#testFuncId");
+      await textEditor.selectFromContentAssist("[]");
+      await textEditor.selectFromContentAssist("specs»api.yaml#testFuncId");
 
       // add test state
       await textEditor.moveCursor(17, 38);
       await textEditor.typeText(Key.ENTER);
-      await selectFromContentAssist(textEditor, "states");
-      await selectFromContentAssist(textEditor, "{}");
+      await textEditor.selectFromContentAssist("states");
+      await textEditor.selectFromContentAssist("{}");
       await textEditor.typeText(Key.ENTER);
       await textEditor.typeText(
         '"name": "testState",\n' + '"type": "operation",\n' + '"actions": [{"functionRef": }],\n' + '"end": true'
@@ -98,10 +98,10 @@ describe("Serverless workflow editor - autocompletion tests", () => {
 
       // complete the state with refName
       await textEditor.moveCursor(21, 33);
-      await selectFromContentAssist(textEditor, "{}");
+      await textEditor.selectFromContentAssist("{}");
       await textEditor.typeText(Key.ENTER);
-      await selectFromContentAssist(textEditor, "refName");
-      await selectFromContentAssist(textEditor, '"testFuncId"');
+      await textEditor.selectFromContentAssist("refName");
+      await textEditor.selectFromContentAssist('"testFuncId"');
 
       // check there are 2 nodes: testState, end
       const nodeIds = await swfEditor.getAllNodeIds();
@@ -124,7 +124,7 @@ describe("Serverless workflow editor - autocompletion tests", () => {
       const textEditor = await swfTextEditor.getSwfTextEditor();
 
       // select the autocompletion
-      await selectFromContentAssist(textEditor, "Serverless Workflow Example");
+      await textEditor.selectFromContentAssist("Serverless Workflow Example");
 
       // check the final editor content is the same as expected result
       const editorContent = await textEditor.getText();
@@ -165,14 +165,14 @@ describe("Serverless workflow editor - autocompletion tests", () => {
       await textEditor.toggleContentAssist(false);
 
       // add function from specs directory
-      await selectFromContentAssist(textEditor, "functions");
+      await textEditor.selectFromContentAssist("functions");
       await textEditor.typeText(":\n  - ");
-      await selectFromContentAssist(textEditor, "specs»api.yaml#testFuncId");
+      await textEditor.selectFromContentAssist("specs»api.yaml#testFuncId");
 
       // add test state
       await textEditor.moveCursor(19, 19);
       await textEditor.typeText(Key.ENTER);
-      await selectFromContentAssist(textEditor, "states");
+      await textEditor.selectFromContentAssist("states");
       await textEditor.typeText(`name: testState
   type: operation
 actions:
@@ -183,8 +183,8 @@ actions:
       await textEditor.typeText(Key.ENTER);
       await textEditor.typeText(Key.TAB);
       await textEditor.typeText(Key.TAB);
-      await selectFromContentAssist(textEditor, "refName");
-      await selectFromContentAssist(textEditor, "testFuncId");
+      await textEditor.selectFromContentAssist("refName");
+      await textEditor.selectFromContentAssist("testFuncId");
       await textEditor.typeText(Key.ENTER);
       await textEditor.typeText(Key.BACK_SPACE);
       await textEditor.typeText(Key.BACK_SPACE);
@@ -212,7 +212,7 @@ actions:
       const textEditor = await swfTextEditor.getSwfTextEditor();
 
       // select the autocompletion
-      await selectFromContentAssist(textEditor, "Serverless Workflow Example");
+      await textEditor.selectFromContentAssist("Serverless Workflow Example");
 
       // check the final editor content is the same as expected result
       const editorContent = await textEditor.getText();
@@ -230,7 +230,7 @@ actions:
       const textEditor = await swfTextEditor.getSwfTextEditor();
 
       // select the autocompletion
-      await selectFromContentAssist(textEditor, "Empty Serverless Workflow");
+      await textEditor.selectFromContentAssist("Empty Serverless Workflow");
 
       // check the final editor content is the same as expected result
       const editorContent = await textEditor.getText();
@@ -241,18 +241,4 @@ actions:
       expect(editorContent).equal(expectedContent);
     });
   });
-
-  async function selectFromContentAssist(textEditor: TextEditor, value: string): Promise<void> {
-    const contentAssist = await textEditor.toggleContentAssist(true);
-    try {
-      const item = await contentAssist?.getItem(value);
-      await sleep(1000);
-      expect(await item?.getLabel()).contain(value);
-      await item?.click();
-    } catch (e) {
-      throw new Error(
-        `The ContentAssist menu is not available or it was not possible to select the element '${value}'!`
-      );
-    }
-  }
 });

--- a/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-events.test.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-events.test.ts
@@ -22,8 +22,8 @@ require("./serverless-workflow-editor-extension-smoke.test");
 import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
-import { Key, TextEditor } from "vscode-extension-tester";
-import { VSCodeTestHelper, sleep } from "@kie-tools/vscode-extension-common-test-helpers";
+import { Key } from "vscode-extension-tester";
+import { VSCodeTestHelper } from "@kie-tools/vscode-extension-common-test-helpers";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
 describe("Serverless workflow editor - events tests", () => {
@@ -73,7 +73,7 @@ describe("Serverless workflow editor - events tests", () => {
     ]);
 
     // add asyncapi event from yaml specification
-    await selectFromContentAssist(textEditor, "specs»asyncapi.yaml#publishYamlOperation");
+    await textEditor.selectFromContentAssist("specs»asyncapi.yaml#publishYamlOperation");
 
     // check the final editor content is the same as expected result
     const editorContent = await textEditor.getText();
@@ -104,19 +104,11 @@ describe("Serverless workflow editor - events tests", () => {
     ]);
 
     // add asyncapi event from json specification
-    await selectFromContentAssist(textEditor, "specs»asyncapi.json#subscribeJsonOperation");
+    await textEditor.selectFromContentAssist("specs»asyncapi.json#subscribeJsonOperation");
 
     // check the final editor content is the same as expected result
     const editorContent = await textEditor.getText();
     const expectedContent = fs.readFileSync(path.resolve(TEST_PROJECT_FOLDER, "event.sw.yaml.result"), "utf-8");
     expect(editorContent).equal(expectedContent);
   });
-
-  async function selectFromContentAssist(textEditor: TextEditor, value: string): Promise<void> {
-    const contentAssist = await textEditor.toggleContentAssist(true);
-    const item = await contentAssist?.getItem(value);
-    await sleep(500);
-    expect(await item?.getLabel()).contain(value);
-    await item?.click();
-  }
 });

--- a/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-functions.test.ts
+++ b/packages/serverless-workflow-vscode-extension/it-tests/serverless-workflow-editor-extension-functions.test.ts
@@ -22,8 +22,8 @@ require("./serverless-workflow-editor-extension-smoke.test");
 import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
-import { Key, TextEditor } from "vscode-extension-tester";
-import { VSCodeTestHelper, sleep } from "@kie-tools/vscode-extension-common-test-helpers";
+import { Key } from "vscode-extension-tester";
+import { VSCodeTestHelper } from "@kie-tools/vscode-extension-common-test-helpers";
 import SwfTextEditorTestHelper from "./helpers/swf/SwfTextEditorTestHelper";
 
 describe("Serverless workflow editor - functions tests", () => {
@@ -77,14 +77,14 @@ describe("Serverless workflow editor - functions tests", () => {
     ]);
 
     // add asyncapi function from yaml specification
-    await selectFromContentAssist(textEditor, "specs»asyncapi.yaml#publishYamlOperation");
+    await textEditor.selectFromContentAssist("specs»asyncapi.yaml#publishYamlOperation");
 
     await textEditor.moveCursor(18, 6);
     await textEditor.typeText("," + Key.ENTER);
 
     // add openapi function from json specification
     await textEditor.typeText("s");
-    await selectFromContentAssist(textEditor, "specs»openapi.json#testPutJsonFunc");
+    await textEditor.selectFromContentAssist("specs»openapi.json#testPutJsonFunc");
 
     await textEditor.moveCursor(23, 6);
     await textEditor.typeText("," + Key.ENTER);
@@ -102,7 +102,7 @@ describe("Serverless workflow editor - functions tests", () => {
     ]);
 
     // add camel function from json specification
-    await selectFromContentAssist(textEditor, "routes»camel.json#camel:direct:routeJson");
+    await textEditor.selectFromContentAssist("routes»camel.json#camel:direct:routeJson");
 
     // check the final editor content is the same as expected result
     const editorContent = await textEditor.getText();
@@ -137,14 +137,14 @@ describe("Serverless workflow editor - functions tests", () => {
     ]);
 
     // add asyncapi function from json specification
-    await selectFromContentAssist(textEditor, "specs»asyncapi.json#subscribeJsonOperation");
+    await textEditor.selectFromContentAssist("specs»asyncapi.json#subscribeJsonOperation");
 
     await textEditor.moveCursor(12, 19);
     await textEditor.typeText(Key.ENTER + Key.BACK_SPACE + "- ");
 
     // add openapi function from yaml specification
     await textEditor.typeText("s");
-    await selectFromContentAssist(textEditor, "specs»openapi.yaml#testGetYamlFunc");
+    await textEditor.selectFromContentAssist("specs»openapi.yaml#testGetYamlFunc");
 
     await textEditor.moveCursor(15, 15);
     await textEditor.typeText(Key.ENTER + Key.BACK_SPACE + "- ");
@@ -162,19 +162,11 @@ describe("Serverless workflow editor - functions tests", () => {
     ]);
 
     // add camel function from yaml specification
-    await selectFromContentAssist(textEditor, "routes»camel.yaml#camel:direct:fromYaml");
+    await textEditor.selectFromContentAssist("routes»camel.yaml#camel:direct:fromYaml");
 
     // check the final editor content is the same as expected result
     const editorContent = await textEditor.getText();
     const expectedContent = fs.readFileSync(path.resolve(TEST_PROJECT_FOLDER, "function.sw.yaml.result"), "utf-8");
     expect(editorContent).equal(expectedContent);
   });
-
-  async function selectFromContentAssist(textEditor: TextEditor, value: string): Promise<void> {
-    const contentAssist = await textEditor.toggleContentAssist(true);
-    const item = await contentAssist?.getItem(value);
-    await sleep(500);
-    expect(await item?.getLabel()).contain(value);
-    await item?.click();
-  }
 });

--- a/packages/serverless-workflow-vscode-extension/tsconfig.it-tests.json
+++ b/packages/serverless-workflow-vscode-extension/tsconfig.it-tests.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "declaration": false,
     "declarationMap": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
+    "target": "es6",
     "outDir": "out"
   },
   "include": ["it-tests"],


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9724

`selectFromContentAssist` function is repeated in few tests. This PR moves the function to SwfTextEditor class.