### PR TITLE
kie-issues#575: standalone-editors doesn't load the new Boxed Expression Editor

### DIFF
--- a/packages/stunner-editors-dmn-loader/webpack.config.js
+++ b/packages/stunner-editors-dmn-loader/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = (env) => {
 
     output: {
       path: path.resolve(__dirname, outputPath),
+      publicPath: "",
       filename: `dmn-loader.js`,
       library: {
         type: "umd",


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-issues/issues/575

The root cause of the issue is the following error:

<img width="516" alt="Screenshot 2023-09-20 at 12 20 51" src="https://github.com/kiegroup/kie-tools/assets/16005046/25a4e885-a5c9-4412-af26-a6ad846fcc5a">

Setting the `publicPath` to an empty string solves the issue

<img width="568" alt="Screenshot 2023-09-20 at 12 23 08" src="https://github.com/kiegroup/kie-tools/assets/16005046/09322442-d1c3-4dae-a687-eb9195b604de">
