### PR TITLE
NO-ISSUE: Minor changes to the UI of Dev deployment DMN Form webapp and fixing issue reporting links

### DIFF
--- a/packages/dev-deployment-dmn-form-webapp/dev-webapp/webapp/static/resources/style.css
+++ b/packages/dev-deployment-dmn-form-webapp/dev-webapp/webapp/static/resources/style.css
@@ -21,6 +21,9 @@
   /* this adjusts the max specifically for our logo */
   --pf-c-page__header-brand-link--c-brand--MaxHeight: 39px;
 }
+.pf-c-page__header-brand-link {
+  text-decoration: none;
+}
 
 .kogito--alert-container {
   position: fixed;

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormApp.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormApp.tsx
@@ -46,11 +46,7 @@ export function DmnFormApp(props: DmnFormAppProps) {
               <HashRouter>
                 <Switch>
                   {app.data && (
-                    <Route
-                      path={routes.form.path({
-                        modelName: ":modelName*",
-                      })}
-                    >
+                    <Route path={routes.form.path({ modelName: ":modelName*" })}>
                       {({ match }) => {
                         const formData = app.data!.forms.find((form) => form.modelName === match?.params.modelName);
                         return formData ? (

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
@@ -45,7 +45,7 @@ export function DmnFormErrorPage() {
             <I18nWrapped
               components={{
                 jira: (
-                  <a href={ISSUES_URL} target={"_blank"}>
+                  <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                     {ISSUES_URL}
                   </a>
                 ),

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
@@ -24,7 +24,7 @@ import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
 import { useDmnFormI18n } from "./i18n";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export function DmnFormErrorPage() {
   const { i18n } = useDmnFormI18n();
@@ -45,8 +45,8 @@ export function DmnFormErrorPage() {
             <I18nWrapped
               components={{
                 jira: (
-                  <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                    {KOGITO_JIRA_LINK}
+                  <a href={ISSUES_URL} target={"_blank"}>
+                    {ISSUES_URL}
                   </a>
                 ),
               }}

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormPage.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormPage.tsx
@@ -126,7 +126,7 @@ export function DmnFormPage(props: Props) {
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={ISSUES_URL} target={"_blank"}>
+                    <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                       {ISSUES_URL}
                     </a>
                   ),

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormPage.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormPage.tsx
@@ -46,7 +46,7 @@ enum AlertTypes {
 }
 
 const AUTO_SAVE_DELAY = 500;
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export function DmnFormPage(props: Props) {
   const { i18n, locale } = useDmnFormI18n();
@@ -126,8 +126,8 @@ export function DmnFormPage(props: Props) {
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                    <a href={ISSUES_URL} target={"_blank"}>
+                      {ISSUES_URL}
                     </a>
                   ),
                 }}

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormToolbar.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormToolbar.tsx
@@ -128,6 +128,7 @@ export function DmnFormToolbar(props: Props) {
         >
           <Text component={TextVariants.a} className="kogito--dmn-form__toolbar a">
             {i18n.names.swaggerUI}
+            &nbsp;
             <ExternalLinkAltIcon className="pf-u-mx-sm" />
           </Text>
         </DropdownItem>
@@ -176,6 +177,7 @@ export function DmnFormToolbar(props: Props) {
               {app.data!.forms.length > 1 && (
                 <Dropdown
                   onSelect={() => setModelDropdownOpen(false)}
+                  isPlain={true}
                   toggle={
                     <DropdownToggle
                       id="dmn-dev-deployment-form-toolbar-model-dropdown-button"

--- a/packages/dev-deployment-dmn-form-webapp/static/resources/style.css
+++ b/packages/dev-deployment-dmn-form-webapp/static/resources/style.css
@@ -21,6 +21,9 @@
   /* this adjusts the max specifically for our logo */
   --pf-c-page__header-brand-link--c-brand--MaxHeight: 39px;
 }
+.pf-c-page__header-brand-link {
+  text-decoration: none;
+}
 
 .kogito--alert-container {
   position: fixed;

--- a/packages/form-dmn/src/FormDmnOutputs.tsx
+++ b/packages/form-dmn/src/FormDmnOutputs.tsx
@@ -283,7 +283,7 @@ export function FormDmnOutputs({ openExecutionTab, ...props }: FormDmnOutputsPro
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={ISSUES_URL} target={"_blank"}>
+                    <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                       {ISSUES_URL}
                     </a>
                   ),

--- a/packages/form-dmn/src/FormDmnOutputs.tsx
+++ b/packages/form-dmn/src/FormDmnOutputs.tsx
@@ -41,7 +41,7 @@ import { ErrorBoundary } from "@kie-tools/dmn-runner/dist/ErrorBoundary";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
 import { DecisionResult, DmnEvaluationStatus, DmnEvaluationResult } from "@kie-tools/extended-services-api";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 const DATE_REGEX = /\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[1-2]\d|3[0-1])T(?:[0-1]\d|2[0-3]):[0-5]\d:[0-5]\dZ/;
 
@@ -283,8 +283,8 @@ export function FormDmnOutputs({ openExecutionTab, ...props }: FormDmnOutputsPro
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                    <a href={ISSUES_URL} target={"_blank"}>
+                      {ISSUES_URL}
                     </a>
                   ),
                 }}

--- a/packages/form/src/FormStatus.tsx
+++ b/packages/form/src/FormStatus.tsx
@@ -26,7 +26,7 @@ import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { ExclamationIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-icon";
 import { FormI18n } from "./i18n";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export enum FormStatus {
   WITHOUT_ERROR,
@@ -114,8 +114,8 @@ export function ValidatorErrorFormStatus({ i18n }: ValidatorErrorFormStatusProps
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                    <a href={ISSUES_URL} target={"_blank"}>
+                      {ISSUES_URL}
                     </a>
                   ),
                 }}

--- a/packages/form/src/FormStatus.tsx
+++ b/packages/form/src/FormStatus.tsx
@@ -114,7 +114,7 @@ export function ValidatorErrorFormStatus({ i18n }: ValidatorErrorFormStatusProps
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={ISSUES_URL} target={"_blank"}>
+                    <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                       {ISSUES_URL}
                     </a>
                   ),

--- a/packages/kie-bc-editors/src/common/i18n/locales/de.ts
+++ b/packages/kie-bc-editors/src/common/i18n/locales/de.ts
@@ -19,8 +19,8 @@
 
 import { KieBcEditorsI18n } from "../KieBcEditorsI18n";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export const de: KieBcEditorsI18n = {
-  unsupportedFile: `Diese Datei enthält ein Konstrukt, das noch nicht unterstützt wird. Bitte konsultieren Sie ${KOGITO_JIRA_LINK} und melden Sie ein Problem. Vergessen Sie nicht, die aktuelle Datei hochzuladen.`,
+  unsupportedFile: `Diese Datei enthält ein Konstrukt, das noch nicht unterstützt wird. Bitte konsultieren Sie ${ISSUES_URL} und melden Sie ein Problem. Vergessen Sie nicht, die aktuelle Datei hochzuladen.`,
 };

--- a/packages/kie-bc-editors/src/common/i18n/locales/en.ts
+++ b/packages/kie-bc-editors/src/common/i18n/locales/en.ts
@@ -19,8 +19,8 @@
 
 import { KieBcEditorsI18n } from "../KieBcEditorsI18n";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export const en: KieBcEditorsI18n = {
-  unsupportedFile: `This file contains a construct that is not yet supported. Please refer to ${KOGITO_JIRA_LINK} and report an issue. Don't forget to upload the current file.`,
+  unsupportedFile: `This file contains a construct that is not yet supported. Please refer to ${ISSUES_URL} and report an issue. Don't forget to upload the current file.`,
 };

--- a/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
@@ -54,7 +54,7 @@ export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={ISSUES_URL} target={"_blank"}>
+                    <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                       {ISSUES_URL}
                     </a>
                   ),

--- a/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerErrorBoundary.tsx
@@ -27,7 +27,7 @@ import { I18nWrapped } from "@kie-tools-core/i18n/dist/react-components";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon";
 import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Text";
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>) {
   const [_, setDmnRunnerError] = useState<boolean>(false);
@@ -54,8 +54,8 @@ export function DmnRunnerErrorBoundary({ children }: React.PropsWithChildren<{}>
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                    <a href={ISSUES_URL} target={"_blank"}>
+                      {ISSUES_URL}
                     </a>
                   ),
                 }}

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -373,7 +373,7 @@ export function EditorPage(props: Props) {
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={ISSUES_URL} target={"_blank"}>
+                    <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
                       {ISSUES_URL}
                     </a>
                   ),

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -67,7 +67,7 @@ export interface Props {
 let saveVersion = 1;
 let refreshVersion = 0;
 
-const KOGITO_JIRA_LINK = "https://issues.jboss.org/projects/KOGITO";
+const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export function EditorPage(props: Props) {
   const { env } = useEnv();
@@ -373,8 +373,8 @@ export function EditorPage(props: Props) {
               <I18nWrapped
                 components={{
                   jira: (
-                    <a href={KOGITO_JIRA_LINK} target={"_blank"}>
-                      {KOGITO_JIRA_LINK}
+                    <a href={ISSUES_URL} target={"_blank"}>
+                      {ISSUES_URL}
                     </a>
                   ),
                 }}

--- a/packages/stunner-editors/appformer-bom/pom.xml
+++ b/packages/stunner-editors/appformer-bom/pom.xml
@@ -61,7 +61,7 @@
 
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.redhat.com/browse/KOGITO</url>
+    <url>https://github.com/apache/incubator-kie-issues/issues</url>
   </issueManagement>
 
   <repositories>

--- a/packages/stunner-editors/drools-wb-bom/pom.xml
+++ b/packages/stunner-editors/drools-wb-bom/pom.xml
@@ -61,7 +61,7 @@
 
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.redhat.com/browse/KOGITO</url>
+    <url>https://github.com/apache/incubator-kie-issues/issues</url>
   </issueManagement>
 
   <repositories>

--- a/packages/stunner-editors/kie-wb-common-bom/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-bom/pom.xml
@@ -61,7 +61,7 @@
 
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.redhat.com/browse/KOGITO</url>
+    <url>https://github.com/apache/incubator-kie-issues/issues</url>
   </issueManagement>
 
   <repositories>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -62,7 +62,7 @@
 
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.redhat.com/browse/KOGITO</url>
+    <url>https://github.com/apache/incubator-kie-issues/issues</url>
   </issueManagement>
 
   <repositories>


### PR DESCRIPTION
Some very low-impact changes I did to make the header of Dev deployment DMN Form webapp look a little more polished and updates all the references to the old Jira project to the new https://github.com/apache/incubator-kie-issues/issues.