### PR TITLE
kie-issues#234: Identify DMN DRD elements with collapsed dependencies with ellipsis (...) notation

### DIFF
--- a/packages/dmn-editor/src/DmnEditor.tsx
+++ b/packages/dmn-editor/src/DmnEditor.tsx
@@ -220,13 +220,6 @@ export const DmnEditorInternal = ({
               allTopLevelItemDefinitionUniqueNames={
                 state.computed(state).getDataTypes(externalModelsByNamespace).allTopLevelItemDefinitionUniqueNames
               }
-              drgNodeIdsBySourceNodeId={
-                state.computed(state).getDiagramData(externalModelsByNamespace).drgNodeIdsBySourceNodeId
-              }
-              drgElementsWithoutVisualRepresentationOnCurrentDrd={
-                state.computed(state).getDiagramData(externalModelsByNamespace)
-                  .drgElementsWithoutVisualRepresentationOnCurrentDrd
-              }
             />
           </g>,
           svg

--- a/packages/dmn-editor/src/DmnEditor.tsx
+++ b/packages/dmn-editor/src/DmnEditor.tsx
@@ -220,6 +220,13 @@ export const DmnEditorInternal = ({
               allTopLevelItemDefinitionUniqueNames={
                 state.computed(state).getDataTypes(externalModelsByNamespace).allTopLevelItemDefinitionUniqueNames
               }
+              drgNodeIdsBySourceNodeId={
+                state.computed(state).getDiagramData(externalModelsByNamespace).drgNodeIdsBySourceNodeId
+              }
+              drgElementsWithoutVisualRepresentationOnCurrentDrd={
+                state.computed(state).getDiagramData(externalModelsByNamespace)
+                  .drgElementsWithoutVisualRepresentationOnCurrentDrd
+              }
             />
           </g>,
           svg

--- a/packages/dmn-editor/src/diagram/Diagram.tsx
+++ b/packages/dmn-editor/src/diagram/Diagram.tsx
@@ -60,7 +60,7 @@ import {
   MIME_TYPE_FOR_DMN_EDITOR_EXTERNAL_NODES_FROM_INCLUDED_MODELS,
 } from "../externalNodes/ExternalNodesPanel";
 import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
-import { nodeNatures } from "../mutations/NodeNature";
+import { NodeNature, nodeNatures } from "../mutations/NodeNature";
 import { addConnectedNode } from "../mutations/addConnectedNode";
 import { addDecisionToDecisionService } from "../mutations/addDecisionToDecisionService";
 import { addEdge } from "../mutations/addEdge";
@@ -1785,6 +1785,10 @@ export function KeyboardShortcuts(props: {}) {
       }
 
       for (const node of rf.getNodes().filter((s) => s.selected)) {
+        // Prevent hiding artifact nodes from DRD;
+        if (nodeNatures[node.type as NodeType] === NodeNature.ARTIFACT) {
+          continue;
+        }
         const { deletedDmnShapeOnCurrentDrd: deletedShape } = deleteNode({
           drgEdges: [], // Deleting from DRD only.
           definitions: state.dmn.model.definitions,

--- a/packages/dmn-editor/src/diagram/connections/ConnectionLine.tsx
+++ b/packages/dmn-editor/src/diagram/connections/ConnectionLine.tsx
@@ -121,7 +121,7 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
             width={defaultSize["@_width"]}
             height={defaultSize["@_height"]}
             isCollection={false}
-            hasHiddenSource={false}
+            hasHiddenRequirements={false}
           />
         </g>
       );
@@ -134,7 +134,7 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
             y={toYsnapped}
             width={defaultSize["@_width"]}
             height={defaultSize["@_height"]}
-            hasHiddenSource={false}
+            hasHiddenRequirements={false}
           />
         </g>
       );
@@ -147,7 +147,7 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
             y={toYsnapped}
             width={defaultSize["@_width"]}
             height={defaultSize["@_height"]}
-            hasHiddenSource={false}
+            hasHiddenRequirements={false}
           />
         </g>
       );

--- a/packages/dmn-editor/src/diagram/connections/ConnectionLine.tsx
+++ b/packages/dmn-editor/src/diagram/connections/ConnectionLine.tsx
@@ -120,6 +120,8 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
             y={toYsnapped}
             width={defaultSize["@_width"]}
             height={defaultSize["@_height"]}
+            isCollection={false}
+            hasHiddenSource={false}
           />
         </g>
       );
@@ -127,7 +129,13 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
       return (
         <g className={"pulse"}>
           {edgeSvg}
-          <BkmNodeSvg x={toXsnapped} y={toYsnapped} width={defaultSize["@_width"]} height={defaultSize["@_height"]} />
+          <BkmNodeSvg
+            x={toXsnapped}
+            y={toYsnapped}
+            width={defaultSize["@_width"]}
+            height={defaultSize["@_height"]}
+            hasHiddenSource={false}
+          />
         </g>
       );
     } else if (nodeType === NODE_TYPES.knowledgeSource) {
@@ -139,6 +147,7 @@ export function ConnectionLine({ toX, toY, fromNode, fromHandle }: RF.Connection
             y={toYsnapped}
             width={defaultSize["@_width"]}
             height={defaultSize["@_height"]}
+            hasHiddenSource={false}
           />
         </g>
       );

--- a/packages/dmn-editor/src/diagram/graph/graph.ts
+++ b/packages/dmn-editor/src/diagram/graph/graph.ts
@@ -40,6 +40,10 @@ export type DrgEdge = {
   };
 };
 
+type NodeId = string & {};
+type TargetNodes = string & {};
+export type DrgNodes = Map<NodeId, Set<TargetNodes>>;
+
 export function getAdjMatrix(edges: DrgEdge[]): AdjMatrix {
   const __adjMatrix: AdjMatrix = {};
   for (const e of edges) {

--- a/packages/dmn-editor/src/diagram/graph/graph.ts
+++ b/packages/dmn-editor/src/diagram/graph/graph.ts
@@ -40,9 +40,7 @@ export type DrgEdge = {
   };
 };
 
-type NodeId = string & {};
-type TargetNodes = string & {};
-export type DrgNodes = Map<NodeId, Set<TargetNodes>>;
+export type DrgNodeIdsBySourceNodeId = Map<string, Set<string>>;
 
 export function getAdjMatrix(edges: DrgEdge[]): AdjMatrix {
   const __adjMatrix: AdjMatrix = {};

--- a/packages/dmn-editor/src/diagram/graph/graph.ts
+++ b/packages/dmn-editor/src/diagram/graph/graph.ts
@@ -40,7 +40,7 @@ export type DrgEdge = {
   };
 };
 
-export type DrgNodeIdsBySourceNodeId = Map<string, Set<string>>;
+export type DrgAdjacencyList = Map<string, { dependencies: Set<string> }>;
 
 export function getAdjMatrix(edges: DrgEdge[]): AdjMatrix {
   const __adjMatrix: AdjMatrix = {};

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -78,7 +78,6 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
     height,
     fillColor,
     strokeColor,
-    hasHiddenNodes,
     props: { isCollection, ...props },
   } = normalize(__props);
 
@@ -112,7 +111,6 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
         ry={ry}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
-      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -29,7 +29,6 @@ export type NodeSvgProps = RF.Dimensions &
     fillColor?: string;
     strokeColor?: string;
     strokeWidth?: number;
-    hasHiddenSource?: boolean;
   };
 
 export const ___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches = { flag: false };
@@ -44,7 +43,6 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: _height,
     fillColor: _fillColor,
     strokeColor: _strokeColor,
-    hasHiddenSource: _hasHiddenSource,
     ...props
   } = _props;
 
@@ -64,12 +62,11 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: height + (___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches.flag ? 0 : 0.1),
     fillColor: _fillColor,
     strokeColor: _strokeColor,
-    hasHiddenSource: _hasHiddenSource,
     props,
   };
 }
 
