### PR TITLE
kie-tools#1953: Unable to import `DmnEditor` from `@kie-tools/kie-editors-standalone/dist/dmn`

### DIFF
--- a/packages/kie-editors-standalone/package.json
+++ b/packages/kie-editors-standalone/package.json
@@ -15,7 +15,8 @@
   "files": [
     "dist/bpmn",
     "dist/common",
-    "dist/dmn"
+    "dist/dmn",
+    "dist/jsdiagram"
   ],
   "scripts": {
     "build:dev": "rimraf dist && webpack --env dev --config webpack.build-resources.config.js && pnpm build:preprocessor && webpack --env dev --config webpack.package-resources.config.js",
@@ -36,6 +37,9 @@
     "test": "run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --verbose --passWithNoTests\"",
     "test:it": "run-script-if --ignore-errors \"$(build-env integrationTests.ignoreFailures)\" --bool \"$(build-env integrationTests.run)\" --then \"pnpm rimraf ./dist-it-tests\" \"pnpm start-server-and-test start:it http-get://0.0.0.0:$(build-env standaloneEditors.dev.port) cy:run\" \"pnpm postreport\""
   },
+  "dependencies": {
+    "@kie-tools/kie-bc-editors": "workspace:*"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
@@ -49,7 +53,6 @@
     "@kie-tools-core/webpack-base": "workspace:*",
     "@kie-tools-core/workspace": "workspace:*",
     "@kie-tools/eslint": "workspace:*",
-    "@kie-tools/kie-bc-editors": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/stunner-editors": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",

--- a/packages/kie-editors-standalone/resources/bpmn/bpmnEnvelopeIndex.template
+++ b/packages/kie-editors-standalone/resources/bpmn/bpmnEnvelopeIndex.template
@@ -62,7 +62,11 @@
             print(', ');
           }
         });
-        print('; ' + fontResource.additionalStyle + ' }');
+        if (fontResource.additionalStyle) {
+          print('; ' + fontResource.additionalStyle + ' }');
+        } else {
+          print(' }');
+        }
       });
       print('\n</style>\n');
     %>

--- a/packages/kie-editors-standalone/resources/dmn/dmnEnvelopeIndex.template
+++ b/packages/kie-editors-standalone/resources/dmn/dmnEnvelopeIndex.template
@@ -62,7 +62,11 @@
             print(', ');
           }
         });
-        print('; ' + fontResource.additionalStyle + ' }');
+        if (fontResource.additionalStyle) {
+          print('; ' + fontResource.additionalStyle + ' }');
+        } else {
+          print(' }');
+        }
       });
       print('\n</style>\n');
     %>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4924,6 +4924,10 @@ importers:
         version: 5.9.0
 
   packages/kie-editors-standalone:
+    dependencies:
+      "@kie-tools/kie-bc-editors":
+        specifier: workspace:*
+        version: link:../kie-bc-editors
     devDependencies:
       "@babel/core":
         specifier: ^7.16.0
@@ -4961,9 +4965,6 @@ importers:
       "@kie-tools/eslint":
         specifier: workspace:*
         version: link:../eslint
-      "@kie-tools/kie-bc-editors":
-        specifier: workspace:*
-        version: link:../kie-bc-editors
       "@kie-tools/root-env":
         specifier: workspace:*
         version: link:../root-env

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -308,7 +308,7 @@ digraph G {
   "kie-editors-dev-vscode-extension" -> "@kie-tools/vscode-java-code-completion-extension-plugin" [ style = "solid", color = "black" ];
   "kie-editors-dev-vscode-extension" -> "@kie-tools/stunner-editors" [ style = "dashed", color = "black" ];
   "kie-editors-dev-vscode-extension" -> "@kie-tools/vscode-extension-common-test-helpers" [ style = "dashed", color = "black" ];
-  "@kie-tools/kie-editors-standalone" -> "@kie-tools/kie-bc-editors" [ style = "dashed", color = "blue" ];
+  "@kie-tools/kie-editors-standalone" -> "@kie-tools/kie-bc-editors" [ style = "solid", color = "blue" ];
   "@kie-tools/kie-editors-standalone" -> "@kie-tools/stunner-editors" [ style = "dashed", color = "blue" ];
   "@kie-tools/kie-sandbox-distribution" -> "@kie-tools/cors-proxy-image" [ style = "solid", color = "black" ];
   "@kie-tools/kie-sandbox-distribution" -> "@kie-tools/kie-sandbox-extended-services-image" [ style = "solid", color = "black" ];


### PR DESCRIPTION
Closes https://github.com/kiegroup/kie-tools/issues/1953

This problem arises in `Angular` + `Typescript` environment. It doesn't reproduce in a plain `React.js` environment.
I guess the Typescript presence produces the compilation issue, that because the compiler is not able to find the required types. 

**Problem 1** (Fixed)
> Error: node_modules/@kie-tools/kie-editors-standalone/dist/dmn/index.d.ts:3:37 - error TS2307: Cannot find module '../jsdiagram/DmnEditorDiagramApi' or its corresponding type declarations.

To fix this, I added `dist/jsdiagram` in the `files` entry of the package.json. 

**Problem 2** (Fixed)
After fixing problem 1, the external project requires multiple `kie-tools` modules to compile. If you notice the https://github.com/kiegroup/kie-tools/issues/1953 thread, the user needs to manually import the following modules to compile:

> Add below dependencies in package.json
> "@kie-tools-core/editor": "^0.31.0",
> "@kie-tools-core/i18n": "^0.31.0",
> "@kie-tools-core/workspace": "^0.31.0",
> "@kie-tools/boxed-expression-component": "^0.31.0",
> "@kie-tools/feel-input-component": "^0.31.0",
> "@kie-tools/kie-editors-standalone": "0.31.0",
> "@kie-tools/uniforms-patternfly": "^0.31.0",

This is not what the README states. The user should import  `@kie-tools/kie-editors-standalone": "0.31.0` as the only kie-tools dependency. To do that, I moved `@kie-tools/kie-bc-editors": "workspace:` from `devDependency` to `dependency`.
In this way, the only dependencies required to compile are :
<img width="289" alt="Screenshot 2023-09-25 at 11 53 43" src="https://github.com/kiegroup/kie-tools/assets/16005046/7c8d76ca-578b-4ec7-971d-809d3becda3d">
Most probably we should create a @types/kie-editors-standalone dependency for that, as a better future solution.

**Problem 3** (Fixed)
I noticed that the generated `bpmnEnvelopeIndex.html` & `dmnEnvelopeIndex.html` contains some errors (undefined values) in some condition. I added an if-else to avoid that. Notice that this issue is not related to the original ticket, I found that during the investigation phase and apparently that doesn't have any impact.

**Tests**
BPMN Editor (React environment): compilation ✅ + runtime ✅
DMN Editor (React environment): compilation ✅ + runtime ✅

BPMN Editor (Angular + TS environment): compilation ✅ + runtime ✅
DMN Editor (Angular + TS environment): compilation ✅ + runtime ❌

Unfortunately for the last tested case, I found an issue at compile time. An exception is thrown and the editor is never loaded 
<img width="1400" alt="Screenshot 2023-09-25 at 10 42 42" src="https://github.com/kiegroup/kie-tools/assets/16005046/6eabff23-2857-406e-9a70-69a775a803c9">


The error message doesn't help so much.

As the investigation of that issue could be a time-consuming task, I suggest fixing the compilation issue (if this PR changes are valid) in this ticket and continuing the runtime error analysis in another task, tackling it based on the team's priorities.

