### PR TITLE
kie-issue#636: DMN Monaco highlighting throws error when used with DMN Runner

### DIFF
--- a/packages/online-editor/src/dmnRunner/DmnRunnerDrawer.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerDrawer.tsx
@@ -27,7 +27,11 @@ import { DmnRunnerErrorBoundary } from "./DmnRunnerErrorBoundary";
 export function DmnRunnerDrawer(props: React.PropsWithChildren<{}>) {
   const dmnRunnerState = useDmnRunnerState();
   return (
-    <Drawer isInline={true} isExpanded={dmnRunnerState.isExpanded && dmnRunnerState.mode === DmnRunnerMode.FORM}>
+    <Drawer
+      isInline={true}
+      isExpanded={dmnRunnerState.isExpanded && dmnRunnerState.mode === DmnRunnerMode.FORM}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
       <DrawerContent
         className={
           !dmnRunnerState.isExpanded ? "kogito--editor__drawer-content-onClose" : "kogito--editor__drawer-content-open"


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/636

This looks like a Monaco issue, reported [here](https://github.com/microsoft/monaco-editor/issues/4213).

This is a fix that prevent key events inside DMN Runner to be "bubbled" outside it.

I didn't found any other key event that trigger that issue in Monaco (properties panel, Data Types editor, renaming the node in diagram editor, etc.).