### PR TITLE
kie-issues#2091: Subflow support on CLI

### DIFF
--- a/packages/kn-plugin-workflow/e2e-tests/create_test.go
+++ b/packages/kn-plugin-workflow/e2e-tests/create_test.go
@@ -93,7 +93,7 @@ func RunCreateTest(t *testing.T, test CfgTestInputCreate) string {
 	VerifyFilesExist(t, projectDir, expectedFiles)
 
 	// Verify the content of the file `workflow.sw.json`
-	workflowFileData, err := common.GetWorkflowTemplate()
+	workflowFileData, err := common.GetWorkflowTemplate(false)
 	expectedFileContent := string(workflowFileData)
 	VerifyFileContent(t, filepath.Join(projectDir, "workflow.sw.json"), expectedFileContent)
 

--- a/packages/kn-plugin-workflow/e2e-tests/quarkus_convert_test.go
+++ b/packages/kn-plugin-workflow/e2e-tests/quarkus_convert_test.go
@@ -143,7 +143,7 @@ func RunQuarkusConvertTest(t *testing.T, cfgTestInputCreateConvert CfgTestInputC
 
 	// Verify the content of the file `workflow.sw.json`
 	workflowFilePath := filepath.Join(projectDir, "src/main/resources/workflow.sw.json")
-	workflowFileData, err := common.GetWorkflowTemplate()
+	workflowFileData, err := common.GetWorkflowTemplate(false)
 	require.NoErrorf(t, err, "Error reading workflow template: %v", err)
 	expectedFileContent := string(workflowFileData)
 	VerifyFileContent(t, workflowFilePath, expectedFileContent)

--- a/packages/kn-plugin-workflow/e2e-tests/quarkus_create_test.go
+++ b/packages/kn-plugin-workflow/e2e-tests/quarkus_create_test.go
@@ -145,7 +145,7 @@ func RunQuarkusCreateTest(t *testing.T, test CfgTestInputQuarkusCreate) string {
 
 	// Verify the content of the file `workflow.sw.json`
 	workflowFilePath := filepath.Join(projectDir, "src/main/resources/workflow.sw.json")
-	workflowFileData, err := common.GetWorkflowTemplate()
+	workflowFileData, err := common.GetWorkflowTemplate(false)
 	require.NoErrorf(t, err, "Error reading workflow template: %v", err)
 	expectedFileContent := string(workflowFileData)
 	VerifyFileContent(t, workflowFilePath, expectedFileContent)

--- a/packages/kn-plugin-workflow/env/index.js
+++ b/packages/kn-plugin-workflow/env/index.js
@@ -39,12 +39,12 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
     },
     KN_PLUGIN_WORKFLOW__devModeImage: {
       name: "KN_PLUGIN_WORKFLOW__devModeImage",
-      default: "quay.io/kiegroup/kogito-swf-devmode:1.42",
+      default: "quay.io/kiegroup/kogito-swf-devmode:1.44",
       description: "SonataFlow dev mode image (used on cli run)",
     },
     KN_PLUGIN_WORKFLOW__kogitoVersion: {
       name: "KN_PLUGIN_WORKFLOW__kogitoVersion",
-      default: "1.42.0.Final",
+      default: "1.44.1.Final",
       description: "Kogito version to be used when creating and converting to Quarkus Projects",
     },
   }),

