### PR TITLE
Bump `yaml` to version `2.3.2`

### DIFF
--- a/packages/serverless-logic-web-tools/package.json
+++ b/packages/serverless-logic-web-tools/package.json
@@ -80,7 +80,7 @@
     "showdown": "^2.1.0",
     "uuid": "^8.3.2",
     "vscode-languageserver-types": "^3.16.0",
-    "yaml": "^2.0.1"
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -50,7 +50,7 @@
     "openapi-types": "^7.0.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
-    "yaml": "^2.0.1"
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@kie-tools-core/webpack-base": "workspace:*",

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -44,7 +44,7 @@
     "openapi-types": "^7.0.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
-    "yaml": "^2.0.1"
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@kie-tools-core/webpack-base": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6483,8 +6483,8 @@ importers:
         specifier: ^3.16.0
         version: 3.17.2
       yaml:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.3.2
+        version: 2.3.2
     devDependencies:
       "@babel/core":
         specifier: ^7.16.0
@@ -7782,8 +7782,8 @@ importers:
         specifier: ^3.16.0
         version: 3.16.0
       yaml:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.3.2
+        version: 2.3.2
     devDependencies:
       "@kie-tools-core/webpack-base":
         specifier: workspace:*
@@ -9668,8 +9668,8 @@ importers:
         specifier: ^3.16.0
         version: 3.17.2
       yaml:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.3.2
+        version: 2.3.2
     devDependencies:
       "@kie-tools-core/webpack-base":
         specifier: workspace:*
@@ -35516,6 +35516,12 @@ packages:
     resolution:
       { integrity: sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg== }
     engines: { node: ">= 14" }
+
+  /yaml@2.3.2:
+    resolution:
+      { integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg== }
+    engines: { node: ">= 14" }
+    dev: false
 
   /yargs-parser@18.1.3:
     resolution:


### PR DESCRIPTION
The current version is affected by [CVE-2023-2251](https://github.com/advisories/GHSA-f9xv-q969-pqx4)  