### PR TITLE
NO-ISSUE: Disable Buildkite upload on Jenkins job

### DIFF
--- a/.ci/jenkins/ci-jobs/Jenkinsfile.ci-build
+++ b/.ci/jenkins/ci-jobs/Jenkinsfile.ci-build
@@ -30,6 +30,7 @@ pipeline {
         END_TO_END_TESTS_REPORTS_PATTERNS = 'kie-tools/packages/**/dist-e2e-tests/junit-report*.xml kie-tools/examples/**/dist-e2e-tests/junit-report*.xml kie-tools/packages/**/target/failsafe-reports/TEST-*.xml kie-tools/examples/**/target/failsafe-reports/TEST-*.xml'
         END_TO_END_TESTS_ARTIFACTS_PATTERNS = 'kie-tools/packages/**/dist-e2e-tests kie-tools/examples/**/dist-e2e-tests'
         BUILD_ARTIFACTS_PATTERNS = 'kie-tools/packages/**/dist kie-tools/examples/**/dist'
+        ENABLE_BUILD_KITE = 'false'
     }
 
     stages {

--- a/.ci/jenkins/ci-jobs/Jenkinsfile.ci-build
+++ b/.ci/jenkins/ci-jobs/Jenkinsfile.ci-build
@@ -30,7 +30,7 @@ pipeline {
         END_TO_END_TESTS_REPORTS_PATTERNS = 'kie-tools/packages/**/dist-e2e-tests/junit-report*.xml kie-tools/examples/**/dist-e2e-tests/junit-report*.xml kie-tools/packages/**/target/failsafe-reports/TEST-*.xml kie-tools/examples/**/target/failsafe-reports/TEST-*.xml'
         END_TO_END_TESTS_ARTIFACTS_PATTERNS = 'kie-tools/packages/**/dist-e2e-tests kie-tools/examples/**/dist-e2e-tests'
         BUILD_ARTIFACTS_PATTERNS = 'kie-tools/packages/**/dist kie-tools/examples/**/dist'
-        ENABLE_BUILD_KITE = 'false'
+        ENABLE_BUILDKITE = 'false'
     }
 
     stages {
@@ -151,7 +151,7 @@ pipeline {
 
                 stage('Upload end-to-end tests results to Buildkite (`main` only)') {
                     when {
-                        expression { !env.CHANGE_ID && env.BRANCH_NAME == 'main' }
+                        expression { !env.CHANGE_ID && env.BRANCH_NAME == 'main' && env.ENABLE_BUILDKITE == 'true' }
                     }
                     steps {
                         dir('kie-tools') {


### PR DESCRIPTION
Let's disable the upload of test results to Buildkite on the CI build Jenkins job as we are already doing it on Github workflows.