-export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolean }) {
+export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection: boolean }) {
   const {
     strokeWidth,
     x,
@@ -116,7 +113,7 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
 }
 
 export function AlternativeInputDataNodeSvg(
-  __props: NodeSvgProps & { isCollection?: boolean; isIcon: boolean; transform?: string }
+  __props: NodeSvgProps & { isCollection: boolean; isIcon: boolean; transform?: string }
 ) {
   const {
     strokeWidth,
@@ -171,7 +168,7 @@ export function AlternativeInputDataNodeSvg(
   );
 }
 
-export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean }) {
+export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean; hasHiddenSource: boolean }) {
   const {
     strokeWidth,
     x,
@@ -180,8 +177,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
     height,
     fillColor,
     strokeColor,
-    hasHiddenSource,
-    props: { isCollection, ...props },
+    props: { isCollection, hasHiddenSource, ...props },
   } = normalize(__props);
 
   return (
@@ -203,8 +199,17 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
   );
 }
 
-export function BkmNodeSvg(__props: NodeSvgProps) {
-  const { strokeWidth, x, y, width, height, fillColor, strokeColor, hasHiddenSource, props } = normalize(__props);
+export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean }) {
+  const {
+    strokeWidth,
+    x,
+    y,
+    width,
+    height,
+    fillColor,
+    strokeColor,
+    props: { hasHiddenSource, ...props },
+  } = normalize(__props);
   const bevel = 25;
   return (
     <>
@@ -222,7 +227,7 @@ export function BkmNodeSvg(__props: NodeSvgProps) {
   );
 }
 
-export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
+export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean }) {
   const {
     strokeWidth,
     x,
@@ -231,8 +236,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
     height: totalHeight,
     fillColor,
     strokeColor,
-    hasHiddenSource,
-    props,
+    props: { hasHiddenSource, ...props },
   } = normalize(__props);
   const amplitude = 20;
   const height = totalHeight - amplitude / 2; // Need to leave some space for the wave at the bottom.

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -108,6 +108,7 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
         ry={ry}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
+      <NodeHiddenInformationMarker {...__props} />
     </>
   );
 }
@@ -438,6 +439,47 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
         y2={y2Position}
         strokeWidth={strokeWidth}
         fill={fillColor ?? DEFAULT_NODE_FILL}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+    </>
+  );
+}
+
+function NodeHiddenInformationMarker(__props: NodeSvgProps) {
+  const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
+
+  const dotRadius = 1;
+  const xPosition = x + width / 2;
+  const xSpacing = 7;
+  const yPosition = y + height - 11;
+
+  return (
+    <>
+      <circle
+        {...props}
+        r={dotRadius}
+        cx={xPosition - xSpacing}
+        cy={yPosition}
+        strokeWidth={strokeWidth}
+        fill={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+      <circle
+        {...props}
+        r={dotRadius}
+        cx={xPosition}
+        cy={yPosition}
+        strokeWidth={strokeWidth}
+        fill={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+        stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
+      />
+      <circle
+        {...props}
+        r={dotRadius}
+        cx={xPosition + xSpacing}
+        cy={yPosition}
+        strokeWidth={strokeWidth}
+        fill={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
     </>

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -29,7 +29,7 @@ export type NodeSvgProps = RF.Dimensions &
     fillColor?: string;
     strokeColor?: string;
     strokeWidth?: number;
-    hasHiddenNodes?: boolean;
+    hasHiddenSource?: boolean;
   };
 
 export const ___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches = { flag: false };
@@ -44,7 +44,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: _height,
     fillColor: _fillColor,
     strokeColor: _strokeColor,
-    hasHiddenNodes: _hasHiddenNodes,
+    hasHiddenSource: _hasHiddenSource,
     ...props
   } = _props;
 
@@ -64,7 +64,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: height + (___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches.flag ? 0 : 0.1),
     fillColor: _fillColor,
     strokeColor: _strokeColor,
-    hasHiddenNodes: _hasHiddenNodes,
+    hasHiddenNodes: _hasHiddenSource,
     props,
   };
 }

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -107,7 +107,18 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection: boolean
         rx={rx}
         ry={ry}
       />
-      {isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
+      {isCollection && (
+        <NodeCollectionMarker
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          fillColor={fillColor}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor={"bottom"}
+        />
+      )}
     </>
   );
 }
@@ -163,12 +174,23 @@ export function AlternativeInputDataNodeSvg(
           />
         </>
       )}
-      {isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
+      {isCollection && (
+        <NodeCollectionMarker
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          fillColor={fillColor}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor={"bottom"}
+        />
+      )}
     </>
   );
 }
 
