### PR TITLE
NO-ISSUE: Fix standalone job in the release workflow

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -908,7 +908,7 @@ jobs:
         run: |
           echo "Copy standalone resources"
           rm -rf $STANDALONE_EDITORS_DIR
-          mkdir $STANDALONE_EDITORS_DIR
+          mkdir $STANDALONE_EDITORS_DIR $STANDALONE_EDITORS_DIR/bpmn $STANDALONE_EDITORS_DIR/dmn $STANDALONE_EDITORS_DIR/swf
           cp ${{ github.workspace }}/kie-tools/packages/kie-editors-standalone/dist/bpmn/index.js $STANDALONE_EDITORS_DIR/bpmn/
           cp ${{ github.workspace }}/kie-tools/packages/kie-editors-standalone/dist/dmn/index.js $STANDALONE_EDITORS_DIR/dmn/
           cp ${{ github.workspace }}/kie-tools/packages/serverless-workflow-standalone-editor/dist/swf/index.js $STANDALONE_EDITORS_DIR/swf/


### PR DESCRIPTION
Fixes https://github.com/kiegroup/kie-tools/actions/runs/6485901985/job/17615030875

Needs cherry-pick to `0.32.0-prerelease` branch