### PR TITLE
NO-ISSUE: Use new `macos-14` runners

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -96,6 +96,7 @@ runs:
         ln -sfn $(brew --prefix)/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
         colima stop
         colima delete
+        which ssh
         colima start --memory 4 --network-address --verbose
       # QEMU is reinstalled due to this bug: https://github.com/lima-vm/lima/issues/1742
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -88,6 +88,8 @@ runs:
         </plist>
         EOF
 
+        touch /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
+        codesign --sign - --entitlements entitlements.xml --force /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
         mkdir -p ~/.docker/cli-plugins
         ln -sfn $(brew --prefix)/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
         brew install docker-Buildx

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -76,7 +76,7 @@ runs:
       run: |
         brew untap homebrew/core homebrew/cask
         brew update
-        brew install docker docker-compose
+        brew install colima docker docker-compose
         cat >entitlements.xml <<EOF
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -88,7 +88,6 @@ runs:
         </plist>
         EOF
 
-        codesign --sign - --entitlements entitlements.xml --force /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
         mkdir -p ~/.docker/cli-plugins
         ln -sfn $(brew --prefix)/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
         brew install docker-Buildx

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Support longpaths"

--- a/.github/workflows/publish_jitexecutor_native.yml
+++ b/.github/workflows/publish_jitexecutor_native.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
 
     steps:
       - name: "Set long paths for Windows"

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-14, windows-latest]
     steps:
       - name: "Support longpaths (Windows only)"
         if: runner.os == 'Windows'

--- a/.github/workflows/staging_build_extended_services.yml
+++ b/.github/workflows/staging_build_extended_services.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-14, windows-latest]
     steps:
       - name: "Support longpaths (Windows only)"
         if: runner.os == 'Windows'


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/