### PR TITLE
KOGITO-9859: SWF Editor - YAML autocompletion is breaking the workflow

### DIFF
--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -234,9 +234,9 @@
         "editor.wordBasedSuggestions": false
       },
       "files.associations": {
-        "*.sw.json": "json",
-        "*.sw.yaml": "yaml",
-        "*.sw.yml": "yaml"
+        "*.sw.json": "serverless-workflow-json",
+        "*.sw.yaml": "serverless-workflow-yaml",
+        "*.sw.yml": "serverless-workflow-yaml"
       },
       "yaml.schemas": {
         "https://serverlessworkflow.io/schemas/0.8/workflow.json": [


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9859

**Description:**
In a YAML workflow, when the user uses autocopletion in order to add a new state from an "array item" the workflow structure gets broken. The YAML state template is injected in the wrong place.   

**Steps to Reproduce:**
- Create a new YAML Workflow from the VsCode (*.sw.yml)
- Click on "Create a Serverless Workflow" and then pick "Serverless Workflow Example"
-  Scroll down until the States session is visible and then click on "Add States"
-  Pick any of the "(array - item)" states

**Current Result:**
 A broken YAML template is injected breaking the workflow structure

**Expected Result:**
"Array Iems" should not be listed 

 **Solution:**
 A simple workaround for YAML would have been:
 `vscode.languages.setTextDocumentLanguage(document, "serverless-workflow-yaml");`
 But searching a bit on the web I found out why our configuration was not getting priority for our file extensions.
 Below is a VSCode issue opened for a Vue VSCode extension with our same problem:
 https://github.com/microsoft/vscode/issues/20074

**Preview:**
Before: 
[KOGITO-9859 before.webm](https://github.com/kiegroup/kie-tools/assets/17780574/3944ca48-a9a2-4aa2-9e1d-78fb3553d212)

After:
[KOGITO-9859 after.webm](https://github.com/kiegroup/kie-tools/assets/17780574/d7ef92a2-8d0c-4b5f-bddf-dd2166ff7a39)