--- a/packages/kn-plugin-workflow/env/index.js
+++ b/packages/kn-plugin-workflow/env/index.js
@@ -34,7 +34,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
     },
     KN_PLUGIN_WORKFLOW__quarkusVersion: {
       name: "KN_PLUGIN_WORKFLOW__quarkusVersion",
-      default: "2.16.9.Final",
+      default: "2.16.10.Final",
       description: "Quarkus version to be used when creating the SonataFlow project",
     },
     KN_PLUGIN_WORKFLOW__devModeImage: {

--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -65,7 +65,7 @@ func NewCreateCommand() *cobra.Command {
 	# Create a project with an specific name
 	{{.Name}} create --name myproject
 
-	# Creates a YAML sample workflow file (json is default)
+	# Creates a YAML sample workflow file (JSON is default)
 	{{.Name}} create --yaml-workflow
 		`,
 		SuggestFor: []string{"vreate", "creaet", "craete", "new"}, //nolint:misspell

--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -54,7 +54,7 @@ func NewCreateCommand() *cobra.Command {
 		/specs (optional)
 		/schemas (optional)
 		/subflows (optional)
-		workflow.json|yaml (mandatory)
+		workflow.sw.{json|yaml|yml} (mandatory)
 
 	`,
 		Example: `

--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -46,7 +46,7 @@ func NewCreateCommand() *cobra.Command {
 	Additionally, you can define the configurable parameters of your application in the 
 	"application.properties" file (inside the root project directory).
 	You can also store your spec files (i.e., Open API files) inside the "specs" folder,
-	schemas file inside "schema" folder and also subflows (inside subflows folder).
+	schemas file inside "schemas" folder and also subflows inside "subflows" folder.
 
 	A SonataFlow project, as the following structure by default:
 

--- a/packages/kn-plugin-workflow/pkg/command/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/create.go
@@ -30,6 +30,7 @@ import (
 
 type CreateCmdConfig struct {
 	ProjectName string
+	YAML        bool
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -43,8 +44,18 @@ func NewCreateCommand() *cobra.Command {
 	Workflow file definition.
 
 	Additionally, you can define the configurable parameters of your application in the 
-	"application.properties" file (inside the root directory). 
-	You can also store your spec files (i.e., Open API files) inside the "specs" folder.
+	"application.properties" file (inside the root project directory).
+	You can also store your spec files (i.e., Open API files) inside the "specs" folder,
+	schemas file inside "schema" folder and also subflows (inside subflows folder).
+
+	A SonataFlow project, as the following structure by default:
+
+	Workflow project root
+		/specs (optional)
+		/schemas (optional)
+		/subflows (optional)
+		workflow.json|yaml (mandatory)
+
 	`,
 		Example: `
 	# Create a project in the local directory
@@ -53,9 +64,12 @@ func NewCreateCommand() *cobra.Command {
 
 	# Create a project with an specific name
 	{{.Name}} create --name myproject
+
+	# Creates a YAML sample workflow file (json is default)
+	{{.Name}} create --yaml-workflow
 		`,
-		SuggestFor: []string{"vreate", "creaet", "craete", "new"},
-		PreRunE:    common.BindEnv("name"),
+		SuggestFor: []string{"vreate", "creaet", "craete", "new"}, //nolint:misspell
+		PreRunE:    common.BindEnv("name", "yaml-workflow"),
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -67,6 +81,7 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("name", "n", "new-project", "Project name created in the current directory.")
+	cmd.Flags().Bool("yaml-workflow", false, "Create a sample YAML workflow file.")
 	cmd.SetHelpFunc(common.DefaultTemplatedHelp)
 
 	return cmd
@@ -79,8 +94,15 @@ func runCreate(cfg CreateCmdConfig) error {
 		return fmt.Errorf("❌ ERROR: Error creating project directory: %w", err)
 	}
 
-	workflowPath := fmt.Sprintf("./%s/%s", cfg.ProjectName, metadata.WorkflowSwJson)
-	if err := common.CreateWorkflow(workflowPath); err != nil {
+	var workflowFormat string
+	if cfg.YAML {
+		workflowFormat = metadata.WorkflowSwYaml
+	} else {
+		workflowFormat = metadata.WorkflowSwJson
+	}
+
+	workflowPath := fmt.Sprintf("./%s/%s", cfg.ProjectName, workflowFormat)
+	if err := common.CreateWorkflow(workflowPath, cfg.YAML); err != nil {
 		return fmt.Errorf("❌ ERROR: Error creating workflow file: %w", err)
 	}
 
@@ -94,6 +116,7 @@ func runCreateCmdConfig() (cfg CreateCmdConfig, err error) {
 
 	cfg = CreateCmdConfig{
 		ProjectName: viper.GetString("name"),
+		YAML:        viper.GetBool("yaml-workflow"),
 	}
 	return cfg, nil
 }

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -35,20 +35,35 @@ func NewDeployCommand() *cobra.Command {
 		Use:   "deploy",
 		Short: "Deploy a SonataFlow project on Kubernetes via SonataFlow Operator",
 		Long: `
-	Deploy a SonataFlow project in Kubernetes via the SonataFlow Operator. 
+	Deploy a SonataFlow project in Kubernetes via the SonataFlow Operator.
+	By default, the deploy command will generate the Operator manifests and apply them to the cluster.
+	You can also provide a custom manifest directory with the --custom-manifests-dir option.
 	`,
 		Example: `
 	# Deploy the workflow project from the current directory's project. 
 	# You must provide target namespace.
 	{{.Name}} deploy --namespace <your_namespace>
+
 	# Persist the generated Operator manifests on a given path and deploy the 
 	# workflow from the current directory's project. 
-	{{.Name}} deploy --manifestPath=<full_directory_path>
-    # Specify a custom support files folder. 
-	{{.Name}} deploy --supportFiles=<full_directory_path>
+	{{.Name}} deploy --custom-generated-manifests-dir=<full_directory_path>
+
+	# Specify a custom manifest files directory.
+	# This option *will not* automatically generate the manifest files, but will use the existing ones.
+	{{.Name}} deploy --custom-manifests-dir=<full_directory_path>
+
+	# Specify a custom subflows files directory. (default: ./subflows)
+	{{.Name}} deploy --subflows-dir=<full_directory_path>
+
+	# Specify a custom support specs directory. (default: ./specs)
+	{{.Name}} deploy --specs-dir=<full_directory_path>
+
+	# Specify a custom support schemas directory. (default: ./schemas)
+	{{.Name}} deploy --schemas-dir=<full_directory_path>
+
 		`,
 
-		PreRunE:    common.BindEnv("namespace", "manifestPath", "supportFilesFolder"),
+		PreRunE:    common.BindEnv("namespace", "custom-manifests-dir", "custom-generated-manifests-dir", "specs-dir", "schemas-dir", "subflows-dir"),
 		SuggestFor: []string{"delpoy", "deplyo"},
 	}
 
@@ -57,8 +72,11 @@ func NewDeployCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("namespace", "n", "", "Target namespace of your deployment.")
-	cmd.Flags().StringP("manifestPath", "c", "", "Target directory of your generated Operator manifests.")
-	cmd.Flags().StringP("supportFilesFolder", "s", "", "Specify a custom support files folder")
+	cmd.Flags().StringP("custom-generated-manifests-dir", "c", "", "Target directory of your generated Operator manifests.")
+	cmd.Flags().StringP("custom-manifests-dir", "m", "", "Specify a custom manifest files directory. This option will not automatically generate the manifest files, but will use the existing ones.")
+	cmd.Flags().StringP("specs-dir", "p", "", "Specify a custom specs files directory")
+	cmd.Flags().StringP("subflows-dir", "s", "", "Specify a custom subflows files directory")
+	cmd.Flags().StringP("schemas-dir", "t", "", "Specify a custom schemas files directory")
 
 	cmd.SetHelpFunc(common.DefaultTemplatedHelp)
 
@@ -87,8 +105,12 @@ func runDeployUndeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("❌ ERROR: checking deploy environment: %w", err)
 	}
 
-	if err := generateManifests(&cfg); err != nil {
-		return fmt.Errorf("❌ ERROR: generating deploy environment: %w", err)
+	if len(cfg.CustomManifestsFileDir) == 0 {
+		if err := generateManifests(&cfg); err != nil {
+			return fmt.Errorf("❌ ERROR: generating deploy environment: %w", err)
+		}
+	} else {
+		fmt.Printf("🛠 Using manifests located at %s\n", cfg.CustomManifestsFileDir)
 	}
 
 	if err = deploy(&cfg); err != nil {
@@ -105,7 +127,12 @@ func deploy(cfg *DeployUndeployCmdConfig) error {
 
 	manifestExtension := []string{".yaml"}
 
-	files, err := common.FindFilesWithExtensions(cfg.ManifestPath, manifestExtension)
+	manifestPath := cfg.CustomGeneratedManifestDir
+	if len(cfg.CustomManifestsFileDir) != 0 {
+		manifestPath = cfg.CustomManifestsFileDir
+	}
+
+	files, err := common.FindFilesWithExtensions(manifestPath, manifestExtension)
 	if err != nil {
 		return fmt.Errorf("❌ ERROR: failed to get manifest directory and files: %w", err)
 	}
@@ -122,18 +149,38 @@ func deploy(cfg *DeployUndeployCmdConfig) error {
 func runDeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err error) {
 
 	cfg = DeployUndeployCmdConfig{
-		NameSpace:         viper.GetString("namespace"),
-		SupportFileFolder: viper.GetString("supportFilesFolder"),
-		ManifestPath:      viper.GetString("manifestPath"),
+		NameSpace:                  viper.GetString("namespace"),
+		CustomManifestsFileDir:     viper.GetString("custom-manifests-dir"),
+		CustomGeneratedManifestDir: viper.GetString("custom-generated-manifests-dir"),
+		SpecsDir:                   viper.GetString("specs-dir"),
+		SchemasDir:                 viper.GetString("schemas-dir"),
+		SubflowsDir:                viper.GetString("subflows-dir"),
 	}
 
-	if len(cfg.SupportFileFolder) == 0 {
+	if len(cfg.SubflowsDir) == 0 {
 		dir, err := os.Getwd()
-		cfg.SupportFileFolder = dir + "/specs"
+		cfg.SubflowsDir = dir + "/subflows"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default subflows workflow files folder: %w", err)
+		}
+	}
+
+	if len(cfg.SpecsDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SpecsDir = dir + "/specs"
 		if err != nil {
 			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
 		}
 	}
+
+	if len(cfg.SchemasDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SchemasDir = dir + "/schemas"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+		}
+	}
+
 	dir, err := os.Getwd()
 	cfg.DefaultDashboardsFolder = dir + "/" + metadata.DashboardsDefaultDirName
 	if err != nil {

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -169,7 +169,7 @@ func runDeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err er
 		dir, err := os.Getwd()
 		cfg.SpecsDir = dir + "/specs"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default specs files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -177,7 +177,7 @@ func runDeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err er
 		dir, err := os.Getwd()
 		cfg.SchemasDir = dir + "/schemas"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default schemas files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/deploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy.go
@@ -125,7 +125,7 @@ func runDeployUndeploy(cmd *cobra.Command, args []string) error {
 func deploy(cfg *DeployUndeployCmdConfig) error {
 	fmt.Printf("🛠 Deploying your SonataFlow project in namespace %s\n", cfg.NameSpace)
 
-	manifestExtension := []string{".yaml"}
+	manifestExtension := []string{metadata.YAMLExtension}
 
 	manifestPath := cfg.CustomGeneratedManifestDir
 	if len(cfg.CustomManifestsFileDir) != 0 {

--- a/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
@@ -29,16 +29,21 @@ import (
 )
 
 type DeployUndeployCmdConfig struct {
-	NameSpace                 string
-	KubectlContext            string
-	SonataFlowFile            string
-	ManifestPath              string
-	TempDir                   string
-	ApplicationPropertiesPath string
-	SupportFileFolder         string
-	DefaultDashboardsFolder   string
-	SupportFilesPath          []string
-	DashboardsPath            []string
+	NameSpace                  string
+	KubectlContext             string
+	SonataFlowFile             string
+	CustomGeneratedManifestDir string
+	TempDir                    string
+	ApplicationPropertiesPath  string
+	SubflowsDir                string
+	SpecsDir                   string
+	SchemasDir                 string
+	CustomManifestsFileDir     string
+	DefaultDashboardsFolder    string
+	SchemasFilesPath           []string
+	SpecsFilesPath             []string
+	SubFlowsFilesPath          []string
+	DashboardsPath             []string
 }
 
 func checkEnvironment(cfg *DeployUndeployCmdConfig) error {
@@ -75,21 +80,37 @@ func checkEnvironment(cfg *DeployUndeployCmdConfig) error {
 }
 
 func generateManifests(cfg *DeployUndeployCmdConfig) error {
+
+	workflowExtensionsType := []string{metadata.YAMLSWExtension, metadata.YMLSWExtensionShort, metadata.JSONSWExtension}
+
 	fmt.Println("\n🛠️  Generating your manifests...")
+
 	fmt.Println("🔍 Looking for your SonataFlow files...")
-	if file, err := findSonataFlowFile(); err != nil {
+	if file, err := findSonataFlowFile(workflowExtensionsType); err != nil {
 		return err
 	} else {
 		cfg.SonataFlowFile = file
 	}
 	fmt.Printf(" - ✅ SonataFlow file found: %s\n", cfg.SonataFlowFile)
 
-	fmt.Println("🔍 Looking for your configuration support files...")
+	fmt.Println("🔍 Looking for your SonataFlow sub flows...")
+	files, err := common.FindFilesWithExtensions(cfg.SubflowsDir, workflowExtensionsType)
+	if err != nil {
+		return fmt.Errorf("❌ ERROR: failed to get subflows directory: %w", err)
+	}
+	cfg.SubFlowsFilesPath = files
+	for _, file := range cfg.SubFlowsFilesPath {
+		fmt.Printf(" - ✅ SonataFlow subflows found: %s\n", file)
+	}
+
+	fmt.Println("🔍 Looking for your workflow support files...")
 
 	dir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("❌ ERROR: failed to get current directory: %w", err)
 	}
+
+	fmt.Println("🔍 Looking for properties files...")
 
 	applicationPropertiesPath := findApplicationPropertiesPath(dir)
 	if applicationPropertiesPath != "" {
@@ -97,20 +118,33 @@ func generateManifests(cfg *DeployUndeployCmdConfig) error {
 		fmt.Printf(" - ✅ Properties file found: %s\n", cfg.ApplicationPropertiesPath)
 	}
 
-	supportFileExtensions := []string{".json", ".yaml", ".yml"}
+	supportFileExtensions := []string{metadata.JSONExtension, metadata.YAMLSWExtension, metadata.YMLExtension}
 
-	files, err := common.FindFilesWithExtensions(cfg.SupportFileFolder, supportFileExtensions)
+	fmt.Println("🔍 Looking for specs files...")
+
+	files, err = common.FindFilesWithExtensions(cfg.SpecsDir, supportFileExtensions)
 	if err != nil {
 		return fmt.Errorf("❌ ERROR: failed to get supportFiles directory: %w", err)
 	}
-	cfg.SupportFilesPath = files
-	for _, file := range cfg.SupportFilesPath {
-		fmt.Printf(" - ✅ Support file found: %s\n", file)
+	cfg.SpecsFilesPath = files
+	for _, file := range cfg.SpecsFilesPath {
+		fmt.Printf(" - ✅ Specs file found: %s\n", file)
+	}
+
+	fmt.Println("🔍 Looking for schema files...")
+	fmt.Println(cfg.SchemasDir)
+	files, err = common.FindFilesWithExtensions(cfg.SchemasDir, supportFileExtensions)
+	if err != nil {
+		return fmt.Errorf("❌ ERROR: failed to get supportFiles directory: %w", err)
+	}
+	cfg.SchemasFilesPath = files
+	for _, file := range cfg.SchemasFilesPath {
+		fmt.Printf(" - ✅ Schemas file found: %s\n", file)
 	}
 
 	fmt.Println("🔍 Looking for your dashboard files...")
 
-	dashboardExtensions := []string{".yaml", ".yml"}
+	dashboardExtensions := []string{metadata.YAMLExtension, metadata.YMLExtension}
 
 	files, err = common.FindFilesWithExtensions(cfg.DefaultDashboardsFolder, dashboardExtensions)
 	if err != nil {
@@ -137,7 +171,23 @@ func generateManifests(cfg *DeployUndeployCmdConfig) error {
 		handler.WithAppProperties(appIO)
 	}
 
-	for _, supportFile := range cfg.SupportFilesPath {
+	for _, subflow := range cfg.SubFlowsFilesPath {
+		specIO, err := common.MustGetFile(subflow)
+		if err != nil {
+			return err
+		}
+		handler.AddResource(filepath.Base(subflow), specIO)
+	}
+
+	for _, supportFile := range cfg.SchemasFilesPath {
+		specIO, err := common.MustGetFile(supportFile)
+		if err != nil {
+			return err
+		}
+		handler.AddResource(filepath.Base(supportFile), specIO)
+	}
+
+	for _, supportFile := range cfg.SpecsFilesPath {
 		specIO, err := common.MustGetFile(supportFile)
 		if err != nil {
 			return err
@@ -158,7 +208,7 @@ func generateManifests(cfg *DeployUndeployCmdConfig) error {
 		return err
 	}
 
-	err = handler.SaveAsKubernetesManifests(cfg.ManifestPath)
+	err = handler.SaveAsKubernetesManifests(cfg.CustomGeneratedManifestDir)
 	if err != nil {
 		return err
 	}
@@ -177,8 +227,7 @@ func findApplicationPropertiesPath(directoryPath string) string {
 	return filePath
 }
 
-func findSonataFlowFile() (string, error) {
-	extensions := []string{metadata.YAMLExtension, metadata.YAMLExtensionShort, metadata.JSONExtension}
+func findSonataFlowFile(extensions []string) (string, error) {
 
 	dir, err := os.Getwd()
 	if err != nil {
@@ -203,17 +252,17 @@ func findSonataFlowFile() (string, error) {
 
 func setupConfigManifestPath(cfg *DeployUndeployCmdConfig) error {
 
-	if len(cfg.ManifestPath) == 0 {
+	if len(cfg.CustomGeneratedManifestDir) == 0 {
 		tempDir, err := os.MkdirTemp("", "manifests")
 		if err != nil {
 			return fmt.Errorf("❌ ERROR: failed to create temporary directory: %w", err)
 		}
-		cfg.ManifestPath = tempDir
+		cfg.CustomGeneratedManifestDir = tempDir
 		cfg.TempDir = tempDir
 	} else {
-		_, err := os.Stat(cfg.ManifestPath)
+		_, err := os.Stat(cfg.CustomGeneratedManifestDir)
 		if err != nil {
-			return fmt.Errorf("❌ ERROR: cannot find or open directory %s : %w", cfg.ManifestPath, err)
+			return fmt.Errorf("❌ ERROR: cannot find or open directory %s : %w", cfg.CustomGeneratedManifestDir, err)
 		}
 	}
 	return nil

--- a/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
@@ -118,7 +118,7 @@ func generateManifests(cfg *DeployUndeployCmdConfig) error {
 		fmt.Printf(" - ✅ Properties file found: %s\n", cfg.ApplicationPropertiesPath)
 	}
 
-	supportFileExtensions := []string{metadata.JSONExtension, metadata.YAMLSWExtension, metadata.YMLExtension}
+	supportFileExtensions := []string{metadata.JSONExtension, metadata.YAMLExtension, metadata.YMLExtension}
 
 	fmt.Println("🔍 Looking for specs files...")
 

--- a/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
+++ b/packages/kn-plugin-workflow/pkg/command/deploy_undeploy_common.go
@@ -81,7 +81,7 @@ func checkEnvironment(cfg *DeployUndeployCmdConfig) error {
 
 func generateManifests(cfg *DeployUndeployCmdConfig) error {
 
-	workflowExtensionsType := []string{metadata.YAMLSWExtension, metadata.YMLSWExtensionShort, metadata.JSONSWExtension}
+	workflowExtensionsType := []string{metadata.YAMLSWExtension, metadata.YMLSWExtension, metadata.JSONSWExtension}
 
 	fmt.Println("\n🛠️  Generating your manifests...")
 

--- a/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
+++ b/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
@@ -127,7 +127,7 @@ func runGenManifestCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, e
 		dir, err := os.Getwd()
 		cfg.SchemasDir = dir + "/schemas"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support schemas files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
+++ b/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
@@ -119,7 +119,7 @@ func runGenManifestCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, e
 		dir, err := os.Getwd()
 		cfg.SpecsDir = dir + "/specs"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support specs files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
+++ b/packages/kn-plugin-workflow/pkg/command/gen_manifest.go
@@ -36,17 +36,26 @@ func NewGenManifest() *cobra.Command {
 		Long: `
 	Generate a list of Operator manifests for a SonataFlow project.
 	By default, the manifests are generated in the ./manifests directory,
-	but they can be configured by --manifestPath flag.
+	but they can be configured by --custom-generated-manifest-dir flag.
 		 `,
 		Example: `
-	# Persist the generated Operator manifests on a default path (./manifests)
+	# Persist the generated Operator manifests on a default path (default ./manifests)
 	{{.Name}} gen-manifest
-	# Persist the generated Operator manifests on a specific path 
-	{{.Name}} gen-manifest --manifestPath=<full_directory_path>
-	# Specify a custom support files folder. 
-	{{.Name}} gen-manifest --supportFilesFolder=<full_directory_path>
+
+	# Persist the generated Operator manifests on a specific custom path
+	{{.Name}} gen-manifest --custom-generated-manifest-dir=<full_directory_path>
+
+	# Specify a custom subflows files directory. (default: ./subflows)
+	{{.Name}} gen-manifest --subflows-dir=<full_directory_path>
+
+	# Specify a custom support specs directory. (default: ./specs)
+	{{.Name}} gen-manifest --specs-dir=<full_directory_path>
+
+	# Specify a custom support schemas directory. (default: ./schemas)
+	{{.Name}} gen-manifest --schemas-dir=<full_directory_path>
+
 			 `,
-		PreRunE:    common.BindEnv("namespace", "manifestPath", "supportFilesFolder"),
+		PreRunE:    common.BindEnv("namespace", "custom-generated-manifests-dir", "specs-dir", "schemas-dir", "subflows-dir"),
 		SuggestFor: []string{"gen-manifests", "generate-manifest"}, //nolint:misspell
 	}
 
@@ -55,8 +64,10 @@ func NewGenManifest() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("namespace", "n", "", "Target namespace of your deployment.")
-	cmd.Flags().StringP("manifestPath", "c", "", "Target directory of your generated Operator manifests.")
-	cmd.Flags().StringP("supportFilesFolder", "s", "", "Specify a custom support files folder")
+	cmd.Flags().StringP("custom-generated-manifests-dir", "c", "", "Target directory of your generated Operator manifests.")
+	cmd.Flags().StringP("specs-dir", "p", "", "Specify a custom specs files directory")
+	cmd.Flags().StringP("subflows-dir", "s", "", "Specify a custom subflows files directory")
+	cmd.Flags().StringP("schemas-dir", "t", "", "Specify a custom schemas files directory")
 
 	cmd.SetHelpFunc(common.DefaultTemplatedHelp)
 
@@ -71,7 +82,7 @@ func generateManifestsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("🛠️️ Generating a list of Operator manifests for a SonataFlow project...")
-	fmt.Printf("📂 Manifests will be generated in %s\n", cfg.ManifestPath)
+	fmt.Printf("📂 Manifests will be generated in %s\n", cfg.CustomGeneratedManifestDir)
 
 	if err := setupEnvironment(&cfg); err != nil {
 		return fmt.Errorf("❌ ERROR: setup environment: %w", err)
@@ -89,18 +100,37 @@ func generateManifestsCmd(cmd *cobra.Command, args []string) error {
 func runGenManifestCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err error) {
 
 	cfg = DeployUndeployCmdConfig{
-		NameSpace:         viper.GetString("namespace"),
-		SupportFileFolder: viper.GetString("supportFilesFolder"),
-		ManifestPath:      viper.GetString("manifestPath"),
+		NameSpace:                  viper.GetString("namespace"),
+		SpecsDir:                   viper.GetString("specs-dir"),
+		SchemasDir:                 viper.GetString("schemas-dir"),
+		SubflowsDir:                viper.GetString("subflows-dir"),
+		CustomGeneratedManifestDir: viper.GetString("custom-generated-manifests-dir"),
 	}
 
-	if len(cfg.SupportFileFolder) == 0 {
+	if len(cfg.SubflowsDir) == 0 {
 		dir, err := os.Getwd()
-		cfg.SupportFileFolder = dir + "/specs"
+		cfg.SubflowsDir = dir + "/subflows"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default subflows workflow files folder: %w", err)
+		}
+	}
+
+	if len(cfg.SpecsDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SpecsDir = dir + "/specs"
 		if err != nil {
 			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
 		}
 	}
+
+	if len(cfg.SchemasDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SchemasDir = dir + "/schemas"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+		}
+	}
+
 	dir, err := os.Getwd()
 	cfg.DefaultDashboardsFolder = dir + "/" + metadata.DashboardsDefaultDirName
 	if err != nil {
@@ -108,11 +138,11 @@ func runGenManifestCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, e
 	}
 
 	//setup manifest path
-	manifestDir, err := resolveManifestDir(cfg.ManifestPath)
+	manifestDir, err := resolveManifestDir(cfg.CustomGeneratedManifestDir)
 	if err != nil {
 		return cfg, fmt.Errorf("❌ ERROR: failed to get manifest directory: %w", err)
 	}
-	cfg.ManifestPath = manifestDir
+	cfg.CustomGeneratedManifestDir = manifestDir
 
 	return cfg, nil
 }

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/create.go
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/create.go
@@ -94,7 +94,7 @@ func runCreate() error {
 	}
 
 	workflowFilePath := fmt.Sprintf("./%s/src/main/resources/%s", cfg.ProjectName, metadata.WorkflowSwJson)
-	common.CreateWorkflow(workflowFilePath)
+	common.CreateWorkflow(workflowFilePath, false)
 
 	fmt.Println("🎉 Quarkus SonataFlow project successfully created")
 	return nil

--- a/packages/kn-plugin-workflow/pkg/command/run.go
+++ b/packages/kn-plugin-workflow/pkg/command/run.go
@@ -42,15 +42,16 @@ func NewRunCommand() *cobra.Command {
 		Short: "Run a SonataFlow project in development mode",
 		Long: `
 	 Run a SonataFlow project in development mode.
+
 	 By default, it runs over ` + metadata.DevModeImage + ` on Docker.
 	 Alternatively, you can run the same image with Podman.
 		
 		 `,
 		Example: `
-    # Run the local directory
+	# Run the workflow inside the current local directory
 	{{.Name}} run
 
-	 # Run the local directory mapping a different host port to the running container port.
+	 # Run the current local directory mapping a different host port to the running container port.
 	{{.Name}} run --port 8081
 
  	# Disable automatic browser launch of SonataFlow  Dev UI 

--- a/packages/kn-plugin-workflow/pkg/command/undeploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/undeploy.go
@@ -168,7 +168,7 @@ func runUndeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err 
 		dir, err := os.Getwd()
 		cfg.SpecsDir = dir + "/specs"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support specs files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/undeploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/undeploy.go
@@ -123,7 +123,7 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 func undeploy(cfg *DeployUndeployCmdConfig) error {
 	fmt.Printf("🔨 Undeploying your SonataFlow project in namespace %s\n", cfg.NameSpace)
 
-	manifestExtension := []string{".yaml"}
+	manifestExtension := []string{metadata.YAMLExtension}
 
 	manifestPath := cfg.CustomGeneratedManifestDir
 	if len(cfg.CustomManifestsFileDir) != 0 {

--- a/packages/kn-plugin-workflow/pkg/command/undeploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/undeploy.go
@@ -176,7 +176,7 @@ func runUndeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err 
 		dir, err := os.Getwd()
 		cfg.SchemasDir = dir + "/schemas"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support schemas files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/command/undeploy.go
+++ b/packages/kn-plugin-workflow/pkg/command/undeploy.go
@@ -41,12 +41,27 @@ func NewUndeployCommand() *cobra.Command {
 	# Undeploy the workflow project from the current directory's project. 
 	# You must provide target namespace.
 	{{.Name}} undeploy --namespace <your_namespace>
+
 	# Persist the generated Kubernetes manifests on a given path and deploy the 
 	# workflow from the current directory's project. 
-	{{.Name}} undeploy --manifestPath=<full_directory_path>
+	{{.Name}} undeploy --custom-generated-manifests-dir=<full_directory_path>
+
+	# Specify a custom manifest files directory.
+	# This option *will not* automatically generate the manifest files, but will use the existing ones.
+	{{.Name}} deploy --custom-manifests-dir=<full_directory_path>
+
+	# Specify a custom subflows files directory. (default: ./subflows)
+	{{.Name}} deploy --subflows-dir=<full_directory_path>
+
+	# Specify a custom support specs directory. (default: ./specs)
+	{{.Name}} deploy --specs-dir=<full_directory_path>
+
+	# Specify a custom support schemas directory. (default: ./schemas)
+	{{.Name}} deploy --schemas-dir=<full_directory_path>
+
 		`,
 
-		PreRunE:    common.BindEnv("namespace", "manifestPath"),
+		PreRunE:    common.BindEnv("namespace", "custom-manifests-dir", "custom-generated-manifests-dir", "specs-dir", "schemas-dir", "subflows-dir"),
 		SuggestFor: []string{"undelpoy", "undeplyo"},
 	}
 
@@ -55,7 +70,11 @@ func NewUndeployCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("namespace", "n", "", "Target namespace of your deployment.")
-	cmd.Flags().StringP("manifestPath", "c", "", "Target directory of your generated Kubernetes manifests.")
+	cmd.Flags().StringP("custom-manifests-dir", "m", "", "Specify a custom manifest files directory. This option will not automatically generate the manifest files, but will use the existing ones.")
+	cmd.Flags().StringP("custom-generated-manifests-dir", "c", "", "Target directory of your generated Kubernetes manifests.")
+	cmd.Flags().StringP("specs-dir", "p", "", "Specify a custom specs files directory")
+	cmd.Flags().StringP("subflows-dir", "s", "", "Specify a custom subflows files directory")
+	cmd.Flags().StringP("schemas-dir", "t", "", "Specify a custom schemas files directory")
 
 	cmd.SetHelpFunc(common.DefaultTemplatedHelp)
 
@@ -84,8 +103,12 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("❌ ERROR: checking undeploy environment: %w", err)
 	}
 
-	if err := generateManifests(&cfg); err != nil {
-		return fmt.Errorf("❌ ERROR: generating undeploy manifests: %w", err)
+	if len(cfg.CustomManifestsFileDir) == 0 {
+		if err := generateManifests(&cfg); err != nil {
+			return fmt.Errorf("❌ ERROR: generating deploy environment: %w", err)
+		}
+	} else {
+		fmt.Printf("🛠 Using manifests located at %s\n", cfg.CustomManifestsFileDir)
 	}
 
 	if err = undeploy(&cfg); err != nil {
@@ -100,10 +123,18 @@ func runUndeploy(cmd *cobra.Command, args []string) error {
 func undeploy(cfg *DeployUndeployCmdConfig) error {
 	fmt.Printf("🔨 Undeploying your SonataFlow project in namespace %s\n", cfg.NameSpace)
 
-	files, err := common.FindServiceFiles(cfg.ManifestPath)
-	if err != nil {
-		return fmt.Errorf("❌ ERROR: failed to get kubernetes manifest service files: %w", err)
+	manifestExtension := []string{".yaml"}
+
+	manifestPath := cfg.CustomGeneratedManifestDir
+	if len(cfg.CustomManifestsFileDir) != 0 {
+		manifestPath = cfg.CustomManifestsFileDir
 	}
+
+	files, err := common.FindFilesWithExtensions(manifestPath, manifestExtension)
+	if err != nil {
+		return fmt.Errorf("❌ ERROR: failed to get manifest directory and files: %w", err)
+	}
+
 	for _, file := range files {
 		if err = common.ExecuteKubectlDelete(file, cfg.NameSpace); err != nil {
 			return fmt.Errorf("❌ ERROR: failed to undeploy manifest %s,  %w", file, err)
@@ -117,16 +148,35 @@ func undeploy(cfg *DeployUndeployCmdConfig) error {
 func runUndeployCmdConfig(cmd *cobra.Command) (cfg DeployUndeployCmdConfig, err error) {
 
 	cfg = DeployUndeployCmdConfig{
-		NameSpace:         viper.GetString("namespace"),
-		SupportFileFolder: viper.GetString("supportFilesFolder"),
-		ManifestPath:      viper.GetString("manifestPath"),
+		NameSpace:                  viper.GetString("namespace"),
+		CustomManifestsFileDir:     viper.GetString("custom-manifests-dir"),
+		CustomGeneratedManifestDir: viper.GetString("custom-generated-manifests-dir"),
+		SpecsDir:                   viper.GetString("specs-dir"),
+		SchemasDir:                 viper.GetString("schemas-dir"),
+		SubflowsDir:                viper.GetString("subflows-dir"),
 	}
 
-	if len(cfg.SupportFileFolder) == 0 {
+	if len(cfg.SubflowsDir) == 0 {
 		dir, err := os.Getwd()
-		cfg.SupportFileFolder = dir + "/specs"
+		cfg.SubflowsDir = dir + "/subflows"
 		if err != nil {
-			return cfg, fmt.Errorf("❌ ERROR: failed to get current directory: %w", err)
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default subflows workflow files folder: %w", err)
+		}
+	}
+
+	if len(cfg.SpecsDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SpecsDir = dir + "/specs"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
+		}
+	}
+
+	if len(cfg.SchemasDir) == 0 {
+		dir, err := os.Getwd()
+		cfg.SchemasDir = dir + "/schemas"
+		if err != nil {
+			return cfg, fmt.Errorf("❌ ERROR: failed to get default support files folder: %w", err)
 		}
 	}
 

--- a/packages/kn-plugin-workflow/pkg/common/create_workflow.go
+++ b/packages/kn-plugin-workflow/pkg/common/create_workflow.go
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 package common
@@ -22,8 +22,8 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
 )
 
 type WorkflowStates struct {
@@ -36,13 +36,14 @@ type WorkflowStates struct {
 type Workflow struct {
 	Id          string           `json:"id"`
 	Version     string           `json:"version"`
-	SpecVersion string           `json:"specVersion"`
+	SpecVersion string           `json:"specVersion" yaml:"specVersion"`
 	Name        string           `json:"name"`
+	Description string           `json:"description"`
 	Start       string           `json:"start"`
 	States      []WorkflowStates `json:"states"`
 }
 
-func GetWorkflowTemplate() (workflowJsonByte []byte, err error) {
+func GetWorkflowTemplate(yamlWorkflow bool) (workflowByte []byte, err error) {
 	workflowStates := WorkflowStates{
 		Name: "HelloWorld",
 		Type: "inject",
@@ -57,28 +58,34 @@ func GetWorkflowTemplate() (workflowJsonByte []byte, err error) {
 		Version:     "1.0",
 		SpecVersion: "0.8.0",
 		Name:        "Hello World",
+		Description: "Description",
 		Start:       "HelloWorld",
 		States:      []WorkflowStates{workflowStates},
 	}
 
-	workflowJsonByte, err = json.MarshalIndent(workflow, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("error marshaling the workflow json file. %w", err)
+	if yamlWorkflow {
+		workflowByte, err = yaml.Marshal(workflow)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling the workflow file. %w", err)
+		}
+	} else {
+		workflowByte, err = json.MarshalIndent(workflow, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling the workflow file. %w", err)
+		}
 	}
-	return
+
+	return workflowByte, nil
 }
 
-func CreateWorkflow(workflowFilePath string) (err error) {
-	workflowFileData, err := GetWorkflowTemplate()
+func CreateWorkflow(workflowFilePath string, yamlWorkflow bool) (err error) {
+
+	workflowByte, err := GetWorkflowTemplate(yamlWorkflow)
+	err = afero.WriteFile(FS, workflowFilePath, workflowByte, 0644)
 	if err != nil {
-		return err
+		return fmt.Errorf("error writing the workflow yaml file: %w", err)
 	}
 
-	err = afero.WriteFile(FS, workflowFilePath, workflowFileData, 0644)
-	if err != nil {
-		return fmt.Errorf("error writing the workflow json file. %w", err)
-	}
-
-	fmt.Printf("Workflow file created on %s \n", workflowFilePath)
-	return
+	fmt.Printf("Workflow YAML file created at %s \n", workflowFilePath)
+	return nil
 }

--- a/packages/kn-plugin-workflow/pkg/common/create_workflow.go
+++ b/packages/kn-plugin-workflow/pkg/common/create_workflow.go
@@ -83,9 +83,9 @@ func CreateWorkflow(workflowFilePath string, yamlWorkflow bool) (err error) {
 	workflowByte, err := GetWorkflowTemplate(yamlWorkflow)
 	err = afero.WriteFile(FS, workflowFilePath, workflowByte, 0644)
 	if err != nil {
-		return fmt.Errorf("error writing the workflow YAML file: %w", err)
+		return fmt.Errorf("error writing the workflow file: %w", err)
 	}
 
-	fmt.Printf("Workflow YAML file created at %s \n", workflowFilePath)
+	fmt.Printf("Workflow file created at %s \n", workflowFilePath)
 	return nil
 }

--- a/packages/kn-plugin-workflow/pkg/common/create_workflow.go
+++ b/packages/kn-plugin-workflow/pkg/common/create_workflow.go
@@ -83,7 +83,7 @@ func CreateWorkflow(workflowFilePath string, yamlWorkflow bool) (err error) {
 	workflowByte, err := GetWorkflowTemplate(yamlWorkflow)
 	err = afero.WriteFile(FS, workflowFilePath, workflowByte, 0644)
 	if err != nil {
-		return fmt.Errorf("error writing the workflow yaml file: %w", err)
+		return fmt.Errorf("error writing the workflow YAML file: %w", err)
 	}
 
 	fmt.Printf("Workflow YAML file created at %s \n", workflowFilePath)

--- a/packages/kn-plugin-workflow/pkg/common/create_workflow_test.go
+++ b/packages/kn-plugin-workflow/pkg/common/create_workflow_test.go
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 package common
@@ -30,7 +30,7 @@ func TestCreateWrokflow(t *testing.T) {
 	filePath := "new-workflow.sw.json"
 	FS = afero.NewMemMapFs()
 
-	err = CreateWorkflow(filePath)
+	err = CreateWorkflow(filePath, false)
 	defer FS.Remove(filePath)
 	if err != nil {
 		t.Errorf("Error when creating workflow: %#v", err)

--- a/packages/kn-plugin-workflow/pkg/common/io.go
+++ b/packages/kn-plugin-workflow/pkg/common/io.go
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 package common
@@ -47,10 +47,10 @@ func FindFilesWithExtensions(directoryPath string, extensions []string) ([]strin
 			continue
 		}
 
-		fileExt := filepath.Ext(file.Name())
+		filename := file.Name()
 		for _, ext := range extensions {
-			if strings.EqualFold(fileExt, ext) {
-				filePath := filepath.Join(directoryPath, file.Name())
+			if strings.HasSuffix(strings.ToLower(filename), strings.ToLower(ext)) {
+				filePath := filepath.Join(directoryPath, filename)
 				filePaths = append(filePaths, filePath)
 				break
 			}

--- a/packages/kn-plugin-workflow/pkg/metadata/constants.go
+++ b/packages/kn-plugin-workflow/pkg/metadata/constants.go
@@ -47,7 +47,7 @@ const (
 	YMLExtension          = ".yml"
 	JSONExtension         = ".json"
 	YAMLSWExtension       = "sw.yaml"
-	YMLSWExtensionShort   = "sw.yml"
+	YMLSWExtension        = "sw.yml"
 	JSONSWExtension       = "sw.json"
 	ApplicationProperties = "application.properties"
 

--- a/packages/kn-plugin-workflow/pkg/metadata/constants.go
+++ b/packages/kn-plugin-workflow/pkg/metadata/constants.go
@@ -6,15 +6,15 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
- * under the License. 
+ * under the License.
  */
 
 package metadata
@@ -38,13 +38,17 @@ const (
 
 	DefaultTag     = "latest"
 	WorkflowSwJson = "workflow.sw.json"
+	WorkflowSwYaml = "workflow.sw.yaml"
 
 	OperatorName       = "sonataflow-operator-system"
 	OperatorManagerPod = "sonataflow-operator-controller-manager"
 
-	YAMLExtension         = "sw.yaml"
-	YAMLExtensionShort    = "sw.yml"
-	JSONExtension         = "sw.json"
+	YAMLExtension         = ".yaml"
+	YMLExtension          = ".yml"
+	JSONExtension         = ".json"
+	YAMLSWExtension       = "sw.yaml"
+	YMLSWExtensionShort   = "sw.yml"
+	JSONSWExtension       = "sw.json"
 	ApplicationProperties = "application.properties"
 
 	ManifestServiceFilesKind = "SonataFlow"

--- a/packages/kn-plugin-workflow/pkg/root/root.go
+++ b/packages/kn-plugin-workflow/pkg/root/root.go
@@ -47,7 +47,7 @@ func NewRootCommand(cfg RootCmdConfig) *cobra.Command {
 	file definition (i.e. workflow.json|yaml).
 
 	Additionally, you can define the configurable parameters of your application in the
-	"application.properties" file (inside the root pproject directory).
+	"application.properties" file (inside the root project directory).
 	You can also store your spec files (i.e., Open API files) inside the "specs" folder,
     schemas file inside "schema" folder and also subflows (inside subflows folder).
 

--- a/packages/kn-plugin-workflow/pkg/root/root.go
+++ b/packages/kn-plugin-workflow/pkg/root/root.go
@@ -57,7 +57,7 @@ func NewRootCommand(cfg RootCmdConfig) *cobra.Command {
 		/specs (optional)
 		/schemas (optional)
 		/subflows (optional)
-		workflow.json|yaml (mandatory)
+		workflow.sw.{json|yaml|yml} (mandatory)
 
 	`,
 		Aliases: []string{"kn-workflow"},

--- a/packages/kn-plugin-workflow/pkg/root/root.go
+++ b/packages/kn-plugin-workflow/pkg/root/root.go
@@ -37,9 +37,29 @@ type RootCmdConfig struct {
 
 func NewRootCommand(cfg RootCmdConfig) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     cfg.Name,
-		Short:   "SonataFlow",
-		Long:    "Manage SonataFlow projects",
+		Use:   cfg.Name,
+		Short: "SonataFlow",
+		Long: `
+	Manage SonataFlow projects
+	==========================
+
+	Currently, SonataFlow targets use cases with a single Serverless Workflow main
+	file definition (i.e. workflow.json|yaml).
+
+	Additionally, you can define the configurable parameters of your application in the
+	"application.properties" file (inside the root pproject directory).
+	You can also store your spec files (i.e., Open API files) inside the "specs" folder,
+    schemas file inside "schema" folder and also subflows (inside subflows folder).
+
+	A SonataFlow project, as the following structure by default:
+
+	Workflow project root
+		/specs (optional)
+		/schemas (optional)
+		/subflows (optional)
+		workflow.json|yaml (mandatory)
+
+	`,
 		Aliases: []string{"kn-workflow"},
 	}
 

--- a/packages/kn-plugin-workflow/pkg/root/root.go
+++ b/packages/kn-plugin-workflow/pkg/root/root.go
@@ -44,7 +44,7 @@ func NewRootCommand(cfg RootCmdConfig) *cobra.Command {
 	==========================
 
 	Currently, SonataFlow targets use cases with a single Serverless Workflow main
-	file definition (i.e. workflow.json|yaml).
+	file definition (i.e. workflow.sw.{json|yaml|yml}).
 
 	Additionally, you can define the configurable parameters of your application in the
 	"application.properties" file (inside the root project directory).

--- a/packages/kn-plugin-workflow/pkg/root/root.go
+++ b/packages/kn-plugin-workflow/pkg/root/root.go
@@ -49,7 +49,7 @@ func NewRootCommand(cfg RootCmdConfig) *cobra.Command {
 	Additionally, you can define the configurable parameters of your application in the
 	"application.properties" file (inside the root project directory).
 	You can also store your spec files (i.e., Open API files) inside the "specs" folder,
-    schemas file inside "schema" folder and also subflows (inside subflows folder).
+    schemas file inside "schemas" folder and also subflows inside "subflows" folder.
 
 	A SonataFlow project, as the following structure by default:
 


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-tools/issues/2091

We should enhance the current CLI to support subflows. To achieve that, we need to introduce a new workflow project default structure:

Workflow project root
/specs (optional)
/schemas (optional)
/subflows (optional)
workflow.json|yaml (mandatory)

To test:
[subflow1.zip](https://github.com/apache/incubator-kie-tools/files/13640914/subflow1.zip)

This PR also introduce a batch of improvements the CLI:

-New workflow project structure

-Upgrade kogito-swf-dev mode to 1.44

-Enable users to create workflows with YAML format
To test: ./cli create --yaml-workflow

-Changed all flags from camelCase to dash notation

-Quarkus convert should copy all content 

-Custom directory to deploy manifests
To test: 
./cli deploy --custom-manifests-dir=/Users/ederign/temp/subflows/sanity/sample-project/manifests


What is still pending:

- Update sonata flow docs
- Manifests will become optional: https://github.com/apache/incubator-kie-kogito-serverless-operator/pull/320 and we need to update the CLI.
