### PR TITLE
KOGITO-9768: SWF Chrome Extension - The node selection on Diagram doesn't move the cursor on the editor

### DIFF
--- a/packages/chrome-extension-serverless-workflow-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApp.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApp.ts
@@ -17,11 +17,23 @@
  * under the License.
  */
 
-import { init } from "@kie-tools-core/editor/dist/envelope";
+import { initCustom } from "@kie-tools-core/editor/dist/envelope";
+import {
+  ServerlessWorkflowTextEditorChannelApi,
+  ServerlessWorkflowTextEditorEnvelopeApi,
+} from "@kie-tools/serverless-workflow-text-editor/dist/api";
 import { ServerlessWorkflowTextEditorFactory } from "@kie-tools/serverless-workflow-text-editor/dist/editor";
+import { ServerlessWorkflowTextEditorEnvelopeApiImpl } from "@kie-tools/serverless-workflow-text-editor/dist/envelope/ServerlessWorkflowTextEditorEnvelopeApiImpl";
+import { ServerlessWorkflowTextEditorApi } from "@kie-tools/serverless-workflow-text-editor/src";
 
-init({
+initCustom<
+  ServerlessWorkflowTextEditorApi,
+  ServerlessWorkflowTextEditorEnvelopeApi,
+  ServerlessWorkflowTextEditorChannelApi
+>({
   container: document.getElementById("text-envelope-app")!,
   bus: { postMessage: (message, targetOrigin, _) => window.parent.postMessage(message, targetOrigin!, _) },
-  editorFactory: new ServerlessWorkflowTextEditorFactory(),
+  apiImplFactory: {
+    create: (args) => new ServerlessWorkflowTextEditorEnvelopeApiImpl(args, new ServerlessWorkflowTextEditorFactory()),
+  },
 });


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9768

**Description:**
The node selection from the diagram editor to the text editor does not work but the node selection from the text editor to the diagram editor works.
This behaviour only occurs in the Chrome extension.

**Preview:**
[KOGITO-9768.webm](https://github.com/kiegroup/kie-tools/assets/17780574/6c84a3d5-7f53-40d8-b291-b4caeab7ef40)
