### PR TITLE
NO-ISSUE: Bump `JDT.LS` to `1.28`

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -42,7 +42,7 @@
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
     <!-- Using a SNAPSHOT version because of https://github.com/eclipse/eclipse.jdt.ls/issues/1970 -->
-    <jdt.ls.version>1.27.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.28.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
Currently the build is broken because of the usual issue with repos of that project. Fix hasn't been provided yet, we need a future snapshot of 1.28.0 after the fix has been pushed  [here](https://github.com/eclipse-jdtls/eclipse.jdt.ls)