### PR TITLE
NO-ISSUE: Fix `kn-plugin-workflow` README documentation link

### DIFF
--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -2,7 +2,7 @@
 
 `kn-plugin-workflow` is a plugin of the Knative Client, to enable users to quickly set up a local SonataFlow project from the command line.
 
-[Read the documentation](https://kiegroup.github.io/kogito-docs/serverlessworkflow/main/tooling/kn-plugin-workflow-overview.html)
+[Read the documentation](https://sonataflow.org/serverlessworkflow/main/testing-and-troubleshooting/kn-plugin-workflow-overview.html)
 
 ## Build from source
 


### PR DESCRIPTION
The current link is broken because of documentation reorganization. It is probable also better to use [sonataflow.org](https://sonataflow.org)

The following link would also work thanks to 301 redirect: https://kiegroup.github.io/kogito-docs/serverlessworkflow/main/testing-and-troubleshooting/kn-plugin-workflow-overview.html