### PR TITLE
KOGITO-9756: SWF Editor - Re-enable tests

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandler.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandler.java
@@ -36,7 +36,6 @@ import elemental2.dom.Event;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.MouseEvent;
-import jsinterop.base.Js;
 import org.gwtproject.timer.client.Timer;
 import org.kie.workbench.common.stunner.client.lienzo.components.views.LienzoPanelWidget;
 import org.kie.workbench.common.stunner.core.client.shape.view.event.NativeHandler;
@@ -152,7 +151,6 @@ public class ShapeGlyphDragHandler {
     }
 
     void attachHandlers(final ShapeGlyphDragHandler.Callback callback) {
-        //TODO: Remove Js.uncheckedCast() when j2cl migration is complete
         HTMLElement panelElement = rootPanelSupplier.get();
 
         mouseMoveHandler = new NativeHandler(MOUSE_MOVE,
@@ -217,7 +215,7 @@ public class ShapeGlyphDragHandler {
     private void clearState(final Command proxyDestroyCommand) {
         clearHandlers();
         if (Objects.nonNull(dragProxyPanel)) {
-            rootPanelSupplier.get().removeChild(Js.cast(dragProxyPanel.getElement()));
+            rootPanelSupplier.get().removeChild(dragProxyPanel.getElement());
             if (null != proxyDestroyCommand) {
                 proxyDestroyCommand.execute();
             }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvasViewTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/canvas/LienzoCanvasViewTest.java
@@ -25,11 +25,9 @@ import java.util.function.BiFunction;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.CSSStyleDeclaration;
+import elemental2.dom.HTMLElement;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvas;
@@ -49,8 +47,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-// TODO: J2CL migration - Drop the Ignore once 2 TODOs fixed
-@Ignore
 @RunWith(LienzoMockitoTestRunner.class)
 public class LienzoCanvasViewTest {
 
@@ -65,9 +61,9 @@ public class LienzoCanvasViewTest {
     @Mock
     private LienzoPanel panel;
     @Mock
-    private Style panelStyle;
-    @Mock
     private CanvasSettings settings;
+
+    private HTMLElement element;
 
     private LienzoCanvasView tested;
 
@@ -76,28 +72,22 @@ public class LienzoCanvasViewTest {
     @Before
     public void setUp() throws Exception {
         decoratorFactory = (integer, integer2) -> decorator;
+        element = new HTMLElement();
         when(lienzoLayer.getLienzoLayer()).thenReturn(layer);
-        Widget panelWidget = mock(Widget.class);
-        Element panelElement = mock(Element.class);
-        // TODO: J2CL migration - when(panel.asWidget()).thenReturn(panelWidget);
-        when(panelWidget.getElement()).thenReturn(panelElement);
-        when(panelElement.getStyle()).thenReturn(panelStyle);
+        when(panel.getElement()).thenReturn(element);
         when(lienzoLayer.getTopLayer()).thenReturn(topLayer);
         when(panel.show(lienzoLayer)).thenReturn(panel);
         this.tested = new LienzoCanvasViewStub(decoratorFactory);
     }
 
-    @Ignore("TODO fix test once gwt widgets is replaced with native ones.")
     @Test
     public void testInitialize() {
-        assertEquals(tested, tested.initialize(panel,
-                                               settings));
+        assertEquals(tested, tested.initialize(panel, settings));
         verify(panel, times(1)).show(eq(lienzoLayer));
-        verify(panelStyle, times(1)).setBackgroundColor(eq(LienzoCanvasView.BG_COLOR));
+        assertEquals(LienzoCanvasView.BG_COLOR, element.style.backgroundColor);
         verify(topLayer, times(1)).add(eq(decorator));
     }
 
-    @Ignore("TODO fix test once gwt widgets is replaced with native ones.")
     @Test
     public void testSetGrid() {
         tested.initialize(panel, settings);
@@ -105,23 +95,21 @@ public class LienzoCanvasViewTest {
         verify(panel, times(1)).setBackgroundLayer(any(Layer.class));
     }
 
-    @Ignore("TODO fix test once gwt widgets is replaced with native ones.")
     @Test
     public void testCursor() {
-        Widget widget = mock(Widget.class);
-        Element element = mock(Element.class);
-        Style style = mock(Style.class);
-        // TODO: J2CL migration - when(panel.asWidget()).thenReturn(widget);
-        when(widget.getElement()).thenReturn(element);
-        when(element.getStyle()).thenReturn(style);
+        HTMLElement panelElement = mock(HTMLElement.class);
+        CSSStyleDeclaration style = mock(CSSStyleDeclaration.class);
+        panelElement.style = style;
+        when(panel.getElement()).thenReturn(panelElement);
+
         tested.initialize(panel, settings);
         tested.setCursor(AbstractCanvas.Cursors.GRAB);
 
         verify(style, times(1))
-                .setProperty(AbstractCanvasView.CURSOR, "grab");
+                .setProperty(AbstractCanvasView.CURSOR,
+                             AbstractCanvasView.toLienzoCursorKey(AbstractCanvas.Cursors.GRAB));
     }
 
-    @Ignore("TODO fix test once gwt widgets is replaced with native ones.")
     @Test
     public void testRemoveGrid() {
         tested.initialize(panel, settings);
@@ -142,7 +130,6 @@ public class LienzoCanvasViewTest {
         assertEquals(transform, tested.getTransform());
     }
 
-    @Ignore("TODO fix test once gwt widgets is replaced with native ones.")
     @Test
     public void testDestroy() {
         tested.initialize(panel,

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/glyph/ShapeGlyphDragHandlerTest.java
@@ -29,7 +29,6 @@ import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.MouseEvent;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.components.glyph.ShapeGlyphDragHandler.Callback;
@@ -111,7 +110,6 @@ public class ShapeGlyphDragHandlerTest {
     }
 
     @Test
-    @Ignore //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
     public void testShowProxy() {
         tested.show(glyphDragItem, 11, 33, mock(Callback.class));
         ArgumentCaptor<Layer> layerArgumentCaptor = ArgumentCaptor.forClass(Layer.class);
@@ -123,11 +121,10 @@ public class ShapeGlyphDragHandlerTest {
         assertEquals("absolute", proxyStyle.position);
         assertEquals((11d + "px"), proxyStyle.left);
         assertEquals((33d + "px"), proxyStyle.top);
-        //verify(rootPanel, times(1)).add(eq(proxyPanel)); //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
+        verify(body, times(1)).appendChild(proxyPanel.getElement());
     }
 
     @Test
-    @Ignore //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
     public void testProxyHandlers() {
         Callback callback = mock(Callback.class);
 
@@ -165,13 +162,12 @@ public class ShapeGlyphDragHandlerTest {
                          callback);
         verify(moveHandlerReg, times(1)).removeHandler();
         verify(upHandlerReg, times(1)).removeHandler();
-        //verify(rootPanel, times(1)).remove(eq(proxyPanel)); //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
+        verify(body, times(1)).removeChild(proxyPanel.getElement());
         verify(callback, times(1)).onComplete(eq(3), eq(5));
         assertTrue(handlerRegistrations.isEmpty());
     }
 
     @Test
-    @Ignore //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
     public void testKeyboardHandling() {
         Callback callback = mock(Callback.class);
         attachHandlers();
@@ -184,12 +180,11 @@ public class ShapeGlyphDragHandlerTest {
         tested.onKeyDown(event);
         verify(moveHandlerReg, times(1)).removeHandler();
         verify(upHandlerReg, times(1)).removeHandler();
-        //verify(rootPanel, times(1)).remove(eq(proxyPanel)); //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
+        verify(body, times(1)).removeChild(proxyPanel.getElement());
         assertTrue(handlerRegistrations.isEmpty());
     }
 
     @Test
-    @Ignore //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
     public void testClear() throws Exception {
         Callback callback = mock(Callback.class);
         attachHandlers();
@@ -198,12 +193,11 @@ public class ShapeGlyphDragHandlerTest {
         verify(proxyPanel, never()).destroy();
         verify(moveHandlerReg, times(1)).removeHandler();
         verify(upHandlerReg, times(1)).removeHandler();
-        //verify(rootPanel, times(1)).remove(eq(proxyPanel));
+        verify(body, times(1)).removeChild(proxyPanel.getElement());
         assertTrue(handlerRegistrations.isEmpty());
     }
 
     @Test
-    @Ignore //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
     public void testDestroy() throws Exception {
         Callback callback = mock(Callback.class);
         attachHandlers();
@@ -212,7 +206,7 @@ public class ShapeGlyphDragHandlerTest {
         verify(proxyPanel, times(1)).destroy();
         verify(moveHandlerReg, times(1)).removeHandler();
         verify(upHandlerReg, times(1)).removeHandler();
-        //verify(rootPanel, times(1)).remove(eq(proxyPanel)); //TODO this test must be fixed, once the rootPanel is replaced with HtmlElement
+        verify(body, times(1)).removeChild(proxyPanel.getElement());
         assertTrue(handlerRegistrations.isEmpty());
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/mediators/ZoomLevelSelectorPresenterTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/components/mediators/ZoomLevelSelectorPresenterTest.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -38,7 +38,6 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
@@ -145,8 +144,7 @@ public class ZoomLevelSelectorPresenterTest {
 
         floatingView = spy(new FloatingWidgetView());
 
-        doReturn(rootPanel).when(((FloatingWidgetView)floatingView)).getRootPanel();
-        //when(((FloatingWidgetView)floatingView).getRootPanel()).thenReturn(rootPanel);
+        doReturn(rootPanel).when(((FloatingWidgetView) floatingView)).getRootPanel();
 
         tested = new ZoomLevelSelectorPresenter(translationService,
                                                 floatingView,
@@ -189,17 +187,13 @@ public class ZoomLevelSelectorPresenterTest {
         verify(floatingView, times(1)).setY(eq(25d));
     }
 
-    //TODO: Fix me when the widgets are migrated to J2CL
-    // temporary Js.uncheckedCast() breaks these tests
-    @Ignore
+    @Test
     public void testShow() {
         tested.show();
         verify(floatingView, times(1)).show();
     }
 
-    //TODO: Fix me when the widgets are migrated to J2CL
-    // temporary Js.uncheckedCast() breaks these tests
-    @Ignore
+    @Test
     public void testHideZoomOnLoad() {
         //First call on canvas loading
         verify(floatingView, times(0)).show();

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -67,10 +67,10 @@ import static org.jboss.errai.common.client.dom.DOMUtil.removeAllChildren;
 @Dependent
 public class StunnerEditor {
 
-    private final ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances;
-    private final ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances;
-    private final ClientTranslationService translationService;
-    private final ErrorPage errorPage;
+    ManagedInstance<SessionEditorPresenter<EditorSession>> editorSessionPresenterInstances;
+    ManagedInstance<SessionViewerPresenter<ViewerSession>> viewerSessionPresenterInstances;
+    ClientTranslationService translationService;
+    ErrorPage errorPage;
     private boolean hasErrors;
 
     private SessionDiagramPresenter diagramPresenter;
@@ -79,7 +79,7 @@ public class StunnerEditor {
     private Consumer<Throwable> exceptionProcessor;
     private AlertsControl<AbstractCanvas> alertsControl;
 
-    private final HTMLDivElement rootContainer = (HTMLDivElement) DomGlobal.document.getElementById("root-container");
+    private HTMLDivElement rootContainer;
 
     // CDI proxy.
     public StunnerEditor() {
@@ -100,6 +100,13 @@ public class StunnerEditor {
         };
         this.exceptionProcessor = e -> {
         };
+    }
+
+    HTMLDivElement getRootContainer() {
+        if (null == rootContainer) {
+            rootContainer = (HTMLDivElement) DomGlobal.document.getElementById("root-container");
+        }
+        return rootContainer;
     }
 
     public void setReadOnly(boolean readOnly) {
@@ -160,23 +167,29 @@ public class StunnerEditor {
                 callback.onError(error);
             }
         });
-        removeAllChildren(rootContainer);
+        removeAllChildren(getRootContainer());
 
-        rootContainer.appendChild(diagramPresenter.getView().getElement());
-        DomGlobal.window.addEventListener("resize", evt -> {
-            resizeTo(DomGlobal.window.innerWidth, DomGlobal.window.innerHeight);
-        });
+        getRootContainer().appendChild(diagramPresenter.getView().getElement());
+
+        addResizeListener();
+
         resize();
     }
 
-    private void resize() {
+    void addResizeListener() {
+        DomGlobal.window.addEventListener("resize", evt -> {
+            resizeTo(DomGlobal.window.innerWidth, DomGlobal.window.innerHeight);
+        });
+    }
+
+    void resize() {
         resizeTo(DomGlobal.document.body.clientWidth,
-                DomGlobal.document.body.clientHeight);
+                 DomGlobal.document.body.clientHeight);
     }
 
     private void resizeTo(int width,
                           int height) {
-        CSSStyleDeclaration style = rootContainer.style;
+        CSSStyleDeclaration style = getRootContainer().style;
         style.width = WidthUnionType.of(width + "px");
         style.height = HeightUnionType.of(height + "px");
     }
@@ -243,8 +256,8 @@ public class StunnerEditor {
                 (diagramPresenter.getView() != null)) {
             addError(message);
         } else {
-            removeAllChildren(rootContainer);
-            rootContainer.appendChild(Js.uncheckedCast(errorPage.getElement()));
+            removeAllChildren(getRootContainer());
+            getRootContainer().appendChild(Js.uncheckedCast(errorPage.getElement()));
         }
     }
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/DelegateLienzoPanelTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/canvas/DelegateLienzoPanelTest.java
@@ -23,9 +23,7 @@ package org.kie.workbench.common.stunner.client.widgets.canvas;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import elemental2.dom.HTMLElement;
-import org.jboss.errai.ui.client.local.api.IsElement;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoLayer;
@@ -92,9 +90,8 @@ public class DelegateLienzoPanelTest {
     }
 
     @Test
-    @Ignore("throws CCE")
     public void testIsElement() {
-        HTMLElement e = (HTMLElement) mock(IsElement.class);
+        HTMLElement e = mock(HTMLElement.class);
         when(delegate.getElement()).thenReturn(e);
         assertEquals(e, tested.getElement());
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/components/glyph/ImageStripDOMGlyphRendererTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/components/glyph/ImageStripDOMGlyphRendererTest.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -29,7 +29,6 @@ import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.components.views.WidgetElementRendererView;
@@ -97,7 +96,6 @@ public class ImageStripDOMGlyphRendererTest {
     }
 
     @Test
-    @Ignore //TODO restore this test when widgets will be replaced with native elms
     public void testRender() {
         IsElement rendered = tested.render(GLYPH,
                                            SIZE,

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditorTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditorTest.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -25,9 +25,9 @@ import java.util.function.Consumer;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.widget.panel.LienzoBoundsPanel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLDivElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.client.lienzo.canvas.LienzoCanvas;
@@ -60,6 +60,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -67,17 +68,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Ignore("Some native apis can't be mocked")
 @RunWith(GwtMockitoTestRunner.class)
 public class StunnerEditorTest {
 
     @Mock
     private SessionEditorPresenter<EditorSession> sessionEditorPresenter;
+
     @Mock
     private ManagedInstance<SessionEditorPresenter<EditorSession>> sessionEditorPresenters;
 
     @Mock
     private SessionViewerPresenter<ViewerSession> sessionViewerPresenter;
+
     @Mock
     private ManagedInstance<SessionViewerPresenter<ViewerSession>> sessionViewerPresenters;
 
@@ -92,26 +94,35 @@ public class StunnerEditorTest {
 
     @Mock
     private EditorSession editorSession;
+
     @Mock
     private ViewerSession viewerSession;
+
     @Mock
     private AbstractCanvasHandler canvasHandler;
+
     @Mock
     private AlertsControl<AbstractCanvas> alertsControl;
+
     @Mock
     private LienzoCanvas canvas;
+
     @Mock
     private WiresCanvasView canvasView;
+
     @Mock
     private LienzoPanel panel;
+
     @Mock
     private LienzoBoundsPanel panelView;
+
     @Mock
     private Layer layer;
 
-    private DiagramImpl diagram;
-
+    @Mock
     private StunnerEditor tested;
+
+    private DiagramImpl diagram;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -136,10 +147,25 @@ public class StunnerEditorTest {
         when(viewerSession.getCanvasHandler()).thenReturn(canvasHandler);
         when(viewerSession.getAlertsControl()).thenReturn(alertsControl);
         when(canvasHandler.getDiagram()).thenReturn(diagram);
-        tested = new StunnerEditor(sessionEditorPresenters,
-                                   sessionViewerPresenters,
-                                   translationService,
-                                   errorPage);
+        when(tested.getRootContainer()).thenReturn(new HTMLDivElement());
+        doCallRealMethod().when(tested).isClosed();
+        doCallRealMethod().when(tested).getSession();
+        doCallRealMethod().when(tested).getCurrentContentHash();
+        doCallRealMethod().when(tested).getCanvasHandler();
+        doCallRealMethod().when(tested).getDiagram();
+        doCallRealMethod().when(tested).setReadOnly(any(Boolean.class));
+        doCallRealMethod().when(tested).close();
+        doCallRealMethod().when(tested).isReadOnly();
+        doCallRealMethod().when(tested).destroy();
+        doCallRealMethod().when(tested).setExceptionProcessor(any(Consumer.class));
+        doCallRealMethod().when(tested).setParsingExceptionProcessor(any(Consumer.class));
+        doCallRealMethod().when(tested).handleError(any(ClientRuntimeError.class));
+        doNothing().when(tested).addResizeListener();
+
+        tested.editorSessionPresenterInstances = sessionEditorPresenters;
+        tested.viewerSessionPresenterInstances = sessionViewerPresenters;
+        tested.translationService = translationService;
+        tested.errorPage = errorPage;
         JsWindow.editor = new JsStunnerEditor();
     }
 
@@ -197,6 +223,7 @@ public class StunnerEditorTest {
         DiagramParsingException dpe = new DiagramParsingException(mock(Metadata.class), "testXml");
         ClientRuntimeError error = new ClientRuntimeError(dpe);
         tested.handleError(error);
+
         verify(parsingExceptionConsumer, times(1)).accept(eq(dpe));
         verify(exceptionConsumer, never()).accept(any());
     }
@@ -228,6 +255,8 @@ public class StunnerEditorTest {
             return null;
         }).when(sessionEditorPresenter).open(eq(diagram), any(SessionPresenter.SessionPresenterCallback.class));
         SessionPresenter.SessionPresenterCallback callback = mock(SessionPresenter.SessionPresenterCallback.class);
+        doCallRealMethod().when(tested).open(diagram, callback);
+
         tested.open(diagram, callback);
         verify(callback, times(1)).onSuccess();
         verify(callback, never()).onError(any());

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/pom.xml
@@ -173,10 +173,16 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.kie.kogito.stunner.serverless.editor</groupId>
-          <artifactId>uberfire-workbench-client</artifactId>
-      </dependency>
+
+    <dependency>
+        <groupId>org.kie.kogito.stunner.serverless.editor</groupId>
+        <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito.stunner.serverless.editor</groupId>
+      <artifactId>lienzo-tests</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxyTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/src/test/java/org/kie/workbench/common/stunner/lienzo/primitive/AbstractDragProxyTest.java
@@ -27,7 +27,6 @@ import com.ait.lienzo.tools.client.event.EventType;
 import elemental2.dom.MouseEvent;
 import org.gwtproject.timer.client.Timer;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -145,7 +144,6 @@ public class AbstractDragProxyTest {
     }
 
     @Test
-    @Ignore("NoSuchMethod")
     public void testOnMouseUp() {
         final int expectedX = 175;
         final int expectedY = 175;

--- a/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/DomGlobal.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/DomGlobal.java
@@ -25,6 +25,10 @@ public class DomGlobal {
         return 0d;
     }
 
+    public static void clearTimeout(double timerId) {
+        // Do nothing
+    }
+
     public static final Promise<Response> fetch(String input) {
         return new Promise<Response>((resolve, reject) ->
                                              new Response()

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/editor/DiagramEditorTest.java
@@ -46,7 +46,6 @@ import org.kie.workbench.common.stunner.client.lienzo.canvas.wires.WiresCanvasVi
 import org.kie.workbench.common.stunner.client.widgets.canvas.ScrollableLienzoPanel;
 import org.kie.workbench.common.stunner.client.widgets.editor.StunnerEditor;
 import org.kie.workbench.common.stunner.core.client.ReadOnlyProvider;
-import org.kie.workbench.common.stunner.core.client.api.JsStunnerEditor;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.CanvasHandler;
 import org.kie.workbench.common.stunner.core.client.canvas.controls.select.AbstractSelectionControl;
@@ -141,9 +140,6 @@ public class DiagramEditorTest {
 
     @Mock
     private Graph graph;
-
-    @Mock
-    private JsStunnerEditor jsEditor;
 
     @Mock
     private JsCanvas jsCanvas;


### PR DESCRIPTION
Reenabling tests after J2CL migration.

**JIRA**: [KOGITO-9756](https://issues.redhat.com/browse/KOGITO-9756)
