### PR TITLE
[0.30.4] NO-ISSUE: Update `selenium` & `JDT.LS`

### DIFF
--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/pom.xml
@@ -145,11 +145,6 @@
 			<artifactId>xmlunit-assertj</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>io.github.bonigarcia</groupId>
-			<artifactId>webdrivermanager</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicShapesExampleTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicShapesExampleTest.java
@@ -18,7 +18,6 @@ package org.kie.lienzo.client;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.lienzo.client.selenium.JsCanvasDriver;
 import org.kie.lienzo.client.selenium.JsCanvasShapeExecutor;

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicShapesExampleTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicShapesExampleTest.java
@@ -32,11 +32,6 @@ public class BasicShapesExampleTest {
     private JsCanvasDriver lienzoDriver;
     private JsCanvasShapeExecutor rectangle;
 
-    @BeforeClass
-    public static void setupClass() {
-        JsCanvasDriver.init();
-    }
-
     @Before
     public void openWebapp() {
         // TODO lienzoDriver = JsCanvasDriver.build();

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicWiresExampleTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicWiresExampleTest.java
@@ -36,11 +36,6 @@ public class BasicWiresExampleTest {
 
     private JsCanvasDriver lienzoDriver;
 
-    @BeforeClass
-    public static void setupClass() {
-        JsCanvasDriver.init();
-    }
-
     @Before
     public void openWebapp() {
         // TODO lienzoDriver = JsCanvasDriver.build();

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicWiresExampleTest.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/BasicWiresExampleTest.java
@@ -18,7 +18,6 @@ package org.kie.lienzo.client;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.lienzo.client.selenium.JsCanvasDriver;
 import org.kie.lienzo.client.selenium.JsCanvasWiresShapeExecutor;

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/selenium/JsCanvasDriver.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/selenium/JsCanvasDriver.java
@@ -34,10 +34,6 @@ public class JsCanvasDriver extends JsCanvasExecutor {
     // TODO: Refactor/remove use of loadTimeMillis by using selenium until conditions
     private long loadTimeMillis = 1000;
 
-    public static void init() {
-        //WebDriverManager.firefoxdriver().useMirror().setup();
-    }
-
     public static JsCanvasDriver devMode() {
         JsCanvasDriver instance = build("http://127.0.0.1:8888/LienzoShowcase.html");
         instance.loadTimeMillis = 3000;

--- a/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/selenium/JsCanvasDriver.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-webapp/src/test/java/org/kie/lienzo/client/selenium/JsCanvasDriver.java
@@ -19,7 +19,6 @@ package org.kie.lienzo.client.selenium;
 import java.io.File;
 import java.time.Duration;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -30,14 +29,13 @@ public class JsCanvasDriver extends JsCanvasExecutor {
 
     private static final String INDEX_HTML = "target/lienzo-webapp-0.0.0/LienzoShowcase.html";
     private static final String INDEX_HTML_PATH = "file:///" + new File(INDEX_HTML).getAbsolutePath();
-    private static final boolean HEADLESS = false;
 
     private final WebDriver driver;
     // TODO: Refactor/remove use of loadTimeMillis by using selenium until conditions
     private long loadTimeMillis = 1000;
 
     public static void init() {
-        WebDriverManager.firefoxdriver().useMirror().setup();
+        //WebDriverManager.firefoxdriver().useMirror().setup();
     }
 
     public static JsCanvasDriver devMode() {
@@ -52,7 +50,6 @@ public class JsCanvasDriver extends JsCanvasExecutor {
 
     public static JsCanvasDriver build(String url) {
         final FirefoxOptions firefoxOptions = new FirefoxOptions();
-        firefoxOptions.setHeadless(HEADLESS);
         WebDriver driver = new FirefoxDriver(firefoxOptions);
         driver.manage().window().maximize();
         driver.get(url);
@@ -76,10 +73,10 @@ public class JsCanvasDriver extends JsCanvasExecutor {
     }
 
     private WebDriverWait waitOperation(long seconds) {
-        return new WebDriverWait(driver, Duration.ofSeconds(seconds).getSeconds());
+        return new WebDriverWait(driver, Duration.ofSeconds(seconds));
     }
 
     private WebDriverWait waitAppLoaded() {
-        return new WebDriverWait(driver, Duration.ofSeconds(5).getSeconds());
+        return new WebDriverWait(driver, Duration.ofSeconds(5));
     }
 }

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -283,7 +283,7 @@
     <version.org.gwtbootstrap3>1.0.1</version.org.gwtbootstrap3>
     <version.org.gwtbootstrap3-extras>1.0.2</version.org.gwtbootstrap3-extras>
     <version.org.javassist>3.26.0-GA</version.org.javassist>
-    <version.org.jboss.arquillian.selenium>3.13.0</version.org.jboss.arquillian.selenium>
+    <version.org.seleniumhq.selenium>4.15.0</version.org.seleniumhq.selenium>
     <version.org.jboss.errai.wildfly>19.1.0.SP1</version.org.jboss.errai.wildfly> <!--  WildFly version used together with  the GWT's Super Dev Mode  -->
     <version.org.jboss.maven-jdocbook-plugin>2.3.5</version.org.jboss.maven-jdocbook-plugin>
     <version.org.jboss.pressbang>2.0.0</version.org.jboss.pressbang>
@@ -293,7 +293,6 @@
     <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
 
     <!-- Test Libraries -->
-    <version.io.github.bonigarcia>5.2.1</version.io.github.bonigarcia>
     <version.junit>4.13.2</version.junit>
     <version.org.assertj>3.22.0</version.org.assertj>
     <version.com.google.gwt.gwtmockito>1.1.9</version.com.google.gwt.gwtmockito>
@@ -309,16 +308,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- There is no official Selenium BOM, so we are using one maintained by Arquillian.
-     (contains only pure Selenium deps, no ARQ deps are leaking from this BOM) -->
-      <dependency>
-        <groupId>org.jboss.arquillian.selenium</groupId>
-        <artifactId>selenium-bom</artifactId>
-        <version>${version.org.jboss.arquillian.selenium}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <!-- All errai's modules and third-party versions are defined in this POM -->
       <dependency>
         <groupId>org.kie.kogito.stunner.serverless.editor</groupId>
@@ -588,9 +577,9 @@
 
       <!-- TEST -->
       <dependency>
-        <groupId>io.github.bonigarcia</groupId>
-        <artifactId>webdrivermanager</artifactId>
-        <version>${version.io.github.bonigarcia}</version>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-java</artifactId>
+        <version>${version.org.seleniumhq.selenium}</version>
         <scope>test</scope>
       </dependency>
 

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/pom.xml
@@ -239,12 +239,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.github.bonigarcia</groupId>
-      <artifactId>webdrivermanager</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/definition/DefinitionTests.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/definition/DefinitionTests.java
@@ -70,16 +70,13 @@ public class DefinitionTests {
      * Selenium web driver
      */
     private WebDriver driver;
-/*
-    @BeforeClass
-    public static void setupClass() {
-        WebDriverManager.firefoxdriver().useMirror().setup();
-    }*/
 
     @Before
     public void openSWEditor() {
         final FirefoxOptions firefoxOptions = new FirefoxOptions();
-        //firefoxOptions.setHeadless(HEADLESS);
+        if (HEADLESS) {
+            firefoxOptions.addArguments("--headless=new");
+        }
         driver = new FirefoxDriver(firefoxOptions);
 
         driver.manage().window().maximize();

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/definition/DefinitionTests.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-api/src/test/java/org/kie/workbench/common/stunner/sw/definition/DefinitionTests.java
@@ -22,11 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.stream.Collectors;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.IOUtils;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -72,16 +70,16 @@ public class DefinitionTests {
      * Selenium web driver
      */
     private WebDriver driver;
-
+/*
     @BeforeClass
     public static void setupClass() {
         WebDriverManager.firefoxdriver().useMirror().setup();
-    }
+    }*/
 
     @Before
     public void openSWEditor() {
         final FirefoxOptions firefoxOptions = new FirefoxOptions();
-        firefoxOptions.setHeadless(HEADLESS);
+        //firefoxOptions.setHeadless(HEADLESS);
         driver = new FirefoxDriver(firefoxOptions);
 
         driver.manage().window().maximize();
@@ -336,6 +334,6 @@ public class DefinitionTests {
     }
 
     private WebDriverWait waitOperation() {
-        return new WebDriverWait(driver, Duration.ofSeconds(2).getSeconds());
+        return new WebDriverWait(driver, Duration.ofSeconds(2));
     }
 }

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/pom.xml
@@ -361,11 +361,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.github.bonigarcia</groupId>
-      <artifactId>webdrivermanager</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/selenium/SWEditorSeleniumBase.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-kogito-app/src/test/java/org/kie/workbench/common/stunner/sw/client/selenium/SWEditorSeleniumBase.java
@@ -22,10 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.stream.Collectors;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -69,19 +68,16 @@ public class SWEditorSeleniumBase {
 
     protected JsCanvasHelper jsHelper;
 
-    @BeforeClass
-    public static void setupClass() {
-        WebDriverManager.chromedriver().useMirror().setup();
-    }
-
     @Before
     public void openSWEditor() {
         ChromeDriverService service = new ChromeDriverService.Builder()
                 .usingAnyFreePort()
                 .build();
-        ChromeOptions options = new ChromeOptions()
-                .setHeadless(HEADLESS);
+        ChromeOptions options = new ChromeOptions();
         driver = new ChromeDriver(service, options);
+        if (HEADLESS) {
+            options.addArguments("--headless=new");
+        }
 
         driver.manage().window().maximize();
 
@@ -95,6 +91,11 @@ public class SWEditorSeleniumBase {
                 .as("Diagram panel is a prerequisite for all tests. " +
                             "its absence is indicator of designer load fail.")
                 .isNotNull();
+    }
+
+    @After
+    public void close() {
+        driver.quit();
     }
 
     protected void waitCanvasPanel() {
@@ -142,6 +143,6 @@ public class SWEditorSeleniumBase {
     }
 
     protected WebDriverWait waitOperation() {
-        return new WebDriverWait(driver, Duration.ofSeconds(10).getSeconds());
+        return new WebDriverWait(driver, Duration.ofSeconds(10));
     }
 }

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -36,7 +36,7 @@
     <tycho.scmUrl>scm:git:https://github.com/kiegroup/kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
     <!-- Using a SNAPSHOT version because of https://github.com/eclipse/eclipse.jdt.ls/issues/1970 -->
-    <jdt.ls.version>1.25.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.29.0-SNAPSHOT</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
SWF Selenium tests are failing because of this https://stackoverflow.com/a/76731553
Updating selenium should do the trick.
The bonigarcia web driver is no longer required, as the  latest versions of selenium have their webdriver integrated.

Updating JDT.LS to 1.29. Current 1.25 is a stale version, no longer valid.