### PR TITLE
KOGITO-9995: E2E Expression.cy.ts test fails

### DIFF
--- a/packages/serverless-logic-web-tools/e2e-tests/fixtures/expression/expression.sw.json
+++ b/packages/serverless-logic-web-tools/e2e-tests/fixtures/expression/expression.sw.json
@@ -19,11 +19,11 @@
   "version": "0.1",
   "specVersion": "0.8",
   "start": "Expression state",
-  "dataInputSchema": "https://raw.githubusercontent.com/kiegroup/kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/schema/expression.json",
+  "dataInputSchema": "https://raw.githubusercontent.com/apache/incubator-kie-kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/schema/expression.json",
   "functions": [
     {
       "name": "callBackFunc",
-      "operation": "https://raw.githubusercontent.com/kiegroup/kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/main/resources/specs/callback.yaml",
+      "operation": "https://raw.githubusercontent.com/apache/incubator-kie-kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/main/resources/specs/callback.yaml",
       "type": "rest"
     },
     {

--- a/packages/serverless-logic-web-tools/e2e-tests/fixtures/expression/expression.sw.yaml
+++ b/packages/serverless-logic-web-tools/e2e-tests/fixtures/expression/expression.sw.yaml
@@ -12,10 +12,10 @@ id: Expression test
 version: "0.1"
 specVersion: "0.8"
 start: Expression state
-dataInputSchema: "https://raw.githubusercontent.com/kiegroup/kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/schema/expression.json"
+dataInputSchema: "https://raw.githubusercontent.com/apache/incubator-kie-kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/schema/expression.json"
 functions:
   - name: callBackFunc
-    operation: "https://raw.githubusercontent.com/kiegroup/kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/main/resources/specs/callback.yaml"
+    operation: "https://raw.githubusercontent.com/apache/incubator-kie-kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-callback-events-over-http-quarkus/callback-workflow/src/main/resources/specs/callback.yaml"
     type: rest
   - name: testFunc
     operation: any


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9995

**Description:**
The e2e test "Expression.cy.ts" is failing:
https://github.com/apache/incubator-kie-tools/actions/runs/7462437691/job/20320955619?pr=2114

Possible cause the schema used in the test is not available:
https://raw.githubusercontent.com/kiegroup/kogito-examples/1.36.0.Final/serverless-workflow-examples/serverless-workflow-expression-quarkus/src/main/resources/schema/expression.json