### PR TITLE
NO-ISSUE: Parametrize dev deployments and extended-services build images

### DIFF
--- a/packages/dev-deployment-base-image/Containerfile
+++ b/packages/dev-deployment-base-image/Containerfile
@@ -20,23 +20,33 @@ ARG BUILDER_IMAGE_ARG
 
 FROM --platform=linux/amd64 ${BUILDER_IMAGE_ARG}
 
-ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME/app
-ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
+ARG USER_ID_ARG=185
+ARG HOME_PATH_ARG=$HOME
 
-RUN mkdir -p -m 777 $HOME/app && mkdir -p -m 777 /tmp/app
-
-COPY dist-dev/dev-deployment-upload-service /usr/local/bin
+ENV USER_ID=${USER_ID_ARG}
+ENV HOME_PATH=${HOME_PATH_ARG}
 
 USER root
 
-RUN chgrp -R 0 $HOME/app && \
-    chmod -R 777 $HOME/app
+ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME_PATH/app
+ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
 
-WORKDIR $HOME/app/
+RUN mkdir -p -m 777 $HOME_PATH/app && mkdir -p -m 777 /tmp/app && mkdir -p -m 777 /.m2
+
+COPY dist-dev/dev-deployment-upload-service /usr/local/bin
+COPY .mvn $HOME_PATH/app/.mvn
+COPY mvnw $HOME_PATH/app
+
+RUN chgrp -R 0 $HOME_PATH/app && \
+    chmod -R 777 $HOME_PATH/app && \
+    chgrp -R 0 /.m2 && \
+    chmod -R 777 /.m2
+
+WORKDIR $HOME_PATH/app/
 
 EXPOSE 8080
 
-USER 185
+USER $USER_ID
 
 ENTRYPOINT ["/bin/bash", "-c"]
 

--- a/packages/dev-deployment-base-image/env/index.js
+++ b/packages/dev-deployment-base-image/env/index.js
@@ -25,6 +25,14 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "registry.access.redhat.com/ubi9/openjdk-17:1.18",
       description: "The image used in the FROM import.",
     },
+    DEV_DEPLOYMENT_BASE_IMAGE__userId: {
+      default: 185,
+      description: "The container User ID.",
+    },
+    DEV_DEPLOYMENT_BASE_IMAGE__homePath: {
+      default: "/home",
+      description: "The container Home Path.",
+    },
     DEV_DEPLOYMENT_BASE_IMAGE__registry: {
       default: "quay.io",
       description: "The image registry.",
@@ -46,6 +54,8 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
     return {
       devDeploymentBaseImage: {
         builderImage: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__builderImage),
+        userId: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__userId),
+        homePath: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__homePath),
         registry: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__registry),
         account: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__account),
         name: getOrDefault(this.vars.DEV_DEPLOYMENT_BASE_IMAGE__name),

--- a/packages/dev-deployment-base-image/install.js
+++ b/packages/dev-deployment-base-image/install.js
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const buildEnv = require("./env");
+const { setup } = require("@kie-tools/maven-config-setup-helper");
+const version = require("./package.json").version;
+
+setup(`
+    -Drevision=${version}
+    -Dquarkus.platform.version=${buildEnv.env.quarkusPlatform.version}
+    -Dversion.org.kie.kogito=${buildEnv.env.kogitoRuntime.version}
+`);

