### PR TITLE
kie-issues#880: On the DMN Editor, all DRG elements list should show invalid names in red

### DIFF
--- a/packages/dmn-editor/src/externalNodes/DmnObjectListItem.tsx
+++ b/packages/dmn-editor/src/externalNodes/DmnObjectListItem.tsx
@@ -25,9 +25,12 @@ import { NodeIcon } from "../icons/Icons";
 import { getNodeTypeFromDmnObject } from "../diagram/maths/DmnMaths";
 import { buildFeelQNameFromNamespace } from "../feel/buildFeelQName";
 import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
-import { DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
+import { DmnBuiltInDataType, generateUuid } from "@kie-tools/boxed-expression-component/dist/api";
 import { useDmnEditorStore } from "../store/StoreContext";
 import { useExternalModels } from "../includedModels/DmnEditorDependenciesContext";
+import { DMN15_SPEC } from "../Dmn15Spec";
+import { useCallback } from "react";
+import { State } from "../store/Store";
 
 export function DmnObjectListItem({
   dmnObject,
@@ -45,12 +48,29 @@ export function DmnObjectListItem({
   const allTopLevelDataTypesByFeelName = useDmnEditorStore(
     (s) => s.computed(s).getDataTypes(externalModelsByNamespace).allTopLevelDataTypesByFeelName
   );
-  if (!dmnObject) {
-    return <>{dmnObjectHref}</>;
-  }
 
-  const Icon = NodeIcon(getNodeTypeFromDmnObject(dmnObject));
-  return (
+  const displayName = dmnObject
+    ? buildFeelQNameFromNamespace({
+        namedElement: dmnObject,
+        importsByNamespace,
+        namespace,
+        relativeToNamespace,
+      }).full
+    : dmnObjectHref;
+
+  const isValid = useDmnEditorStore((s) =>
+    DMN15_SPEC.namedElement.isValidName(
+      dmnObject?.["@_id"] ?? generateUuid(),
+      displayName,
+      s.computed(s).getAllFeelVariableUniqueNames()
+    )
+  );
+
+  const Icon = dmnObject ? NodeIcon(getNodeTypeFromDmnObject(dmnObject)) : () => <></>;
+
+  return !dmnObject ? (
+    <>{dmnObjectHref}</>
+  ) : (
     <Flex
       alignItems={{ default: "alignItemsCenter" }}
       justifyContent={{ default: "justifyContentFlexStart" }}
@@ -59,14 +79,7 @@ export function DmnObjectListItem({
       <div style={{ width: "40px", height: "40px", marginRight: 0 }}>
         <Icon />
       </div>
-      <div>{`${
-        buildFeelQNameFromNamespace({
-          namedElement: dmnObject,
-          importsByNamespace,
-          namespace,
-          relativeToNamespace,
-        }).full
-      }`}</div>
+      <div style={{ color: isValid ? undefined : "red" }}>{`${displayName}`}</div>
       <div>
         {dmnObject.__$$element !== "knowledgeSource" ? (
           <>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/880

---

Before:
<img width="300" alt="image" src="https://github.com/apache/incubator-kie-tools/assets/1584568/e83d5ca3-2975-4884-ac55-f2c7b63d0454">

After:
<img width="300" alt="image" src="https://github.com/apache/incubator-kie-tools/assets/1584568/b0e14ce6-a6ec-4508-8e5e-c433a39202a8">
