### PR TITLE
[0.32.0] NO-ISSUE: Fix asset url on `OpenFromSource` test

### DIFF
--- a/packages/online-editor/it-tests/e2e/OpenFromSource.cy.ts
+++ b/packages/online-editor/it-tests/e2e/OpenFromSource.cy.ts
@@ -19,7 +19,7 @@
 
 describe("Open from source test", () => {
   const SAMPLES_URL: string =
-    "https://raw.githubusercontent.com/kiegroup/kie-tools/main/packages/online-editor/it-tests/fixtures/";
+    "https://raw.githubusercontent.com/kiegroup/kie-tools/0.32.0-prerelease/packages/online-editor/it-tests/fixtures/";
 
   beforeEach(() => {
     cy.visit("/");


### PR DESCRIPTION
The `it-tests` folder does not exist on `main` anymore.