### PR TITLE
NO-ISSUE: Bump guava to 32.0.1 (SWF stunner-editors)

### DIFF
--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -263,7 +263,7 @@
     <!-- Third party Libraries -->
     <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.guava>30.1-jre</version.com.google.guava>
+    <version.com.google.guava>32.0.1-jre</version.com.google.guava>
     <version.gwt.nio>1.1</version.gwt.nio>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>


### PR DESCRIPTION
The current version is affected by https://github.com/advisories/GHSA-7g45-4rm6-3mm3
