### PR TITLE
NO-ISSUE: Fix Staging build Jenkins job (Method too large exception)

### DIFF
--- a/.ci/jenkins/Jenkinsfile.staging-build
+++ b/.ci/jenkins/Jenkinsfile.staging-build
@@ -106,13 +106,7 @@ pipeline {
         stage('Load local shared scripts') {
             steps {
                 script {
-                    pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
-                    buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
-                    githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
-                    openShiftUtils = load '.ci/jenkins/shared-scripts/openShiftUtils.groovy'
-                    dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
-                    helmUtils = load '.ci/jenkins/shared-scripts/helmUtils.groovy'
-                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
+                    loadLocalSharedScripts()
                 }
             }
         }
@@ -186,7 +180,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildPartial(params)
+                        buildPartial()
                     }
                 }
             }
@@ -552,17 +546,7 @@ pipeline {
             }
             steps {
                 script {
-                    appName = 'staging-kie-sandbox-extended-services'
-                    openShiftUtils.createOrUpdateApp(
-                        "${env.OPENSHIFT_NAMESPACE}",
-                        "${appName}",
-                        "${env.DEPLOY_TAG}",
-                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${env.DEPLOY_TAG}",
-                        "${env.OPENSHIFT_PART_OF}",
-                        'golang',
-                        "${pipelineVars.openshiftCredentialsId}"
-                    )
-                    env.KIE_SANDBOX_EXTENDED_SERVICES_URL = openShiftUtils.getAppRoute("${env.OPENSHIFT_NAMESPACE}", "${appName}", "${pipelineVars.openshiftCredentialsId}")
+                    deployKieSandboxExtendedServicesImageToOpenshift()
                 }
             }
         }
@@ -589,17 +573,7 @@ pipeline {
             }
             steps {
                 script {
-                    appName = 'staging-cors-proxy'
-                    openShiftUtils.createOrUpdateApp(
-                        "${env.OPENSHIFT_NAMESPACE}",
-                        "${appName}",
-                        "${env.DEPLOY_TAG}",
-                        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${env.DEPLOY_TAG}",
-                        "${env.OPENSHIFT_PART_OF}",
-                        'nodejs',
-                        "${pipelineVars.openshiftCredentialsId}"
-                    )
-                    env.KIE_SANDBOX_CORS_PROXY_URL = openShiftUtils.getAppRoute("${env.OPENSHIFT_NAMESPACE}", "${appName}", "${pipelineVars.openshiftCredentialsId}")
+                    deployCorsProxyImageToOpenshift()
                 }
             }
         }
@@ -638,16 +612,7 @@ pipeline {
             }
             steps {
                 script {
-                    openShiftUtils.createOrUpdateApp(
-                        "${env.OPENSHIFT_NAMESPACE}",
-                        'staging-kie-sandbox',
-                        "${env.DEPLOY_TAG}",
-                        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${env.DEPLOY_TAG}",
-                        "${env.OPENSHIFT_PART_OF}",
-                        'js',
-                        "${pipelineVars.openshiftCredentialsId}",
-                        './deployment.env'
-                    )
+                    deployKieSandboxImageToOpenshift()
                 }
             }
         }
@@ -655,13 +620,9 @@ pipeline {
         stage('Build (serverless-logic-web-tools-swf-dev-mode-image)') {
             steps {
                 dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    export KIE_TOOLS_BUILD__runTests=true
-                    export KIE_TOOLS_BUILD__buildContainerImages=true
-                    docker system prune -af
-                    echo "Build @kie-tools/serverless-logic-web-tools-swf-dev-mode-image"
-                    pnpm -F @kie-tools/serverless-logic-web-tools-swf-dev-mode-image... --workspace-concurrency=1 build:prod
-                    '''.trim()
+                    script {
+                        buildServerlessLogicWebToolsSwfDevModeImage()
+                    }
                 }
             }
         }
@@ -685,13 +646,9 @@ pipeline {
         stage('Build (dev-deployment-base-image)') {
             steps {
                 dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    export KIE_TOOLS_BUILD__runTests=true
-                    export KIE_TOOLS_BUILD__buildContainerImages=true
-                    docker system prune -af
-                    echo "Build @kie-tools/dev-deployment-base-image"
-                    pnpm -F @kie-tools/dev-deployment-base-image... --workspace-concurrency=1 build:prod
-                    '''.trim()
+                    script {
+                        buildDevDeploymentBaseImage()
+                    }
                 }
             }
         }
