### PR TITLE
NO-ISSUE: `jspdf` CVEs

### DIFF
--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -179,6 +179,8 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jspdf</outputDirectory>
+                  <includes
+                  >META-INF/resources/webjars/jspdf/dist/</includes>
                 </artifactItem>
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>

--- a/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/packages/stunner-editors/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -179,8 +179,7 @@
                   <type>jar</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/jspdf</outputDirectory>
-                  <includes
-                  >META-INF/resources/webjars/jspdf/dist/</includes>
+                  <includes>META-INF/resources/webjars/jspdf/dist/</includes>
                 </artifactItem>
               </artifactItems>
               <overWriteReleases>false</overWriteReleases>


### PR DESCRIPTION
Including `META-INF/resources/webjars/jspdf/dist/`, in order to don't unpack unnecessary files that contain CVEs (eg. a package-lock file )