### PR TITLE
NO-ISSUE: Copy samples to e2e directory

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples/test.bpmn
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples/test.bpmn
@@ -1,0 +1,104 @@
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_6l2UYPaYEDiczJLLECPinQ" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__3E710EFA-1334-4396-B321-DB5404ADF0A6_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:process id="myProcessId" drools:packageName="default" drools:version="1.0" drools:adHoc="false" name="myProcess" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_966AD620-B5B5-49FB-83CB-1E34B19EA0A3" sourceRef="_3E710EFA-1334-4396-B321-DB5404ADF0A6" targetRef="_4DDDD822-B263-48E7-8377-00ADC6B851DD">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_3B0456C5-24A1-42C2-890C-45CD8324C5EB" sourceRef="_53ED90ED-5D7E-40AE-86A5-3B1FA8675F54" targetRef="_3E710EFA-1334-4396-B321-DB5404ADF0A6">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_4DDDD822-B263-48E7-8377-00ADC6B851DD" name="MyEnd">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[MyEnd]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_966AD620-B5B5-49FB-83CB-1E34B19EA0A3</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="_3E710EFA-1334-4396-B321-DB5404ADF0A6" name="MyTask">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[MyTask]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_3B0456C5-24A1-42C2-890C-45CD8324C5EB</bpmn2:incoming>
+      <bpmn2:outgoing>_966AD620-B5B5-49FB-83CB-1E34B19EA0A3</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputX" drools:dtype="Object" itemSubjectRef="__3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[myTestingTask]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_3E710EFA-1334-4396-B321-DB5404ADF0A6_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_3E710EFA-1334-4396-B321-DB5404ADF0A6_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="_53ED90ED-5D7E-40AE-86A5-3B1FA8675F54" name="MyStart">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[MyStart]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_3B0456C5-24A1-42C2-890C-45CD8324C5EB</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="myProcessId">
+      <bpmndi:BPMNShape id="shape__53ED90ED-5D7E-40AE-86A5-3B1FA8675F54" bpmnElement="_53ED90ED-5D7E-40AE-86A5-3B1FA8675F54">
+        <dc:Bounds height="56" width="56" x="410" y="347"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__3E710EFA-1334-4396-B321-DB5404ADF0A6" bpmnElement="_3E710EFA-1334-4396-B321-DB5404ADF0A6">
+        <dc:Bounds height="102" width="154" x="546" y="324"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__4DDDD822-B263-48E7-8377-00ADC6B851DD" bpmnElement="_4DDDD822-B263-48E7-8377-00ADC6B851DD">
+        <dc:Bounds height="56" width="56" x="780" y="347"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__53ED90ED-5D7E-40AE-86A5-3B1FA8675F54_to_shape__3E710EFA-1334-4396-B321-DB5404ADF0A6" bpmnElement="_3B0456C5-24A1-42C2-890C-45CD8324C5EB">
+        <di:waypoint x="466" y="375"/>
+        <di:waypoint x="546" y="375"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__3E710EFA-1334-4396-B321-DB5404ADF0A6_to_shape__4DDDD822-B263-48E7-8377-00ADC6B851DD" bpmnElement="_966AD620-B5B5-49FB-83CB-1E34B19EA0A3">
+        <di:waypoint x="700" y="375"/>
+        <di:waypoint x="780" y="375"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples/test.dmn
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples/test.dmn
@@ -1,0 +1,71 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_9D68CD11-14FF-4BD4-944F-F1EDB28581DF" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" id="_D71ACC78-2638-49F6-B51A-5C7D2A305E4A" name="myDmn" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_9D68CD11-14FF-4BD4-944F-F1EDB28581DF">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_4C70A861-1AE8-4170-869C-839C622739AB" name="MyInputData">
+    <dmn:extensionElements/>
+    <dmn:variable id="_4B5A1B33-4181-4C9D-AF89-1C08BA4E8FA3" name="MyInputData"/>
+  </dmn:inputData>
+  <dmn:decision id="_5A588D65-6E03-4CFE-B08C-91C66BA40684" name="MyDecision">
+    <dmn:extensionElements/>
+    <dmn:variable id="_C27A006B-25EE-4119-A48E-C5B87282F086" name="MyDecision"/>
+    <dmn:informationRequirement id="_E4FBAD0D-4982-4C1B-B224-31FB1FE7BFBA">
+      <dmn:requiredInput href="#_4C70A861-1AE8-4170-869C-839C622739AB"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement id="_6C2C5DDE-0F1F-4FC7-A166-A5F488A0D2A8">
+      <dmn:requiredKnowledge href="#_BA05450F-7856-45F8-8F18-721F07C36D5F"/>
+    </dmn:knowledgeRequirement>
+  </dmn:decision>
+  <dmn:businessKnowledgeModel id="_BA05450F-7856-45F8-8F18-721F07C36D5F" name="MyModel">
+    <dmn:extensionElements/>
+    <dmn:variable id="_40D7EF42-115C-4B79-83CE-79CE118EA9BB" name="MyModel"/>
+    <dmn:encapsulatedLogic id="_C541DB3E-60B1-4D73-B789-BAFDEB42A32F" kind="FEEL">
+      <dmn:literalExpression id="_C7D5ABA0-F297-4D00-827F-727C83FABBA8">
+        <dmn:text/>
+      </dmn:literalExpression>
+    </dmn:encapsulatedLogic>
+  </dmn:businessKnowledgeModel>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_3A5EF1D8-CDD9-46C3-AAFE-5C952B7CD2D2" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_C7D5ABA0-F297-4D00-827F-727C83FABBA8"/>
+          <kie:ComponentWidths dmnElementRef="_C541DB3E-60B1-4D73-B789-BAFDEB42A32F"/>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_4C70A861-1AE8-4170-869C-839C622739AB" dmnElementRef="_4C70A861-1AE8-4170-869C-839C622739AB" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="594" y="460" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_5A588D65-6E03-4CFE-B08C-91C66BA40684" dmnElementRef="_5A588D65-6E03-4CFE-B08C-91C66BA40684" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="595" y="296" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_BA05450F-7856-45F8-8F18-721F07C36D5F" dmnElementRef="_BA05450F-7856-45F8-8F18-721F07C36D5F" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="377" y="460" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_E4FBAD0D-4982-4C1B-B224-31FB1FE7BFBA" dmnElementRef="_E4FBAD0D-4982-4C1B-B224-31FB1FE7BFBA">
+        <di:waypoint x="644" y="485"/>
+        <di:waypoint x="645" y="296"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_6C2C5DDE-0F1F-4FC7-A166-A5F488A0D2A8" dmnElementRef="_6C2C5DDE-0F1F-4FC7-A166-A5F488A0D2A8">
+        <di:waypoint x="427" y="485"/>
+        <di:waypoint x="645" y="321"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.json
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.json
@@ -1,0 +1,41 @@
+{
+  "id": "chrome_extension_sample_json",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "Chrome Extension Sample JSON",
+  "description": "This JSON sample is created for testing purposes.",
+  "start": "StartState",
+  "functions": [
+    {
+      "name": "ChromeFunction",
+      "operation": "localhost#operation",
+      "type": "rest"
+    }
+  ],
+  "events": [
+    {
+      "name": "ChromeEvent",
+      "source": "CloudEvent source",
+      "type": "CloudEvent type"
+    }
+  ],
+  "states": [
+    {
+      "name": "StartState",
+      "type": "operation",
+      "actions": [
+        {
+          "name": "chromeAction",
+          "functionRef": {
+            "refName": "ChromeFunction",
+            "arguments": {
+              "firstArgument": "",
+              "secondArgument": ""
+            }
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.yaml
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.yaml
@@ -1,0 +1,25 @@
+id: "chrome_extension_sample_yaml"
+version: "1.0"
+specVersion: "0.8"
+name: "Chrome Extension Sample YAML"
+description: "This YAML sample is created for testing purposes."
+start: "StartState"
+functions:
+  - name: "ChromeFunction"
+    operation: "localhost#operation"
+    type: "rest"
+events:
+  - name: "ChromeEvent"
+    source: "CloudEvent source"
+    type: "CloudEvent type"
+states:
+  - name: "StartState"
+    type: "operation"
+    actions:
+      - name: "ChromeAction"
+        functionRef:
+          refName: "ChromeFunction"
+          arguments:
+            firstArgument: ""
+            secondArgument: ""
+    end: true


### PR DESCRIPTION
This PR copies Chrome extension test samples from it-tests directory to e2e directory. The it-tests directory will be deleted in https://github.com/kiegroup/kie-tools/pull/1992. 
This is necessary because the Chrome tests use samples from the main branch, so the samples should be present before the tests are executed.