@@ -715,13 +672,9 @@ pipeline {
         stage('Build (dev-deployment-dmn-form-webapp-image)') {
             steps {
                 dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    export KIE_TOOLS_BUILD__runTests=true
-                    export KIE_TOOLS_BUILD__buildContainerImages=true
-                    docker system prune -af
-                    echo "Build @kie-tools/dev-deployment-dmn-form-webapp-image"
-                    pnpm -F @kie-tools/dev-deployment-dmn-form-webapp-image... --workspace-concurrency=1 build:prod
-                    '''.trim()
+                    script {
+                        buildDevDeploymentDmnFormWebappImage()
+                    }
                 }
             }
         }
@@ -745,13 +698,9 @@ pipeline {
         stage('Build (serverless-logic-web-tools-base-builder-image)') {
             steps {
                 dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    export KIE_TOOLS_BUILD__runTests=true
-                    export KIE_TOOLS_BUILD__buildContainerImages=true
-                    docker system prune -af
-                    echo "Build @kie-tools/serverless-logic-web-tools-base-builder-image"
-                    pnpm -F @kie-tools/serverless-logic-web-tools-base-builder-image... --workspace-concurrency=1 build:prod
-                    '''.trim()
+                    script {
+                        buildServerlessLogicWebToolsBaseBuilderImage()
+                    }
                 }
             }
         }
