### PR TITLE
kie-issues#1012: Removing `kie-soup-commons` dependency in DashBuilder

### DIFF
--- a/packages/dashbuilder/appformer/uberfire-api/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-api/pom.xml
@@ -44,11 +44,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/plugin/PluginUtil.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/plugin/PluginUtil.java
@@ -24,12 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Utilities for working with external (GWT-compiled) plugins.
@@ -59,6 +58,10 @@ public class PluginUtil {
         @SuppressWarnings("unchecked")
         final List<T> tmp = (List<T>) Arrays.asList(externalList.toArray());
         return Collections.unmodifiableList(tmp);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/NamedPosition.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/NamedPosition.java
@@ -20,10 +20,10 @@
 
 package org.uberfire.workbench.model;
 
+import java.util.Objects;
+
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Represents the position of a child panel by name. For example, within a templated perspective, panels are positioned
@@ -52,6 +52,10 @@ public class NamedPosition implements Position {
     public NamedPosition(@MapsTo("fieldName") String fieldName) {
         this.fieldName = checkNotNull("fieldName",
                                       fieldName);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PanelDefinitionImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PanelDefinitionImpl.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import jsinterop.annotations.JsIgnore;
@@ -37,7 +38,6 @@ import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
 import org.uberfire.workbench.model.Position;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.workbench.model.ContextDisplayMode.SHOW;
 
 /**
@@ -240,6 +240,10 @@ public class PanelDefinitionImpl implements PanelDefinition {
     public void setPanelType(String fqcn) {
         this.panelType = checkNotNull("fqcn",
                                       fqcn);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @Override

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PerspectiveDefinitionImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PerspectiveDefinitionImpl.java
@@ -19,13 +19,14 @@
 
 package org.uberfire.workbench.model.impl;
 
+import java.util.Objects;
+
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.workbench.model.ContextDefinition;
 import org.uberfire.workbench.model.ContextDisplayMode;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.workbench.model.ContextDisplayMode.SHOW;
 
 /**
@@ -51,6 +52,10 @@ public class PerspectiveDefinitionImpl
         PanelDefinitionImpl root = new PanelDefinitionImpl(panelType);
         root.setRoot(true);
         this.root = root;
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @Override

--- a/packages/dashbuilder/appformer/uberfire-client-api/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-client-api/pom.xml
@@ -66,11 +66,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-dom</artifactId>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-commons/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-commons/pom.xml
@@ -43,10 +43,6 @@
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>

--- a/packages/dashbuilder/appformer/uberfire-commons/src/main/resources/org/uberfire/commons/UberfireCommons.gwt.xml
+++ b/packages/dashbuilder/appformer/uberfire-commons/src/main/resources/org/uberfire/commons/UberfireCommons.gwt.xml
@@ -21,8 +21,6 @@
   "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
 <module>
 
-  <inherits name='org.kie.soup.commons.KIESoupCommons' />
-
   <source path='data' />
   <source path='lifecycle' />
   <source path='uuid' />

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -54,11 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterForceSaveReOpenCancelButtons.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterForceSaveReOpenCancelButtons.java
@@ -19,6 +19,8 @@
 
 package org.uberfire.ext.widgets.common.client.common.popups.footers;
 
+import java.util.Objects;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -29,8 +31,6 @@ import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.uberfire.mvp.Command;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * A Modal Footer with OK and Cancel buttons
@@ -64,6 +64,10 @@ public class ModalFooterForceSaveReOpenCancelButtons extends ModalFooter {
         this.panel = checkNotNull("panel",
                                   panel);
         add(uiBinder.createAndBindUi(this));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @UiHandler("forceSaveButton")

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterOKButton.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterOKButton.java
@@ -19,6 +19,8 @@
 
 package org.uberfire.ext.widgets.common.client.common.popups.footers;
 
+import java.util.Objects;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -28,7 +30,7 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ModalFooter;
-import org.kie.soup.commons.validation.PortablePreconditions;
+
 
 /**
  * A Modal Footer with a single OK button
@@ -42,9 +44,12 @@ public class ModalFooterOKButton extends ModalFooter {
     Button okButton;
 
     public ModalFooterOKButton(final Command okCommand) {
-        this.okCommand = PortablePreconditions.checkNotNull("okCommand",
-                                                            okCommand);
+        this.okCommand = checkNotNull("okCommand", okCommand);
         add(uiBinder.createAndBindUi(this));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     public void enableOkButton(final boolean enabled) {

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterOKCancelButtons.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterOKCancelButtons.java
@@ -19,6 +19,8 @@
 
 package org.uberfire.ext.widgets.common.client.common.popups.footers;
 
+import java.util.Objects;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -28,7 +30,6 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ModalFooter;
-import org.kie.soup.commons.validation.PortablePreconditions;
 
 /**
  * A Modal Footer with OK and Cancel buttons
@@ -46,11 +47,13 @@ public class ModalFooterOKCancelButtons extends ModalFooter {
 
     public ModalFooterOKCancelButtons(final Command okCommand,
                                       final Command cancelCommand) {
-        this.okCommand = PortablePreconditions.checkNotNull("okCommand",
-                                                            okCommand);
-        this.cancelCommand = PortablePreconditions.checkNotNull("cancelCommand",
-                                                                cancelCommand);
+        this.okCommand = checkNotNull("okCommand", okCommand);
+        this.cancelCommand = checkNotNull("cancelCommand", cancelCommand);
         add(uiBinder.createAndBindUi(this));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     public void enableOkButton(final boolean enabled) {

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterReOpenIgnoreButtons.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/footers/ModalFooterReOpenIgnoreButtons.java
@@ -19,6 +19,8 @@
 
 package org.uberfire.ext.widgets.common.client.common.popups.footers;
 
+import java.util.Objects;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -29,8 +31,6 @@ import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.uberfire.mvp.Command;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * A Modal Footer with OK and Cancel buttons
@@ -59,6 +59,10 @@ public class ModalFooterReOpenIgnoreButtons extends ModalFooter {
                                   panel);
         add(uiBinder.createAndBindUi(this));
         this.actionButton.setText(buttonText);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @UiHandler("actionButton")

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/select/SelectOptionImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/select/SelectOptionImpl.java
@@ -20,8 +20,6 @@
 
 package org.uberfire.ext.widgets.common.client.select;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotEmpty;
-
 public class SelectOptionImpl implements SelectOption {
 
     private final String selector;
@@ -33,6 +31,13 @@ public class SelectOptionImpl implements SelectOption {
         this.selector = checkNotEmpty("selector",
                                       selector).toUpperCase();
         this.name = name;
+    }
+
+    private static String checkNotEmpty(String name, String parameter) {
+        if (parameter == null || parameter.trim().isEmpty()) {
+            throw new IllegalArgumentException("Parameter named '" + name + "' should be filled!");
+        }
+        return parameter;
     }
 
     public String getSelector() {

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
@@ -68,11 +68,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/FSTreeItem.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/FSTreeItem.java
@@ -20,13 +20,12 @@
 
 package org.uberfire.ext.widgets.core.client.tree;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.constants.IconType;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 public class FSTreeItem extends TreeItem<FSTreeItem> {
 
@@ -52,6 +51,10 @@ public class FSTreeItem extends TreeItem<FSTreeItem> {
               createIcon(type));
         this.fstype = checkNotNull("type",
                                    type);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     private static final Type createType(final FSType type) {

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/TreeItem.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/TreeItem.java
@@ -21,6 +21,7 @@
 package org.uberfire.ext.widgets.core.client.tree;
 
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -40,8 +41,6 @@ import org.uberfire.client.workbench.ouia.OuiaComponentIdAttribute;
 import org.uberfire.client.workbench.ouia.OuiaComponentTypeAttribute;
 import org.uberfire.ext.widgets.core.client.resources.TreeNavigatorResources;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
-
 public class TreeItem<I extends TreeItem> extends Composite implements OuiaComponent {
 
     private static final String OUIA_COMPONENT_TYPE = "tree-item";
@@ -58,6 +57,10 @@ public class TreeItem<I extends TreeItem> extends Composite implements OuiaCompo
     private FlowPanel header;
     private IsWidget icon;
     private FlowPanel item;
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
+    }
 
     public TreeItem(final Type type,
                     final String value,

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/wizards/WizardPopupFooter.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/wizards/WizardPopupFooter.java
@@ -19,6 +19,8 @@
 
 package org.uberfire.ext.widgets.core.client.wizards;
 
+import java.util.Objects;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -29,7 +31,6 @@ import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
-import org.kie.soup.commons.validation.PortablePreconditions;
 
 /**
  * A Modal Footer used by the Wizard
@@ -55,15 +56,19 @@ public class WizardPopupFooter extends ModalFooter {
                              final Command cmdNextButton,
                              final Command cmdCancelButton,
                              final Command cmdFinishButton) {
-        this.cmdPreviousButton = PortablePreconditions.checkNotNull("cmdPreviousButton",
+        this.cmdPreviousButton = checkNotNull("cmdPreviousButton",
                                                                     cmdPreviousButton);
-        this.cmdNextButton = PortablePreconditions.checkNotNull("cmdNextButton",
+        this.cmdNextButton = checkNotNull("cmdNextButton",
                                                                 cmdNextButton);
-        this.cmdCancelButton = PortablePreconditions.checkNotNull("cmdCancelButton",
+        this.cmdCancelButton = checkNotNull("cmdCancelButton",
                                                                   cmdCancelButton);
-        this.cmdFinishButton = PortablePreconditions.checkNotNull("cmdFinishButton",
+        this.cmdFinishButton = checkNotNull("cmdFinishButton",
                                                                   cmdFinishButton);
         add(uiBinder.createAndBindUi(this));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     public void enablePreviousButton(final boolean enabled) {

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
@@ -53,10 +53,7 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/ResizableMovableHeader.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/ResizableMovableHeader.java
@@ -22,6 +22,7 @@ package org.uberfire.ext.widgets.table.client;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.Cell.Context;
@@ -42,7 +43,6 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import org.gwtbootstrap3.client.ui.gwt.DataGrid;
-import org.kie.soup.commons.validation.PortablePreconditions;
 
 import static com.google.gwt.dom.client.Style.Unit.PX;
 
@@ -82,15 +82,19 @@ public abstract class ResizableMovableHeader<T> extends Header<String> {
                                   final UberfireColumnPicker columnPicker,
                                   final Column<T, ?> column) {
         super(new HeaderCell());
-        this.title = PortablePreconditions.checkNotNull("title",
+        this.title = checkNotNull("title",
                                                         title);
-        this.table = PortablePreconditions.checkNotNull("table",
+        this.table = checkNotNull("table",
                                                         table);
-        this.columnPicker = PortablePreconditions.checkNotNull("columnPicker",
+        this.columnPicker = checkNotNull("columnPicker",
                                                                columnPicker);
-        this.column = PortablePreconditions.checkNotNull("column",
+        this.column = checkNotNull("column",
                                                          column);
         this.tableElement = table.getElement();
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     private static NativeEvent getEventAndPreventPropagation(final NativePreviewEvent event) {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -70,10 +70,6 @@
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.allen-sauer.gwt.dnd</groupId>
       <artifactId>gwt-dnd</artifactId>
     </dependency>
@@ -115,13 +111,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
-      <classifier>sources</classifier>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
       <classifier>sources</classifier>
       <scope>test</scope>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/maximize/MaximizeToggleButton.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/maximize/MaximizeToggleButton.java
@@ -20,6 +20,8 @@
 
 package org.uberfire.client.views.pfly.maximize;
 
+import java.util.Objects;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -30,8 +32,6 @@ import org.uberfire.client.resources.i18n.WorkbenchConstants;
 import org.uberfire.client.workbench.panels.MaximizeToggleButtonPresenter;
 import org.uberfire.client.workbench.panels.MaximizeToggleButtonPresenter.View;
 import org.uberfire.mvp.Command;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 public class MaximizeToggleButton extends Button implements View {
 
@@ -61,6 +61,10 @@ public class MaximizeToggleButton extends Button implements View {
     public void init(MaximizeToggleButtonPresenter presenter) {
         this.presenter = checkNotNull("presenter",
                                       presenter);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/modal/Bs3Modal.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/modal/Bs3Modal.java
@@ -20,6 +20,8 @@
 
 package org.uberfire.client.views.pfly.modal;
 
+import java.util.Objects;
+
 import javax.enterprise.context.Dependent;
 
 import com.google.gwt.core.client.GWT;
@@ -42,8 +44,6 @@ import org.uberfire.client.resources.WorkbenchResources;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.Commands;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
-
 /**
  * A modal dialog that floats above the workbench. Each instance can only be shown once.
  */
@@ -51,6 +51,10 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 public class Bs3Modal extends Modal {
 
     private final ModalBody body = GWT.create(ModalBody.class);
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
+    }
 
     /**
      * Used for enforcing the "only show one time" rule.

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupsManagerView.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/notifications/NotificationPopupsManagerView.java
@@ -22,6 +22,7 @@ package org.uberfire.client.views.pfly.notifications;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -30,7 +31,6 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PlaceManager;
@@ -56,8 +56,12 @@ public class NotificationPopupsManagerView implements NotificationManager.View {
 
     @Override
     public void setContainer(final IsWidget container) {
-        this.container = PortablePreconditions.checkNotNull("container",
+        this.container = checkNotNull("container",
                 container);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @Override
@@ -204,10 +208,8 @@ public class NotificationPopupsManagerView implements NotificationManager.View {
 
         PopupHandle(NotificationPopupView view,
                     NotificationEvent event) {
-            this.view = PortablePreconditions.checkNotNull("view",
-                    view);
-            this.event = PortablePreconditions.checkNotNull("event",
-                    event);
+            this.view = checkNotNull("view", view);
+            this.event = checkNotNull("event", event);
         }
     }
 }

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
@@ -58,8 +59,6 @@ import org.uberfire.client.workbench.part.WorkbenchPartPresenter.View;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * A wrapper around {@link TabPanelWithDropdowns} that adds the following capabilities:
@@ -98,6 +97,10 @@ public class UberTabPanel extends ResizeComposite implements MultiPartWidget,
                                          panelManager);
         this.tabPanel = checkNotNull("tabPanel",
                                      tabPanel);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @PostConstruct

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -66,10 +66,6 @@
       <artifactId>elemental2-dom</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractActivity.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractActivity.java
@@ -19,9 +19,9 @@
 
 package org.uberfire.client.mvp;
 
-import org.uberfire.mvp.PlaceRequest;
+import java.util.Objects;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import org.uberfire.mvp.PlaceRequest;
 
 /**
  * Implementation of behaviour common to all activity types.
@@ -46,8 +46,8 @@ public abstract class AbstractActivity implements Activity {
      */
     @Override
     public void onStartup(PlaceRequest place) {
-        this.place = checkNotNull("place",
-                place);
+        Objects.requireNonNull(place, "Parameter named 'place' should be not null!");
+        this.place = place;
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityLifecycleError.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityLifecycleError.java
@@ -20,9 +20,9 @@
 
 package org.uberfire.client.mvp;
 
-import org.uberfire.workbench.events.UberFireEvent;
+import java.util.Objects;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import org.uberfire.workbench.events.UberFireEvent;
 
 /**
  * CDI event fired by the framework each time an Activity lifecycle method throws an exception. Observers of the event
@@ -44,6 +44,10 @@ public class ActivityLifecycleError implements UberFireEvent {
         this.failedCall = checkNotNull("failedCall",
                                        failedCall);
         this.exception = exception;
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveManagerImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveManagerImpl.java
@@ -22,6 +22,7 @@ package org.uberfire.client.mvp;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -40,7 +41,6 @@ import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.plugin.PluginUtil.ensureIterable;
 
 @ApplicationScoped
@@ -66,6 +66,10 @@ public class PerspectiveManagerImpl implements PerspectiveManager {
     private PerspectiveDefinition livePerspectiveDef;
 
     private PlaceRequest currentPerspectivePlaceRequest;
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
+    }
 
     @Override
     public void switchToPerspective(final PlaceRequest placeRequest,

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -21,6 +21,7 @@
 package org.uberfire.client.mvp;
 
 import java.util.List;
+import java.util.Objects;
 
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsType;
@@ -32,8 +33,6 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * A Workbench-centric abstraction over the browser's history mechanism. Allows the application to initiate navigation
@@ -91,6 +90,10 @@ public interface PlaceManager {
         if (callbacks != null) {
             callbacks.forEach(Command::execute);
         }
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     List<Command> getOnOpenCallbacks(PlaceRequest place);

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -73,7 +74,6 @@ import org.uberfire.workbench.model.Position;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
 
 import static java.util.Collections.unmodifiableCollection;
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.plugin.PluginUtil.ensureIterable;
 import static org.uberfire.plugin.PluginUtil.toInteger;
 
@@ -584,6 +584,10 @@ public class PlaceManagerImpl implements PlaceManager {
 
         perspectiveCloseChain.put(perspectiveIdentifier,
                 closeChain);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
@@ -23,6 +23,7 @@ package org.uberfire.client.workbench;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -68,7 +69,6 @@ import org.uberfire.workbench.model.Position;
 import org.uberfire.workbench.model.impl.CustomPanelDefinitionImpl;
 import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.plugin.PluginUtil.ensureIterable;
 
 /**
@@ -264,6 +264,10 @@ public class PanelManagerImpl implements PanelManager {
 
         //Select newly inserted part
         selectPlaceEvent.fire(new SelectPlaceEvent(place));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @Override

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/AbstractPlaceEvent.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/AbstractPlaceEvent.java
@@ -20,10 +20,11 @@
 
 package org.uberfire.client.workbench.events;
 
+import java.util.Objects;
+
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.events.UberFireEvent;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Created by Cristiano Nicolai.
@@ -33,9 +34,12 @@ public abstract class AbstractPlaceEvent implements UberFireEvent {
     private final PlaceRequest place;
 
     AbstractPlaceEvent(final PlaceRequest place) {
-        checkNotNull("place",
-                     place);
+        Objects.requireNonNull(place, "Parameter named 'place' should be not null!");
         this.place = place;
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     public PlaceRequest getPlace() {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/MaximizeToggleButtonPresenter.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/MaximizeToggleButtonPresenter.java
@@ -17,10 +17,10 @@
  * under the License. 
  */
 
-
 package org.uberfire.client.workbench.panels;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
+import java.util.Objects;
+
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.mvp.Command;
 
@@ -37,9 +37,12 @@ public class MaximizeToggleButtonPresenter {
     private Command unmaximizeCommand;
 
     public MaximizeToggleButtonPresenter(View view) {
-        this.view = PortablePreconditions.checkNotNull("view",
-                                                       view);
+        this.view = checkNotNull("view", view);
         view.init(this);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractDockingWorkbenchPanelView.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractDockingWorkbenchPanelView.java
@@ -21,6 +21,7 @@
 package org.uberfire.client.workbench.panels.impl;
 
 import java.util.IdentityHashMap;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -43,7 +44,6 @@ import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.Position;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.client.util.Layouts.setToFillParent;
 import static org.uberfire.client.util.Layouts.widthOrHeight;
 import static org.uberfire.plugin.PluginUtil.toInteger;
@@ -276,6 +276,10 @@ public abstract class AbstractDockingWorkbenchPanelView<P extends WorkbenchPanel
         //browser has added the new DIVs to the HTML tree. This does occasionally
         //add slight flicker when adding a new Panel.
         scheduleResize(splitPanel);
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     @Override

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
@@ -19,14 +19,14 @@
 
 package org.uberfire.client.workbench.widgets.common;
 
+import java.util.Objects;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.uberfire.client.annotations.WorkbenchPopup;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.Commands;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Shows simple text-only error messages in a modal popup dialog that sits above the workbench.
@@ -57,6 +57,10 @@ public class ErrorPopupPresenter {
                                       afterShow),
                          checkNotNull("afterClose",
                                       afterClose));
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     /**

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
@@ -21,6 +21,7 @@ package org.uberfire.client.workbench.widgets.notifications;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -31,7 +32,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RootPanel;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.WorkbenchActivity;
@@ -202,8 +202,8 @@ public class NotificationManager {
         private NotificationPopupHandle handle;
 
         HideNotificationCommand(final View notificationContainerView) {
-            this.notificationContainerView = PortablePreconditions.checkNotNull("notificationContainerView",
-                                                                                notificationContainerView);
+            Objects.requireNonNull(notificationContainerView, "notificationContainerView");
+            this.notificationContainerView = notificationContainerView;
         }
 
         @Override

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/pom.xml
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/pom.xml
@@ -53,11 +53,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServicesImpl.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServicesImpl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -49,8 +50,6 @@ import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
-
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Default implementation
@@ -102,6 +101,10 @@ public class DataSetClientServicesImpl implements DataSetClientServices {
         this.dataSetModifiedEvent = dataSetModifiedEvent;
         this.dataSetLookupServices = dataSetLookupServices;
         this.dataSetDefServices = dataSetDefServices;
+    }
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
     }
 
     public boolean isPushRemoteDataSetEnabled() {

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/pom.xml
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/pom.xml
@@ -64,11 +64,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerViewer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerViewer.java
@@ -19,6 +19,8 @@
 
 package org.dashbuilder.displayer.client.widgets;
 
+import java.util.Objects;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -36,8 +38,6 @@ import org.dashbuilder.displayer.client.DisplayerLocator;
 import org.dashbuilder.displayer.client.resources.i18n.CommonConstants;
 import org.uberfire.mvp.Command;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
-
 @Dependent
 public class DisplayerViewer extends Composite {
 
@@ -53,6 +53,10 @@ public class DisplayerViewer extends Composite {
     protected RendererSelector rendererSelector;
     ClientRuntimeError displayerInitializationError;
     CommonConstants i18n = CommonConstants.INSTANCE;
+
+    private static <T> T checkNotNull(String objName, T obj) {
+        return Objects.requireNonNull(obj, "Parameter named '" + objName + "' should be not null!");
+    }
 
     DisplayerListener displayerListener = new AbstractDisplayerListener() {
 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/pom.xml
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/pom.xml
@@ -73,11 +73,6 @@
     </dependency>
 
     <!-- Dashbuilder -->
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.dashbuilder</groupId>
@@ -449,8 +444,6 @@
             <compileSourcesArtifact>org.uberfire:uberfire-layout-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-widgets-commons</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-widgets-table</compileSourcesArtifact>
-
-            <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>

--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -151,17 +151,6 @@
         <version>${version.org.javassist}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-commons</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-commons</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
       <!-- TESTING -->
       <dependency>
         <groupId>org.assertj</groupId>

--- a/packages/dashbuilder/pom.xml
+++ b/packages/dashbuilder/pom.xml
@@ -61,7 +61,6 @@
     <version.org.junit>4.13.2</version.org.junit>
     <version.org.assertj>3.14.0</version.org.assertj>
     <version.org.mockito>3.6.0</version.org.mockito>
-    <version.org.kie>7.59.0.Final</version.org.kie>
     <version.org.jboss.resteasy>3.15.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.errai>4.15.0.Final</version.org.jboss.errai>
     <version.commons-io>2.7</version.commons-io>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1012

Dashbuild still depends on a 7.59.0 version of kie-soup-commons. 
That dependency is required to perform null (and empty) checks on Objects only, so we can safely remove it and replace it with native Java API.