### PR TITLE
kie-issues:129: Revisit 'Open in KIE Sandbox' button

### DIFF
--- a/packages/chrome-extension/src/app/Dependencies.ts
+++ b/packages/chrome-extension/src/app/Dependencies.ts
@@ -61,6 +61,9 @@ export class Dependencies {
   };
 
   public readonly openRepoInExternalEditor = {
+    buttonContainerOnRepoHome: () => {
+      return document.querySelector("#repository-details-container .pagehead-actions") as HTMLElement | null;
+    },
     buttonContainerOnRepoFilesList: () => {
       return document.querySelector(".d-flex.gap-2")?.parentElement as HTMLElement | null;
     },

--- a/packages/chrome-extension/src/app/components/openRepoInExternalEditor/openRepoInExternalEditorApp.tsx
+++ b/packages/chrome-extension/src/app/components/openRepoInExternalEditor/openRepoInExternalEditorApp.tsx
@@ -20,15 +20,15 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Globals, Main } from "../common/Main";
-import { createAndGetMainContainer, openRepoInExternalEditorContainer, removeAllChildren } from "../../utils";
+import {
+  createAndGetMainContainer,
+  openRepoInExternalEditorContainer,
+  openRepoInExternalEditorContainerFromRepositoryHome,
+  removeAllChildren,
+} from "../../utils";
 import { OpenInExternalEditorButton } from "./OpenInExternalEditorButton";
 import { GitHubPageType } from "../../github/GitHubPageType";
