### PR TITLE
kie-issues#232: Identify DMN 1.4 collections with ||| on the DMN Editor diagram

### DIFF
--- a/packages/dmn-editor/dev-webapp/src/AvailableModelsToInclude.ts
+++ b/packages/dmn-editor/dev-webapp/src/AvailableModelsToInclude.ts
@@ -67,7 +67,7 @@ export const modelsByNamespace = Object.values(avaiableModels).reduce((acc, v) =
   if (v.type === "dmn") {
     acc[v.model.definitions["@_namespace"]] = v;
   } else if (v.type === "pmml") {
-    acc[getPmmlNamespace({ normalizedPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] = v;
+    acc[getPmmlNamespace({ normalizedPosixPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] = v;
   }
   return acc;
 }, {} as DmnEditor.ExternalModelsIndex);

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -66,7 +66,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
   };
 }
 
-export function InputDataNodeSvg(__props: NodeSvgProps) {
+export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolean }) {
   const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
   const rx =
     typeof height === "number"
@@ -97,11 +97,12 @@ export function InputDataNodeSvg(__props: NodeSvgProps) {
         rx={rx}
         ry={ry}
       />
+      {props.isCollection && <IsCollectionSvg {...__props} anchor={"bottom"} />}
     </>
   );
 }
 
-export function DecisionNodeSvg(__props: NodeSvgProps) {
+export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean }) {
   const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
 
   return (
@@ -117,6 +118,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps) {
         strokeLinejoin={"round"}
         {...props}
       />
+      {props.isCollection && <IsCollectionSvg {...__props} anchor="top" />}
     </>
   );
 }
@@ -378,3 +380,47 @@ export const UnknownNodeSvg = (_props: NodeSvgProps & { strokeDasharray?: string
     </>
   );
 };
+
+function IsCollectionSvg(__props: NodeSvgProps & { anchor: "top" | "bottom" }) {
+  const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
+
+  const line_position_x = x + width / 2;
+  const line_x_spacing = 7;
+  const line_position_y1 = props.anchor === "bottom" ? y + height - 4 : y + 4;
+  const line_position_y2 = props.anchor === "bottom" ? y + height - 18 : y + 18;
+
+  return (
+    <>
+      <line
+        {...props}
+        x1={line_position_x - line_x_spacing}
+        x2={line_position_x - line_x_spacing}
+        y1={line_position_y1}
+        y2={line_position_y2}
+        strokeWidth={strokeWidth}
+        fill={fillColor ?? DEFAULT_NODE_FILL}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+      <line
+        {...props}
+        x1={line_position_x}
+        x2={line_position_x}
+        y1={line_position_y1}
+        y2={line_position_y2}
+        strokeWidth={strokeWidth}
+        fill={fillColor ?? DEFAULT_NODE_FILL}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+      <line
+        {...props}
+        x1={line_position_x + line_x_spacing}
+        x2={line_position_x + line_x_spacing}
+        y1={line_position_y1}
+        y2={line_position_y2}
+        strokeWidth={strokeWidth}
+        fill={fillColor ?? DEFAULT_NODE_FILL}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+    </>
+  );
+}

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -384,7 +384,7 @@ export const UnknownNodeSvg = (_props: NodeSvgProps & { strokeDasharray?: string
 function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom" }) {
   const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
 
-  const positionX = x + width / 2;
+  const xPosition = x + width / 2;
   const xSpacing = 7;
   const y1Position = props.anchor === "bottom" ? y + height - 4 : y + 4;
   const y2Position = props.anchor === "bottom" ? y + height - 18 : y + 18;
@@ -393,8 +393,8 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
     <>
       <line
         {...props}
-        x1={positionX - xSpacing}
-        x2={positionX - xSpacing}
+        x1={xPosition - xSpacing}
+        x2={xPosition - xSpacing}
         y1={y1Position}
         y2={y2Position}
         strokeWidth={strokeWidth}
@@ -403,8 +403,8 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
       />
       <line
         {...props}
-        x1={positionX}
-        x2={positionX}
+        x1={xPosition}
+        x2={xPosition}
         y1={y1Position}
         y2={y2Position}
         strokeWidth={strokeWidth}
@@ -413,8 +413,8 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
       />
       <line
         {...props}
-        x1={positionX + xSpacing}
-        x2={positionX + xSpacing}
+        x1={xPosition + xSpacing}
+        x2={xPosition + xSpacing}
         y1={y1Position}
         y2={y2Position}
         strokeWidth={strokeWidth}

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -97,7 +97,7 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
         rx={rx}
         ry={ry}
       />
-      {props.isCollection && <IsCollectionSvg {...__props} anchor={"bottom"} />}
+      {props.isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
     </>
   );
 }
@@ -118,7 +118,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
         strokeLinejoin={"round"}
         {...props}
       />
-      {props.isCollection && <IsCollectionSvg {...__props} anchor="top" />}
+      {props.isCollection && <NodeCollectionMarker {...__props} anchor="top" />}
     </>
   );
 }
