### PR TITLE
NO ISSUE: Fix git requests headers when not proxied

### DIFF
--- a/packages/online-editor/src/bitbucket/Hooks.tsx
+++ b/packages/online-editor/src/bitbucket/Hooks.tsx
@@ -234,9 +234,13 @@ export function getBitbucketClient(args: {
     auth: args.auth,
     proxyUrl: args.insecurelyDisableTlsCertificateValidation ? args.proxyUrl : undefined,
     headers: {
-      [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
-        args.insecurelyDisableTlsCertificateValidation
-      ).toString(),
+      ...(args.insecurelyDisableTlsCertificateValidation
+        ? {
+            [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
+              args.insecurelyDisableTlsCertificateValidation
+            ).toString(),
+          }
+        : {}),
     },
   });
 }

--- a/packages/online-editor/src/github/Hooks.tsx
+++ b/packages/online-editor/src/github/Hooks.tsx
@@ -41,9 +41,13 @@ export function getOctokitClient(args: {
         return fetch(newUrl, {
           ...options,
           headers: {
-            [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
-              args.insecurelyDisableTlsCertificateValidation
-            ).toString(),
+            ...(args.insecurelyDisableTlsCertificateValidation
+              ? {
+                  [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
+                    args.insecurelyDisableTlsCertificateValidation
+                  ).toString(),
+                }
+              : {}),
             ...options.headers,
           },
         });

--- a/packages/workspaces-git-fs/src/services/GitService.tsx
+++ b/packages/workspaces-git-fs/src/services/GitService.tsx
@@ -88,11 +88,13 @@ export class GitService {
   public constructor(private readonly corsProxy: Promise<string>) {}
 
   private getRequestHeaders(args: { insecurelyDisableTlsCertificateValidation?: boolean }) {
-    return {
-      [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
-        args.insecurelyDisableTlsCertificateValidation
-      ).toString(),
-    };
+    return args.insecurelyDisableTlsCertificateValidation
+      ? {
+          [CorsProxyHeaderKeys.INSECURELY_DISABLE_TLS_CERTIFICATE_VALIDATION]: Boolean(
+            args.insecurelyDisableTlsCertificateValidation
+          ).toString(),
+        }
+      : undefined;
   }
 
   public async listServerRefs(args: {


### PR DESCRIPTION
The `insecurely-disable-tls-certificate-validation` header was being added to requests even though its value was false and the AuthProvider didn't need proxying.