### PR TITLE
NO-ISSUE: Bump `jsonata` to `1.8.7`

### DIFF
--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -54,7 +54,7 @@
     <version.org.webjars.npm.js-yaml>4.1.0</version.org.webjars.npm.js-yaml>
     <version.org.webjars.bower.d3geoprojection>2.5.1</version.org.webjars.bower.d3geoprojection>
     <version.org.webjars.npm.marked>4.3.0</version.org.webjars.npm.marked>
-    <version.org.webjars.npm.jsonata>1.8.0</version.org.webjars.npm.jsonata>
+    <version.org.webjars.npm.jsonata>1.8.7</version.org.webjars.npm.jsonata>
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
     <!-- Resolved artifacts -->

--- a/packages/pmml-editor-marshaller/package.json
+++ b/packages/pmml-editor-marshaller/package.json
@@ -24,7 +24,7 @@
     "test": "run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --verbose --passWithNoTests\""
   },
   "dependencies": {
-    "jsonata": "^1.8.3",
+    "jsonata": "^1.8.7",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/serverless-workflow-language-service/package.json
+++ b/packages/serverless-workflow-language-service/package.json
@@ -31,7 +31,7 @@
     "@kie-tools/yaml-language-server": "workspace:*",
     "@severlessworkflow/sdk-typescript": "^3.0.3",
     "json-to-ast": "^2.1.0",
-    "jsonata": "^1.8.3",
+    "jsonata": "^1.8.7",
     "jsonc-parser": "^3.0.0",
     "path-browserify": "^1.0.1",
     "vscode-json-languageservice": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6593,8 +6593,8 @@ importers:
   packages/pmml-editor-marshaller:
     dependencies:
       jsonata:
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.7
+        version: 1.8.7
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -8449,8 +8449,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       jsonata:
-        specifier: ^1.8.3
-        version: 1.8.3
+        specifier: ^1.8.7
+        version: 1.8.7
       jsonc-parser:
         specifier: ^3.0.0
         version: 3.0.0
@@ -38539,9 +38539,9 @@ packages:
     hasBin: true
     dev: true
 
-  /jsonata@1.8.3:
+  /jsonata@1.8.7:
     resolution:
-      { integrity: sha512-r6ztI6ohbpRo77AxBm6vMs3aHZi2L2PaakW7TCPwSkeGcuAZ/SxXGLWH2Npwqq5+YBM/fg/g0EXg/pI9HvXQ8Q== }
+      { integrity: sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ== }
     engines: { node: ">= 8" }
     dev: false
 


### PR DESCRIPTION
Fixes a critical issue raised by dependabot.