### PR TITLE
NO-ISSUE: "Unfixed" versions for base image dependencies

### DIFF
--- a/packages/cors-proxy-image/Containerfile
+++ b/packages/cors-proxy-image/Containerfile
@@ -29,7 +29,7 @@ RUN mkdir $HOME \
   && chgrp -R 0 $HOME \
   && chmod -R g=u $HOME \
   && chown -R 1000:0 $HOME \
-  && microdnf --disableplugin=subscription-manager install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
+  && microdnf --disableplugin=subscription-manager install -y tar gzip \
   && microdnf --disableplugin=subscription-manager clean all \
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
   && /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION" \

--- a/packages/cors-proxy-image/Containerfile
+++ b/packages/cors-proxy-image/Containerfile
@@ -5,15 +5,15 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
@@ -29,13 +29,14 @@ RUN mkdir $HOME \
   && chgrp -R 0 $HOME \
   && chmod -R g=u $HOME \
   && chown -R 1000:0 $HOME \
-  && microdnf install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
+  && microdnf --disableplugin=subscription-manager install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
+  && microdnf --disableplugin=subscription-manager clean all \
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
   && /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION" \
   && export CORS_PROXY_HTTP_PORT=$CORS_PROXY_DEFAULT_PORT \
   && export CORS_PROXY_ORIGIN=CORS_PROXY_DEFAULT_ORIGIN \
   && export CORS_PROXY_VERBOSE=CORS_PROXY_DEFAULT_VERBOSE
-  
+
 
 ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
 ENV PATH $NODE_PATH:$PATH

--- a/packages/dashbuilder-viewer-image/Containerfile
+++ b/packages/dashbuilder-viewer-image/Containerfile
@@ -5,19 +5,19 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
-RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.57-5.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all \
   && sed -i -e 's/Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/#ServerName www.example.com:80/ServerName 127.0.0.1:8080/' /etc/httpd/conf/httpd.conf \

--- a/packages/dev-deployment-base-image/Containerfile
+++ b/packages/dev-deployment-base-image/Containerfile
@@ -31,8 +31,8 @@ USER root
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME_PATH/app
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
 
-RUN microdnf install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
-    && microdnf clean all \
+RUN microdnf --disableplugin=subscription-manager install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
+    && microdnf --disableplugin=subscription-manager clean all \
     && mkdir -p -m 777 $HOME_PATH/app \
     && mkdir -p -m 777 /tmp/app \
     && mkdir -p -m 777 /.m2

--- a/packages/dev-deployment-base-image/Containerfile
+++ b/packages/dev-deployment-base-image/Containerfile
@@ -31,7 +31,7 @@ USER root
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME_PATH/app
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
 
-RUN microdnf --disableplugin=subscription-manager install -y tar-2:1.34-6.el9_1.x86_64 gzip-1.12-1.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager install -y tar gzip \
     && microdnf --disableplugin=subscription-manager clean all \
     && mkdir -p -m 777 $HOME_PATH/app \
     && mkdir -p -m 777 /tmp/app \

--- a/packages/dev-deployment-dmn-form-webapp-image/Containerfile
+++ b/packages/dev-deployment-dmn-form-webapp-image/Containerfile
@@ -5,19 +5,19 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
-RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.57-5.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all \
   && echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/Listen 80/Listen 8081/' /etc/httpd/conf/httpd.conf \

--- a/packages/dev-deployment-upload-service/dev/Containerfile.ddus-buildtime-install
+++ b/packages/dev-deployment-upload-service/dev/Containerfile.ddus-buildtime-install
@@ -28,7 +28,7 @@ ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8091
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_API_KEY=dev
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_ROOT_PATH="/"
 
-RUN microdnf install -y tar gzip findutils
+RUN microdnf --disableplugin=subscription-manager install -y tar gzip findutils
 
 RUN curl ${DDUS_FILESERVER_IP}:${DDUS_FILESERVER_PORT}/apache/incubator-kie-tools/releases/download/${DDUS_VERSION}/getDevDeploymentUploadService.sh | sed 's/localhost:${DDUS_FILESERVER_PORT}/${DDUS_FILESERVER_IP}:${DDUS_FILESERVER_PORT}/; s/https:\/\/github.com/http:\/\/${DDUS_FILESERVER_IP}:${DDUS_FILESERVER_PORT}/' | bash
 

