### PR TITLE
kie-tools#2093: [@kie-tools/uniforms-patternfly] Add description icon

### DIFF
--- a/examples/uniforms-patternfly/src/schemas/json-schema.ts
+++ b/examples/uniforms-patternfly/src/schemas/json-schema.ts
@@ -55,6 +55,7 @@ const schema = {
           type: "string",
           format: "date-time",
           max: "2000-04-04T10:30:00.000Z",
+          description: "this is date and time field",
         },
       },
       disabled: false,

--- a/packages/uniforms-patternfly/src/wrapField.tsx
+++ b/packages/uniforms-patternfly/src/wrapField.tsx
@@ -19,6 +19,8 @@
 
 import * as React from "react";
 import { FormGroup, FormGroupProps } from "@patternfly/react-core/dist/js/components/Form";
+import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
+import { HelpIcon } from "@patternfly/react-icons/dist/js/icons/help-icon";
 import { filterDOMProps } from "uniforms";
 
 declare module "uniforms" {
@@ -50,10 +52,23 @@ type WrapperProps = {
   errorMessage?: string;
   help?: string;
   showInlineError?: boolean;
+  description?: React.ReactNode;
 } & Omit<FormGroupProps, "onChange" | "fieldId">;
 
 export default function wrapField(
-  { id, label, type, disabled, error, errorMessage, showInlineError, help, required, ...props }: WrapperProps,
+  {
+    id,
+    label,
+    type,
+    disabled,
+    error,
+    errorMessage,
+    showInlineError,
+    help,
+    required,
+    description,
+    ...props
+  }: WrapperProps,
   children: React.ReactNode
 ) {
   return (
@@ -61,6 +76,20 @@ export default function wrapField(
       data-testid={"wrapper-field"}
       fieldId={id}
       label={label}
+      labelIcon={
+        description ? (
+          <Popover bodyContent={description}>
+            <button
+              type="button"
+              aria-label="field description"
+              onClick={(e) => e.preventDefault()}
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        ) : undefined
+      }
       isRequired={required}
       validated={error ? "error" : "default"}
       type={type}


### PR DESCRIPTION
# Issue
Closes [#2093](https://github.com/apache/incubator-kie-tools/issues/2093)

This PR adds the option to use the `description` property of a JSON schema to render a "Help Icon" button alongside the field title.

Example:
https://github.com/apache/incubator-kie-tools/assets/24302289/480ae497-17d3-452b-9270-a3ae1c9d6d89

