### PR TITLE
KOGITO-9961: Node coloring stopped working on runtime tools

### DIFF
--- a/packages/serverless-workflow-diagram-editor/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/diagramApi/DiagramApiService.java
+++ b/packages/serverless-workflow-diagram-editor/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/diagramApi/DiagramApiService.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -196,13 +196,13 @@ public class StunnerEditor {
         LienzoCanvas canvas = (LienzoCanvas) session.getCanvasHandler().getCanvas();
         LienzoPanel panel = (LienzoPanel) canvas.getView().getPanel();
         LienzoBoundsPanel lienzoPanel = panel.getView();
-        JsCanvas jsCanvas = new JsCanvas(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
+        JsCanvas jsCanvas = JsCanvas.getInstance().init(lienzoPanel, lienzoPanel.getLayer(), new StunnerStateApplier() {
             @Override
             public Shape getShape(String uuid) {
                 return canvas.getShape(uuid);
             }
         });
-        JsCanvasWrapper jsCanvasWrapper = new JsCanvasWrapper().setWrapper(jsCanvas);
+        JsCanvasWrapper jsCanvasWrapper = new JsCanvasWrapper();
         JsWindow.setCanvas(jsCanvasWrapper);
         JsWindow.getEditor().setCanvas(jsCanvasWrapper);
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -186,7 +186,7 @@ public class StunnerEditor {
 
     @SuppressWarnings("all")
     private void initializeJsSession(AbstractSession session) {
-        JsStunnerSession jssession = new JsStunnerSession(session);
+        JsStunnerSession jssession = new JsStunnerSession().setSession(session);
         JsWindow.getEditor().setSession(jssession);
         initializeJsCanvas(session);
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/editor/StunnerEditor.java
@@ -186,7 +186,7 @@ public class StunnerEditor {
 
     @SuppressWarnings("all")
     private void initializeJsSession(AbstractSession session) {
-        JsStunnerSession jssession = new JsStunnerSession().setSession(session);
+        JsStunnerSession jssession = new JsStunnerSession(session);
         JsWindow.getEditor().setSession(jssession);
         initializeJsCanvas(session);
     }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsCanvasWrapper.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsCanvasWrapper.java
@@ -37,12 +37,7 @@ import org.treblereel.j2cl.processors.annotations.GWT3Export;
 @GWT3Export
 public class JsCanvasWrapper {
 
-    private JsCanvas wrapper;
-
-    public JsCanvasWrapper setWrapper(JsCanvas wrapper) {
-        this.wrapper = wrapper;
-        return this;
-    }
+    private JsCanvas wrapper = JsCanvas.getInstance();
 
     public Layer getLayer() {
         return wrapper.getLayer();

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
@@ -22,6 +22,7 @@ package org.kie.workbench.common.stunner.core.client.api;
 import java.util.Collection;
 import java.util.stream.StreamSupport;
 
+import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -44,11 +45,11 @@ import org.treblereel.j2cl.processors.annotations.GWT3Export;
 @GWT3Export
 public class JsStunnerSession {
 
+    @JsIgnore
     private AbstractSession session;
 
-    public JsStunnerSession setSession(AbstractSession session) {
+    public JsStunnerSession(AbstractSession session) {
         this.session = session;
-        return this;
     }
 
     public Diagram getDiagram() {

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/api/JsStunnerSession.java
@@ -22,7 +22,6 @@ package org.kie.workbench.common.stunner.core.client.api;
 import java.util.Collection;
 import java.util.stream.StreamSupport;
 
-import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
@@ -39,15 +38,17 @@ import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.definition.Definition;
 import org.kie.workbench.common.stunner.core.graph.content.view.View;
 import org.kie.workbench.common.stunner.core.graph.processing.index.Index;
+import org.treblereel.j2cl.processors.annotations.GWT3Export;
 
 @JsType
+@GWT3Export
 public class JsStunnerSession {
 
-    @JsIgnore
     private AbstractSession session;
 
-    public JsStunnerSession(AbstractSession session) {
+    public JsStunnerSession setSession(AbstractSession session) {
         this.session = session;
+        return this;
     }
 
     public Diagram getDiagram() {

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/pom.xml
@@ -60,6 +60,17 @@
       <artifactId>uberfire-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.treblereel.j2cl.processors</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.treblereel.j2cl.processors</groupId>
+      <artifactId>processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test scope. -->
 
     <dependency>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewConnectorImpl.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -27,8 +27,10 @@ import java.util.stream.Stream;
 import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
 import org.kie.workbench.common.stunner.core.util.HashUtil;
+import org.treblereel.j2cl.processors.annotations.GWT3Export;
 
 @JsType
+@GWT3Export
 public final class ViewConnectorImpl<W> implements ViewConnector<W> {
 
     protected W definition;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/content/view/ViewImpl.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -22,8 +22,10 @@ package org.kie.workbench.common.stunner.core.graph.content.view;
 
 import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.graph.content.Bounds;
+import org.treblereel.j2cl.processors.annotations.GWT3Export;
 
 @JsType
+@GWT3Export
 public final class ViewImpl<W> implements View<W> {
 
     protected W definition;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/AbstractElement.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/EdgeImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/EdgeImpl.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -23,8 +23,10 @@ package org.kie.workbench.common.stunner.core.graph.impl;
 import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
+import org.treblereel.j2cl.processors.annotations.GWT3Export;
 
 @JsType
+@GWT3Export
 public class EdgeImpl<C> extends AbstractElement<C> implements Edge<C, Node> {
 
     private Node sourceNode;

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/NodeImpl.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/impl/NodeImpl.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 
@@ -23,16 +23,20 @@ package org.kie.workbench.common.stunner.core.graph.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import jsinterop.annotations.JsType;
 import org.kie.workbench.common.stunner.core.graph.Edge;
 import org.kie.workbench.common.stunner.core.graph.Node;
 import org.kie.workbench.common.stunner.core.graph.content.view.ViewConnector;
+import org.treblereel.j2cl.processors.annotations.GWT3Export;
 
-@JsType
+@GWT3Export
 public class NodeImpl<C> extends AbstractElement<C> implements Node<C, Edge> {
 
     private final List<Edge> inEdges = new ArrayList<Edge>();
     private final List<Edge> outEdges = new ArrayList<Edge>();
+
+    public NodeImpl() {
+        super("default");
+    }
 
     public NodeImpl(String uuid) {
         super(uuid);

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/client/core/types/JsCanvas.java
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 package com.ait.lienzo.client.core.types;
@@ -43,6 +43,8 @@ import jsinterop.annotations.JsType;
 @JsType
 public class JsCanvas implements JsCanvasNodeLister {
 
+    private static JsCanvas INSTANCE = null;
+
     public static JsCanvasEvents events;
     public static JsCanvasAnimations animations;
     public static JsCanvasLogger logger;
@@ -50,11 +52,23 @@ public class JsCanvas implements JsCanvasNodeLister {
     LienzoPanel panel;
     Layer layer;
 
-    public JsCanvas(LienzoPanel panel, Layer layer, JSShapeStateApplier stateApplier) {
+    private JsCanvas() {
+
+    }
+
+    public static JsCanvas getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new JsCanvas();
+        }
+        return INSTANCE;
+    }
+
+    public JsCanvas init(LienzoPanel panel, Layer layer, JSShapeStateApplier stateApplier) {
         this.panel = panel;
         this.layer = layer;
         this.stateApplier = stateApplier;
         this.events = null;
+        return this;
     }
 
     @SuppressWarnings("all")

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -288,7 +288,7 @@
     <version.org.uberfire.patternfly>7.74.1.Final</version.org.uberfire.patternfly>
 
     <version.io.crysknife>0.6</version.io.crysknife>
-    <version.org.gwt3.processors>0.6.3</version.org.gwt3.processors>
+    <version.org.gwt3.processors>0.6.4</version.org.gwt3.processors>
     <version.j2cl>0.11.0-9336533b6</version.j2cl>
     <version.j2cl.maven.plugin>0.21.0</version.j2cl.maven.plugin>
 


### PR DESCRIPTION
Hi @caponetto,

This fix should do the trick. Please, could you take a look.

Basically J2CL has some issues handling "JsTypes". 
For now we have to use @GWT3Export along with "JsTypes" to get it working.  

**JIRA**: [KOGITO-9961](https://issues.redhat.com/browse/KOGITO-9961)

Thanks