### PR TITLE
NO-ISSUE: Avoid render loop in Extended Services Wizard component in KIE Sandbox

### DIFF
--- a/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
@@ -784,7 +784,7 @@ function ExtendedServicesWizardFooter(props: WizardImperativeControlProps) {
   const { i18n } = useOnlineI18n();
 
   useEffect(() => {
-    if (status === ExtendedServicesStatus.STOPPED) {
+    if (status === ExtendedServicesStatus.STOPPED && wizardContext.activeStep.name !== props.steps[1].name) {
       wizardContext.goToStepByName(props.steps[1].name);
     }
   }, [status, props.steps, wizardContext]);


### PR DESCRIPTION
Setting the new step would cause the `wizardContext` to update, even if the new step was the same as the active one.