-export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean; hasHiddenSource: boolean }) {
+export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean; hasHiddenRequirements: boolean }) {
   const {
     strokeWidth,
     x,
@@ -177,7 +199,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean;
     height,
     fillColor,
     strokeColor,
-    props: { isCollection, hasHiddenSource, ...props },
+    props: { isCollection, hasHiddenRequirements, ...props },
   } = normalize(__props);
 
   return (
@@ -193,13 +215,34 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean;
         strokeLinejoin={"round"}
         {...props}
       />
-      {isCollection && <NodeCollectionMarker {...__props} anchor="top" />}
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"middle"} />}
+      {isCollection && (
+        <NodeCollectionMarker
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          fillColor={fillColor}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor="top"
+        />
+      )}
+      {hasHiddenRequirements && (
+        <NodeHiddenRequirementMarker
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor={"middle"}
+        />
+      )}
     </>
   );
 }
 
-export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean }) {
+export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenRequirements: boolean }) {
   const {
     strokeWidth,
     x,
@@ -208,7 +251,7 @@ export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean })
     height,
     fillColor,
     strokeColor,
-    props: { hasHiddenSource, ...props },
+    props: { hasHiddenRequirements, ...props },
   } = normalize(__props);
   const bevel = 25;
   return (
@@ -222,12 +265,22 @@ export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean })
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"middle"} />}
+      {hasHiddenRequirements && (
+        <NodeHiddenRequirementMarker
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor={"middle"}
+        />
+      )}
     </>
   );
 }
 
-export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean }) {
+export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenRequirements: boolean }) {
   const {
     strokeWidth,
     x,
@@ -236,7 +289,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenSource
     height: totalHeight,
     fillColor,
     strokeColor,
-    props: { hasHiddenSource, ...props },
+    props: { hasHiddenRequirements, ...props },
   } = normalize(__props);
   const amplitude = 20;
   const height = totalHeight - amplitude / 2; // Need to leave some space for the wave at the bottom.
@@ -254,7 +307,17 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenSource
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"left"} />}
+      {hasHiddenRequirements && (
+        <NodeHiddenRequirementMarker
+          x={x}
+          y={y}
+          width={width}
+          height={totalHeight}
+          strokeColor={strokeColor}
+          strokeWidth={strokeWidth}
+          anchor={"left"}
+        />
+      )}
     </>
   );
 }
@@ -477,18 +540,34 @@ export function UnknownNodeSvg(_props: NodeSvgProps & { strokeDasharray?: string
   );
 }
 
-function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom" }) {
-  const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
-
+function NodeCollectionMarker({
+  strokeWidth,
+  strokeColor,
+  fillColor,
+  x,
+  y,
+  width,
+  height,
+  anchor,
+}: {
+  strokeWidth: number;
+  strokeColor?: string;
+  fillColor?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  anchor: "top" | "bottom";
+}) {
   const xPosition = x + width / 2;
+  // Arbitrary space between the lines
   const xSpacing = 7;
-  const y1Position = props.anchor === "bottom" ? y + height - 4 : y + 4;
-  const y2Position = props.anchor === "bottom" ? y + height - 18 : y + 18;
+  const y1Position = anchor === "bottom" ? y + height - 4 : y + 4;
+  const y2Position = anchor === "bottom" ? y + height - 18 : y + 18;
 
   return (
     <>
       <line
-        {...props}
         x1={xPosition - xSpacing}
         x2={xPosition - xSpacing}
         y1={y1Position}
@@ -498,7 +577,6 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <line
-        {...props}
         x1={xPosition}
         x2={xPosition}
         y1={y1Position}
@@ -508,7 +586,6 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <line
-        {...props}
         x1={xPosition + xSpacing}
         x2={xPosition + xSpacing}
         y1={y1Position}
@@ -521,18 +598,35 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
   );
 }
 
-function NodeHiddenInformationMarker(__props: NodeSvgProps & { anchor: "middle" | "left" }) {
-  const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
-
+function NodeHiddenRequirementMarker({
+  strokeWidth,
+  strokeColor,
+  x,
+  y,
+  width,
+  height,
+  anchor,
+}: {
+  strokeWidth: number;
+  strokeColor?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  anchor: "middle" | "left";
+}) {
+  // Set the radius to 1 to create a dot.
   const dotRadius = 1;
-  const xPosition = props.anchor === "middle" ? x + width / 2 : x + width / 4;
+  const xPosition = anchor === "middle" ? x + width / 2 : x + width / 4;
+  // Arbitrary spacing between the dots;
   const xSpacing = 7;
-  const yPosition = props.anchor === "middle" ? y + height - 18 : y + height - 11;
+  // For the nodes where we position in the middle we need to take into account the "Edit" button
+  // making it necessary to be into a heigher position.
+  const yPosition = anchor === "middle" ? y + height - 18 : y + height - 11;
 
   return (
     <>
       <circle
-        {...props}
         r={dotRadius}
         cx={xPosition - xSpacing}
         cy={yPosition}
@@ -541,7 +635,6 @@ function NodeHiddenInformationMarker(__props: NodeSvgProps & { anchor: "middle" 
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <circle
-        {...props}
         r={dotRadius}
         cx={xPosition}
         cy={yPosition}
@@ -550,7 +643,6 @@ function NodeHiddenInformationMarker(__props: NodeSvgProps & { anchor: "middle" 
         stroke={strokeColor ?? DEFAULT_NODE_STROKE_COLOR}
       />
       <circle
-        {...props}
         r={dotRadius}
         cx={xPosition + xSpacing}
         cy={yPosition}

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -194,7 +194,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection: boolean;
         {...props}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor="top" />}
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"middle"} />}
     </>
   );
 }
@@ -222,7 +222,7 @@ export function BkmNodeSvg(__props: NodeSvgProps & { hasHiddenSource: boolean })
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"middle"} />}
     </>
   );
 }
@@ -254,7 +254,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps & { hasHiddenSource
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} anchor={"left"} />}
     </>
   );
 }
@@ -521,13 +521,13 @@ function NodeCollectionMarker(__props: NodeSvgProps & { anchor: "top" | "bottom"
   );
 }
 
-function NodeHiddenInformationMarker(__props: NodeSvgProps) {
+function NodeHiddenInformationMarker(__props: NodeSvgProps & { anchor: "middle" | "left" }) {
   const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
 
   const dotRadius = 1;
-  const xPosition = x + width / 2;
+  const xPosition = props.anchor === "middle" ? x + width / 2 : x + width / 4;
   const xSpacing = 7;
-  const yPosition = y + height - 18;
+  const yPosition = props.anchor === "middle" ? y + height - 18 : y + height - 11;
 
   return (
     <>

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -64,7 +64,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: height + (___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches.flag ? 0 : 0.1),
     fillColor: _fillColor,
     strokeColor: _strokeColor,
-    hasHiddenNodes: _hasHiddenSource,
+    hasHiddenSource: _hasHiddenSource,
     props,
   };
 }
@@ -180,7 +180,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
     height,
     fillColor,
     strokeColor,
-    hasHiddenNodes,
+    hasHiddenSource,
     props: { isCollection, ...props },
   } = normalize(__props);
 
