### PR TITLE
kie-issues#954: Extended Services Runner erases data on dates with Decision Update

### DIFF
--- a/packages/dmn-runner/src/ajv.ts
+++ b/packages/dmn-runner/src/ajv.ts
@@ -50,7 +50,7 @@ import {
  * ajv: 'date-time'
  * dmn: 'date and time'
  */
-enum DmnAjvSchemaFormat {
+export enum DmnAjvSchemaFormat {
   DATE = "date",
   TIME = "time",
   DATE_TIME = "date-time",

--- a/packages/dmn-runner/src/jsonSchema.ts
+++ b/packages/dmn-runner/src/jsonSchema.ts
@@ -77,8 +77,8 @@ export function removeChangedPropertiesAndAdditionalProperties<T extends Validat
         return;
       }
 
-      // uniforms-patternfly saves date-time component value as a Date object and
-      // AJV handles data-time as an string, causing an error with keyword type.
+      // uniforms-patternfly saves the DateTimeField component value as a Date object and
+      // AJV handles data-time as a string, causing an error with keyword type.
       // Also, the ajv.ErrorObject doesn't correctly type the parentSchema property
       if (
         error.keyword === "type" &&

--- a/packages/dmn-runner/src/jsonSchema.ts
+++ b/packages/dmn-runner/src/jsonSchema.ts
@@ -77,6 +77,17 @@ export function removeChangedPropertiesAndAdditionalProperties<T extends Validat
         return;
       }
 
+      // uniforms-patternfly saves date-time component value as a Date object and
+      // AJV handles data-time as an string, causing an error with keyword type.
+      // Also, the ajv.ErrorObject doesn't correctly type the parentSchema property
+      if (
+        error.keyword === "type" &&
+        (error.parentSchema as any)?.format === "date-time" &&
+        error.data instanceof Date
+      ) {
+        return;
+      }
+
       const pathList = error.dataPath
         .replace(/\['([^']+)'\]/g, "$1")
         .replace(/\[(\d+)\]/g, ".$1")

--- a/packages/dmn-runner/src/jsonSchema.ts
+++ b/packages/dmn-runner/src/jsonSchema.ts
@@ -18,7 +18,7 @@
  */
 
 import { JSON_SCHEMA_INPUT_SET_PATH, RECURSION_KEYWORD, RECURSION_REF_KEYWORD, X_DMN_TYPE_KEYWORD } from "./constants";
-import { ValidateFunction } from "./ajv";
+import { DmnAjvSchemaFormat, ValidateFunction } from "./ajv";
 import {
   ExtendedServicesDmnJsonSchema,
   DmnInputFieldProperties,
@@ -82,7 +82,7 @@ export function removeChangedPropertiesAndAdditionalProperties<T extends Validat
       // Also, the ajv.ErrorObject doesn't correctly type the parentSchema property
       if (
         error.keyword === "type" &&
-        (error.parentSchema as any)?.format === "date-time" &&
+        (error.parentSchema as any)?.format === DmnAjvSchemaFormat.DATE_TIME &&
         error.data instanceof Date
       ) {
         return;


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/954

## Description
The `DateTimeField` component saves its value as a `Date` object and AJV handles the `date-time` type as a `string`. This discrepancy caused the `Date` value to be removed after a new edit. This PR skips the error keyword `type` for the `date-time` type when the data is a `Date`.

https://github.com/apache/incubator-kie-tools/assets/24302289/8c1f17a8-e7ff-44c7-8743-6875a9465389