--- a/packages/dev-deployment-upload-service/dev/Containerfile.ddus-fileserver
+++ b/packages/dev-deployment-upload-service/dev/Containerfile.ddus-fileserver
@@ -19,7 +19,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 ARG DDUS_VERSION="0.0.0"
 
-RUN microdnf -y install httpd \
+RUN microdnf --disableplugin=subscription-manager install -y httpd \
   && echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/Listen 80/Listen 8090/' /etc/httpd/conf/httpd.conf \
   && sed -i -e 's/#ServerName www.example.com:80/ServerName 127.0.0.1:8090/' /etc/httpd/conf/httpd.conf \

--- a/packages/dev-deployment-upload-service/dev/Containerfile.ddus-runtime-install
+++ b/packages/dev-deployment-upload-service/dev/Containerfile.ddus-runtime-install
@@ -28,7 +28,7 @@ ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8092
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_API_KEY=dev
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_ROOT_PATH="/"
 
-RUN microdnf install -y tar gzip findutils
+RUN microdnf --disableplugin=subscription-manager install -y tar gzip findutils
 
 CMD curl $DDUS_FILESERVER_IP:${DDUS_FILESERVER_PORT}/apache/incubator-kie-tools/releases/download/$DDUS_VERSION/getDevDeploymentUploadService.sh | sed 's/localhost:${DDUS_FILESERVER_PORT}/$DDUS_FILESERVER_IP:${DDUS_FILESERVER_PORT}/; s/https:\/\/github.com/http:\/\/$DDUS_FILESERVER_IP:${DDUS_FILESERVER_PORT}/' | bash \
   && dev-deployment-upload-service \

--- a/packages/kie-sandbox-image/Containerfile
+++ b/packages/kie-sandbox-image/Containerfile
@@ -5,15 +5,15 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License. 
+# under the License.
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
@@ -21,7 +21,7 @@ ARG KIE_SANDBOX_DEFAULT_PORT=8080
 
 COPY entrypoint.sh dist-dev/image-env-to-json-standalone dist-dev/EnvJson.schema.json /tmp/
 
-RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.57-5.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all \
   && echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
   && sed -i "s/Listen 80/Listen $KIE_SANDBOX_DEFAULT_PORT/g" /etc/httpd/conf/httpd.conf \

--- a/packages/kogito-management-console/Containerfile
+++ b/packages/kogito-management-console/Containerfile
@@ -23,7 +23,7 @@ ENV RUNTIME_TOOLS_MANAGEMENT_CONSOLE_KOGITO_ENV_MODE="PROD"
 
 COPY entrypoint.sh dist-dev/image-env-to-json-standalone dist-dev/EnvJson.schema.json /tmp/
 
-RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.57-5.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all \
   && echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
   && sed -i -e "/#ServerName www.example.com:80/aHeader set Content-Security-Policy \"frame-ancestors 'self';\"" /etc/httpd/conf/httpd.conf \

--- a/packages/kogito-task-console/Containerfile
+++ b/packages/kogito-task-console/Containerfile
@@ -23,7 +23,7 @@ ENV RUNTIME_TOOLS_TASK_CONSOLE_KOGITO_ENV_MODE="PROD"
 
 COPY entrypoint.sh dist-dev/image-env-to-json-standalone dist-dev/EnvJson.schema.json /tmp/
 
-RUN microdnf --disableplugin=subscription-manager -y install httpd-2.4.57-5.el9.x86_64 \
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all \
   && echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
   && sed -i -e "/#ServerName www.example.com:80/aHeader set Content-Security-Policy \"frame-ancestors 'self';\"" /etc/httpd/conf/httpd.conf \


### PR DESCRIPTION
Changed images:
- cors-proxy-image
- dashbuilder-viewer-image
- dev-deployment-base-image
- dev-deployment-dmn-form-webapp-image
- kie-sandbox-image
- kogito-management-console
- kogito-task-console

Changed packages:
- tar
- gzip
- httpd

Now, for these packages, the default version available from the base image repository will be installed.