@@ -198,13 +198,13 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
         {...props}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor="top" />}
-      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
 
 export function BkmNodeSvg(__props: NodeSvgProps) {
-  const { strokeWidth, x, y, width, height, fillColor, strokeColor, hasHiddenNodes, props } = normalize(__props);
+  const { strokeWidth, x, y, width, height, fillColor, strokeColor, hasHiddenSource, props } = normalize(__props);
   const bevel = 25;
   return (
     <>
@@ -217,7 +217,7 @@ export function BkmNodeSvg(__props: NodeSvgProps) {
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
@@ -231,7 +231,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
     height: totalHeight,
     fillColor,
     strokeColor,
-    hasHiddenNodes,
+    hasHiddenSource,
     props,
   } = normalize(__props);
   const amplitude = 20;
@@ -250,7 +250,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
-      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
+      {hasHiddenSource && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }

--- a/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -29,6 +29,7 @@ export type NodeSvgProps = RF.Dimensions &
     fillColor?: string;
     strokeColor?: string;
     strokeWidth?: number;
+    hasHiddenNodes?: boolean;
   };
 
 export const ___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches = { flag: false };
@@ -43,6 +44,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: _height,
     fillColor: _fillColor,
     strokeColor: _strokeColor,
+    hasHiddenNodes: _hasHiddenNodes,
     ...props
   } = _props;
 
@@ -62,6 +64,7 @@ export function normalize<T extends NodeSvgProps>(_props: T) {
     height: height + (___NASTY_HACK_FOR_SAFARI_to_force_redrawing_svgs_and_avoid_repaint_glitches.flag ? 0 : 0.1),
     fillColor: _fillColor,
     strokeColor: _strokeColor,
+    hasHiddenNodes: _hasHiddenNodes,
     props,
   };
 }
@@ -75,6 +78,7 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
     height,
     fillColor,
     strokeColor,
+    hasHiddenNodes,
     props: { isCollection, ...props },
   } = normalize(__props);
 
@@ -108,7 +112,7 @@ export function InputDataNodeSvg(__props: NodeSvgProps & { isCollection?: boolea
         ry={ry}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor={"bottom"} />}
-      <NodeHiddenInformationMarker {...__props} />
+      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
@@ -122,6 +126,7 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
     height,
     fillColor,
     strokeColor,
+    hasHiddenNodes,
     props: { isCollection, ...props },
   } = normalize(__props);
 