-import {
-  KOGITO_IFRAME_CONTAINER_PR_CLASS,
-  KOGITO_OPEN_REPO_IN_EXTERNAL_EDITOR_CONTAINER_CLASS,
-  KOGITO_TOOLBAR_CONTAINER_PR_CLASS,
-  KOGITO_VIEW_ORIGINAL_LINK_CONTAINER_PR_CLASS,
-} from "../../constants";
+import { KOGITO_OPEN_REPO_IN_EXTERNAL_EDITOR_CONTAINER_CLASS } from "../../constants";
 
 export function renderOpenRepoInExternalEditorApp(
   args: Globals & { className: string; pageType: GitHubPageType; container: () => HTMLElement }
@@ -50,7 +50,9 @@ export function renderOpenRepoInExternalEditorApp(
     >
       {ReactDOM.createPortal(
         <OpenInExternalEditorButton className={args.className} pageType={args.pageType} />,
-        openRepoInExternalEditorContainer(args.id, args.container())
+        GitHubPageType.REPO_HOME === args.pageType
+          ? openRepoInExternalEditorContainerFromRepositoryHome(args.id, args.container())
+          : openRepoInExternalEditorContainer(args.id, args.container())
       )}
     </Main>,
     createAndGetMainContainer(args.id, args.dependencies.all.body()),

--- a/packages/chrome-extension/src/app/components/single/singleEditorView.tsx
+++ b/packages/chrome-extension/src/app/components/single/singleEditorView.tsx
@@ -23,6 +23,7 @@ import {
   extractOpenFileExtension,
   extractOpenFilePath,
   iframeFullscreenContainer,
+  openRepoInExternalEditorContainer,
   removeAllChildren,
   waitForElementToBeReady,
 } from "../../utils";
@@ -35,6 +36,8 @@ import { KOGITO_IFRAME_CONTAINER_CLASS, KOGITO_TOOLBAR_CONTAINER_CLASS } from ".
 import { fetchFile } from "../../github/api";
 import { useGitHubApi } from "../common/GitHubContext";
 import { useGlobals } from "../common/GlobalContext";
+import { OpenInExternalEditorButton } from "../openRepoInExternalEditor/OpenInExternalEditorButton";
+import { GitHubPageType } from "../../github/GitHubPageType";
 
 export interface FileInfo {
   repo: string;
@@ -43,7 +46,9 @@ export interface FileInfo {
   gitRef: string;
 }
 
-export async function renderSingleEditorReadonlyApp(args: Globals & { fileInfo: FileInfo }) {
+export async function renderSingleEditorReadonlyApp(
+  args: Globals & { className: string; pageType: GitHubPageType; container: () => HTMLElement; fileInfo: FileInfo }
+) {
   // wait for the dom element to be ready before rendering
   await waitForElementToBeReady("textarea[id='read-only-cursor-text-area']");
   // Checking whether this text editor exists is a good way to determine if the page is "ready",
@@ -80,6 +85,10 @@ export async function renderSingleEditorReadonlyApp(args: Globals & { fileInfo: 
       resourceContentServiceFactory={args.resourceContentServiceFactory}
       externalEditorManager={args.externalEditorManager}
     >
+      {ReactDOM.createPortal(
+        <OpenInExternalEditorButton className={args.className} pageType={args.pageType} />,
+        openRepoInExternalEditorContainer(args.id, args.container())
+      )}
       <SingleEditorViewApp fileInfo={args.fileInfo} openFileExtension={openFileExtension} />
     </Main>,
     createAndGetMainContainer(args.id, args.dependencies.all.body()!),

--- a/packages/chrome-extension/src/app/github/GitHubPageType.ts
+++ b/packages/chrome-extension/src/app/github/GitHubPageType.ts
@@ -24,4 +24,5 @@ export enum GitHubPageType {
   CAN_OPEN_REPO_IN_EXTERNAL_EDITOR,
   ANY,
   PR_HOME,
+  REPO_HOME,
 }

--- a/packages/chrome-extension/src/app/github/GitHubPageType.ts
+++ b/packages/chrome-extension/src/app/github/GitHubPageType.ts
@@ -21,7 +21,6 @@ export enum GitHubPageType {
   VIEW,
   EDIT,
   PR_FILES_OR_COMMITS,
-  CAN_OPEN_REPO_IN_EXTERNAL_EDITOR,
   ANY,
   PR_HOME,
   REPO_HOME,

--- a/packages/chrome-extension/src/app/utils.ts
+++ b/packages/chrome-extension/src/app/utils.ts
@@ -111,6 +111,19 @@ export function openRepoInExternalEditorContainer(id: string, container: HTMLEle
   return element();
 }
 
+export function openRepoInExternalEditorContainerFromRepositoryHome(id: string, container: HTMLElement) {
+  const element = () => document.querySelector(`.${KOGITO_OPEN_REPO_IN_EXTERNAL_EDITOR_CONTAINER_CLASS}.${id}`)!;
+
+  if (!element()) {
+    container.insertAdjacentHTML(
+      "beforeend",
+      `<li><div class="${KOGITO_OPEN_REPO_IN_EXTERNAL_EDITOR_CONTAINER_CLASS} ${id}"></div></li>`
+    );
+  }
+
+  return element();
+}
+
 export function extractOpenFileExtension(url: string) {
   return url
     .split(".")

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -115,13 +115,6 @@ function init(globals: Globals) {
       className: "btn btn-sm",
       container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnPrs()!,
     });
-  } else if (pageType === GitHubPageType.CAN_OPEN_REPO_IN_EXTERNAL_EDITOR) {
-    renderOpenRepoInExternalEditorApp({
-      ...globals,
-      pageType,
-      className: "btn ml-2 d-none d-md-block",
-      container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnRepoFilesList()!,
-    });
   } else if (pageType === GitHubPageType.REPO_HOME) {
     renderOpenRepoInExternalEditorApp({
       ...globals,
@@ -190,10 +183,6 @@ export function discoverCurrentGitHubPageType() {
 
   if (isOrgSlashRepo || isOrgSlashRepoSlashTreeSlashName) {
     return GitHubPageType.REPO_HOME;
-  }
-
-  if (pathnameMatches(`/.*/.*/tree/.*`)) {
-    return GitHubPageType.CAN_OPEN_REPO_IN_EXTERNAL_EDITOR;
   }
 
   if (pathnameMatches(`.*/.*/pull/[0-9]+/files.*`)) {

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -99,7 +99,13 @@ function init(globals: Globals) {
   if (pageType === GitHubPageType.EDIT) {
     renderSingleEditorApp({ ...globals, fileInfo });
   } else if (pageType === GitHubPageType.VIEW) {
-    renderSingleEditorReadonlyApp({ ...globals, fileInfo });
+    renderSingleEditorReadonlyApp({
+      ...globals,
+      pageType,
+      className: "btn ml-2 d-none d-md-block",
+      container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnRepoFilesList()!,
+      fileInfo,
+    });
   } else if (pageType === GitHubPageType.PR_FILES_OR_COMMITS) {
     renderPrEditorsApp({ ...globals });
   } else if (pageType === GitHubPageType.PR_HOME) {
@@ -115,6 +121,13 @@ function init(globals: Globals) {
       pageType,
       className: "btn ml-2 d-none d-md-block",
       container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnRepoFilesList()!,
+    });
+  } else if (pageType === GitHubPageType.REPO_HOME) {
+    renderOpenRepoInExternalEditorApp({
+      ...globals,
+      pageType,
+      className: "btn ml-2 d-none d-md-block",
+      container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnRepoHome()!,
     });
   } else {
     throw new Error(`Unknown GitHubPageType ${pageType}`);
@@ -172,8 +185,13 @@ export function discoverCurrentGitHubPageType() {
   }
 
   const isOrgSlashRepo = window.location.pathname.split("/").length === 3;
+  const isOrgSlashRepoSlashTreeSlashName = pathnameMatches(`/.*/.*/tree/[^/]*`);
 
-  if (pathnameMatches(`/.*/.*/tree/.*`) || isOrgSlashRepo) {
+  if (isOrgSlashRepo || isOrgSlashRepoSlashTreeSlashName) {
+    return GitHubPageType.REPO_HOME;
+  }
+
+  if (pathnameMatches(`/.*/.*/tree/.*`)) {
     return GitHubPageType.CAN_OPEN_REPO_IN_EXTERNAL_EDITOR;
   }
 

--- a/packages/chrome-extension/src/index.ts
+++ b/packages/chrome-extension/src/index.ts
@@ -126,7 +126,7 @@ function init(globals: Globals) {
     renderOpenRepoInExternalEditorApp({
       ...globals,
       pageType,
-      className: "btn ml-2 d-none d-md-block",
+      className: "btn btn-sm",
       container: () => globals.dependencies.openRepoInExternalEditor.buttonContainerOnRepoHome()!,
     });
   } else {
@@ -185,7 +185,8 @@ export function discoverCurrentGitHubPageType() {
   }
 
   const isOrgSlashRepo = window.location.pathname.split("/").length === 3;
-  const isOrgSlashRepoSlashTreeSlashName = pathnameMatches(`/.*/.*/tree/[^/]*`);
+  const isOrgSlashRepoSlashTreeSlashName =
+    window.location.pathname.split("/tree/").length === 2 && !window.location.pathname.split("/tree/")[1].includes("/");
 
   if (isOrgSlashRepo || isOrgSlashRepoSlashTreeSlashName) {
     return GitHubPageType.REPO_HOME;

--- a/packages/chrome-extension/tests/index.test.ts
+++ b/packages/chrome-extension/tests/index.test.ts
@@ -53,6 +53,18 @@ describe("discoverCurrentGitHubPageType", () => {
     expect(type).toStrictEqual(GitHubPageType.EDIT);
   });
 
+  test("repo home", async () => {
+    setWindowLocationPathname("github.com/organization/repositoryName");
+    const type = index.discoverCurrentGitHubPageType();
+    expect(type).toStrictEqual(GitHubPageType.REPO_HOME);
+  });
+
+  test("repo home with branch", async () => {
+    setWindowLocationPathname("github.com/organization/repositoryName/tree/main");
+    const type = index.discoverCurrentGitHubPageType();
+    expect(type).toStrictEqual(GitHubPageType.REPO_HOME);
+  });
+
   test("pr home", async () => {
     setWindowLocationPathname("/org/repo/pull/1");
     const type = index.discoverCurrentGitHubPageType();
@@ -69,18 +81,6 @@ describe("discoverCurrentGitHubPageType", () => {
     setWindowLocationPathname("/org/repo/pull/1/commits");
     const type = index.discoverCurrentGitHubPageType();
     expect(type).toStrictEqual(GitHubPageType.PR_FILES_OR_COMMITS);
-  });
-
-  test("tree repo", async () => {
-    setWindowLocationPathname("/user/repo/tree/some_ref");
-    const type = index.discoverCurrentGitHubPageType();
-    expect(type).toStrictEqual(GitHubPageType.CAN_OPEN_REPO_IN_EXTERNAL_EDITOR);
-  });
-
-  test("tree repo root", async () => {
-    setWindowLocationPathname("/user/repo");
-    const type = index.discoverCurrentGitHubPageType();
-    expect(type).toStrictEqual(GitHubPageType.CAN_OPEN_REPO_IN_EXTERNAL_EDITOR);
   });
 
   test("any", async () => {


### PR DESCRIPTION
This PR **display** the 'Open in KIE Sandbox' button for:
- Project home screen (e.g. https://github.com/apache/incubator-kie-kogito-examples or https://github.com/apache/incubator-kie-kogito-examples/tree/stable)
- Project file screen (e.g. https://github.com/apache/incubator-kie-kogito-examples/blob/stable/kogito-quarkus-examples/dmn-quarkus-example/src/main/resources/Traffic%20Violation.dmn)

and this PR **removes** the 'Open in KIE Sandbox' button for:
- Paths of the repository, that are just folders (e.g. https://github.com/apache/incubator-kie-kogito-examples/blob/stable/kogito-quarkus-examples/dmn-quarkus-example/src/main/resources)

For more details see:
- https://github.com/apache/incubator-kie-issues/issues/129