### PR TITLE
kie-issues#630: KIE Tools `Publish jitexecutor-native` job is failing due to path names being too long on Windows

### DIFF
--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -23,6 +23,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
+      - name: "Set long paths for Windows"
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: "Checkout kogito-apps"
         uses: actions/checkout@v3
         with:
@@ -40,10 +44,6 @@ jobs:
         with:
           java-version: "11"
           distribution: "zulu"
-
-      - name: "Set long paths for Windows"
-        if: runner.os == 'Windows'
-        run: git config --system core.longpaths true
 
       - name: "Build macOS"
         if: runner.os == 'macOS'


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-issues/issues/630

First tentative. The `git config --system core.longpaths true` is required before checking out the repo.