### PR TITLE
KOGITO-9907: Enable to use GitHub token without logged in user

### DIFF
--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
@@ -34,9 +34,7 @@ const buildEnv: any = env;
 
 beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
-});
 
-test(TEST_NAME, async () => {
   if (buildEnv.swfChromeExtension.e2eTestingToken !== "") {
     const gitHubRepoPage: GitHubRepoPage = await tools.openPage(
       GitHubRepoPage,
@@ -44,7 +42,9 @@ test(TEST_NAME, async () => {
     );
     await gitHubRepoPage.addToken(buildEnv.swfChromeExtension.e2eTestingToken);
   }
+});
 
+test(TEST_NAME, async () => {
   const workflowUrl: string =
     "https://github.com/kiegroup/kie-tools/blob/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.yaml";
   let swfPage: GitHubEditorPage = await tools.openPage(GitHubEditorPage, workflowUrl);

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
@@ -20,17 +20,31 @@
 import SwfEditor from "@kie-tools/chrome-extension-test-helper/dist/framework/editor/swf/SwfEditor";
 import FullScreenPage from "@kie-tools/chrome-extension-test-helper/dist/framework/fullscreen-editor/FullScreenPage";
 import GitHubEditorPage from "@kie-tools/chrome-extension-test-helper/dist/framework/github-editor/GitHubEditorPage";
+import GitHubRepoPage from "@kie-tools/chrome-extension-test-helper/dist/framework/github-repo/GitHubRepoPage";
 import Tools from "@kie-tools/chrome-extension-test-helper/dist/utils/Tools";
+
+// @ts-ignore
+import { env } from "../../env";
 
 const TEST_NAME = "SwfFullScreenTest";
 
 let tools: Tools;
+
+const buildEnv: any = env;
 
 beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
 test(TEST_NAME, async () => {
+  if (buildEnv.swfChromeExtension.e2eTestingToken !== "") {
+    const gitHubRepoPage: GitHubRepoPage = await tools.openPage(
+      GitHubRepoPage,
+      "https://github.com/kiegroup/kie-tools"
+    );
+    await gitHubRepoPage.addToken(buildEnv.swfChromeExtension.e2eTestingToken);
+  }
+
   const workflowUrl: string =
     "https://github.com/kiegroup/kie-tools/blob/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.yaml";
   let swfPage: GitHubEditorPage = await tools.openPage(GitHubEditorPage, workflowUrl);

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
@@ -35,9 +35,7 @@ const buildEnv: any = env;
 
 beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
-});
 
-test(TEST_NAME, async () => {
   if (buildEnv.swfChromeExtension.e2eTestingToken !== "") {
     const gitHubRepoPage: GitHubRepoPage = await tools.openPage(
       GitHubRepoPage,
@@ -45,7 +43,9 @@ test(TEST_NAME, async () => {
     );
     await gitHubRepoPage.addToken(buildEnv.swfChromeExtension.e2eTestingToken);
   }
+});
 
+test(TEST_NAME, async () => {
   const gitHubListPage: GitHubListPage = await tools.openPage(
     GitHubListPage,
     "https://github.com/kiegroup/kie-tools/tree/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples"

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
@@ -21,17 +21,31 @@ import Tools from "@kie-tools/chrome-extension-test-helper/dist/utils/Tools";
 import GitHubListItem from "@kie-tools/chrome-extension-test-helper/dist/framework/github-file-list/GitHubListItem";
 import GitHubListPage from "@kie-tools/chrome-extension-test-helper/dist/framework/github-file-list/GitHubListPage";
 import GitHubEditorPage from "@kie-tools/chrome-extension-test-helper/dist/framework/github-editor/GitHubEditorPage";
+import GitHubRepoPage from "@kie-tools/chrome-extension-test-helper/dist/framework/github-repo/GitHubRepoPage";
 import SwfEditor from "@kie-tools/chrome-extension-test-helper/dist/framework/editor/swf/SwfEditor";
+
+// @ts-ignore
+import { env } from "../../env";
 
 const TEST_NAME = "SwfTest";
 
 let tools: Tools;
+
+const buildEnv: any = env;
 
 beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
 test(TEST_NAME, async () => {
+  if (buildEnv.swfChromeExtension.e2eTestingToken !== "") {
+    const gitHubRepoPage: GitHubRepoPage = await tools.openPage(
+      GitHubRepoPage,
+      "https://github.com/kiegroup/kie-tools"
+    );
+    await gitHubRepoPage.addToken(buildEnv.swfChromeExtension.e2eTestingToken);
+  }
+
   const gitHubListPage: GitHubListPage = await tools.openPage(
     GitHubListPage,
     "https://github.com/kiegroup/kie-tools/tree/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples"

--- a/packages/chrome-extension-serverless-workflow-editor/env/index.js
+++ b/packages/chrome-extension-serverless-workflow-editor/env/index.js
@@ -33,7 +33,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "manifest.dev.json",
       description: "",
     },
-    SWF__e2eTestingToken: {
+    SWF_CHROME_EXTENSION__e2eTestingToken: {
       default: "",
       description: "",
     },
@@ -48,7 +48,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
         routerTargetOrigin: getOrDefault(this.vars.SWF_CHROME_EXTENSION__routerTargetOrigin),
         routerRelativePath: getOrDefault(this.vars.SWF_CHROME_EXTENSION__routerRelativePath),
         manifestFile: getOrDefault(this.vars.SWF_CHROME_EXTENSION__manifestFile),
-        e2eTestingToken: getOrDefault(this.vars.SWF__e2eTestingToken),
+        e2eTestingToken: getOrDefault(this.vars.SWF_CHROME_EXTENSION__e2eTestingToken),
       },
     };
   },

--- a/packages/chrome-extension-serverless-workflow-editor/env/index.js
+++ b/packages/chrome-extension-serverless-workflow-editor/env/index.js
@@ -33,6 +33,10 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "manifest.dev.json",
       description: "",
     },
+    SWF__e2eTestingToken: {
+      default: "",
+      description: "",
+    },
   }),
   get env() {
     return {
@@ -44,6 +48,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
         routerTargetOrigin: getOrDefault(this.vars.SWF_CHROME_EXTENSION__routerTargetOrigin),
         routerRelativePath: getOrDefault(this.vars.SWF_CHROME_EXTENSION__routerRelativePath),
         manifestFile: getOrDefault(this.vars.SWF_CHROME_EXTENSION__manifestFile),
+        e2eTestingToken: getOrDefault(this.vars.SWF__e2eTestingToken),
       },
     };
   },

--- a/packages/chrome-extension-test-helper/src/framework/github-repo/GitHubRepoPage.ts
+++ b/packages/chrome-extension-test-helper/src/framework/github-repo/GitHubRepoPage.ts
@@ -1,0 +1,22 @@
+import { By, Key } from "selenium-webdriver";
+import Page from "../Page";
+
+export default class GitHubRepoPage extends Page {
+  private static readonly TOKEN_ICON: By = By.className("kogito-menu-icon");
+  private static readonly TOKEN_INPUT: By = By.className("kogito-github-token-input");
+
+  public async waitUntilLoaded(): Promise<void> {
+    return await this.tools.by(GitHubRepoPage.TOKEN_ICON).wait(1000).untilPresent();
+  }
+
+  public async addToken(token: string): Promise<void> {
+    const tokenIcon = await this.tools.by(GitHubRepoPage.TOKEN_ICON).getElement();
+    await tokenIcon.click();
+    await this.tools.by(GitHubRepoPage.TOKEN_INPUT).wait(1000).untilPresent();
+    const tokenInput = await this.tools.by(GitHubRepoPage.TOKEN_INPUT).getElement();
+    await tokenInput.click();
+    await this.tools.clipboard().setContent(token);
+    await tokenInput.sendKeys(this.tools.clipboard().getCtrvKeys());
+    await this.tools.by(GitHubRepoPage.TOKEN_INPUT).wait(5000).untilAbsent();
+  }
+}

--- a/packages/chrome-extension-test-helper/src/utils/tools/Clipboard.ts
+++ b/packages/chrome-extension-test-helper/src/utils/tools/Clipboard.ts
@@ -35,6 +35,14 @@ export default class Clipboard {
     return await this.getTextFromHelperInput();
   }
 
+  /**
+   * Set the clipboard content.
+   * @param textToClipboard Text to set as the content of the clipboard.
+   */
+  public async setContent(textToClipboard: string): Promise<void> {
+    await this.driver.executeScript("navigator.clipboard.writeText('" + textToClipboard + "');");
+  }
+
   private async getTextFromHelperInput(): Promise<string> {
     const GET_TEXT_FROM_INPUT_CMD: string =
       "input=document.getElementById('copyPaste');" +
@@ -55,7 +63,11 @@ export default class Clipboard {
     );
   }
 
-  private getCtrvKeys(): string {
+  /**
+   * Return Ctrl + v command for specific OS.
+   * @returns Ctrl + v command.
+   */
+  public getCtrvKeys(): string {
     // "darwin" is  MacOS
     if (platform() === "darwin") {
       return Key.SHIFT + Key.INSERT;

--- a/packages/chrome-extension/src/app/Dependencies.ts
+++ b/packages/chrome-extension/src/app/Dependencies.ts
@@ -74,6 +74,9 @@ export class Dependencies {
       return (document.querySelector(".notification-indicator") ??
         document.querySelector(".AppHeader-search")) as HTMLElement | null;
     },
+    notLoggedInNotificationIndicator: () => {
+      return document.querySelector("#repository-details-container") as HTMLInputElement | null;
+    },
     body: () => {
       return document.body;
     },

--- a/packages/chrome-extension/src/app/components/common/Main.tsx
+++ b/packages/chrome-extension/src/app/components/common/Main.tsx
@@ -46,15 +46,25 @@ function KogitoMenuPortal(props: { id: string }) {
   const githubApi = useGitHubApi();
   const globals = useGlobals();
 
-  return (
-    <>
-      {githubApi.userIsLoggedIn() &&
-        ReactDOM.createPortal(
+  if (githubApi.userIsLoggedIn()) {
+    return (
+      <>
+        {ReactDOM.createPortal(
           <KogitoMenu />,
           kogitoMenuContainer(props.id, globals.dependencies.all.notificationIndicator()!.parentElement!)
         )}
-    </>
-  );
+      </>
+    );
+  } else {
+    return (
+      <>
+        {ReactDOM.createPortal(
+          <KogitoMenu />,
+          kogitoMenuContainer(props.id, globals.dependencies.all.notLoggedInNotificationIndicator()!)
+        )}
+      </>
+    );
+  }
 }
 
 export const Main: React.FunctionComponent<Globals> = (props) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9907

Sometimes it happens that GitHub access limit API is exceeded and the Selenium Chrome extensions tests failed (only QE Jenkins tests). This PR allows to add the GitHub token even no user is logged in and it fixes the issues with the exceeded access limit. As default the token is not set and the GitHub CI tests will run without it.

In the tests, it is not possible to login to GitHub as the GitHub requires confirmation by email/code.

![image](https://github.com/kiegroup/kie-tools/assets/4498639/3836e015-5cd7-4418-99c3-25d8150e0b07)