--- a/packages/dev-deployment-base-image/package.json
+++ b/packages/dev-deployment-base-image/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/apache/incubator-kie-tools/issues"
   },
   "scripts": {
-    "build:dev": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy-assets\" \"pnpm image:docker:build\"",
-    "build:prod": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy-assets\" \"pnpm image:docker:build\"",
+    "build:dev": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy-assets\" \"pnpm install:mvnw\" \"pnpm image:docker:build\"",
+    "build:prod": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy-assets\" \"pnpm install:mvnw\" \"pnpm image:docker:build\"",
     "copy-assets": "rimraf dist-dev && pnpm copy-upload-service-assets",
     "copy-upload-service-assets": "run-script-os",
     "copy-upload-service-assets:linux:darwin": "mkdir -p ./dist-dev && cp -R ../dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64 ./dist-dev/dev-deployment-upload-service",
@@ -23,8 +23,12 @@
     "create-test-image:kind": "kie-tools--image-builder kind -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\" --kind-cluster-name kie-sandbox-dev-cluster",
     "create-test-image:minikube": "kie-tools--image-builder minikube -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\"",
     "create-test-image:openshift": "kie-tools--image-builder openshift -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\"",
-    "image:docker:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\"",
-    "image:podman:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\" -e podman",
+    "image:docker:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\" --build-arg USER_ID_ARG=\"$(build-env devDeploymentBaseImage.userId)\" --build-arg HOME_PATH_ARG=\"$(build-env devDeploymentBaseImage.homePath)\"",
+    "image:podman:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentBaseImage.registry)\" -a \"$(build-env devDeploymentBaseImage.account)\" -n \"$(build-env devDeploymentBaseImage.name)\" -t \"$(build-env devDeploymentBaseImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentBaseImage.builderImage)\" --build-arg USER_ID_ARG=\"$(build-env devDeploymentBaseImage.userId)\" --build-arg HOME_PATH_ARG=\"$(build-env devDeploymentBaseImage.homePath)\" -e podman",
+    "install": "node install.js",
+    "install:mvnw": "run-script-os",
+    "install:mvnw:darwin:linux": "mvn wrapper:wrapper",
+    "install:mvnw:win32": "pnpm powershell \"mvn wrapper:wrapper\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command"
   },
   "dependencies": {

--- a/packages/dev-deployment-base-image/pom.xml
+++ b/packages/dev-deployment-base-image/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.kie.kogito</groupId>
+  <artifactId>dev-deployment-base-image</artifactId>
+  <version>${revision}</version>
+
+  <repositories>
+    <repository>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the Apache Nexus one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the Apache Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use Apache repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>apache-public-repository-group</id>
+      <name>Apache Public Repository Group</name>
+      <url>https://repository.apache.org/content/groups/public/</url>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <properties>
+    <compiler-plugin.version>3.12.1</compiler-plugin.version>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <version.junit>4.13.2</version.junit>
+  </properties>
+</project>

--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
@@ -20,19 +20,21 @@ ARG BUILDER_IMAGE_ARG
 
 FROM --platform=linux/amd64 ${BUILDER_IMAGE_ARG}
 
+USER root
+
 ENV ROOT_PATH=""
-ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME/app/src/main/resources
+ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME_PATH/app/src/main/resources
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
 
-COPY --chown=185:185 dist-dev/quarkus-app $HOME/app/
+COPY --chown=$USER_ID:$USER_ID dist-dev/quarkus-app $HOME_PATH/app/
 
-RUN ./mvnw dependency:go-offline -Dmaven.repo.local=/tmp/kogito/.m2/repository && ./mvnw clean package -B -ntp -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
-  && chgrp -R 0 $HOME/app && chmod -R g=u $HOME/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito
+RUN ./mvnw clean package -B -ntp -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
+  && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2
 
-USER 185
+USER $USER_ID
 
 EXPOSE 8080
 
 ENTRYPOINT ["/bin/bash", "-c"]
 
-CMD ["dev-deployment-upload-service && cp -r $HOME/app/. /tmp/app && cd /tmp/app && ./mvnw quarkus:dev -Ddebug=false -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH}"]
+CMD ["dev-deployment-upload-service && cp -r $HOME_PATH/app/. /tmp/app && cd /tmp/app && ./mvnw quarkus:dev -Ddebug=false -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH}"]

--- a/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
@@ -7,15 +7,15 @@
   ~ to you under the Apache License, Version 2.0 (the
   ~ "License"); you may not use this file except in compliance
   ~ with the License.  You may obtain a copy of the License at
-  ~ 
+  ~
   ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~ 
+  ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
   ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
-  ~ under the License.      
+  ~ under the License.
 -->
 <project
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
@@ -66,6 +66,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
     <version.junit>4.13.2</version.junit>
+    <quarkus.analytics.disabled>true</quarkus.analytics.disabled>
   </properties>
 
   <dependencyManagement>

--- a/packages/kie-sandbox-extended-services-image/Containerfile
+++ b/packages/kie-sandbox-extended-services-image/Containerfile
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/openjdk-17:1.18
+# Defaults to registry.access.redhat.com/ubi9/openjdk-17 (check env/index.js)
+ARG BUILDER_IMAGE_ARG
+
+FROM --platform=linux/amd64 ${BUILDER_IMAGE_ARG}
 
 ARG EXTENDED_SERVICES_DEFAULT_HOST
 ARG EXTENDED_SERVICES_DEFAULT_PORT

--- a/packages/kie-sandbox-extended-services-image/env/index.js
+++ b/packages/kie-sandbox-extended-services-image/env/index.js
@@ -21,6 +21,10 @@ const { varsWithName, getOrDefault, composeEnv } = require("@kie-tools-scripts/b
 
 module.exports = composeEnv([require("@kie-tools/root-env/env"), require("@kie-tools/extended-services-java/env")], {
   vars: varsWithName({
+    KIE_SANDBOX_EXTENDED_SERVICES__builderImage: {
+      default: "registry.access.redhat.com/ubi9/openjdk-17:1.18",
+      description: "The image used in the FROM import.",
+    },
     KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry: {
       default: "quay.io",
       description: "",
@@ -41,6 +45,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env"), require("@kie-t
   get env() {
     return {
       extendedServicesImage: {
+        builderImage: getOrDefault(this.vars.KIE_SANDBOX_EXTENDED_SERVICES__builderImage),
         registry: getOrDefault(this.vars.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry),
         account: getOrDefault(this.vars.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount),
         name: getOrDefault(this.vars.KIE_SANDBOX_EXTENDED_SERVICES__imageName),

--- a/packages/kie-sandbox-extended-services-image/package.json
+++ b/packages/kie-sandbox-extended-services-image/package.json
@@ -13,15 +13,15 @@
     "url": "https://github.com/apache/incubator-kie-tools/issues"
   },
   "scripts": {
-    "build:dev": "pnpm cleanup && pnpm copy:assets && run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm docker:build\"",
-    "build:prod": "pnpm cleanup && pnpm copy:assets && run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm docker:build\"",
+    "build:dev": "pnpm cleanup && pnpm copy:assets && run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm image:docker:build\"",
+    "build:prod": "pnpm cleanup && pnpm copy:assets && run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm image:docker:build\"",
     "cleanup": "rimraf dist-dev && mkdir dist-dev",
     "copy:assets": "pnpm copy:extended-services-java",
     "copy:extended-services-java": "run-script-os",
     "copy:extended-services-java:linux:darwin": "cp -R ../extended-services-java/dist/extended-services-java ./dist-dev/kie_sandbox_extended_services",
     "copy:extended-services-java:win32": "pnpm powershell \"Copy-Item ../extended-services-java/dist/extended-services-java ./dist-dev/kie_sandbox_extended_services\"",
-    "docker:build": "kie-tools--image-builder build -r \"$(build-env extendedServicesImage.registry)\" -a \"$(build-env extendedServicesImage.account)\" -n \"$(build-env extendedServicesImage.name)\" -t \"$(build-env extendedServicesImage.buildTags)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_PORT=$(build-env extendedServicesJava.port)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_HOST=$(build-env extendedServicesJava.host)\"",
-    "podman:build": "kie-tools--image-builder build -r \"$(build-env extendedServicesImage.registry)\" -a \"$(build-env extendedServicesImage.account)\" -n \"$(build-env extendedServicesImage.name)\" -t \"$(build-env extendedServicesImage.buildTags)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_PORT=$(build-env extendedServicesJava.port)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_HOST=$(build-env extendedServicesJava.host)\" -e podman"
+    "image:docker:build": "kie-tools--image-builder build -r \"$(build-env extendedServicesImage.registry)\" -a \"$(build-env extendedServicesImage.account)\" -n \"$(build-env extendedServicesImage.name)\" -t \"$(build-env extendedServicesImage.buildTags)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_PORT=$(build-env extendedServicesJava.port)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_HOST=$(build-env extendedServicesJava.host)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env extendedServicesImage.builderImage)\"",
+    "image:podman:build": "kie-tools--image-builder build -r \"$(build-env extendedServicesImage.registry)\" -a \"$(build-env extendedServicesImage.account)\" -n \"$(build-env extendedServicesImage.name)\" -t \"$(build-env extendedServicesImage.buildTags)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_PORT=$(build-env extendedServicesJava.port)\" --build-arg \"EXTENDED_SERVICES_DEFAULT_HOST=$(build-env extendedServicesJava.host)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env extendedServicesImage.builderImage)\" -e podman"
   },
   "dependencies": {
     "@kie-tools/extended-services-java": "workspace:*"

--- a/packages/kubernetes-bridge/src/resources/common.ts
+++ b/packages/kubernetes-bridge/src/resources/common.ts
@@ -73,7 +73,7 @@ export const commonLabels = (args: { resourceName: string; createdBy: string }) 
 
 export const runtimeLabels = () => ({
   [OpenShiftLabelNames.RUNTIME]: "quarkus",
-  [OpenShiftLabelNames.VERSION]: "openjdk-11-el7",
+  [OpenShiftLabelNames.VERSION]: "openjdk-17-el7",
 });
 
 export enum DeploymentState {

--- a/packages/online-editor/src/devDeployments/services/deploymentOptions/customImage/index.ts
+++ b/packages/online-editor/src/devDeployments/services/deploymentOptions/customImage/index.ts
@@ -84,7 +84,7 @@ ${ServiceYaml()}
         id: "command",
         name: "Command",
         description: "The command to be executed when the container starts (passed as args to the Deployment)",
-        defaultValue: "mvn quarkus:dev",
+        defaultValue: "./mvnw quarkus:dev",
         type: "text",
         resourcePatches: [
           {

--- a/packages/online-editor/src/devDeployments/services/kubernetes/KubernetesDeploymentOptions.ts
+++ b/packages/online-editor/src/devDeployments/services/kubernetes/KubernetesDeploymentOptions.ts
@@ -86,7 +86,7 @@ export function KubernetesDeploymentOptions(args: DeploymentOptionArgs): Array<D
         name: "Command",
         description: "The command to be executed when the container starts",
         defaultValue:
-          "mvn quarkus:dev -Dquarkus.http.non-application-root-path=/${{ devDeployment.uniqueName }}/q -Dquarkus.http.root-path=/${{ devDeployment.uniqueName }}",
+          "./mvnw quarkus:dev -Dquarkus.http.non-application-root-path=/${{ devDeployment.uniqueName }}/q -Dquarkus.http.root-path=/${{ devDeployment.uniqueName }}",
         type: "text",
         resourcePatches: [
           {


### PR DESCRIPTION
## Parameters

Created new environment variables to configure the builder image used for building `dev-deployment-base-image` and `kie-sandbox-extended-services-image`.

- DEV_DEPLOYMENT_BASE_IMAGE__builderImage
- DEV_DEPLOYMENT_BASE_IMAGE__userId
- DEV_DEPLOYMENT_BASE_IMAGE__homePath
- KIE_SANDBOX_EXTENDED_SERVICES__builderImage

## Compatibility

Images were tested and built with the following base images:
- `registry.access.redhat.com/ubi9/openjdk-17:1.18`
- `ibm-semeru-runtimes:open-17.0.10_7-jdk`

## Other changes
- Updated OpenShift deployment labels on `kubernetes-bridge`
- Added Maven Wrapper (`mvnw`) to dev-deployment-base-image (to support base images that don't have Maven preinstalled)
- Small adjustments to build scripts 