### PR TITLE
kie-issues#424: Add form-generation-tool 'bin' entry point

### DIFF
--- a/packages/form-generation-tool/README.md
+++ b/packages/form-generation-tool/README.md
@@ -30,13 +30,26 @@ After the command has finished, go to `packages/form-generation-tool/dist` folde
 
 ## Running the CLI
 
-In the command line just execute the CLI binary:
+If you built the `form-generation-tool` package as described above locally, then in the command line just execute the CLI binary:
 
 ```shell script
 ./form-generation-cli-linux
 ```
 
-This command will start a wizard to help you generate the forms:
+For those, who do not want to build `form-generation-tool` package locally, they can install last published version and then run it:
+
+```shell script
+npm i -g @kie-tools/form-generation-tool
+form-generation-tool
+```
+
+For those, who want to try `form-generation-tool` without instalation they can start it as:
+
+```shell script
+npx @kie-tools/form-generation-tool
+```
+
+All commands will start a wizard to help you generate the forms:
 
 1. First set the path to your Kogito Project.
 

--- a/packages/form-generation-tool/bin.js
+++ b/packages/form-generation-tool/bin.js
@@ -21,4 +21,4 @@
 /**
  * This file is used as entry point of the form-generation-tool cli command
  */
-require("../../dist/index");
+require("./dist/index");

--- a/packages/form-generation-tool/package.json
+++ b/packages/form-generation-tool/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/apache/incubator-kie-tools/issues"
   },
   "bin": {
-    "form-generation-tool": "src/cli/cli.js"
+    "form-generation-tool": "bin.js"
   },
   "types": "./dist/index.d.ts",
   "main": "dist/index.js",

--- a/packages/form-generation-tool/package.json
+++ b/packages/form-generation-tool/package.json
@@ -12,6 +12,9 @@
   "bugs": {
     "url": "https://github.com/apache/incubator-kie-tools/issues"
   },
+  "bin": {
+    "form-generation-tool": "src/cli/cli.js"
+  },
   "types": "./dist/index.d.ts",
   "main": "dist/index.js",
   "files": [

--- a/packages/form-generation-tool/src/cli/cli.js
+++ b/packages/form-generation-tool/src/cli/cli.js
@@ -1,0 +1,24 @@
+#! /usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This file is used as entry point of the form-generation-tool cli command
+ */
+require("../../dist/index");


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/424

For testing this PR, only these methods should be available, as we are about to test ci command of the unpublished package

# 01 npx
See this [documentation](https://exploringjs.com/nodejs-shell-scripting/ch_installing-packages.html#npx). It is enough to run:
- `cd kie-tools/packages/form-generation-tool`
- `npx form-generation-tool` 

# 02 npm link
See this [documentation](https://exploringjs.com/nodejs-shell-scripting/ch_installing-packages.html#npm-link-installing-a-globally-linked-package-locally).
- `cd kie-tools/packages/form-generation-tool`
- `npm link`
- `form-generation-tool`

Once done with testing, do `npm uninstall -g` from `kie-tools/packages/form-generation-tool`

# 03 npm install [local path]
[updated] See this [docuementation](https://exploringjs.com/nodejs-shell-scripting/ch_installing-packages.html#installing-unpublished-packages-via-local-paths) and hint form the [comment](https://github.com/apache/incubator-kie-tools/pull/2123#pullrequestreview-1828045799).

We need to update `version` in packages that are dependencies of the `form-generation-tools` and use `pnpm pack`

-  update `"version": "0.0.0",` to `"version": "0.32.0",` in `kie-tools/packages/uniforms-bootstrap4-codegen/package.json` 
-  update `"version": "0.0.0",` to `"version": "0.32.0",` in `kie-tools/packages/uniforms-patternfly-codegen/package.json` 
- `cd kie-tools/packages/form-generation-tool`
- `pnpm pack`
- `npm i -g kie-tools-form-generation-tool-0.0.0.tgz`
- `form-generation-tool`

Once done with testing, do `npm uninstall -g` from `kie-tools/packages/form-generation-tool`