### PR TITLE
NO-ISSUE: Upgrade NodeJS version of `cors-proxy-image` Containerfile

### DIFF
--- a/packages/cors-proxy-image/Containerfile
+++ b/packages/cors-proxy-image/Containerfile
@@ -19,7 +19,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 ENV HOME          /home/kie-sandbox
 ENV NVM_DIR       $HOME/.nvm
-ENV NODE_VERSION  v20.3.1
+ENV NODE_VERSION  v20.8.1
 
 ENV CORS_PROXY_ORIGIN=*
 ENV CORS_PROXY_VERBOSE=false
@@ -29,7 +29,7 @@ RUN mkdir $HOME \
   && chmod -R g=u $HOME \
   && chown -R 1000:0 $HOME \
   && microdnf install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
   && /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION"
 
 ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin


### PR DESCRIPTION
Fixes the following CVEs
- CVE-2023-32558
- CVE-2023-32006
- CVE-2023-32002
- CVE-2023-32004
- CVE-2023-32559
- CVE-2023-32005
- CVE-2023-32003