### PR TITLE
NO-ISSUE: Bump `semver` to `7.5.4` version

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,7 @@
     "axios": "^0.27.2",
     "fast-xml-parser": "^4.2.4",
     "portfinder": "^1.0.32",
-    "semver": "^7.3.5",
+    "semver": "^7.5.4",
     "sinon": "^11.1.1"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/jest": "^26.0.23",
     "@types/jest-when": "^2.7.4",
-    "@types/semver": "^7.3.6",
+    "@types/semver": "^7.5.2",
     "@types/sinon": "^10.0.2",
     "@types/vscode": "1.67.0",
     "jest": "^26.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,8 +674,8 @@ importers:
         specifier: ^1.0.32
         version: 1.0.32
       semver:
-        specifier: ^7.3.5
-        version: 7.3.5
+        specifier: ^7.5.4
+        version: 7.5.4
       sinon:
         specifier: ^11.1.1
         version: 11.1.1
@@ -705,8 +705,8 @@ importers:
         specifier: ^2.7.4
         version: 2.7.4
       "@types/semver":
-        specifier: ^7.3.6
-        version: 7.3.6
+        specifier: ^7.5.2
+        version: 7.5.2
       "@types/sinon":
         specifier: ^10.0.2
         version: 10.0.2
@@ -14576,7 +14576,7 @@ packages:
     deprecated: this version had an improper engines field added, update to 1.1.1
     dependencies:
       "@gar/promisify": 1.1.2
-      semver: 7.3.8
+      semver: 7.5.4
     dev: true
 
   /@npmcli/fs@2.1.2:
@@ -15145,7 +15145,7 @@ packages:
       path-exists: 4.0.0
       ramda: /@pnpm/ramda@0.28.1
       run-groups: 3.0.1
-      semver: 7.3.7
+      semver: 7.5.4
       version-selector-type: 3.0.0
     transitivePeerDependencies:
       - "@yarnpkg/core"
@@ -15185,7 +15185,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       right-pad: 1.0.1
       rxjs: 7.5.6
-      semver: 7.3.7
+      semver: 7.5.4
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -15470,7 +15470,7 @@ packages:
       js-yaml: /@zkochan/js-yaml@0.0.6
       normalize-path: 3.0.0
       ramda: /@pnpm/ramda@0.28.1
-      semver: 7.3.7
+      semver: 7.5.4
       sort-keys: 4.2.0
       strip-bom: 4.0.0
       write-file-atomic: 3.0.3
@@ -15562,7 +15562,7 @@ packages:
       "@pnpm/lockfile-types": 4.3.1
       comver-to-semver: 1.0.0
       ramda: /@pnpm/ramda@0.28.1
-      semver: 7.3.7
+      semver: 7.5.4
     dev: true
 
   /@pnpm/modules-cleaner@12.0.19(@pnpm/logger@4.0.0):
@@ -15648,7 +15648,7 @@ packages:
     engines: { node: ">=14.6" }
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.3.7
+      semver: 7.5.4
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -15677,7 +15677,7 @@ packages:
       parse-npm-tarball-url: 3.0.0
       path-temp: 2.0.0
       rename-overwrite: 4.0.2
-      semver: 7.3.7
+      semver: 7.5.4
       ssri: 8.0.1
       version-selector-type: 3.0.0
     transitivePeerDependencies:
@@ -15708,7 +15708,7 @@ packages:
       detect-libc: 2.0.1
       execa: /safe-execa@0.1.3
       mem: 8.1.1
-      semver: 7.3.7
+      semver: 7.5.4
     dev: true
 
   /@pnpm/package-requester@19.0.0(@pnpm/logger@4.0.0):
@@ -15740,7 +15740,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       rename-overwrite: 4.0.2
       safe-promise-defer: 1.0.1
-      semver: 7.3.7
+      semver: 7.5.4
       ssri: 8.0.1
     dev: true
 
@@ -15945,7 +15945,7 @@ packages:
       rename-overwrite: 4.0.2
       replace-string: 3.1.0
       safe-promise-defer: 1.0.1
-      semver: 7.3.7
+      semver: 7.5.4
       semver-range-intersect: 0.3.1
       version-selector-type: 3.0.0
     transitivePeerDependencies:
@@ -15958,7 +15958,7 @@ packages:
       { integrity: sha512-QxD0/kp8IAxQDw7hYLcNmBuk5XGNfyuseU1EveJI0+HG7eO8hQINS6WyyVE7IiqzG6rBe3nrZk4iJBpk1hGIYw== }
     engines: { node: ">=14.19" }
     dependencies:
-      semver: 7.3.7
+      semver: 7.5.4
     dev: true
 
   /@pnpm/resolver-base@9.1.0:
@@ -17121,14 +17121,9 @@ packages:
       { integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A== }
     dev: true
 
-  /@types/semver@7.3.6:
+  /@types/semver@7.5.2:
     resolution:
-      { integrity: sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw== }
-    dev: true
-
-  /@types/semver@7.5.0:
-    resolution:
-      { integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw== }
+      { integrity: sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw== }
     dev: true
 
   /@types/send@0.17.1:
