### PR TITLE
kie-issues#842: The new DMN editor resets the node color styles to its initial value after an edit

### DIFF
--- a/packages/dmn-editor/src/propertiesPanel/SingleNodeProperties.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/SingleNodeProperties.tsx
@@ -56,6 +56,7 @@ export function SingleNodeProperties({ nodeId }: { nodeId: string }) {
   const { externalModelsByNamespace } = useExternalModels();
   const node = useDmnEditorStore((s) => s.computed(s).getDiagramData(externalModelsByNamespace).nodesById.get(nodeId));
   const [isSectionExpanded, setSectionExpanded] = useState<boolean>(true);
+  const nodeIds = useMemo(() => (node?.id ? [node.id] : []), [node?.id]);
 
   if (!node) {
     return <>Node not found: {nodeId}</>;
@@ -177,10 +178,10 @@ export function SingleNodeProperties({ nodeId }: { nodeId: string }) {
           </>
         )}
 
-        <FontOptions startExpanded={false} nodeIds={[node.id]} />
+        <FontOptions startExpanded={false} nodeIds={nodeIds} />
         <ShapeOptions
           startExpanded={false}
-          nodeIds={[node.id]}
+          nodeIds={nodeIds}
           isDimensioningEnabled={true}
           isPositioningEnabled={true}
         />


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/842

--

The solution here was to not use stale values in `useEffects`.