### PR TITLE
kie-issues#129: Import private repository into sandbox via chrome-extension [backend-part]

### DIFF
--- a/packages/online-editor/src/importFromUrl/NewWorkspaceFromUrlPage.tsx
+++ b/packages/online-editor/src/importFromUrl/NewWorkspaceFromUrlPage.tsx
@@ -75,8 +75,7 @@ export function NewWorkspaceFromUrlPage() {
 
   const authProviders = useAuthProviders();
   const { authSessions, authSessionStatus } = useAuthSessions();
-  const authSessionInfo = useAuthSession(queryParamAuthSessionId);
-  const { authSession, gitConfig, authInfo } = authSessionInfo;
+  const { authSession, gitConfig, authInfo } = useAuthSession(queryParamAuthSessionId);
   const authProvider = useAuthProvider(authSession);
   const insecurelyDisableTlsCertificateValidation = useMemo(() => {
     if (typeof queryParamInsecurelyDisableTlsCertificateValidation === "string") {


### PR DESCRIPTION
Related to https://github.com/apache/incubator-kie-issues/issues/129

This PR doesn't not fix completely https://github.com/apache/incubator-kie-issues/issues/129 as it is split into two problems:
- importing private repository via chrome extension
- displaying `Open in Sandbox` button in the chrome extension

This PR solves only the first 'backend' issue, importing a private repository. If there is a compatible session configured in sandbox, this PR tries to use that one for importing automatically.