@@ -17335,7 +17330,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
-      semver: 7.3.8
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@4.8.4)
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -17414,7 +17409,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@4.8.4)
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -17430,7 +17425,7 @@ packages:
     dependencies:
       "@eslint-community/eslint-utils": 4.4.0(eslint@8.43.0)
       "@types/json-schema": 7.0.11
-      "@types/semver": 7.5.0
+      "@types/semver": 7.5.2
       "@typescript-eslint/scope-manager": 5.60.1
       "@typescript-eslint/types": 5.60.1
       "@typescript-eslint/typescript-estree": 5.60.1(typescript@4.8.4)
@@ -17861,7 +17856,7 @@ packages:
     engines: { node: ">=12 <14 || 14.2 - 14.9 || >14.10.0" }
     dependencies:
       "@arcanis/slice-ansi": 1.1.1
-      "@types/semver": 7.3.6
+      "@types/semver": 7.5.2
       "@types/treeify": 1.0.0
       "@yarnpkg/fslib": 2.7.0
       "@yarnpkg/json-proxy": 2.1.1
@@ -17884,7 +17879,7 @@ packages:
       p-limit: 2.3.0
       pluralize: 7.0.0
       pretty-bytes: 5.6.0
-      semver: 7.3.7
+      semver: 7.5.4
       stream-to-promise: 2.2.0
       strip-ansi: 6.0.1
       tar: 6.1.11
@@ -17902,7 +17897,7 @@ packages:
     engines: { node: ">=12 <14 || 14.2 - 14.9 || >14.10.0" }
     dependencies:
       "@arcanis/slice-ansi": 1.1.1
-      "@types/semver": 7.3.6
+      "@types/semver": 7.5.2
       "@types/treeify": 1.0.0
       "@yarnpkg/fslib": 2.7.0
       "@yarnpkg/json-proxy": 2.1.1
@@ -17925,7 +17920,7 @@ packages:
       p-limit: 2.3.0
       pluralize: 7.0.0
       pretty-bytes: 5.6.0
-      semver: 7.3.7
+      semver: 7.5.4
       stream-to-promise: 2.2.0
       strip-ansi: 6.0.1
       tar: 6.1.11
@@ -17943,7 +17938,7 @@ packages:
     engines: { node: ">=18.12.0" }
     dependencies:
       "@arcanis/slice-ansi": 1.1.1
-      "@types/semver": 7.5.0
+      "@types/semver": 7.5.2
       "@types/treeify": 1.0.0
       "@yarnpkg/fslib": 3.0.0-rc.50
       "@yarnpkg/libzip": 3.0.0-rc.50(@yarnpkg/fslib@3.0.0-rc.50)
@@ -20604,7 +20599,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.12)
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
-      semver: 7.3.7
+      semver: 7.5.4
       webpack: 5.88.2(webpack-cli@4.10.0)
     dev: true
 
@@ -20838,7 +20833,7 @@ packages:
       pretty-bytes: 5.6.0
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
-      semver: 7.3.8
+      semver: 7.5.4
       supports-color: 8.1.1
       tmp: 0.2.1
       untildify: 4.0.0
@@ -21498,7 +21493,7 @@ packages:
       "@pnpm/crypto.base32-hash": 1.0.1
       "@pnpm/types": 8.5.0
       encode-registry: 3.0.0
-      semver: 7.3.7
+      semver: 7.5.4
     dev: true
 
   /deprecation@2.3.1:
@@ -28330,7 +28325,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.0
       rimraf: 3.0.2
-      semver: 7.3.8
+      semver: 7.5.4
       tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
@@ -28446,7 +28441,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.8.1
-      semver: 7.3.7
+      semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -28539,7 +28534,7 @@ packages:
     dependencies:
       hosted-git-info: 5.2.1
       proc-log: 2.0.1
-      semver: 7.3.8
+      semver: 7.5.4
       validate-npm-package-name: 4.0.0
     dev: true
 
@@ -28575,7 +28570,7 @@ packages:
       npm-install-checks: 5.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 9.1.0
-      semver: 7.3.8
+      semver: 7.5.4
     dev: true
 
   /npm-registry-fetch@13.3.1:
@@ -31840,15 +31835,6 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@7.3.5:
-    resolution:
-      { integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ== }
-    engines: { node: ">=10" }
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: false
-
   /semver@7.3.7:
     resolution:
       { integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g== }
@@ -33460,7 +33446,7 @@ packages:
       chalk: 4.1.2
       enhanced-resolve: 5.9.3
       micromatch: 4.0.5
-      semver: 7.3.7
+      semver: 7.5.4
       typescript: 4.8.4
       webpack: 5.88.2(webpack-cli@4.10.0)
     dev: true
@@ -34060,7 +34046,7 @@ packages:
       { integrity: sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA== }
     engines: { node: ">=10.13" }
     dependencies:
-      semver: 7.3.7
+      semver: 7.5.4
     dev: true
 
   /victory-area@36.6.8(react@17.0.2):


### PR DESCRIPTION
The current version is affected by https://github.com/advisories/GHSA-c2qf-rxjj-qqgw