### PR TITLE
NO-ISSUE: Change `boxed-expression-component` Storybook port to 9900

### DIFF
--- a/packages/boxed-expression-component/env/index.js
+++ b/packages/boxed-expression-component/env/index.js
@@ -25,7 +25,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
     return {
       boxedExpressionComponent: {
         storybook: {
-          port: 6006,
+          port: 9900,
         },
       },
     };


### PR DESCRIPTION
The port 6006 is part of the x11 server usage range (6000-6063), and consequently, this can cause port conflicts. 