@@ -139,12 +144,13 @@ export function DecisionNodeSvg(__props: NodeSvgProps & { isCollection?: boolean
         {...props}
       />
       {isCollection && <NodeCollectionMarker {...__props} anchor="top" />}
+      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
 
 export function BkmNodeSvg(__props: NodeSvgProps) {
-  const { strokeWidth, x, y, width, height, fillColor, strokeColor, props } = normalize(__props);
+  const { strokeWidth, x, y, width, height, fillColor, strokeColor, hasHiddenNodes, props } = normalize(__props);
   const bevel = 25;
   return (
     <>
@@ -157,12 +163,23 @@ export function BkmNodeSvg(__props: NodeSvgProps) {
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
+      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
 
 export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
-  const { strokeWidth, x, y, width, height: totalHeight, fillColor, strokeColor, props } = normalize(__props);
+  const {
+    strokeWidth,
+    x,
+    y,
+    width,
+    height: totalHeight,
+    fillColor,
+    strokeColor,
+    hasHiddenNodes,
+    props,
+  } = normalize(__props);
   const amplitude = 20;
   const height = totalHeight - amplitude / 2; // Need to leave some space for the wave at the bottom.
 
@@ -179,6 +196,7 @@ export function KnowledgeSourceNodeSvg(__props: NodeSvgProps) {
         strokeLinejoin={"round"}
         transform={`translate(${x},${y})`}
       />
+      {hasHiddenNodes && <NodeHiddenInformationMarker {...__props} />}
     </>
   );
 }
@@ -451,7 +469,7 @@ function NodeHiddenInformationMarker(__props: NodeSvgProps) {
   const dotRadius = 1;
   const xPosition = x + width / 2;
   const xSpacing = 7;
-  const yPosition = y + height - 11;
+  const yPosition = y + height - 18;
 
   return (
     <>

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -88,6 +88,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
   dmnObject: T;
   shape: DMNDI15__DMNShape & { index: number };
   index: number;
+  hasHiddenNodes: boolean;
   /**
    * We don't use Reactflow's parenting mechanism because it is
    * too opinionated on how it deletes nodes/edges that are
@@ -98,7 +99,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
 
 export const InputDataNode = React.memo(
   ({
-    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace },
+    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -185,6 +186,7 @@ export const InputDataNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
+            hasHiddenNodes={hasHiddenNodes}
           />
         </svg>
         <PositionalNodeHandles isTargeted={isTargeted && isValidConnectionTarget} nodeId={id} />
@@ -243,7 +245,7 @@ export const InputDataNode = React.memo(
 
 export const DecisionNode = React.memo(
   ({
-    data: { parentRfNode, dmnObject: decision, shape, index, dmnObjectQName, dmnObjectNamespace },
+    data: { parentRfNode, dmnObject: decision, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -330,6 +332,7 @@ export const DecisionNode = React.memo(
             strokeWidth={parentRfNode ? 3 : shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
+            hasHiddenNodes={hasHiddenNodes}
           />
         </svg>
 
@@ -392,7 +395,7 @@ export const DecisionNode = React.memo(
 
 export const BkmNode = React.memo(
   ({
-    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace },
+    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -465,6 +468,7 @@ export const BkmNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
+            hasHiddenNodes={hasHiddenNodes}
           />
         </svg>
 
@@ -525,7 +529,7 @@ export const BkmNode = React.memo(
 
 export const KnowledgeSourceNode = React.memo(
   ({
-    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName },
+    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -585,6 +589,7 @@ export const KnowledgeSourceNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
+            hasHiddenNodes={hasHiddenNodes}
           />
         </svg>
 

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -89,7 +89,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
   dmnObject: T;
   shape: DMNDI15__DMNShape & { index: number };
   index: number;
-  hasHiddenSource: boolean;
+  hasHiddenRequirements: boolean;
   /**
    * We don't use Reactflow's parenting mechanism because it is
    * too opinionated on how it deletes nodes/edges that are
@@ -319,7 +319,15 @@ export const InputDataNode = React.memo(
 
 export const DecisionNode = React.memo(
   ({
-    data: { parentRfNode, dmnObject: decision, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
+    data: {
+      parentRfNode,
+      dmnObject: decision,
+      shape,
+      index,
+      dmnObjectQName,
+      dmnObjectNamespace,
+      hasHiddenRequirements: hasHiddenRequirements,
+    },
     selected,
     dragging,
     zIndex,
@@ -411,7 +419,7 @@ export const DecisionNode = React.memo(
             strokeWidth={parentRfNode ? 3 : shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenSource={hasHiddenSource}
+            hasHiddenRequirements={hasHiddenRequirements}
           />
         </svg>
 
@@ -474,7 +482,14 @@ export const DecisionNode = React.memo(
 
 export const BkmNode = React.memo(
   ({
-    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
+    data: {
+      dmnObject: bkm,
+      shape,
+      index,
+      dmnObjectQName,
+      dmnObjectNamespace,
+      hasHiddenRequirements: hasHiddenRequirements,
+    },
     selected,
     dragging,
     zIndex,
@@ -547,7 +562,7 @@ export const BkmNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenSource={hasHiddenSource}
+            hasHiddenRequirements={hasHiddenRequirements}
           />
         </svg>
 
@@ -608,7 +623,7 @@ export const BkmNode = React.memo(
 
 export const KnowledgeSourceNode = React.memo(
   ({
-    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenSource },
+    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenRequirements: hasHiddenRequirements },
     selected,
     dragging,
     zIndex,
@@ -673,7 +688,7 @@ export const KnowledgeSourceNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenSource={hasHiddenSource}
+            hasHiddenRequirements={hasHiddenRequirements}
           />
         </svg>
 

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -326,7 +326,7 @@ export const DecisionNode = React.memo(
       index,
       dmnObjectQName,
       dmnObjectNamespace,
-      hasHiddenRequirements: hasHiddenRequirements,
+      hasHiddenRequirements,
     },
     selected,
     dragging,
@@ -482,14 +482,7 @@ export const DecisionNode = React.memo(
 
 export const BkmNode = React.memo(
   ({
-    data: {
-      dmnObject: bkm,
-      shape,
-      index,
-      dmnObjectQName,
-      dmnObjectNamespace,
-      hasHiddenRequirements: hasHiddenRequirements,
-    },
+    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenRequirements },
     selected,
     dragging,
     zIndex,
@@ -623,7 +616,7 @@ export const BkmNode = React.memo(
 
 export const KnowledgeSourceNode = React.memo(
   ({
-    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenRequirements: hasHiddenRequirements },
+    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenRequirements },
     selected,
     dragging,
     zIndex,

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -99,7 +99,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
 
 export const InputDataNode = React.memo(
   ({
-    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
+    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace },
     selected,
     dragging,
     zIndex,
@@ -186,7 +186,6 @@ export const InputDataNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenSource={hasHiddenSource}
           />
         </svg>
         <PositionalNodeHandles isTargeted={isTargeted && isValidConnectionTarget} nodeId={id} />

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -99,7 +99,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
 
 export const InputDataNode = React.memo(
   ({
-    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource: hasHiddenNodes },
+    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
     selected,
     dragging,
     zIndex,
@@ -186,7 +186,7 @@ export const InputDataNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenNodes={hasHiddenNodes}
+            hasHiddenSource={hasHiddenSource}
           />
         </svg>
         <PositionalNodeHandles isTargeted={isTargeted && isValidConnectionTarget} nodeId={id} />
@@ -245,15 +245,7 @@ export const InputDataNode = React.memo(
 
 export const DecisionNode = React.memo(
   ({
-    data: {
-      parentRfNode,
-      dmnObject: decision,
-      shape,
-      index,
-      dmnObjectQName,
-      dmnObjectNamespace,
-      hasHiddenSource: hasHiddenNodes,
-    },
+    data: { parentRfNode, dmnObject: decision, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
     selected,
     dragging,
     zIndex,
@@ -340,7 +332,7 @@ export const DecisionNode = React.memo(
             strokeWidth={parentRfNode ? 3 : shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenNodes={hasHiddenNodes}
+            hasHiddenSource={hasHiddenSource}
           />
         </svg>
 
@@ -403,7 +395,7 @@ export const DecisionNode = React.memo(
 
 export const BkmNode = React.memo(
   ({
-    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource: hasHiddenNodes },
+    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource },
     selected,
     dragging,
     zIndex,
@@ -476,7 +468,7 @@ export const BkmNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenNodes={hasHiddenNodes}
+            hasHiddenSource={hasHiddenSource}
           />
         </svg>
 
@@ -537,7 +529,7 @@ export const BkmNode = React.memo(
 
 export const KnowledgeSourceNode = React.memo(
   ({
-    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenSource: hasHiddenNodes },
+    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenSource },
     selected,
     dragging,
     zIndex,
@@ -597,7 +589,7 @@ export const KnowledgeSourceNode = React.memo(
             strokeWidth={shapeStyle.strokeWidth}
             fillColor={shapeStyle.fillColor}
             strokeColor={shapeStyle.strokeColor}
-            hasHiddenNodes={hasHiddenNodes}
+            hasHiddenSource={hasHiddenSource}
           />
         </svg>
 

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -88,7 +88,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
   dmnObject: T;
   shape: DMNDI15__DMNShape & { index: number };
   index: number;
-  hasHiddenNodes: boolean;
+  hasHiddenSource: boolean;
   /**
    * We don't use Reactflow's parenting mechanism because it is
    * too opinionated on how it deletes nodes/edges that are
@@ -99,7 +99,7 @@ export type DmnDiagramNodeData<T extends NodeDmnObjects = NodeDmnObjects> = {
 
 export const InputDataNode = React.memo(
   ({
-    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
+    data: { dmnObject: inputData, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource: hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -245,7 +245,15 @@ export const InputDataNode = React.memo(
 
 export const DecisionNode = React.memo(
   ({
-    data: { parentRfNode, dmnObject: decision, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
+    data: {
+      parentRfNode,
+      dmnObject: decision,
+      shape,
+      index,
+      dmnObjectQName,
+      dmnObjectNamespace,
+      hasHiddenSource: hasHiddenNodes,
+    },
     selected,
     dragging,
     zIndex,
@@ -395,7 +403,7 @@ export const DecisionNode = React.memo(
 
 export const BkmNode = React.memo(
   ({
-    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenNodes },
+    data: { dmnObject: bkm, shape, index, dmnObjectQName, dmnObjectNamespace, hasHiddenSource: hasHiddenNodes },
     selected,
     dragging,
     zIndex,
@@ -529,7 +537,7 @@ export const BkmNode = React.memo(
 
 export const KnowledgeSourceNode = React.memo(
   ({
-    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenNodes },
+    data: { dmnObject: knowledgeSource, shape, index, dmnObjectQName, hasHiddenSource: hasHiddenNodes },
     selected,
     dragging,
     zIndex,

--- a/packages/dmn-editor/src/diagram/nodes/OutgoingStuffNodePanel.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/OutgoingStuffNodePanel.tsx
@@ -117,9 +117,11 @@ export function OutgoingStuffNodePanel(props: { isVisible: boolean; nodeTypes: N
                   viewBox={`0 0 ${nodeSvgViewboxSize} ${nodeSvgViewboxSize}`}
                   style={{ padding: `${svgViewboxPadding}px` }}
                 >
-                  {nodeType === NODE_TYPES.inputData && <InputDataNodeSvg {...nodeSvgProps} />}
-                  {nodeType === NODE_TYPES.decision && <DecisionNodeSvg {...nodeSvgProps} />}
-                  {nodeType === NODE_TYPES.bkm && <BkmNodeSvg {...nodeSvgProps} />}
+                  {nodeType === NODE_TYPES.inputData && <InputDataNodeSvg {...nodeSvgProps} isCollection={false} />}
+                  {nodeType === NODE_TYPES.decision && (
+                    <DecisionNodeSvg {...nodeSvgProps} isCollection={false} hasHiddenSource={false} />
+                  )}
+                  {nodeType === NODE_TYPES.bkm && <BkmNodeSvg {...nodeSvgProps} hasHiddenSource={false} />}
                   {nodeType === NODE_TYPES.decisionService && (
                     <DecisionServiceNodeSvg
                       {...nodeSvgProps}
@@ -129,7 +131,9 @@ export function OutgoingStuffNodePanel(props: { isVisible: boolean; nodeTypes: N
                       isReadonly={true}
                     />
                   )}
-                  {nodeType === NODE_TYPES.knowledgeSource && <KnowledgeSourceNodeSvg {...nodeSvgProps} />}
+                  {nodeType === NODE_TYPES.knowledgeSource && (
+                    <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
+                  )}
                   {nodeType === NODE_TYPES.textAnnotation && <TextAnnotationNodeSvg {...nodeSvgProps} />}
                   {nodeType === NODE_TYPES.group && <GroupNodeSvg {...nodeSvgProps} />}
                 </svg>

--- a/packages/dmn-editor/src/diagram/nodes/OutgoingStuffNodePanel.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/OutgoingStuffNodePanel.tsx
@@ -119,9 +119,9 @@ export function OutgoingStuffNodePanel(props: { isVisible: boolean; nodeTypes: N
                 >
                   {nodeType === NODE_TYPES.inputData && <InputDataNodeSvg {...nodeSvgProps} isCollection={false} />}
                   {nodeType === NODE_TYPES.decision && (
-                    <DecisionNodeSvg {...nodeSvgProps} isCollection={false} hasHiddenSource={false} />
+                    <DecisionNodeSvg {...nodeSvgProps} isCollection={false} hasHiddenRequirements={false} />
                   )}
-                  {nodeType === NODE_TYPES.bkm && <BkmNodeSvg {...nodeSvgProps} hasHiddenSource={false} />}
+                  {nodeType === NODE_TYPES.bkm && <BkmNodeSvg {...nodeSvgProps} hasHiddenRequirements={false} />}
                   {nodeType === NODE_TYPES.decisionService && (
                     <DecisionServiceNodeSvg
                       {...nodeSvgProps}
@@ -132,7 +132,7 @@ export function OutgoingStuffNodePanel(props: { isVisible: boolean; nodeTypes: N
                     />
                   )}
                   {nodeType === NODE_TYPES.knowledgeSource && (
-                    <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
+                    <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenRequirements={false} />
                   )}
                   {nodeType === NODE_TYPES.textAnnotation && <TextAnnotationNodeSvg {...nodeSvgProps} />}
                   {nodeType === NODE_TYPES.group && <GroupNodeSvg {...nodeSvgProps} />}

--- a/packages/dmn-editor/src/icons/Icons.tsx
+++ b/packages/dmn-editor/src/icons/Icons.tsx
@@ -118,21 +118,21 @@ export function AlternativeInputDataIcon(props: {
 export function DecisionIcon() {
   return (
     <RoundSvg>
-      <DecisionNodeSvg {...nodeSvgProps} hasHiddenSource={false} isCollection={false} />
+      <DecisionNodeSvg {...nodeSvgProps} hasHiddenRequirements={false} isCollection={false} />
     </RoundSvg>
   );
 }
 export function BkmIcon() {
   return (
     <RoundSvg>
-      <BkmNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
+      <BkmNodeSvg {...nodeSvgProps} hasHiddenRequirements={false} />
     </RoundSvg>
   );
 }
 export function KnowledgeSourceIcon() {
   return (
     <RoundSvg>
-      <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
+      <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenRequirements={false} />
     </RoundSvg>
   );
 }

--- a/packages/dmn-editor/src/icons/Icons.tsx
+++ b/packages/dmn-editor/src/icons/Icons.tsx
@@ -89,7 +89,7 @@ export function NodeIcon({ isAlternativeInputDataShape, nodeType }: NodeIcons) {
 export function InputDataIcon(props: { padding?: string; height?: number }) {
   return (
     <RoundSvg padding={props.padding} height={props.height}>
-      <InputDataNodeSvg {...nodeSvgProps} />
+      <InputDataNodeSvg {...nodeSvgProps} isCollection={false} />
     </RoundSvg>
   );
 }
@@ -109,6 +109,7 @@ export function AlternativeInputDataIcon(props: {
         height={100}
         strokeWidth={8}
         transform={props.transform ?? "translate(80, 60)"}
+        isCollection={false}
       />
     </RoundSvg>
   );
@@ -117,21 +118,21 @@ export function AlternativeInputDataIcon(props: {
 export function DecisionIcon() {
   return (
     <RoundSvg>
-      <DecisionNodeSvg {...nodeSvgProps} />
+      <DecisionNodeSvg {...nodeSvgProps} hasHiddenSource={false} isCollection={false} />
     </RoundSvg>
   );
 }
 export function BkmIcon() {
   return (
     <RoundSvg>
-      <BkmNodeSvg {...nodeSvgProps} />
+      <BkmNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
     </RoundSvg>
   );
 }
 export function KnowledgeSourceIcon() {
   return (
     <RoundSvg>
-      <KnowledgeSourceNodeSvg {...nodeSvgProps} />
+      <KnowledgeSourceNodeSvg {...nodeSvgProps} hasHiddenSource={false} />
     </RoundSvg>
   );
 }

--- a/packages/dmn-editor/src/mutations/deleteNode.ts
+++ b/packages/dmn-editor/src/mutations/deleteNode.ts
@@ -107,10 +107,11 @@ export function deleteNode({
   if (!dmnObjectQName.prefix) {
     // Delete the dmnObject itself
     if (nodeNature === NodeNature.ARTIFACT) {
-      if (mode === NodeDeletionMode.FROM_DRG_AND_ALL_DRDS) {
-        const nodeIndex = (definitions.artifact ?? []).findIndex((a) => a["@_id"] === dmnObjectId);
-        dmnObject = definitions.artifact?.splice(nodeIndex, 1)?.[0];
-      }
+      const nodeIndex = (definitions.artifact ?? []).findIndex((a) => a["@_id"] === dmnObjectId);
+      dmnObject =
+        mode === NodeDeletionMode.FROM_DRG_AND_ALL_DRDS
+          ? definitions.artifact?.splice(nodeIndex, 1)?.[0]
+          : definitions.artifact?.[nodeIndex];
     } else if (nodeNature === NodeNature.DRG_ELEMENT) {
       const nodeIndex = (definitions.drgElement ?? []).findIndex((d) => d["@_id"] === dmnObjectId);
       dmnObject =

--- a/packages/dmn-editor/src/mutations/deleteNode.ts
+++ b/packages/dmn-editor/src/mutations/deleteNode.ts
@@ -107,11 +107,12 @@ export function deleteNode({
   if (!dmnObjectQName.prefix) {
     // Delete the dmnObject itself
     if (nodeNature === NodeNature.ARTIFACT) {
-      const nodeIndex = (definitions.artifact ?? []).findIndex((a) => a["@_id"] === dmnObjectId);
-      dmnObject =
-        mode === NodeDeletionMode.FROM_DRG_AND_ALL_DRDS
-          ? definitions.artifact?.splice(nodeIndex, 1)?.[0]
-          : definitions.artifact?.[nodeIndex];
+      if (mode === NodeDeletionMode.FROM_DRG_AND_ALL_DRDS) {
+        const nodeIndex = (definitions.artifact ?? []).findIndex((a) => a["@_id"] === dmnObjectId);
+        dmnObject = definitions.artifact?.splice(nodeIndex, 1)?.[0];
+      } else {
+        throw new Error(`DMN MUTATION: Can't hide an artifact node.`);
+      }
     } else if (nodeNature === NodeNature.DRG_ELEMENT) {
       const nodeIndex = (definitions.drgElement ?? []).findIndex((d) => d["@_id"] === dmnObjectId);
       dmnObject =

--- a/packages/dmn-editor/src/store/computed/computeDiagramData.ts
+++ b/packages/dmn-editor/src/store/computed/computeDiagramData.ts
@@ -336,11 +336,10 @@ export function computeDiagramData(
     .filter((e) => nodesById.has(e.source) && nodesById.has(e.target))
     .sort((a, b) => Number(selectedEdges.has(a.id)) - Number(selectedEdges.has(b.id)));
 
+  // console.timeEnd("nodes");
   if (diagram.overlays.enableNodeHierarchyHighlight) {
     assignClassesToHighlightedHierarchyNodes(diagram._selectedNodes, nodesById, edgesById, drgEdges);
   }
-
-  // console.timeEnd("nodes");
 
   return {
     drgEdges,

--- a/packages/dmn-editor/src/store/computed/computeDiagramData.ts
+++ b/packages/dmn-editor/src/store/computed/computeDiagramData.ts
@@ -116,11 +116,11 @@ export function computeDiagramData(
 
     drgEdges.push({ id, sourceId: source, targetId: target, dmnObject });
 
-    const sourceAdjancyList = drgAdjacencyList.get(source);
-    if (!sourceAdjancyList) {
-      drgAdjacencyList.set(source, { dependencies: new Set([target]) });
+    const targetAdjancyList = drgAdjacencyList.get(target);
+    if (!targetAdjancyList) {
+      drgAdjacencyList.set(target, { dependencies: new Set([source]) });
     } else {
-      sourceAdjancyList.dependencies.add(target);
+      targetAdjancyList.dependencies.add(source);
     }
 
     return edge;
@@ -331,14 +331,14 @@ export function computeDiagramData(
     .filter((e) => nodesById.has(e.source) && nodesById.has(e.target))
     .sort((a, b) => Number(selectedEdges.has(a.id)) - Number(selectedEdges.has(b.id)));
 
-  for (const elementWithoutVisualRepresentation of drgElementsWithoutVisualRepresentationOnCurrentDrd) {
-    // Set hasHiddenRequirements for the dependencies of all elements without visual representation
-    drgAdjacencyList.get(elementWithoutVisualRepresentation)?.dependencies?.forEach((dependencyNodeId) => {
-      const node = nodesById.get(dependencyNodeId);
-      if (node) {
+  // Search on the node list for the missing dependencies on the DRD.
+  for (const node of sortedNodes) {
+    for (const dependencyNodeId of drgAdjacencyList.get(node.id)?.dependencies ?? new Set()) {
+      if (!nodesById.get(dependencyNodeId)) {
         node.data.hasHiddenRequirements = true;
+        break;
       }
-    });
+    }
   }
 
   // console.timeEnd("nodes");

--- a/packages/dmn-editor/src/svg/DmnDiagramSvg.tsx
+++ b/packages/dmn-editor/src/svg/DmnDiagramSvg.tsx
@@ -59,6 +59,7 @@ import { Text } from "@visx/text";
 import { TypeOrReturnType } from "../store/ComputedStateCache";
 import { UniqueNameIndex } from "../Dmn15Spec";
 import { DataTypeIndex } from "../dataTypes/DataTypes";
+import { DrgNodeIdsBySourceNodeId } from "../diagram/graph/graph";
 
 export function DmnDiagramSvg({
   nodes,
@@ -69,6 +70,8 @@ export function DmnDiagramSvg({
   isAlternativeInputDataShape,
   allDataTypesById,
   allTopLevelItemDefinitionUniqueNames,
+  drgNodeIdsBySourceNodeId,
+  drgElementsWithoutVisualRepresentationOnCurrentDrd,
 }: {
   nodes: RF.Node<DmnDiagramNodeData>[];
   edges: RF.Edge<DmnDiagramEdgeData>[];
@@ -78,7 +81,18 @@ export function DmnDiagramSvg({
   isAlternativeInputDataShape: boolean;
   allDataTypesById: DataTypeIndex;
   allTopLevelItemDefinitionUniqueNames: UniqueNameIndex;
+  drgNodeIdsBySourceNodeId: DrgNodeIdsBySourceNodeId;
+  drgElementsWithoutVisualRepresentationOnCurrentDrd: string[];
 }) {
+  const nodesWithHiddenSource = useMemo(() => {
+    return drgElementsWithoutVisualRepresentationOnCurrentDrd.reduce((acc, hiddenElementId) => {
+      drgNodeIdsBySourceNodeId.get(hiddenElementId)?.forEach((targetIds) => {
+        acc.add(targetIds);
+      });
+      return acc;
+    }, new Set<string>());
+  }, [drgElementsWithoutVisualRepresentationOnCurrentDrd, drgNodeIdsBySourceNodeId]);
+
   const { nodesSvg, nodesById } = useMemo(() => {
     const nodesById = new Map<string, RF.Node<DmnDiagramNodeData>>();
 
@@ -155,6 +169,7 @@ export function DmnDiagramSvg({
               {...style}
               {...shapeStyle}
               isCollection={isCollection}
+              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
             />
           )}
           {node.type === NODE_TYPES.bkm && (
@@ -165,6 +180,7 @@ export function DmnDiagramSvg({
               y={node.positionAbsolute!.y}
               {...style}
               {...shapeStyle}
+              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
             />
           )}
           {node.type === NODE_TYPES.knowledgeSource && (
@@ -175,6 +191,7 @@ export function DmnDiagramSvg({
               y={node.positionAbsolute!.y}
               {...style}
               {...shapeStyle}
+              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
             />
           )}
           {node.type === NODE_TYPES.decisionService && (

--- a/packages/dmn-editor/src/svg/DmnDiagramSvg.tsx
+++ b/packages/dmn-editor/src/svg/DmnDiagramSvg.tsx
@@ -59,7 +59,6 @@ import { Text } from "@visx/text";
 import { TypeOrReturnType } from "../store/ComputedStateCache";
 import { UniqueNameIndex } from "../Dmn15Spec";
 import { DataTypeIndex } from "../dataTypes/DataTypes";
-import { DrgNodeIdsBySourceNodeId } from "../diagram/graph/graph";
 
 export function DmnDiagramSvg({
   nodes,
@@ -70,8 +69,6 @@ export function DmnDiagramSvg({
   isAlternativeInputDataShape,
   allDataTypesById,
   allTopLevelItemDefinitionUniqueNames,
-  drgNodeIdsBySourceNodeId,
-  drgElementsWithoutVisualRepresentationOnCurrentDrd,
 }: {
   nodes: RF.Node<DmnDiagramNodeData>[];
   edges: RF.Edge<DmnDiagramEdgeData>[];
@@ -81,18 +78,7 @@ export function DmnDiagramSvg({
   isAlternativeInputDataShape: boolean;
   allDataTypesById: DataTypeIndex;
   allTopLevelItemDefinitionUniqueNames: UniqueNameIndex;
-  drgNodeIdsBySourceNodeId: DrgNodeIdsBySourceNodeId;
-  drgElementsWithoutVisualRepresentationOnCurrentDrd: string[];
 }) {
-  const nodesWithHiddenSource = useMemo(() => {
-    return drgElementsWithoutVisualRepresentationOnCurrentDrd.reduce((acc, hiddenElementId) => {
-      drgNodeIdsBySourceNodeId.get(hiddenElementId)?.forEach((targetIds) => {
-        acc.add(targetIds);
-      });
-      return acc;
-    }, new Set<string>());
-  }, [drgElementsWithoutVisualRepresentationOnCurrentDrd, drgNodeIdsBySourceNodeId]);
-
   const { nodesSvg, nodesById } = useMemo(() => {
     const nodesById = new Map<string, RF.Node<DmnDiagramNodeData>>();
 
@@ -169,7 +155,7 @@ export function DmnDiagramSvg({
               {...style}
               {...shapeStyle}
               isCollection={isCollection}
-              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
+              hasHiddenRequirements={node.data.hasHiddenRequirements ?? false}
             />
           )}
           {node.type === NODE_TYPES.bkm && (
@@ -180,7 +166,7 @@ export function DmnDiagramSvg({
               y={node.positionAbsolute!.y}
               {...style}
               {...shapeStyle}
-              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
+              hasHiddenRequirements={node.data.hasHiddenRequirements ?? false}
             />
           )}
           {node.type === NODE_TYPES.knowledgeSource && (
@@ -191,7 +177,7 @@ export function DmnDiagramSvg({
               y={node.positionAbsolute!.y}
               {...style}
               {...shapeStyle}
-              hasHiddenSource={nodesWithHiddenSource.has(node.id) ?? false}
+              hasHiddenRequirements={node.data.hasHiddenRequirements ?? false}
             />
           )}
           {node.type === NODE_TYPES.decisionService && (


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/234

## Description
- Adds the ellipsis into the Decision, BKM and Knowledge Source nodes;
- Fix the delete Text Annotation node from DRD;
- This PR removes the optionality of the "isCollection" on Input Data and Decision Node;

## Video

https://github.com/apache/incubator-kie-tools/assets/24302289/bd4d02c2-da5d-4d3c-9e69-f2da99192568


