### PR TITLE
NO-ISSUE: KIE Sandbox helm chart version fix on daily dev publish Jenkins job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.daily-dev-publish
+++ b/.ci/jenkins/Jenkinsfile.daily-dev-publish
@@ -79,7 +79,7 @@ pipeline {
         KIE_SANDBOX_HELM_CHART__registry = 'quay.io'
         KIE_SANDBOX_HELM_CHART__account = 'kie-tools'
         KIE_SANDBOX_HELM_CHART__name = 'kie-sandbox-helm-chart'
-        KIE_SANDBOX_HELM_CHART__tag = 'daily-dev'
+        KIE_SANDBOX_HELM_CHART__tag = '0.0.0-daily-dev'
 
         OPENSHIFT_NAMESPACE = 'kie-sandbox'
         OPENSHIFT_PART_OF = 'daily-dev-kie-sandbox-app'

--- a/.ci/jenkins/Jenkinsfile.release-build
+++ b/.ci/jenkins/Jenkinsfile.release-build
@@ -23,7 +23,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 600, unit: 'MINUTES')
+        timeout(time: 900, unit: 'MINUTES')
     }
 
     parameters {

--- a/.ci/jenkins/Jenkinsfile.release-dry-run
+++ b/.ci/jenkins/Jenkinsfile.release-dry-run
@@ -22,7 +22,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 600, unit: 'MINUTES')
+        timeout(time: 900, unit: 'MINUTES')
     }
 
     stages {

--- a/.ci/jenkins/Jenkinsfile.staging-build
+++ b/.ci/jenkins/Jenkinsfile.staging-build
@@ -23,7 +23,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 360, unit: 'MINUTES')
+        timeout(time: 600, unit: 'MINUTES')
     }
 
     parameters {

--- a/.ci/jenkins/Jenkinsfile.staging-dry-run
+++ b/.ci/jenkins/Jenkinsfile.staging-dry-run
@@ -22,7 +22,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 360, unit: 'MINUTES')
+        timeout(time: 600, unit: 'MINUTES')
     }
 
     stages {

--- a/.ci/jenkins/Jenkinsfile.staging-publish
+++ b/.ci/jenkins/Jenkinsfile.staging-publish
@@ -22,7 +22,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 360, unit: 'MINUTES')
+        timeout(time: 600, unit: 'MINUTES')
     }
 
     stages {

--- a/packages/kie-sandbox-helm-chart/install.js
+++ b/packages/kie-sandbox-helm-chart/install.js
@@ -32,13 +32,10 @@ files.forEach((file) => {
   const doc = yaml.load(fs.readFileSync(file, "utf8"));
   doc.version = buildEnv.env.kieSandboxHelmChart.tag;
   doc.appVersion = buildEnv.env.kieSandboxHelmChart.tag;
-  if (!doc.version.match(/(\d+)\.(\d+)\.(\d+)/)) {
-    doc.version = "0.0.0-" + doc.version;
-  }
   if (doc.dependencies) {
     doc.dependencies = doc.dependencies.map((dep) => {
       if (["extended_services", "cors_proxy", "kie_sandbox"].includes(dep.name)) {
-        return { ...dep, version: doc.version };
+        return { ...dep, version: buildEnv.env.kieSandboxHelmChart.tag };
       }
       return dep;
     });

--- a/packages/kie-sandbox-helm-chart/install.js
+++ b/packages/kie-sandbox-helm-chart/install.js
@@ -32,10 +32,13 @@ files.forEach((file) => {
   const doc = yaml.load(fs.readFileSync(file, "utf8"));
   doc.version = buildEnv.env.kieSandboxHelmChart.tag;
   doc.appVersion = buildEnv.env.kieSandboxHelmChart.tag;
+  if (!doc.version.match(/(\d+)\.(\d+)\.(\d+)/)) {
+    doc.version = "0.0.0-" + doc.version;
+  }
   if (doc.dependencies) {
     doc.dependencies = doc.dependencies.map((dep) => {
       if (["extended_services", "cors_proxy", "kie_sandbox"].includes(dep.name)) {
-        return { ...dep, version: buildEnv.env.kieSandboxHelmChart.tag };
+        return { ...dep, version: doc.version };
       }
       return dep;
     });


### PR DESCRIPTION
Helm charts only works with [semantic versioning ](https://semver.org/) and in the daily dev publish job we are setting the version to `daily-dev` causing an error.

This PR updates the version to `0.0.0-daily-dev` to comply with SemVer.

The PR also increases the timeout limit for staging and release jobs as we have seen timeout errors when running those jobs in dry-run mode on the ASF Jenkins cluster.