### PR TITLE
NO-ISSUE: Nix.dev: Moving PATH around so DevBox path is first

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -17,7 +17,7 @@
     "DEVBOX_COREPACK_ENABLED": "true",
     "GOFLAGS": "-modcacherw",
     "GOPATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs",
-    "PATH": "$PATH:$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin"
+    "PATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin:$PATH"
   },
   "shell": {
     "init_hook": [". $VENV_DIR/bin/activate"],

--- a/devbox.json
+++ b/devbox.json
@@ -20,7 +20,10 @@
     "PATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin:$PATH"
   },
   "shell": {
-    "init_hook": [". $VENV_DIR/bin/activate"],
+    "init_hook": [
+      ". $VENV_DIR/bin/activate",
+      "[[ $OSTYPE == 'darwin'* ]] && export PATH=$(echo $PATH | tr ':' '\n' | sed '\\|^/nix/store/|d' | paste -sd ':' -)"
+    ],
     "scripts": {
       "versions": [
         "java --version && mvn -v && node -v && pnpm -v && go version && helm version && make -v && python --version && pip --version"


### PR DESCRIPTION
We want anything that devbox is supplying to be listed first in the PATH.