### PR TITLE
kie-issues#1004: Start Chrome extensions tests with empty browser data

### DIFF
--- a/packages/chrome-extension-test-helper/src/framework/github-repo/GitHubRepoPage.ts
+++ b/packages/chrome-extension-test-helper/src/framework/github-repo/GitHubRepoPage.ts
@@ -23,6 +23,7 @@ import Page from "../Page";
 export default class GitHubRepoPage extends Page {
   private static readonly TOKEN_ICON: By = By.className("kogito-menu-icon");
   private static readonly TOKEN_INPUT: By = By.className("kogito-github-token-input");
+  private static readonly RESET_BUTTON: By = By.xpath("//button[text()='Reset']");
 
   public async waitUntilLoaded(): Promise<void> {
     return await this.tools.by(GitHubRepoPage.TOKEN_ICON).wait(1000).untilPresent();
@@ -31,7 +32,10 @@ export default class GitHubRepoPage extends Page {
   public async addToken(token: string): Promise<void> {
     const tokenIcon = await this.tools.by(GitHubRepoPage.TOKEN_ICON).getElement();
     await tokenIcon.click();
+    await this.tools.by(GitHubRepoPage.RESET_BUTTON).wait(1000).untilPresent();
     await this.tools.by(GitHubRepoPage.TOKEN_INPUT).wait(1000).untilPresent();
+    const resetButton = await this.tools.by(GitHubRepoPage.RESET_BUTTON).getElement();
+    await resetButton.click();
     const tokenInput = await this.tools.by(GitHubRepoPage.TOKEN_INPUT).getElement();
     await tokenInput.click();
     await this.tools.clipboard().setContent(token);

--- a/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
+++ b/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
@@ -50,10 +50,13 @@ export default class Driver {
     // init chrome options
     const chromeOptions: Options = new Options();
     chromeOptions.addArguments(
+      "--user-data-dir=" + CHROME_DIR,
       "--load-extension=" + chromeExtensionPath,
       "--enable-features=UnexpireFlagsM118",
       "--allow-insecure-localhost",
-      "--user-data-dir=" + CHROME_DIR
+      "--disable-web-security",
+      "--remote-allow-origins=*",
+      "--disable-gpu"
     );
 
     // init chrome driver log

--- a/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
+++ b/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
@@ -41,12 +41,19 @@ export default class Driver {
       );
     }
 
+    // create directory for chrome browser data
+    const CHROME_DIR: string = resolve("dist-e2e-tests", "chrome_data");
+    if (!existsSync(CHROME_DIR)) {
+      mkdirSync(CHROME_DIR, { recursive: true });
+    }
+
     // init chrome options
     const chromeOptions: Options = new Options();
     chromeOptions.addArguments(
       "--load-extension=" + chromeExtensionPath,
       "--enable-features=UnexpireFlagsM118",
-      "--allow-insecure-localhost"
+      "--allow-insecure-localhost",
+      "--user-data-dir=" + CHROME_DIR
     );
 
     // init chrome driver log


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-kie-issues/issues/1004

- Add parameter `user-data-dir` to start browser with clean data
- Add parameters `disable-web-security`, `remote-allow-origins=*`, `disable-gpu` for better test stability
- When token is used reset button is clicked before the token is added to secure clean input