@@ -775,13 +724,9 @@ pipeline {
         stage('Build (dashbuilder-viewer-image)') {
             steps {
                 dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    export KIE_TOOLS_BUILD__runTests=true
-                    export KIE_TOOLS_BUILD__buildContainerImages=true
-                    docker system prune -af
-                    echo "Build @kie-tools/dashbuilder-viewer-image"
-                    pnpm -F @kie-tools/dashbuilder-viewer-image... --workspace-concurrency=1 build:prod
-                    '''.trim()
+                    script {
+                        buildDashbuilderViewerImage()
+                    }
                 }
             }
         }
@@ -809,11 +754,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        helmUtils.pushChartToRegistry(
-                            "${env.KIE_SANDBOX_HELM_CHART__registry}/${env.KIE_SANDBOX_HELM_CHART__account}",
-                            "packages/kie-sandbox-helm-chart/dist/${env.KIE_SANDBOX_HELM_CHART__name}-${env.KIE_SANDBOX_HELM_CHART__tag}.tgz",
-                            "${pipelineVars.quayPushCredentialsId}"
-                        )
+                        pushKieSandboxHelmChartToQuay()
                     }
                 }
             }
@@ -827,7 +768,7 @@ pipeline {
     }
 }
 
-def buildPartial(params) {
+def buildPartial() {
     sh """#!/bin/bash -el
     export KIE_TOOLS_BUILD__runEndToEndTests=false
     export KIE_TOOLS_BUILD__runTests=false
@@ -864,6 +805,63 @@ def buildPartial(params) {
     """.trim()
 }
 
+def buildServerlessLogicWebToolsSwfDevModeImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    docker system prune -af
+    echo "Build @kie-tools/serverless-logic-web-tools-swf-dev-mode-image"
+    pnpm -F @kie-tools/serverless-logic-web-tools-swf-dev-mode-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def buildDevDeploymentBaseImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    docker system prune -af
+    echo "Build @kie-tools/dev-deployment-base-image"
+    pnpm -F @kie-tools/dev-deployment-base-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def buildDevDeploymentDmnFormWebappImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    docker system prune -af
+    echo "Build @kie-tools/dev-deployment-dmn-form-webapp-image"
+    pnpm -F @kie-tools/dev-deployment-dmn-form-webapp-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def buildServerlessLogicWebToolsBaseBuilderImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    docker system prune -af
+    echo "Build @kie-tools/serverless-logic-web-tools-base-builder-image"
+    pnpm -F @kie-tools/serverless-logic-web-tools-base-builder-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def buildDashbuilderViewerImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    docker system prune -af
+    echo "Build @kie-tools/dashbuilder-viewer-image"
+    pnpm -F @kie-tools/dashbuilder-viewer-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def pushKieSandboxHelmChartToQuay() {
+    helmUtils.pushChartToRegistry(
+        "${env.KIE_SANDBOX_HELM_CHART__registry}/${env.KIE_SANDBOX_HELM_CHART__account}",
+        "packages/kie-sandbox-helm-chart/dist/${env.KIE_SANDBOX_HELM_CHART__name}-${env.KIE_SANDBOX_HELM_CHART__tag}.tgz",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
 
 def deployOnlineEditor(String tag, String credentialsId) {
     DEPLOYMENT_DIR = "${tag}-prerelease"
@@ -905,4 +903,55 @@ def deployOnlineEditor(String tag, String credentialsId) {
     """.trim()
 
     githubUtils.pushObject('origin', 'main', "${credentialsId}")
+}
+
+def deployKieSandboxExtendedServicesImageToOpenshift() {
+    appName = 'staging-kie-sandbox-extended-services'
+    openShiftUtils.createOrUpdateApp(
+        "${env.OPENSHIFT_NAMESPACE}",
+        "${appName}",
+        "${env.DEPLOY_TAG}",
+        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${env.DEPLOY_TAG}",
+        "${env.OPENSHIFT_PART_OF}",
+        'golang',
+        "${pipelineVars.openshiftCredentialsId}"
+    )
+    env.KIE_SANDBOX_EXTENDED_SERVICES_URL = openShiftUtils.getAppRoute("${env.OPENSHIFT_NAMESPACE}", "${appName}", "${pipelineVars.openshiftCredentialsId}")
+}
+
+def deployCorsProxyImageToOpenshift() {
+    appName = 'staging-cors-proxy'
+    openShiftUtils.createOrUpdateApp(
+        "${env.OPENSHIFT_NAMESPACE}",
+        "${appName}",
+        "${env.DEPLOY_TAG}",
+        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${env.DEPLOY_TAG}",
+        "${env.OPENSHIFT_PART_OF}",
+        'nodejs',
+        "${pipelineVars.openshiftCredentialsId}"
+    )
+    env.KIE_SANDBOX_CORS_PROXY_URL = openShiftUtils.getAppRoute("${env.OPENSHIFT_NAMESPACE}", "${appName}", "${pipelineVars.openshiftCredentialsId}")
+}
+
+def deployKieSandboxImageToOpenshift() {
+    openShiftUtils.createOrUpdateApp(
+        "${env.OPENSHIFT_NAMESPACE}",
+        'staging-kie-sandbox',
+        "${env.DEPLOY_TAG}",
+        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${env.DEPLOY_TAG}",
+        "${env.OPENSHIFT_PART_OF}",
+        'js',
+        "${pipelineVars.openshiftCredentialsId}",
+        './deployment.env'
+    )
+}
+
+def loadLocalSharedScripts() {
+    pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
+    buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
+    githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+    openShiftUtils = load '.ci/jenkins/shared-scripts/openShiftUtils.groovy'
+    dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+    helmUtils = load '.ci/jenkins/shared-scripts/helmUtils.groovy'
+    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
 }

--- a/.ci/jenkins/Jenkinsfile.staging-build
+++ b/.ci/jenkins/Jenkinsfile.staging-build
@@ -47,6 +47,10 @@ pipeline {
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name = 'dev-deployment-dmn-form-webapp-image'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "${params.TAG}-prerelease"
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry = 'quay.io'
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account = 'kie-tools'
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name = 'dev-deployment-kogito-quarkus-blank-app-image'
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "${params.TAG}-prerelease"
         ONLINE_EDITOR__devDeploymentBaseImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentBaseImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentBaseImageName = 'dev-deployment-base-image'
@@ -192,12 +196,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushServerlessLogicWebToolsSWFBuilderImageToQuay()
                 }
             }
         }
@@ -530,12 +529,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}",
-                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}",
-                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushKieSandboxExtendedServicesImageToQuay()
                 }
             }
         }
@@ -557,12 +551,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}",
-                        "${env.CORS_PROXY_IMAGE__imageName}",
-                        "${env.CORS_PROXY_IMAGE__imageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushCorsProxyImageToQuay()
                 }
             }
         }
@@ -584,12 +573,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}",
-                        "${env.KIE_SANDBOX__imageName}",
-                        "${env.KIE_SANDBOX__imageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushKieSandboxImageToQuay()
                 }
             }
         }
@@ -633,12 +617,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushServerlessLogicWebToolsSWFDevModeImageToQuay()
                 }
             }
         }
@@ -659,12 +638,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.DEV_DEPLOYMENT_BASE_IMAGE__registry}/${env.DEV_DEPLOYMENT_BASE_IMAGE__account}",
-                        "${env.DEV_DEPLOYMENT_BASE_IMAGE__name}",
-                        "${env.DEV_DEPLOYMENT_BASE_IMAGE__buildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushDevDeploymentBaseImageToQuay()
                 }
             }
         }
@@ -685,12 +659,28 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account}",
-                        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}",
-                        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushDevDeploymentDmnFormWebappImageToQuay()
+                }
+            }
+        }
+
+        stage('Build (dev-deployment-kogito-quarkus-blank-app-image)') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildDevDeploymentKogitoQuarkusBlankAppImage()
+                    }
+                }
+            }
+        }
+
+        stage('STAGING: Push dev-deployment-kogito-quarkus-blank-app-image to quay.io') {
+            when {
+                expression { !params.DRY_RUN }
+            }
+            steps {
+                script {
+                    pushDevDeploymentKogitoQuarkusBlankAppImageToQuay()
                 }
             }
         }
@@ -711,12 +701,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}",
-                        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushServerlessLogicWebToolsBaseBuilderImageToQuay()
                 }
             }
         }
@@ -737,12 +722,7 @@ pipeline {
             }
             steps {
                 script {
-                    dockerUtils.pushImageToRegistry(
-                        "${env.DASHBUILDER__viewerImageRegistry}/${env.DASHBUILDER__viewerImageAccount}",
-                        "${env.DASHBUILDER__viewerImageName}",
-                        "${env.DASHBUILDER__viewerImageBuildTags}",
-                        "${pipelineVars.quayPushCredentialsId}"
-                    )
+                    pushDashbuilderViewerImageToQuay()
                 }
             }
         }
@@ -799,6 +779,7 @@ def buildPartial() {
     pnpm -F='!@kie-tools/serverless-logic-web-tools-swf-dev-mode-image' \
     -F='!@kie-tools/dev-deployment-base-image' \
     -F='!@kie-tools/dev-deployment-dmn-form-webapp-image' \
+    -F='!@kie-tools/dev-deployment-kogito-quarkus-blank-app-image' \
     -F='!@kie-tools/serverless-logic-web-tools-base-builder-image' \
     -F='!@kie-tools/dashbuilder-viewer-image' \
     -r --workspace-concurrency=1 build:prod
@@ -829,9 +810,17 @@ def buildDevDeploymentDmnFormWebappImage() {
     sh '''#!/bin/bash -el
     export KIE_TOOLS_BUILD__runTests=true
     export KIE_TOOLS_BUILD__buildContainerImages=true
-    docker system prune -af
     echo "Build @kie-tools/dev-deployment-dmn-form-webapp-image"
     pnpm -F @kie-tools/dev-deployment-dmn-form-webapp-image... --workspace-concurrency=1 build:prod
+    '''.trim()
+}
+
+def buildDevDeploymentKogitoQuarkusBlankAppImage() {
+    sh '''#!/bin/bash -el
+    export KIE_TOOLS_BUILD__runTests=true
+    export KIE_TOOLS_BUILD__buildContainerImages=true
+    echo "Build @kie-tools/dev-deployment-kogito-quarkus-blank-app-image"
+    pnpm -F @kie-tools/dev-deployment-kogito-quarkus-blank-app-image... --workspace-concurrency=1 build:prod
     '''.trim()
 }
 
@@ -943,6 +932,96 @@ def deployKieSandboxImageToOpenshift() {
         'js',
         "${pipelineVars.openshiftCredentialsId}",
         './deployment.env'
+    )
+}
+
+def pushServerlessLogicWebToolsSWFBuilderImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushKieSandboxExtendedServicesImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}",
+        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}",
+        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushCorsProxyImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}",
+        "${env.CORS_PROXY_IMAGE__imageName}",
+        "${env.CORS_PROXY_IMAGE__imageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushKieSandboxImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}",
+        "${env.KIE_SANDBOX__imageName}",
+        "${env.KIE_SANDBOX__imageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushServerlessLogicWebToolsSWFDevModeImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushDevDeploymentBaseImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.DEV_DEPLOYMENT_BASE_IMAGE__registry}/${env.DEV_DEPLOYMENT_BASE_IMAGE__account}",
+        "${env.DEV_DEPLOYMENT_BASE_IMAGE__name}",
+        "${env.DEV_DEPLOYMENT_BASE_IMAGE__buildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushDevDeploymentDmnFormWebappImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account}",
+        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}",
+        "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushDevDeploymentKogitoQuarkusBlankAppImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account}",
+        "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name}",
+        "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushDashbuilderViewerImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.DASHBUILDER__viewerImageRegistry}/${env.DASHBUILDER__viewerImageAccount}",
+        "${env.DASHBUILDER__viewerImageName}",
+        "${env.DASHBUILDER__viewerImageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
+    )
+}
+
+def pushServerlessLogicWebToolsBaseBuilderImageToQuay() {
+    dockerUtils.pushImageToRegistry(
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}",
+        "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags}",
+        "${pipelineVars.quayPushCredentialsId}"
     )
 }
 


### PR DESCRIPTION
Recently we have extended the staging build Jenkins job to build the new KIE Tools images and that change has caused an error when running the job on ASF Jenkins:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
General error during class generation: Method too large: WorkflowScript.___cps___862629 ()Lcom/cloudbees/groovy/cps/impl/CpsFunction;

groovyjarjarasm.asm.MethodTooLargeException: Method too large: WorkflowScript.___cps___862629 ()Lcom/cloudbees/groovy/cps/impl/CpsFunction;
```

This PR split the code into smaller functions to mitigate the issue. It also adds the build of the dev deployment kogito quarkus blank app image that was missing in the job.

The code changes have been tested on ASF Jenkins. See the job execution [here](https://ci-builds.apache.org/job/KIE/job/kie-tools/job/kie-tools-staging-dry-run/7/)

More information about this error can be found [here](https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/troubleshooting-guides/method-code-too-large-error)