### PR TITLE
KOGITO-10020: In Runtime-tools the Serverless Workflow diagram is not loading

### DIFF
--- a/packages/runtime-tools-enveloped-components/src/workflowDetails/envelope/components/SwfCombinedEditor/SwfCombinedEditor.tsx
+++ b/packages/runtime-tools-enveloped-components/src/workflowDetails/envelope/components/SwfCombinedEditor/SwfCombinedEditor.tsx
@@ -87,6 +87,7 @@ const SwfCombinedEditor: React.FC<ISwfCombinedEditorProps & OUIAProps> = ({
       isReadOnly: true,
       fileExtension: `sw.${getFileType()}`,
       fileName: `workflow.sw.${getFileType()}`,
+      path: `*.sw.${getFileType()}`,
     };
   }, [source]);
 


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-10020

**Description:**
In Serverless Workflow Combined Editor, the spinner continues to be there and there are no messages between the frames.

We need to align our components to follow the work in this PR:
https://github.com/apache/incubator-kie-tools/pull/2064
Specifically:
https://github.com/apache/incubator-kie-tools/pull/2064/files#diff-5ce7e50647ba8e30e21ee9888219fcf8ff3b84418aa615103cb72ea3f0bfed98

**Preview:**
[KOGITO-10020.webm](https://github.com/apache/incubator-kie-tools/assets/17780574/27d3f526-1cf2-4a07-ada1-9c468e94e194)
