### PR TITLE
NO-ISSUE: Skipping build of `serverless-logic-web-tools-swf-builder-image` because the nightly build of `quay.io/kiegroup/kogito-swf-builder` are pointing to 999-SNAPSHOT

### DIFF
--- a/packages/serverless-logic-web-tools-swf-builder-image/package.json
+++ b/packages/serverless-logic-web-tools-swf-builder-image/package.json
@@ -14,9 +14,10 @@
   },
   "scripts": {
     "build:dev": "echo Nothing to do",
-    "build:prod": "pnpm cleanup && pnpm copy:assets && run-script-os",
+    "build:prod": "echo Build is temporarily skipped because of https://github.com/apache/incubator-kie-issues/issues/1082",
     "build:prod:darwin": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm image:docker:build\"",
     "build:prod:linux": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm image:podman:build\"",
+    "build:prod:skipped": "pnpm cleanup && pnpm copy:assets && run-script-os",
     "build:prod:win32": "echo \"Build not supported on Windows\"",
     "cleanup": "rimraf dist-dev && mkdir dist-dev",
     "copy:assets": "pnpm copy:webapp",


### PR DESCRIPTION
This unblocks PRs as the build is currently broken.