@@ -381,42 +381,42 @@ export const UnknownNodeSvg = (_props: NodeSvgProps & { strokeDasharray?: string
   );
 };
 
-function IsCollectionSvg(__props: NodeSvgProps & { anchor: "top" | "bottom" }) {
+function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom" }) {
   const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
 
-  const line_position_x = x + width / 2;
-  const line_x_spacing = 7;
-  const line_position_y1 = props.anchor === "bottom" ? y + height - 4 : y + 4;
-  const line_position_y2 = props.anchor === "bottom" ? y + height - 18 : y + 18;
+  const positionX = x + width / 2;
+  const xSpacing = 7;
+  const y1Position = props.anchor === "bottom" ? y + height - 4 : y + 4;
+  const y2Position = props.anchor === "bottom" ? y + height - 18 : y + 18;
 
   return (
     <>
       <line
         {...props}
-        x1={line_position_x - line_x_spacing}
-        x2={line_position_x - line_x_spacing}
-        y1={line_position_y1}
-        y2={line_position_y2}
+        x1={positionX - xSpacing}
+        x2={positionX - xSpacing}
+        y1={y1Position}
+        y2={y2Position}
         strokeWidth={strokeWidth}
         fill={fillColor ?? DEFAULT_NODE_FILL}
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <line
         {...props}
-        x1={line_position_x}
-        x2={line_position_x}
-        y1={line_position_y1}
-        y2={line_position_y2}
+        x1={positionX}
+        x2={positionX}
+        y1={y1Position}
+        y2={y2Position}
         strokeWidth={strokeWidth}
         fill={fillColor ?? DEFAULT_NODE_FILL}
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <line
         {...props}
-        x1={line_position_x + line_x_spacing}
-        x2={line_position_x + line_x_spacing}
-        y1={line_position_y1}
-        y2={line_position_y2}
+        x1={positionX + xSpacing}
+        x2={positionX + xSpacing}
+        y1={y1Position}
+        y2={y2Position}
         strokeWidth={strokeWidth}
         fill={fillColor ?? DEFAULT_NODE_FILL}
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -29,7 +29,7 @@ import {
   DMNDI15__DMNShape,
 } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import * as React from "react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import * as RF from "reactflow";
 import { renameDrgElement, renameGroupNode, updateTextAnnotation } from "../../mutations/renameNode";
 import { DmnEditorTab, DropTargetNode, SnapGrid, useDmnEditorStore, useDmnEditorStoreApi } from "../../store/Store";
@@ -141,8 +141,8 @@ export const InputDataNode = React.memo(
       [dmnEditorStoreApi, index, inputData]
     );
 
-    const { allFeelVariableUniqueNames } = useDmnEditorDerivedStore();
-
+    const { allFeelVariableUniqueNames, allTopLevelItemDefinitionUniqueNames, allDataTypesById } =
+      useDmnEditorDerivedStore();
     const onCreateDataType = useDataTypeCreationCallbackForNodes(index, inputData["@_name"]);
 
     const { fontCssProperties, shapeStyle } = useNodeStyle({
@@ -151,10 +151,17 @@ export const InputDataNode = React.memo(
       isEnabled: diagram.overlays.enableStyles,
     });
 
+    const isCollection = useMemo(() => {
+      return allDataTypesById.get(
+        allTopLevelItemDefinitionUniqueNames.get(inputData.variable?.["@_typeRef"] ?? "") ?? ""
+      )?.itemDefinition?.["@_isCollection"];
+    }, [allDataTypesById, allTopLevelItemDefinitionUniqueNames, inputData.variable]);
+
     return (
       <>
         <svg className={`kie-dmn-editor--node-shape ${className} ${dmnObjectQName.prefix ? "external" : ""}`}>
           <InputDataNodeSvg
+            isCollection={isCollection}
             {...nodeDimensions}
             x={0}
             y={0}
@@ -260,7 +267,8 @@ export const DecisionNode = React.memo(
       [decision, dmnEditorStoreApi, index]
     );
 
-    const { allFeelVariableUniqueNames } = useDmnEditorDerivedStore();
+    const { allFeelVariableUniqueNames, allTopLevelItemDefinitionUniqueNames, allDataTypesById } =
+      useDmnEditorDerivedStore();
 
     const onCreateDataType = useDataTypeCreationCallbackForNodes(index, decision["@_name"]);
 
@@ -270,10 +278,17 @@ export const DecisionNode = React.memo(
       isEnabled: diagram.overlays.enableStyles,
     });
 
+    const isCollection = useMemo(() => {
+      return allDataTypesById.get(
+        allTopLevelItemDefinitionUniqueNames.get(decision.variable?.["@_typeRef"] ?? "") ?? ""
+      )?.itemDefinition?.["@_isCollection"];
+    }, [allDataTypesById, allTopLevelItemDefinitionUniqueNames, decision.variable]);
+
     return (
       <>
         <svg className={`kie-dmn-editor--node-shape ${className} ${dmnObjectQName.prefix ? "external" : ""}`}>
           <DecisionNodeSvg
+            isCollection={isCollection}
             {...nodeDimensions}
             x={0}
             y={0}

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -152,9 +152,10 @@ export const InputDataNode = React.memo(
     });
 
     const isCollection = useMemo(() => {
-      return allDataTypesById.get(
-        allTopLevelItemDefinitionUniqueNames.get(inputData.variable?.["@_typeRef"] ?? "") ?? ""
-      )?.itemDefinition?.["@_isCollection"];
+      return (
+        allDataTypesById.get(allTopLevelItemDefinitionUniqueNames.get(inputData.variable?.["@_typeRef"] ?? "") ?? "")
+          ?.itemDefinition?.["@_isCollection"] ?? false
+      );
     }, [allDataTypesById, allTopLevelItemDefinitionUniqueNames, inputData.variable]);
 
     return (
@@ -279,9 +280,10 @@ export const DecisionNode = React.memo(
     });
 
     const isCollection = useMemo(() => {
-      return allDataTypesById.get(
-        allTopLevelItemDefinitionUniqueNames.get(decision.variable?.["@_typeRef"] ?? "") ?? ""
-      )?.itemDefinition?.["@_isCollection"];
+      return (
+        allDataTypesById.get(allTopLevelItemDefinitionUniqueNames.get(decision.variable?.["@_typeRef"] ?? "") ?? "")
+          ?.itemDefinition?.["@_isCollection"] ?? false
+      );
     }, [allDataTypesById, allTopLevelItemDefinitionUniqueNames, decision.variable]);
 
     return (


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/232

## About
This PR adds the three lines to the input and decision nodes when they are from a collection data type.

## Video
https://github.com/apache/incubator-kie-tools/assets/24302289/e1a6a00e-1682-4fb8-9e8f-cae7032572a0

