### PR TITLE
kie-issues#1020: Adds missing features from previous #2244 

### DIFF
--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -357,10 +357,8 @@ export function DataTypePanel({
               typeRef={resolvedTypeRef}
               onChange={changeTypeRef}
             />
-
             <br />
             <br />
-
             {dataType.itemDefinition["@_isCollection"] === true ? (
               <>
                 <Title size={"md"} headingLevel="h4">
@@ -371,8 +369,6 @@ export function DataTypePanel({
                   itemDefinition={dataType.itemDefinition}
                   editItemDefinition={editItemDefinition}
                   defaultsToAllowedValues={false}
-                  isEnumDisabled={true}
-                  isRangeDisabled={true}
                 />
                 <br />
                 <br />

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -109,6 +109,7 @@ export function DataTypePanel({
                 ...itemDefinition.allowedValues,
               }
             : undefined;
+          itemDefinition.allowedValues = undefined;
         }
       });
     },

--- a/packages/dmn-editor/src/dataTypes/DataTypeSpec.ts
+++ b/packages/dmn-editor/src/dataTypes/DataTypeSpec.ts
@@ -75,6 +75,10 @@ export function getNewItemDefinition(partial?: Partial<DMN15__tItemDefinition>) 
   };
 }
 
+export function isCollection(itemDefinition: DMN15__tItemDefinition) {
+  return itemDefinition["@_isCollection"] ?? false;
+}
+
 export function isStruct(itemDefinition: DMN15__tItemDefinition) {
   return !itemDefinition.typeRef && !!itemDefinition.itemComponent;
 }
@@ -94,8 +98,9 @@ export const constrainableBuiltInFeelTypes = new Map<DmnBuiltInDataType, KIE__tC
 
 export function canHaveConstraints(itemDefinition: DMN15__tItemDefinition) {
   return (
-    !isStruct(itemDefinition) &&
-    (constrainableBuiltInFeelTypes.get(itemDefinition.typeRef?.__$$text as DmnBuiltInDataType)?.length ?? 0) > 0
+    isCollection(itemDefinition) ||
+    (!isStruct(itemDefinition) &&
+      (constrainableBuiltInFeelTypes.get(itemDefinition.typeRef?.__$$text as DmnBuiltInDataType)?.length ?? 0) > 0)
   );
 }
 


### PR DESCRIPTION
This PR adds missing features of the https://github.com/apache/incubator-kie-tools/pull/2244

## On this PR
Enables to create constraints to the `<Undefined>`, `boolean` and `context` collections.

- \<Undefined>
![image](https://github.com/apache/incubator-kie-tools/assets/24302289/4353deb5-5dfa-49de-9b03-4d71747373e5)

- boolean
![image](https://github.com/apache/incubator-kie-tools/assets/24302289/3ec50408-ff8f-47bd-bf62-5fb3d00846d3)

- context
![image](https://github.com/apache/incubator-kie-tools/assets/24302289/1599f76f-c7df-4d7d-9923-b44ec6d83bd5)