### PR TITLE
kie-issues#596: KIE Sandbox image uses the root filesystem on the container to store its assets and configuration files

### DIFF
--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -34,9 +34,9 @@ RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.53-11.el9
   && chmod -R g=u /var/log/httpd /var/run/httpd /var/www/html /kie-sandbox \
   && chmod +x /kie-sandbox/entrypoint.sh /kie-sandbox/image-env-to-json-standalone
 
-COPY dist-dev/online-editor /var/www/html
+COPY dist-dev/online-editor /kie-sandbox/app
 
-RUN if [ -f /var/www/html/env.json ]; then chmod a+w /var/www/html/env.json; fi
+RUN if [ -f /kie-sandbox/app/env.json ]; then chmod a+w /kie-sandbox/app/env.json; fi
 
 EXPOSE 8080
 

--- a/packages/kie-sandbox-image/entrypoint.sh
+++ b/packages/kie-sandbox-image/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Copying the KIE Sandbox assets here is essential for when the container is running with the readOnlyRootFilesystem flag.
+# But, just like any other directory modified during runtime, the /var/www/html must be a mounted volume in the container in this case.
+cp -R /kie-sandbox/app/* /var/www/html
+
 /kie-sandbox/image-env-to-json-standalone --directory /var/www/html --json-schema /kie-sandbox/EnvJson.schema.json
 
 httpd -D FOREGROUND


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/596

With this PR the `/var/www/html` directory is only populated with the KIE Sandbox assets during the Entrypoint script, making it possible to start it as an empty mounted volume (bypassing the read-only root file system limitations)