### PR TITLE
NO-ISSUE: `jQuery` CVE resolution

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/resources/images/dmn-shapes-tester.html
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/resources/images/dmn-shapes-tester.html
@@ -20,7 +20,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>DMN - SVG Shape Tester</title>
-    <script src="https://code.jquery.com/jquery-1.11.3.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
     <script src="https://raw.githubusercontent.com/kiegroup/kie-tools/main/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-svg/kie-wb-common-stunner-svg-gen/src/test/resources/org/kie/workbench/common/stunner/svg/gen/tester/svg-stencil-tester.js"></script>
   </head>
   <body>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/resources/images/bpmn-shapes-tester.html
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/resources/images/bpmn-shapes-tester.html
@@ -20,7 +20,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>BPMN - SVG Shapes Tester</title>
-    <script src="https://code.jquery.com/jquery-1.11.3.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
     <script src="/kie-wb-common-stunner/kie-wb-common-stunner-svg-gen/org/kie/workbench/common/stunner/svg/gen/tester/svg-stencil-tester.js"></script>
   </head>
   <body>

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -209,6 +209,7 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/bootstrap-select</outputDirectory>
+                  <excludes>META-INF/resources/webjars/bootstrap-select/${version.org.webjars.bower.bootstrap-select}/docs/</excludes>
                 </artifactItem>
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>

--- a/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -209,7 +209,8 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/bootstrap-select</outputDirectory>
-                  <excludes>META-INF/resources/webjars/bootstrap-select/${version.org.webjars.bower.bootstrap-select}/docs/</excludes>
+                  <excludes
+                  >META-INF/resources/webjars/bootstrap-select/${version.org.webjars.bower.bootstrap-select}/docs/</excludes>
                 </artifactItem>
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>


### PR DESCRIPTION
Managed cases:

- Do not process `kie-tools/packages/stunner-editors/uberfire-workbench/uberfire-workbench-client-views-patternfly/target/bootstrap-select/META-INF/resources/webjars/bootstrap-select/1.10.0/docs/custom_theme/base.html` reported by MEND, adding an exclusion rule at unpacking phase
- Updating` jQuery` version in test-scoped `html`s file. These HTML files are apparently not working in the main version as well, I didn't notice any impact updating the dependency. (As an alternative, we can remove these html files)