### PR TITLE
kie-issues#1020: React-Based DMN Editor: typeConstraint unsupported

### DIFF
--- a/packages/dmn-editor/src/dataTypes/Constraints.tsx
+++ b/packages/dmn-editor/src/dataTypes/Constraints.tsx
@@ -256,11 +256,16 @@ export function Constraints({
   editItemDefinition: EditItemDefinition;
 }) {
   const allowedValues = useMemo(() => itemDefinition?.allowedValues, [itemDefinition?.allowedValues]);
+  const typeConstraint = useMemo(() => itemDefinition?.typeConstraint, [itemDefinition?.typeConstraint]);
+
   const constraintValue = useMemo(
-    () => allowedValues?.text.__$$text ?? allowedValues?.text.__$$text,
-    [allowedValues?.text.__$$text]
+    () => typeConstraint?.text.__$$text ?? allowedValues?.text.__$$text,
+    [typeConstraint?.text.__$$text, allowedValues?.text.__$$text]
   );
-  const kieConstraintType = useMemo(() => allowedValues?.["@_kie:constraintType"], [allowedValues]);
+  const kieConstraintType = useMemo(
+    () => typeConstraint?.["@_kie:constraintType"] ?? allowedValues?.["@_kie:constraintType"],
+    [allowedValues, typeConstraint]
+  );
   const typeRef: DmnBuiltInDataType = useMemo(
     () => (itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined,
     [itemDefinition?.typeRef?.__$$text]
@@ -334,29 +339,31 @@ export function Constraints({
   const onEnumChange = useCallback(
     (value?: string) => {
       editItemDefinition(itemDefinitionId!, (itemDefinition) => {
-        itemDefinition.allowedValues ??= { text: { __$$text: "" } };
-        itemDefinition.allowedValues.text.__$$text = value ?? "";
-        itemDefinition.allowedValues["@_id"] = itemDefinition.allowedValues?.["@_id"] ?? generateUuid();
+        itemDefinition.typeConstraint ??= { text: { __$$text: "" } };
+        itemDefinition.typeConstraint.text.__$$text = value ?? "";
+        itemDefinition.typeConstraint["@_id"] = itemDefinition.typeConstraint?.["@_id"] ?? generateUuid();
       });
     },
     [editItemDefinition, itemDefinitionId]
   );
+
   const onExpressionChange = useCallback(
     (value?: string) => {
       editItemDefinition(itemDefinitionId!, (itemDefinition) => {
-        itemDefinition.allowedValues ??= { text: { __$$text: "" } };
-        itemDefinition.allowedValues.text.__$$text = value ?? "";
-        itemDefinition.allowedValues["@_id"] = itemDefinition.allowedValues?.["@_id"] ?? generateUuid();
+        itemDefinition.typeConstraint ??= { text: { __$$text: "" } };
+        itemDefinition.typeConstraint.text.__$$text = value ?? "";
+        itemDefinition.typeConstraint["@_id"] = itemDefinition.typeConstraint?.["@_id"] ?? generateUuid();
       });
     },
     [editItemDefinition, itemDefinitionId]
   );
+
   const onRangeChange = useCallback(
     (value?: string) => {
       editItemDefinition(itemDefinitionId!, (itemDefinition) => {
-        itemDefinition.allowedValues ??= { text: { __$$text: "" } };
-        itemDefinition.allowedValues.text.__$$text = value ?? "";
-        itemDefinition.allowedValues["@_id"] = itemDefinition.allowedValues?.["@_id"] ?? generateUuid();
+        itemDefinition.typeConstraint ??= { text: { __$$text: "" } };
+        itemDefinition.typeConstraint.text.__$$text = value ?? "";
+        itemDefinition.typeConstraint["@_id"] = itemDefinition.typeConstraint?.["@_id"] ?? generateUuid();
       });
     },
     [editItemDefinition, itemDefinitionId]
@@ -370,15 +377,15 @@ export function Constraints({
       const selection = event.currentTarget.id as ConstraintsType;
       if (selection === ConstraintsType.NONE) {
         editItemDefinition(itemDefinitionId!, (itemDefinition) => {
-          itemDefinition.allowedValues = undefined;
+          itemDefinition.typeConstraint = undefined;
         });
         return;
       }
 
       editItemDefinition(itemDefinitionId!, (itemDefinition) => {
-        itemDefinition.allowedValues ??= { text: { __$$text: "" } };
-        const previousKieContraintType = itemDefinition.allowedValues["@_kie:constraintType"];
-        itemDefinition.allowedValues["@_kie:constraintType"] = enumToKieConstraintType(selection);
+        itemDefinition.typeConstraint ??= { text: { __$$text: "" } };
+        const previousKieContraintType = itemDefinition.typeConstraint["@_kie:constraintType"];
+        itemDefinition.typeConstraint["@_kie:constraintType"] = enumToKieConstraintType(selection);
 
         if (selection === ConstraintsType.EXPRESSION) {
           return;
@@ -388,7 +395,7 @@ export function Constraints({
           previousKieContraintType === "expression" &&
           selection === ConstraintsType.ENUMERATION &&
           isEnum(
-            itemDefinition.allowedValues.text.__$$text,
+            itemDefinition.typeConstraint.text.__$$text,
             constraintTypeHelper(
               (itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined
             ).check
@@ -401,7 +408,7 @@ export function Constraints({
           previousKieContraintType === "expression" &&
           selection === ConstraintsType.RANGE &&
           isRange(
-            itemDefinition.allowedValues.text.__$$text,
+            itemDefinition.typeConstraint.text.__$$text,
             constraintTypeHelper(
               (itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined
             ).check
@@ -410,7 +417,7 @@ export function Constraints({
           return;
         }
 
-        itemDefinition.allowedValues.text.__$$text = "";
+        itemDefinition.typeConstraint.text.__$$text = "";
       });
     },
     [editItemDefinition, enumToKieConstraintType, itemDefinitionId]

--- a/packages/dmn-editor/src/dataTypes/Constraints.tsx
+++ b/packages/dmn-editor/src/dataTypes/Constraints.tsx
@@ -252,9 +252,13 @@ export const constraintTypeHelper = (typeRef: DmnBuiltInDataType): TypeHelper =>
 export function useConstraint({
   constraint,
   itemDefinition,
+  isEnumDisabled,
+  isRangeDisabled,
 }: {
   constraint: DMN15__tUnaryTests | undefined;
   itemDefinition: DMN15__tItemDefinition;
+  isEnumDisabled: boolean;
+  isRangeDisabled: boolean;
 }) {
   const constraintValue = useMemo(() => constraint?.text.__$$text, [constraint?.text.__$$text]);
 
@@ -266,13 +270,13 @@ export function useConstraint({
   );
 
   const isConstraintEnum = useMemo(
-    () => isEnum(constraintValue, constraintTypeHelper(typeRef).check),
-    [constraintValue, typeRef]
+    () => (isEnumDisabled ? undefined : isEnum(constraintValue, constraintTypeHelper(typeRef).check)),
+    [constraintValue, isEnumDisabled, typeRef]
   );
 
   const isConstraintRange = useMemo(
-    () => isRange(constraintValue, constraintTypeHelper(typeRef).check),
-    [constraintValue, typeRef]
+    () => (isRangeDisabled ? undefined : isRange(constraintValue, constraintTypeHelper(typeRef).check)),
+    [constraintValue, isRangeDisabled, typeRef]
   );
 
   const itemDefinitionId = useMemo(() => itemDefinition["@_id"], [itemDefinition]);
@@ -297,11 +301,12 @@ export function useConstraint({
   const isConstraintEnabled = useMemo(() => {
     const enabledConstraints = constrainableBuiltInFeelTypes.get(typeRef);
     return {
-      enumeration: (enabledConstraints ?? []).includes(enumToKieConstraintType(ConstraintsType.ENUMERATION)!),
-      range: (enabledConstraints ?? []).includes(enumToKieConstraintType(ConstraintsType.RANGE)!),
+      enumeration:
+        !isEnumDisabled && (enabledConstraints ?? []).includes(enumToKieConstraintType(ConstraintsType.ENUMERATION)!),
+      range: !isRangeDisabled && (enabledConstraints ?? []).includes(enumToKieConstraintType(ConstraintsType.RANGE)!),
       expression: (enabledConstraints ?? []).includes(enumToKieConstraintType(ConstraintsType.EXPRESSION)!),
     };
-  }, [enumToKieConstraintType, typeRef]);
+  }, [enumToKieConstraintType, isEnumDisabled, isRangeDisabled, typeRef]);
 
   const selectedConstraint = useMemo<ConstraintsType>(() => {
     if (isConstraintEnabled.enumeration && kieConstraintType === "enumeration") {
@@ -356,14 +361,18 @@ export function useConstraint({
   ]);
 }
 
-export function AllowedValuesConstraints({
+export function ConstraintsFromAllowedValuesAttribute({
   isReadonly,
   itemDefinition,
   editItemDefinition,
+  isEnumDisabled,
+  isRangeDisabled,
 }: {
   isReadonly: boolean;
   itemDefinition: DMN15__tItemDefinition;
   editItemDefinition: EditItemDefinition;
+  isEnumDisabled?: boolean;
+  isRangeDisabled?: boolean;
 }) {
   const allowedValues = useMemo(() => itemDefinition?.allowedValues, [itemDefinition?.allowedValues]);
 
@@ -376,7 +385,12 @@ export function AllowedValuesConstraints({
     itemDefinitionId,
     selectedConstraint,
     enumToKieConstraintType,
-  } = useConstraint({ constraint: allowedValues, itemDefinition });
+  } = useConstraint({
+    constraint: allowedValues,
+    itemDefinition,
+    isEnumDisabled: isEnumDisabled ?? false,
+    isRangeDisabled: isRangeDisabled ?? false,
+  });
 
   const onConstraintChange = useCallback(
     (value?: string) => {
@@ -461,16 +475,20 @@ export function AllowedValuesConstraints({
   );
 }
 
-export function TypeConstraintConstraints({
+export function ConstraintsFromTypeConstraintAttribute({
   isReadonly,
   itemDefinition,
   editItemDefinition,
   defaultsToAllowedValues,
+  isEnumDisabled,
+  isRangeDisabled,
 }: {
   isReadonly: boolean;
   itemDefinition: DMN15__tItemDefinition;
   editItemDefinition: EditItemDefinition;
   defaultsToAllowedValues: boolean;
+  isEnumDisabled?: boolean;
+  isRangeDisabled?: boolean;
 }) {
   const typeConstraint = useMemo(
     () =>
@@ -489,7 +507,12 @@ export function TypeConstraintConstraints({
     itemDefinitionId,
     selectedConstraint,
     enumToKieConstraintType,
-  } = useConstraint({ constraint: typeConstraint, itemDefinition });
+  } = useConstraint({
+    constraint: typeConstraint,
+    itemDefinition,
+    isEnumDisabled: isEnumDisabled ?? false,
+    isRangeDisabled: isRangeDisabled ?? false,
+  });
 
   const onConstraintChange = useCallback(
     (value?: string) => {

--- a/packages/dmn-editor/src/dataTypes/Constraints.tsx
+++ b/packages/dmn-editor/src/dataTypes/Constraints.tsx
@@ -465,12 +465,20 @@ export function TypeConstraintConstraints({
   isReadonly,
   itemDefinition,
   editItemDefinition,
+  defaultsToAllowedValues,
 }: {
   isReadonly: boolean;
   itemDefinition: DMN15__tItemDefinition;
   editItemDefinition: EditItemDefinition;
+  defaultsToAllowedValues: boolean;
 }) {
-  const typeConstraint = useMemo(() => itemDefinition?.typeConstraint, [itemDefinition?.typeConstraint]);
+  const typeConstraint = useMemo(
+    () =>
+      defaultsToAllowedValues
+        ? itemDefinition?.typeConstraint ?? itemDefinition?.allowedValues
+        : itemDefinition?.typeConstraint,
+    [defaultsToAllowedValues, itemDefinition?.allowedValues, itemDefinition?.typeConstraint]
+  );
 
   const {
     constraintValue,

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -45,7 +45,7 @@ import { CopyIcon } from "@patternfly/react-icons/dist/js/icons/copy-icon";
 import { UniqueNameIndex } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
 import { buildFeelQNameFromNamespace } from "../feel/buildFeelQName";
 import { buildClipboardFromDataType } from "../clipboard/Clipboard";
-import { Constraints } from "./Constraints";
+import { AllowedValuesConstraints, TypeConstraintConstraints } from "./Constraints";
 import { original } from "immer";
 import { builtInFeelTypeNames } from "./BuiltInFeelTypes";
 import { useDmnEditor } from "../DmnEditorContext";
@@ -94,8 +94,21 @@ export function DataTypePanel({
 
       editItemDefinition(dataType.itemDefinition["@_id"]!, (itemDefinition) => {
         itemDefinition["@_isCollection"] = isChecked;
-        itemDefinition.typeConstraint = undefined;
-        itemDefinition.allowedValues = undefined;
+        if (isChecked === true) {
+          itemDefinition.allowedValues = itemDefinition.typeConstraint
+            ? {
+                ...itemDefinition.typeConstraint,
+              }
+            : undefined;
+
+          itemDefinition.typeConstraint = undefined;
+        } else {
+          itemDefinition.typeConstraint = itemDefinition.allowedValues
+            ? {
+                ...itemDefinition.allowedValues,
+              }
+            : undefined;
+        }
       });
     },
     [dataType.itemDefinition, editItemDefinition, isReadonly]
@@ -346,14 +359,41 @@ export function DataTypePanel({
 
             <br />
             <br />
-            <Title size={"md"} headingLevel="h4">
-              Constraints
-            </Title>
-            <Constraints
-              isReadonly={isReadonly}
-              itemDefinition={dataType.itemDefinition}
-              editItemDefinition={editItemDefinition}
-            />
+
+            {dataType.itemDefinition["@_isCollection"] === true ? (
+              <>
+                <Title size={"md"} headingLevel="h4">
+                  Collection constraint
+                </Title>
+                <TypeConstraintConstraints
+                  isReadonly={isReadonly}
+                  itemDefinition={dataType.itemDefinition}
+                  editItemDefinition={editItemDefinition}
+                />
+                <br />
+                <br />
+                <br />
+                <Title size={"md"} headingLevel="h4">
+                  Collection item constraint
+                </Title>
+                <AllowedValuesConstraints
+                  isReadonly={isReadonly}
+                  itemDefinition={dataType.itemDefinition}
+                  editItemDefinition={editItemDefinition}
+                />
+              </>
+            ) : (
+              <>
+                <Title size={"md"} headingLevel="h4">
+                  Constraints
+                </Title>
+                <TypeConstraintConstraints
+                  isReadonly={isReadonly}
+                  itemDefinition={dataType.itemDefinition}
+                  editItemDefinition={editItemDefinition}
+                />
+              </>
+            )}
           </>
         )}
         {isStruct(dataType.itemDefinition) && (

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -369,6 +369,7 @@ export function DataTypePanel({
                   isReadonly={isReadonly}
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}
+                  defaultsToAllowedValues={false}
                 />
                 <br />
                 <br />
@@ -391,6 +392,7 @@ export function DataTypePanel({
                   isReadonly={isReadonly}
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}
+                  defaultsToAllowedValues={true}
                 />
               </>
             )}

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -75,6 +75,7 @@ export function DataTypePanel({
         if (isChecked) {
           itemDefinition.typeRef = undefined;
           itemDefinition.itemComponent = [];
+          itemDefinition.typeConstraint = undefined;
           itemDefinition.allowedValues = undefined;
         } else {
           itemDefinition.typeRef = { __$$text: DmnBuiltInDataType.Any };
@@ -93,6 +94,7 @@ export function DataTypePanel({
 
       editItemDefinition(dataType.itemDefinition["@_id"]!, (itemDefinition) => {
         itemDefinition["@_isCollection"] = isChecked;
+        itemDefinition.typeConstraint = undefined;
         itemDefinition.allowedValues = undefined;
       });
     },
@@ -109,6 +111,7 @@ export function DataTypePanel({
         itemDefinition.typeRef = { __$$text: typeRef };
         const originalItemDefinition = original(itemDefinition);
         if (originalItemDefinition?.typeRef?.__$$text !== typeRef) {
+          itemDefinition.typeConstraint = undefined;
           itemDefinition.allowedValues = undefined;
         }
       });

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -45,12 +45,13 @@ import { CopyIcon } from "@patternfly/react-icons/dist/js/icons/copy-icon";
 import { UniqueNameIndex } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
 import { buildFeelQNameFromNamespace } from "../feel/buildFeelQName";
 import { buildClipboardFromDataType } from "../clipboard/Clipboard";
-import { AllowedValuesConstraints, TypeConstraintConstraints } from "./Constraints";
+import { ConstraintsFromAllowedValuesAttribute, ConstraintsFromTypeConstraintAttribute } from "./Constraints";
 import { original } from "immer";
 import { builtInFeelTypeNames } from "./BuiltInFeelTypes";
 import { useDmnEditor } from "../DmnEditorContext";
 import { useResolvedTypeRef } from "./useResolvedTypeRef";
 import { useExternalModels } from "../includedModels/DmnEditorDependenciesContext";
+import { Alert } from "@patternfly/react-core/dist/js/components/Alert/Alert";
 
 export function DataTypePanel({
   isReadonly,
@@ -365,19 +366,29 @@ export function DataTypePanel({
                 <Title size={"md"} headingLevel="h4">
                   Collection constraint
                 </Title>
-                <TypeConstraintConstraints
+                <ConstraintsFromTypeConstraintAttribute
                   isReadonly={isReadonly}
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}
                   defaultsToAllowedValues={false}
+                  isEnumDisabled={true}
+                  isRangeDisabled={true}
                 />
-                <br />
                 <br />
                 <br />
                 <Title size={"md"} headingLevel="h4">
                   Collection item constraint
                 </Title>
-                <AllowedValuesConstraints
+                <Alert variant="warning" isInline isPlain title="Deprecated">
+                  <p>
+                    Creating constraints for the collection items directly on the collection itself is deprecated since
+                    DMN 1.5 and will possibly be removed in future versions. To prepare your DMN model for future
+                    updates, please create a dedicated Data Type for the items of this list and add constraints there.
+                  </p>
+                </Alert>
+                <br />
+
+                <ConstraintsFromAllowedValuesAttribute
                   isReadonly={isReadonly}
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}
@@ -388,7 +399,7 @@ export function DataTypePanel({
                 <Title size={"md"} headingLevel="h4">
                   Constraints
                 </Title>
-                <TypeConstraintConstraints
+                <ConstraintsFromTypeConstraintAttribute
                   isReadonly={isReadonly}
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}

--- a/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
+++ b/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
@@ -269,13 +269,22 @@ export function ItemComponentsTable({
                 level * BRIGHTNESS_DECREASE_STEP_IN_PERCENTAGE_PER_NESTING_LEVEL;
 
               const constraintLabel = () => {
-                if (dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "enumeration") {
+                if (
+                  dt.itemDefinition.typeConstraint?.["@_kie:constraintType"] === "enumeration" ||
+                  dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "enumeration"
+                ) {
                   return <>Enumeration</>;
                 }
-                if (dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "expression") {
+                if (
+                  dt.itemDefinition.typeConstraint?.["@_kie:constraintType"] === "expression" ||
+                  dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "expression"
+                ) {
                   return <>Expression</>;
                 }
-                if (dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "range") {
+                if (
+                  dt.itemDefinition.typeConstraint?.["@_kie:constraintType"] === "range" ||
+                  dt.itemDefinition.allowedValues?.["@_kie:constraintType"] === "range"
+                ) {
                   return <>Range</>;
                 }
 
@@ -380,9 +389,11 @@ export function ItemComponentsTable({
                               if (isChecked) {
                                 itemDefinition.typeRef = undefined;
                                 itemDefinition.itemComponent = [];
+                                itemDefinition.typeConstraint = undefined;
                                 itemDefinition.allowedValues = undefined;
                               } else {
                                 itemDefinition.typeRef = { __$$text: DmnBuiltInDataType.Any };
+                                itemDefinition.typeConstraint = undefined;
                                 itemDefinition.allowedValues = undefined;
                               }
                             });
@@ -406,6 +417,7 @@ export function ItemComponentsTable({
                               editItemDefinition(dt.itemDefinition["@_id"]!, (itemDefinition, items) => {
                                 itemDefinition.typeRef = { __$$text: newDataType };
                                 if (itemDefinition.typeRef?.__$$text !== newDataType) {
+                                  itemDefinition.typeConstraint = undefined;
                                   itemDefinition.allowedValues = undefined;
                                 }
                               });
@@ -420,6 +432,7 @@ export function ItemComponentsTable({
                           onChange={(isChecked) => {
                             editItemDefinition(dt.itemDefinition["@_id"]!, (itemDefinition, items) => {
                               itemDefinition["@_isCollection"] = isChecked;
+                              itemDefinition.typeConstraint = undefined;
                               itemDefinition.allowedValues = undefined;
                             });
                           }}


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1020

## On this PR
- Save the default value to `typeConstraint`.
- Add an additional constraint for collections.
- Don't reset the constraint while tweaking the data type to collection.

## Demo
https://github.com/apache/incubator-kie-tools/assets/24302289/11627bed-c3f7-4ae4-b4e4-21ecd9c6a137


