### PR TITLE
kie-issues#389: kie-sandbox-image invalid multiline command in readme

### DIFF
--- a/packages/kie-sandbox-image/README.md
+++ b/packages/kie-sandbox-image/README.md
@@ -93,15 +93,22 @@ This package contains the `Containerfile/Dockerfile` and scripts to build a cont
    2. Enabling authentication with a GitHub Enterprise Server instance.
 
       ```bash
-      docker run -t -p 8080:8080 -e KIE_SANDBOX_AUTH_PROVIDERS='[{
-        "id":"github_at_my_company", \
-        "domain":"github.my-company.com", \
-        "supportedGitRemoteDomains":["github.my-company.com","gist.github.my-company.com"], \
-        "type":"github", \
-        "name":"GitHub @ MyCompany", \
-        "enabled":true, \
-        "group":"git" \
-      }]' -i --rm quay.io/kie-tools/kie-sandbox-image:latest
+      docker run -t -p 8080:8080 \
+      -e "KIE_SANDBOX_AUTH_PROVIDERS=$(cat << EOConfig
+      [
+          {
+            "id":"github_at_my_company",
+            "domain":"github.ibm.com",
+            "supportedGitRemoteDomains":["github.ibm.com","gist.github.ibm.com"],
+            "type":"github",
+            "name":"GitHub @ MyCompany",
+            "enabled":true,
+            "group":"git"
+          }
+      ]
+      EOConfig
+      )" \
+      -i --rm quay.io/kie-tools/kie-sandbox-image:latest
       ```
 
       _NOTE: Replace `docker` with `podman` if necessary._
@@ -125,15 +132,22 @@ This package contains the `Containerfile/Dockerfile` and scripts to build a cont
    5. Adding Accelerators available for your users.
 
       ```bash
-      docker run -t -p 8080:8080 -e KIE_SANDBOX_ACCELERATORS='[{ \
-        name: "Quarkus", \
-        iconUrl: "https://github.com/apache/incubator-kie-sandbox-quarkus-accelerator/raw/0.0.0/quarkus-logo.png", \
-        gitRepositoryUrl: "https://github.com/apache/incubator-kie-sandbox-quarkus-accelerator", \
-        gitRepositoryGitRef: "0.0.0", \
-        dmnDestinationFolder: "src/main/resources/dmn", \
-        bpmnDestinationFolder: "src/main/resources/bpmn", \
-        otherFilesDestinationFolder: "src/main/resources/others", \
-      }]' -i --rm quay.io/kie-tools/kie-sandbox-image:latest
+      docker run -t -p 8080:8080 \
+      -e "KIE_SANDBOX_AUTH_PROVIDERS=$(cat << EOConfig
+      [
+        {
+          "name": "Quarkus",
+          "iconUrl": "https://github.com/apache/incubator-kie-sandbox-quarkus-accelerator/raw/0.0.0/quarkus-logo.png",
+          "gitRepositoryUrl": "https://github.com/apache/incubator-kie-sandbox-quarkus-accelerator",
+          "gitRepositoryGitRef": "0.0.0",
+          "dmnDestinationFolder": "src/main/resources/dmn",
+          "bpmnDestinationFolder": "src/main/resources/bpmn",
+          "otherFilesDestinationFolder": "src/main/resources/others",
+        }
+      ]
+      EOConfig
+      )" \
+      -i --rm quay.io/kie-tools/kie-sandbox-image:latest
       ```
 
       _NOTE: Replace `docker` with `podman` if necessary._


### PR DESCRIPTION
The example commands in the README did not work due to the use of double quotes and an unescaped line break.
The new commands work and are easier to customize.