### PR TITLE
NO-ISSUE: bump ch.qos.logback:logback-core from 1.2.11 to 1.3.12

### DIFF
--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -251,7 +251,7 @@
     <version.j2cl.plugin>0.21.0</version.j2cl.plugin>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
+    <version.ch.qos.logback>1.3.12</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.jsinterop.annotations>2.0.0</version.jsinterop.annotations>
     <version.com.google.guava>32.1.3-jre</version.com.google.guava>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -276,7 +276,7 @@
     <version.org.kogito.gwt-jsonix-schema-compiler>1.3.0</version.org.kogito.gwt-jsonix-schema-compiler>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.2.11</version.ch.qos.logback>
+    <version.ch.qos.logback>1.3.12</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.com.google.guava>32.1.3-jre</version.com.google.guava>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>


### PR DESCRIPTION
Fixes
https://github.com/kiegroup/kie-tools/security/dependabot/274
https://github.com/kiegroup/kie-tools/security/dependabot/275
https://github.com/kiegroup/kie-tools/security/dependabot/277
https://github.com/kiegroup/kie-tools/security/dependabot/278