### PR TITLE
incubator-kie-issues#743: AuthSessions migration scripts can't handle expired auth sessions on KIE Sandbox

### DIFF
--- a/packages/kie-sandbox-fs/src/PromisifiedFS.js
+++ b/packages/kie-sandbox-fs/src/PromisifiedFS.js
@@ -180,6 +180,9 @@ module.exports = class PromisifiedKieSandboxFs {
     }
     await this._activationPromise;
   }
+  async deactivate() {
+    await this._deactivate();
+  }
   async _deactivate() {
     if (this._activationPromise) await this._activationPromise;
 

--- a/packages/kie-sandbox-fs/src/index.js
+++ b/packages/kie-sandbox-fs/src/index.js
@@ -16,6 +16,7 @@ module.exports = class KieSandboxFs {
     this.promises = new PromisifiedKieSandboxFs(...args);
     // Needed so things don't break if you destructure fs and pass individual functions around
     this.init = this.init.bind(this);
+    this.deactivate = this.deactivate.bind(this);
     this.readFile = this.readFile.bind(this);
     this.readFileBulk = this.readFileBulk.bind(this);
     this.writeFile = this.writeFile.bind(this);
@@ -35,6 +36,9 @@ module.exports = class KieSandboxFs {
   }
   init(name, options) {
     return this.promises.init(name, options);
+  }
+  deactivate() {
+    return this.promises.deactivate();
   }
   readFile(filepath, opts, cb) {
     const [resolve, reject] = wrapCallback(opts, cb);

--- a/packages/online-editor/src/accounts/AccountsContext.tsx
+++ b/packages/online-editor/src/accounts/AccountsContext.tsx
@@ -20,7 +20,6 @@
 import * as React from "react";
 import { useCallback, useContext, useReducer } from "react";
 import {
-  AuthProvider,
   AuthProviderGroup,
   GitAuthProvider,
   KubernetesAuthProvider,

--- a/packages/online-editor/src/accounts/git/ConnectToGitSection.tsx
+++ b/packages/online-editor/src/accounts/git/ConnectToGitSection.tsx
@@ -35,7 +35,7 @@ import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancela
 import { AccountsDispatchActionKind, AccountsSection, useAccounts, useAccountsDispatch } from "../AccountsContext";
 import { useAuthSessions, useAuthSessionsDispatch } from "../../authSessions/AuthSessionsContext";
 import { AuthSessionDescriptionList } from "../../authSessions/AuthSessionsList";
-import { AUTH_SESSION_VERSION, GitAuthSession } from "../../authSessions/AuthSessionApi";
+import { AUTH_SESSION_VERSION_NUMBER, GitAuthSession } from "../../authSessions/AuthSessionApi";
 import { PromiseStateStatus, usePromiseState } from "@kie-tools-core/react-hooks/dist/PromiseState";
 import {
   GitAuthProvider,
@@ -145,7 +145,7 @@ export function ConnectToGitSection(props: { authProvider: GitAuthProvider }) {
 
             const newAuthSession: GitAuthSession = {
               id: uuid(),
-              version: AUTH_SESSION_VERSION,
+              version: AUTH_SESSION_VERSION_NUMBER,
               token: tokenInput,
               type: "git",
               login: response.data.login,

--- a/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSection.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSection.tsx
@@ -19,7 +19,6 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { KubernetesInstanceStatus } from "./KubernetesInstanceStatus";
-import { useExtendedServices } from "../../extendedServices/ExtendedServicesContext";
 import { ConnectToKubernetesSimple } from "./ConnectToKubernetesSimple";
 import { AccountsDispatchActionKind, AccountsSection, useAccounts, useAccountsDispatch } from "../AccountsContext";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";

--- a/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSimple.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSimple.tsx
@@ -29,7 +29,11 @@ import { TimesIcon } from "@patternfly/react-icons/dist/js/icons/times-icon";
 import { useOnlineI18n } from "../../i18n";
 import { useAuthSessionsDispatch } from "../../authSessions/AuthSessionsContext";
 import { v4 as uuid } from "uuid";
-import { AUTH_SESSION_VERSION, CloudAuthSessionType, KubernetesAuthSession } from "../../authSessions/AuthSessionApi";
+import {
+  AUTH_SESSION_VERSION_NUMBER,
+  CloudAuthSessionType,
+  KubernetesAuthSession,
+} from "../../authSessions/AuthSessionApi";
 import { KieSandboxKubernetesService } from "../../devDeployments/services/KieSandboxKubernetesService";
 import { KubernetesInstanceStatus } from "./KubernetesInstanceStatus";
 import {
@@ -81,7 +85,7 @@ export function ConnectToKubernetesSimple(props: {
     if (isConnectionEstablished === KubernetesConnectionStatus.CONNECTED && props.kieSandboxKubernetesService) {
       const newAuthSession: KubernetesAuthSession = {
         type: CloudAuthSessionType.Kubernetes,
-        version: AUTH_SESSION_VERSION,
+        version: AUTH_SESSION_VERSION_NUMBER,
         id: uuid(),
         ...props.connection,
         authProviderId: "kubernetes",

--- a/packages/online-editor/src/accounts/kubernetes/ConnectToLocalKubernetesClusterWizard.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToLocalKubernetesClusterWizard.tsx
@@ -33,7 +33,11 @@ import { KubernetesSettingsTabMode } from "./ConnectToKubernetesSection";
 import { KubernetesInstanceStatus } from "./KubernetesInstanceStatus";
 import { v4 as uuid } from "uuid";
 import { useAuthSessionsDispatch } from "../../authSessions/AuthSessionsContext";
-import { AUTH_SESSION_VERSION, CloudAuthSessionType, KubernetesAuthSession } from "../../authSessions/AuthSessionApi";
+import {
+  AUTH_SESSION_VERSION_NUMBER,
+  CloudAuthSessionType,
+  KubernetesAuthSession,
+} from "../../authSessions/AuthSessionApi";
 import {
   KubernetesConnection,
   KubernetesConnectionStatus,
@@ -252,7 +256,7 @@ export function ConnectToLocalKubernetesClusterWizard(props: {
     if (isConnectionEstablished === KubernetesConnectionStatus.CONNECTED && props.kieSandboxKubernetesService) {
       const newAuthSession: KubernetesAuthSession = {
         type: CloudAuthSessionType.Kubernetes,
-        version: AUTH_SESSION_VERSION,
+        version: AUTH_SESSION_VERSION_NUMBER,
         id: uuid(),
         ...props.connection,
         authProviderId: "kubernetes",

--- a/packages/online-editor/src/accounts/openshift/ConnecToOpenShiftSimple.tsx
+++ b/packages/online-editor/src/accounts/openshift/ConnecToOpenShiftSimple.tsx
@@ -34,7 +34,11 @@ import { OpenShiftSettingsTabMode } from "./ConnectToOpenShiftSection";
 import { KieSandboxOpenShiftService } from "../../devDeployments/services/KieSandboxOpenShiftService";
 import { useAuthSessionsDispatch } from "../../authSessions/AuthSessionsContext";
 import { v4 as uuid } from "uuid";
-import { AUTH_SESSION_VERSION, CloudAuthSessionType, OpenShiftAuthSession } from "../../authSessions/AuthSessionApi";
+import {
+  AUTH_SESSION_VERSION_NUMBER,
+  CloudAuthSessionType,
+  OpenShiftAuthSession,
+} from "../../authSessions/AuthSessionApi";
 import {
   KubernetesConnection,
   KubernetesConnectionStatus,
@@ -81,7 +85,7 @@ export function ConnecToOpenShiftSimple(props: {
     if (isConnectionEstablished === KubernetesConnectionStatus.CONNECTED && props.kieSandboxOpenShiftService) {
       const newAuthSession: OpenShiftAuthSession = {
         type: CloudAuthSessionType.OpenShift,
-        version: AUTH_SESSION_VERSION,
+        version: AUTH_SESSION_VERSION_NUMBER,
         id: uuid(),
         ...props.connection,
         authProviderId: "openshift",

--- a/packages/online-editor/src/accounts/openshift/ConnectToDeveloperSandboxForRedHatOpenShiftWizard.tsx
+++ b/packages/online-editor/src/accounts/openshift/ConnectToDeveloperSandboxForRedHatOpenShiftWizard.tsx
@@ -36,7 +36,11 @@ import { OpenShiftInstanceStatus } from "./OpenShiftInstanceStatus";
 import { KieSandboxOpenShiftService } from "../../devDeployments/services/KieSandboxOpenShiftService";
 import { v4 as uuid } from "uuid";
 import { useAuthSessionsDispatch } from "../../authSessions/AuthSessionsContext";
-import { AUTH_SESSION_VERSION, CloudAuthSessionType, OpenShiftAuthSession } from "../../authSessions/AuthSessionApi";
+import {
+  AUTH_SESSION_VERSION_NUMBER,
+  CloudAuthSessionType,
+  OpenShiftAuthSession,
+} from "../../authSessions/AuthSessionApi";
 import {
   KubernetesConnection,
   isHostValid,
@@ -159,7 +163,7 @@ export function ConnectToDeveloperSandboxForRedHatOpenShiftWizard(props: {
     if (isConnectionEstablished === KubernetesConnectionStatus.CONNECTED && props.kieSandboxOpenShiftService) {
       const newAuthSession: OpenShiftAuthSession = {
         type: CloudAuthSessionType.OpenShift,
-        version: AUTH_SESSION_VERSION,
+        version: AUTH_SESSION_VERSION_NUMBER,
         id: uuid(),
         ...props.connection,
         authProviderId: "openshift",

--- a/packages/online-editor/src/accounts/openshift/ConnectToOpenShiftSection.tsx
+++ b/packages/online-editor/src/accounts/openshift/ConnectToOpenShiftSection.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useMemo, useState, useEffect, useCallback } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import { OpenShiftInstanceStatus } from "./OpenShiftInstanceStatus";
 import { KieSandboxOpenShiftService } from "../../devDeployments/services/KieSandboxOpenShiftService";
 import { ConnecToOpenShiftSimple } from "./ConnecToOpenShiftSimple";

--- a/packages/online-editor/src/authSessions/AuthSessionApi.ts
+++ b/packages/online-editor/src/authSessions/AuthSessionApi.ts
@@ -18,15 +18,43 @@
  */
 
 import { K8sApiServerEndpointByResourceKind } from "@kie-tools-core/k8s-yaml-to-apiserver-requests/dist";
+import { LfsFsCache } from "@kie-tools-core/workspaces-git-fs/dist/lfs/LfsFsCache";
+import { LfsStorageService } from "@kie-tools-core/workspaces-git-fs/dist/lfs/LfsStorageService";
 
-export const AUTH_SESSION_VERSION = 1;
+export const authSessionFsCache = new LfsFsCache();
+export const authSessionFsService = new LfsStorageService();
+export const authSessionBroadcastChannel = new BroadcastChannel("auth_sessions");
+
+export const AUTH_SESSIONS_FILE_PATH = "/authSessions.json";
+export const AUTH_SESSIONS_FS_NAME = "auth_sessions";
+export const AUTH_SESSION_VERSION_NUMBER = 1;
+export const AUTH_SESSIONS_FS_NAME_WITH_VERSION = `${AUTH_SESSIONS_FS_NAME}_v${AUTH_SESSION_VERSION_NUMBER.toString()}`;
+
+export function mapSerializer(_: string, value: any) {
+  if (value instanceof Map) {
+    return {
+      __$$jsClassName: "Map",
+      value: Array.from(value.entries()),
+    };
+  }
+  return value;
+}
+
+export function mapDeSerializer(_: string, value: any) {
+  if (typeof value === "object" && value) {
+    if (value.__$$jsClassName === "Map") {
+      return new Map(value.value);
+    }
+  }
+  return value;
+}
 
 export const AUTH_SESSION_NONE = {
   id: "none",
   name: "Unauthenticated",
   type: "none",
   login: "Unauthenticated",
-  version: AUTH_SESSION_VERSION,
+  version: AUTH_SESSION_VERSION_NUMBER,
 } as const;
 
 export type NoneAuthSession = typeof AUTH_SESSION_NONE;

--- a/packages/online-editor/src/authSessions/AuthSessionsContext.tsx
+++ b/packages/online-editor/src/authSessions/AuthSessionsContext.tsx
@@ -42,11 +42,7 @@ import { switchExpression } from "../switchExpression/switchExpression";
 import { KubernetesConnectionStatus } from "@kie-tools-core/kubernetes-bridge/dist/service";
 import { useEnv } from "../env/hooks/EnvContext";
 import { KieSandboxKubernetesService } from "../devDeployments/services/KieSandboxKubernetesService";
-import {
-  applyAuthSessionMigrations,
-  deleteOlderAuthSessionsStorage,
-  migrateAuthSessions,
-} from "./AuthSessionMigrations";
+import { deleteOlderAuthSessionsStorage, migrateAuthSessions } from "./AuthSessionMigrations";
 
 export type AuthSessionsContextType = {
   authSessions: Map<string, AuthSession>;
@@ -73,8 +69,10 @@ export function useAuthSessionsDispatch() {
 export function AuthSessionsContextProvider(props: PropsWithChildren<{}>) {
   const authProviders = useAuthProviders();
   const { env } = useEnv();
-  const [authSessions, setAuthSessions] = useState<Map<string, AuthSession>>();
-  const [authSessionStatus, setAuthSessionStatus] = useState<Map<string, AuthSessionStatus>>();
+  const [authSessions, setAuthSessions] = useState<Map<string, AuthSession>>(new Map<string, AuthSession>());
+  const [authSessionStatus, setAuthSessionStatus] = useState<Map<string, AuthSessionStatus>>(
+    new Map<string, AuthSessionStatus>()
+  );
 
   const getAuthSessionsFromFile = useCallback(async () => {
     const fs = authSessionFsCache.getOrCreateFs(AUTH_SESSIONS_FS_NAME_WITH_VERSION);
@@ -138,7 +136,6 @@ export function AuthSessionsContextProvider(props: PropsWithChildren<{}>) {
     useCallback(
       ({ canceled }) => {
         const run = async () => {
-          console.log("running migrations");
           const migratedAuthSessions = await migrateAuthSessions();
           if (canceled.get()) {
             return;
@@ -242,7 +239,7 @@ export function AuthSessionsContextProvider(props: PropsWithChildren<{}>) {
   }, [add, remove, recalculateAuthSessionStatus]);
 
   const value = useMemo(() => {
-    return authSessions && authSessionStatus ? { authSessions, authSessionStatus } : undefined;
+    return { authSessions, authSessionStatus };
   }, [authSessionStatus, authSessions]);
 
   return (


### PR DESCRIPTION
Fixes:
- Try/catch for failed migration attempts (the failing auth sessions are removed, probably because they were expired);
- Using useCancelableEffect for the init effect on the AuthSessionContextProvider.

Improvements:
- Added the version number to the indexedDb storage to avoid conflicts and enable users to move between versions of KIE Sandbox;
- Cleanup of old auth sessions from storage;
- Unblock rendering the rest of the app during migration execution.