### PR TITLE
NO-ISSUE: Tweak Staging and Release Jenkins jobs

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release-build
+++ b/.ci/jenkins/Jenkinsfile.release-build
@@ -148,7 +148,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -167,7 +167,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -186,7 +186,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -205,7 +205,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -225,7 +225,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
 
@@ -246,7 +246,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
 
@@ -267,7 +267,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL', value: "${env.KIE_SANDBOX_EXTENDED_SERVICES_URL}"),
                             string(name: 'KIE_SANDBOX_CORS_PROXY_URL', value: "${env.KIE_SANDBOX_CORS_PROXY_URL}")
                         ]
@@ -291,7 +291,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -311,7 +311,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -330,7 +330,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -350,7 +350,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -370,7 +370,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -390,7 +390,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -409,7 +409,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -428,7 +428,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}"),
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                         ]
                     ).result
@@ -448,7 +448,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -467,7 +467,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -486,7 +486,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -505,7 +505,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -514,17 +514,17 @@ pipeline {
 
         stage('Serverless Logic Web Tools') {
             when {
-                expression { env.SERVERLESS_LOGIC_WEB_TOOLS == 'true' && (env.SERVERLESS_LOGIC_WEB_TOOLS_SWF_BUILDER_IMAGE_JOB_RESULT == 'SUCCESS' || env.SERVERLESS_LOGIC_WEB_TOOLS_SWF_BUILDER_IMAGE_JOB_RESULT == 'SKIPPED') && (env.SERVERLESS_LOGIC_WEB_TOOLS_BASE_BUILDER_IMAGE_JOB_RESULT == 'SUCCESS' || env.SERVERLESS_LOGIC_WEB_TOOLS_BASE_BUILDER_IMAGE_JOB_RESULT == 'SKIPPED') && (env.SERVERLESS_LOGIC_WEB_TOOLS_SWF_DEV_MODE_IMAGE_JOB_RESULT == 'SUCCESS' || env.SERVERLESS_LOGIC_WEB_TOOLS_SWF_DEV_MODE_IMAGE_JOB_RESULT == 'SKIPPED') && (env.DASHBUILDER_VIEWER_IMAGE_JOB_RESULT == 'SUCCESS' || env.DASHBUILDER_VIEWER_IMAGE_JOB_RESULT == 'SKIPPED') }
+                expression { env.SERVERLESS_LOGIC_WEB_TOOLS == 'true') }
             }
             steps {
                 script {
-                    env.DASHBUILDER_VIEWER_IMAGE_JOB_RESULT = build(
+                    env.SERVERLESS_LOGIC_WEB_TOOLS_JOB_RESULT = build(
                         wait: true,
                         job: 'KIE/kie-tools/kie-tools-release-jobs/serverless-logic-web-tools',
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -543,7 +543,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -562,7 +562,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -581,7 +581,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -600,7 +600,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -619,7 +619,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }
@@ -638,7 +638,7 @@ pipeline {
                         parameters: [
                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                            string(name: 'TAG', value: "${params.TAG}")
+                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                         ]
                     ).result
                 }

--- a/.ci/jenkins/Jenkinsfile.staging-build
+++ b/.ci/jenkins/Jenkinsfile.staging-build
@@ -33,7 +33,7 @@ pipeline {
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Base Ref', name: 'BASE_REF')
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Commit SHA', name: 'COMMIT_SHA', defaultValue: 'main')
         string(description: 'Download asset url', name: 'DOWNLOAD_ASSET_URL', defaultValue: '')
         string(description: 'Upload asset url', name: 'UPLOAD_ASSET_URL', defaultValue: '')
@@ -46,91 +46,91 @@ pipeline {
         DEV_DEPLOYMENT_BASE_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_BASE_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_BASE_IMAGE__name = 'dev-deployment-base-image'
-        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "${params.TAG}-prerelease"
+        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "${params.RELEASE_VERSION}-staging"
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name = 'dev-deployment-dmn-form-webapp-image'
-        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "${params.TAG}-prerelease"
+        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "${params.RELEASE_VERSION}-staging"
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name = 'dev-deployment-kogito-quarkus-blank-app-image'
-        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "${params.TAG}-prerelease"
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "${params.RELEASE_VERSION}-staging"
         ONLINE_EDITOR__devDeploymentBaseImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentBaseImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentBaseImageName = 'dev-deployment-base-image'
-        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.TAG}-prerelease"
+        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.RELEASE_VERSION}-staging"
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageName = 'dev-deployment-dmn-form-webapp-image'
-        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.TAG}-prerelease"
+        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.RELEASE_VERSION}-staging"
 
         KIE_SANDBOX__imageRegistry = 'quay.io'
         KIE_SANDBOX__imageAccount = 'kie-tools'
         KIE_SANDBOX__imageName = 'kie-sandbox-image'
-        KIE_SANDBOX__imageBuildTags = "${params.TAG}-prerelease"
+        KIE_SANDBOX__imageBuildTags = "${params.RELEASE_VERSION}-staging"
 
         KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry = 'quay.io'
         KIE_SANDBOX_EXTENDED_SERVICES__imageAccount = 'kie-tools'
         KIE_SANDBOX_EXTENDED_SERVICES__imageName = 'kie-sandbox-extended-services-image'
-        KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags = "${params.TAG}-prerelease"
+        KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags = "${params.RELEASE_VERSION}-staging"
 
         CORS_PROXY_IMAGE__imageRegistry = 'quay.io'
         CORS_PROXY_IMAGE__imageAccount = 'kie-tools'
         CORS_PROXY_IMAGE__imageName = 'cors-proxy-image'
-        CORS_PROXY_IMAGE__imageBuildTags = "${params.TAG}-prerelease"
+        CORS_PROXY_IMAGE__imageBuildTags = "${params.RELEASE_VERSION}-staging"
 
-        DEPLOY_TAG = "${params.TAG}-prerelease"
+        DEPLOY_TAG = "${params.RELEASE_VERSION}-staging"
 
         DASHBUILDER__viewerImageRegistry = 'quay.io'
         DASHBUILDER__viewerImageAccount = 'kie-tools'
         DASHBUILDER__viewerImageName = 'dashbuilder-viewer-image'
-        DASHBUILDER__viewerImageBuildTags = "${params.TAG}-prerelease"
-        SERVERLESS_LOGIC_WEB_TOOLS__dashbuilderViewerImageTag = "${params.TAG}-prerelease"
+        DASHBUILDER__viewerImageBuildTags = "${params.RELEASE_VERSION}-staging"
+        SERVERLESS_LOGIC_WEB_TOOLS__dashbuilderViewerImageTag = "${params.RELEASE_VERSION}-staging"
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName = 'serverless-logic-web-tools-swf-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag = "${params.TAG}-prerelease"
-        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags = "${params.TAG}-prerelease"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag = "${params.RELEASE_VERSION}-staging"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags = "${params.RELEASE_VERSION}-staging"
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName = 'serverless-logic-web-tools-base-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageTag = "${params.TAG}-prerelease"
-        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags = "${params.TAG}-prerelease"
+        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageTag = "${params.RELEASE_VERSION}-staging"
+        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags = "${params.RELEASE_VERSION}-staging"
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName = 'serverless-logic-web-tools-swf-dev-mode-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag = "${params.TAG}-prerelease"
-        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags = "${params.TAG}-prerelease"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag = "${params.RELEASE_VERSION}-staging"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags = "${params.RELEASE_VERSION}-staging"
 
         KIE_SANDBOX_HELM_CHART__registry = 'quay.io'
         KIE_SANDBOX_HELM_CHART__account = 'kie-tools'
         KIE_SANDBOX_HELM_CHART__name = 'kie-sandbox-helm-chart'
-        KIE_SANDBOX_HELM_CHART__tag = "${params.TAG}-prerelease"
+        KIE_SANDBOX_HELM_CHART__tag = "${params.RELEASE_VERSION}-staging"
 
         KOGITO_TASK_CONSOLE__registry = 'quay.io'
         KOGITO_TASK_CONSOLE__account = 'kie-tools'
         KOGITO_TASK_CONSOLE__name = 'kogito-task-console'
-        KOGITO_TASK_CONSOLE__buildTags = "${params.TAG}-prerelease"
+        KOGITO_TASK_CONSOLE__buildTags = "${params.RELEASE_VERSION}-staging"
 
         KOGITO_MANAGEMENT_CONSOLE__registry = 'quay.io'
         KOGITO_MANAGEMENT_CONSOLE__account = 'kie-tools'
         KOGITO_MANAGEMENT_CONSOLE__name = 'kogito-management-console'
-        KOGITO_MANAGEMENT_CONSOLE__buildTags = "${params.TAG}-prerelease"
+        KOGITO_MANAGEMENT_CONSOLE__buildTags = "${params.RELEASE_VERSION}-staging"
 
         KOGITO_SWF_BUILDER_IMAGE__registry = 'quay.io'
         KOGITO_SWF_BUILDER_IMAGE__account = 'kiegroup'
         KOGITO_SWF_BUILDER_IMAGE__name = 'kogito-swf-builder'
-        KOGITO_SWF_BUILDER_IMAGE__buildTag = "${params.TAG}-prerelease"
+        KOGITO_SWF_BUILDER_IMAGE__buildTag = "${params.RELEASE_VERSION}-staging"
 
         KOGITO_SWF_DEVMODE_IMAGE__registry = 'quay.io'
         KOGITO_SWF_DEVMODE_IMAGE__account = 'kiegroup'
         KOGITO_SWF_DEVMODE_IMAGE__name = 'kogito-swf-devmode'
-        KOGITO_SWF_DEVMODE_IMAGE__buildTag = "${params.TAG}-prerelease"
+        KOGITO_SWF_DEVMODE_IMAGE__buildTag = "${params.RELEASE_VERSION}-staging"
 
         KOGITO_SERVERLESS_OPERATOR__registry = 'quay.io'
         KOGITO_SERVERLESS_OPERATOR__account = 'kiegroup'
         KOGITO_SERVERLESS_OPERATOR__name = 'kogito-serverless-operator'
-        KOGITO_SERVERLESS_OPERATOR__buildTag = "${params.TAG}-prerelease"
+        KOGITO_SERVERLESS_OPERATOR__buildTag = "${params.RELEASE_VERSION}-staging"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
     }
@@ -209,11 +209,11 @@ pipeline {
             }
         }
 
-        stage('Build (without some images)') {
+        stage('Build') {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildPartial()
+                        build()
                     }
                 }
             }
@@ -237,7 +237,7 @@ pipeline {
             steps {
                 dir('kogito-online-staging') {
                     script {
-                        deployOnlineEditor("${params.TAG}", "${pipelineVars.asfGithubPushCredentialsId}")
+                        deployOnlineEditor("${params.RELEASE_VERSION}", "${pipelineVars.asfGithubPushCredentialsId}")
                     }
                 }
             }
@@ -539,16 +539,6 @@ pipeline {
             }
         }
 
-        stage('STAGING: Build (serverless-logic-web-tools-swf-dev-mode-image)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('serverless-logic-web-tools-swf-dev-mode-image')
-                    }
-                }
-            }
-        }
-
         stage('STAGING: Push serverless-logic-web-tools-swf-dev-mode-image to quay.io') {
             when {
                 expression { !params.DRY_RUN }
@@ -556,17 +546,6 @@ pipeline {
             steps {
                 script {
                     pushServerlessLogicWebToolsSWFDevModeImageToQuay()
-                }
-            }
-        }
-
-        stage('Build (dev-deployment-base-image and dev-deployment-kogito-quarkus-blank-app-image)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('dev-deployment-base-image')
-                        buildImage('dev-deployment-kogito-quarkus-blank-app-image')
-                    }
                 }
             }
         }
@@ -583,16 +562,6 @@ pipeline {
             }
         }
 
-        stage('STAGING: Build (dev-deployment-dmn-form-webapp-image)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('dev-deployment-dmn-form-webapp-image')
-                    }
-                }
-            }
-        }
-
         stage('STAGING: Push dev-deployment-dmn-form-webapp-image to quay.io') {
             when {
                 expression { !params.DRY_RUN }
@@ -604,16 +573,6 @@ pipeline {
             }
         }
 
-        stage('STAGING: Build (serverless-logic-web-tools-base-builder-image)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('serverless-logic-web-tools-base-builder-image')
-                    }
-                }
-            }
-        }
-
         stage('STAGING: Push serverless-logic-web-tools-base-builder-image to quay.io') {
             when {
                 expression { !params.DRY_RUN }
@@ -621,16 +580,6 @@ pipeline {
             steps {
                 script {
                     pushServerlessLogicWebToolsBaseBuilderImageToQuay()
-                }
-            }
-        }
-
-        stage('STAGING: Build (dashbuilder-viewer-image)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('dashbuilder-viewer-image')
-                    }
                 }
             }
         }
@@ -659,16 +608,6 @@ pipeline {
             }
         }
 
-        stage('STAGING: Build (kogito-task-console)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('kogito-task-console')
-                    }
-                }
-            }
-        }
-
         stage('STAGING: Push kogito-task-console to quay.io') {
             when {
                 expression { !params.DRY_RUN }
@@ -676,16 +615,6 @@ pipeline {
             steps {
                 script {
                     pushKogitoTaskConsoleToQuay()
-                }
-            }
-        }
-
-        stage('STAGING: Build (kogito-management-console)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('kogito-management-console')
-                    }
                 }
             }
         }
@@ -701,16 +630,6 @@ pipeline {
             }
         }
 
-        stage('STAGING: Build (kogito-swf-builder)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('kogito-swf-builder')
-                    }
-                }
-            }
-        }
-
         stage('STAGING: Push kogito-swf-builder to quay.io') {
             when {
                 expression { !params.DRY_RUN }
@@ -718,16 +637,6 @@ pipeline {
             steps {
                 script {
                     pushKogitoSwfBuilderToQuay()
-                }
-            }
-        }
-
-        stage('STAGING: Build (kogito-swf-devmode)') {
-            steps {
-                dir('kie-tools') {
-                    script {
-                        buildImage('kogito-swf-devmode')
-                    }
                 }
             }
         }
@@ -762,7 +671,7 @@ pipeline {
     }
 }
 
-def buildPartial() {
+def build() {
     sh """#!/bin/bash -el
     export KIE_TOOLS_BUILD__runEndToEndTests=false
     export KIE_TOOLS_BUILD__runTests=false
@@ -771,34 +680,26 @@ def buildPartial() {
     export WEBPACK__minimize=true
     export WEBPACK__tsLoaderTranspileOnly=false
     export CHROME_EXTENSION__routerTargetOrigin=https://apache.github.io
-    export CHROME_EXTENSION__routerRelativePath=incubator-kie-kogito-online-staging/${params.TAG}-prerelease/chrome-extension
-    export CHROME_EXTENSION__onlineEditorUrl=https://apache.github.io/incubator-kie-kogito-online-staging/${params.TAG}-prerelease
+    export CHROME_EXTENSION__routerRelativePath=incubator-kie-kogito-online-staging/${params.RELEASE_VERSION}-staging/chrome-extension
+    export CHROME_EXTENSION__onlineEditorUrl=https://apache.github.io/incubator-kie-kogito-online-staging/${params.RELEASE_VERSION}-staging
     export CHROME_EXTENSION__manifestFile=manifest.prod.json
     export SWF_CHROME_EXTENSION__routerTargetOrigin=https://apache.github.io
-    export SWF_CHROME_EXTENSION__routerRelativePath=incubator-kie-kogito-online-staging/${params.TAG}-prerelease/swf-chrome-extension
+    export SWF_CHROME_EXTENSION__routerRelativePath=incubator-kie-kogito-online-staging/${params.RELEASE_VERSION}-staging/swf-chrome-extension
     export SWF_CHROME_EXTENSION__manifestFile=manifest.prod.json
-    export ONLINE_EDITOR__buildInfo="${params.TAG} (staging) @ ${params.COMMIT_SHA}"
-    export ONLINE_EDITOR__extendedServicesDownloadUrlLinux=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_linux_${params.TAG}.tar.gz
-    export ONLINE_EDITOR__extendedServicesDownloadUrlMacOs=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_macos_${params.TAG}.dmg
-    export ONLINE_EDITOR__extendedServicesDownloadUrlWindows=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_windows_${params.TAG}.exe
-    export ONLINE_EDITOR__extendedServicesCompatibleVersion=${params.TAG}
+    export ONLINE_EDITOR__buildInfo="${params.RELEASE_VERSION} (staging) @ ${params.COMMIT_SHA}"
+    export ONLINE_EDITOR__extendedServicesDownloadUrlLinux=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz
+    export ONLINE_EDITOR__extendedServicesDownloadUrlMacOs=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_macos_${params.RELEASE_VERSION}.dmg
+    export ONLINE_EDITOR__extendedServicesDownloadUrlWindows=${params.DOWNLOAD_ASSET_URL}/STAGING__kie_sandbox_extended_services_windows_${params.RELEASE_VERSION}.exe
+    export ONLINE_EDITOR__extendedServicesCompatibleVersion=${params.RELEASE_VERSION}
     export ONLINE_EDITOR__gtmId=""
     export ONLINE_EDITOR__corsProxyUrl=https://staging-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud
-    export EXTENDED_SERVICES__kieSandboxUrl=https://apache.github.io/incubator-kie-kogito-online-staging/${params.TAG}-prerelease
-    export SERVERLESS_LOGIC_WEB_TOOLS__version=${params.TAG}-prerelease
-    export SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef=${params.TAG}
-    export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${params.TAG} (staging) @ ${params.COMMIT_SHA}"
+    export EXTENDED_SERVICES__kieSandboxUrl=https://apache.github.io/incubator-kie-kogito-online-staging/${params.RELEASE_VERSION}-staging
+    export SERVERLESS_LOGIC_WEB_TOOLS__version=${params.RELEASE_VERSION}-staging
+    export SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef=${params.RELEASE_VERSION}
+    export SERVERLESS_LOGIC_WEB_TOOLS__buildInfo="${params.RELEASE_VERSION} (staging) @ ${params.COMMIT_SHA}"
     export SERVERLESS_LOGIC_WEB_TOOLS__corsProxyUrl=https://staging-cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud
 
-    pnpm -F='!@kie-tools/serverless-logic-web-tools-swf-dev-mode-image' \
-    -F='!@kie-tools/dev-deployment-base-image' \
-    -F='!@kie-tools/dev-deployment-dmn-form-webapp-image' \
-    -F='!@kie-tools/dev-deployment-kogito-quarkus-blank-app-image' \
-    -F='!@kie-tools/serverless-logic-web-tools-base-builder-image' \
-    -F='!@kie-tools/dashbuilder-viewer-image' \
-    -F='!@kie-tools/kogito-task-console' \
-    -F='!@kie-tools/kogito-management-console' \
-    -r --workspace-concurrency=1 build:prod
+    pnpm -r --workspace-concurrency=1 build:prod
     """.trim()
 }
 
@@ -806,7 +707,7 @@ def uploadKnativeCliWorkflowPluginForWindows() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-windows-amd64.exe',
-        "STAGING__kn-workflow-windows-amd64-${params.TAG}.exe",
+        "STAGING__kn-workflow-windows-amd64-${params.RELEASE_VERSION}.exe",
         'application/octet-stream',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -816,7 +717,7 @@ def uploadKnativeCliWorkflowPluginForMacOsM1() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-darwin-arm64',
-        "STAGING__kn-workflow-darwin-arm64-${params.TAG}",
+        "STAGING__kn-workflow-darwin-arm64-${params.RELEASE_VERSION}",
         'application/octet-stream',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -826,7 +727,7 @@ def uploadKnativeCliWorkflowPluginForMacOs() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-darwin-amd64',
-        "STAGING__kn-workflow-darwin-amd64-${params.TAG}",
+        "STAGING__kn-workflow-darwin-amd64-${params.RELEASE_VERSION}",
         'application/octet-stream',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -836,7 +737,7 @@ def uploadKnativeCliWorkflowPluginForLinux() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-linux-amd64',
-        "STAGING__kn-workflow-linux-amd64-${params.TAG}",
+        "STAGING__kn-workflow-linux-amd64-${params.RELEASE_VERSION}",
         'application/octet-stream',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -846,7 +747,7 @@ def uploadExtendedServicesForLinux() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz',
-        "STAGING__kie_sandbox_extended_services_linux_${params.TAG}.tar.gz",
+        "STAGING__kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -855,8 +756,8 @@ def uploadExtendedServicesForLinux() {
 def uploadChromeExtensionForServerlessWorkflowEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.TAG}.zip",
-        "STAGING__chrome_extension_serverless_workflow_editor_${params.TAG}.zip",
+        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip",
+        "STAGING__chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -865,8 +766,8 @@ def uploadChromeExtensionForServerlessWorkflowEditor() {
 def uploadChromeExtensionForKieEditors() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.TAG}.zip",
-        "STAGING__chrome_extension_kogito_kie_editors_${params.TAG}.zip",
+        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip",
+        "STAGING__chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -875,8 +776,8 @@ def uploadChromeExtensionForKieEditors() {
 def uploadVSCodeExtensionKieBusinessAutomationBundle() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.TAG}.vsix",
-        "STAGING__vscode_extension_kie_ba_bundle_${params.TAG}.vsix",
+        "kie-tools/packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix",
+        "STAGING__vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -885,8 +786,8 @@ def uploadVSCodeExtensionKieBusinessAutomationBundle() {
 def uploadVSCodeExtensionKogitoBundle() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.TAG}.vsix",
-        "STAGING__vscode_extension_kogito_bundle_${params.TAG}.vsix",
+        "kie-tools/packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix",
+        "STAGING__vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -895,8 +796,8 @@ def uploadVSCodeExtensionKogitoBundle() {
 def uploadVSCodeExtensionDashbuilderEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.TAG}.vsix",
-        "STAGING__vscode_extension_dashbuilder_editor_${params.TAG}.vsix",
+        "kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix",
+        "STAGING__vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -905,8 +806,8 @@ def uploadVSCodeExtensionDashbuilderEditor() {
 def uploadVSCodeExtensionServerlessWorkflowEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.TAG}.vsix",
-        "STAGING__serverless_workflow_vscode_extension_${params.TAG}.vsix",
+        "kie-tools/packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix",
+        "STAGING__serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -915,8 +816,8 @@ def uploadVSCodeExtensionServerlessWorkflowEditor() {
 def uploadVSCodeExtensionPMMLEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.TAG}.vsix",
-        "STAGING__pmml_vscode_extension_${params.TAG}.vsix",
+        "kie-tools/packages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.RELEASE_VERSION}.vsix",
+        "STAGING__pmml_vscode_extension_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -925,8 +826,8 @@ def uploadVSCodeExtensionPMMLEditor() {
 def uploadVSCodeExtensionDMNEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.TAG}.vsix",
-        "STAGING__dmn_vscode_extension_${params.TAG}.vsix",
+        "kie-tools/packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
+        "STAGING__dmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -935,8 +836,8 @@ def uploadVSCodeExtensionDMNEditor() {
 def uploadVSCodeExtension() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
-        "kie-tools/packages/kie-editors-dev-vscode-extension/dist/kie_editors_dev_vscode_extension_${params.TAG}.vsix",
-        "STAGING__vscode_extension_dev_${params.TAG}.vsix",
+        "kie-tools/packages/kie-editors-dev-vscode-extension/dist/kie_editors_dev_vscode_extension_${params.RELEASE_VERSION}.vsix",
+        "STAGING__vscode_extension_dev_${params.RELEASE_VERSION}.vsix",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -946,7 +847,7 @@ def uploadServerlessLogicWebTools() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/serverless-logic-web-tools/dist.zip',
-        "STAGING__serverless_logic_web_tools_${params.TAG}.zip",
+        "STAGING__serverless_logic_web_tools_${params.RELEASE_VERSION}.zip",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -956,7 +857,7 @@ def uploadOnlineEditor() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/online-editor/dist.zip',
-        "STAGING__online_editor_${params.TAG}.zip",
+        "STAGING__online_editor_${params.RELEASE_VERSION}.zip",
         'application/zip',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )
@@ -966,7 +867,7 @@ def uploadKogitoServerlessOperator() {
     githubUtils.uploadReleaseAsset(
         "${params.UPLOAD_ASSET_URL}",
         'kie-tools/packages/kogito-serverless-operator/operator.yaml',
-        "STAGING__operator_${params.TAG}.yaml",
+        "STAGING__operator_${params.RELEASE_VERSION}.yaml",
         'application/yaml',
         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
     )

--- a/.ci/jenkins/Jenkinsfile.staging-publish
+++ b/.ci/jenkins/Jenkinsfile.staging-publish
@@ -57,20 +57,9 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        env.TAG = sh(returnStdout: true, script: "#!/bin/bash -el \n node -p \"'\${GIT_BRANCH}'.match(/(.+)-prerelease/)[1]\"").trim()
-                        env.PACKAGE_VERSION = sh(returnStdout: true, script: "#!/bin/bash -el \n node -p \"require('./package.json').version\"").trim()
+                        env.RELEASE_VERSION = sh(returnStdout: true, script: "#!/bin/bash -el \n node -p \"require('./package.json').version\"").trim()
                         env.COMMIT_SHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
                     }
-                }
-            }
-        }
-
-        stage('Check `tag` against `package.json.version`') {
-            steps {
-                dir('kie-tools') {
-                    sh """#!/bin/bash -el
-                    [[ "${env.TAG}" == "${env.PACKAGE_VERSION}" ]]
-                    """.trim()
                 }
             }
         }
@@ -80,8 +69,8 @@ pipeline {
                 script {
                     response = githubUtils.createRelease(
                         "${pipelineVars.githubRepositorySlug}",
-                        "${env.TAG} @ (alpha)",
-                        "${env.TAG}",
+                        "${env.RELEASE_VERSION} @ (alpha)",
+                        "${env.RELEASE_VERSION}",
                         "${env.COMMIT_SHA}",
                         true,
                         true,
@@ -110,7 +99,7 @@ pipeline {
                 build job: 'KIE/kie-tools/kie-tools-staging-build', parameters: [
                     booleanParam(name: 'DRY_RUN', value: false),
                     string(name: 'BASE_REF', value: "${GIT_BRANCH}"),
-                    string(name: 'TAG', value: "${env.TAG}"),
+                    string(name: 'RELEASE_VERSION', value: "${env.RELEASE_VERSION}"),
                     string(name: 'COMMIT_SHA', value: "${env.COMMIT_SHA}"),
                     string(name: 'DOWNLOAD_ASSET_URL', value: "${env.RELEASE_DOWNLOAD_ASSET_URL}"),
                     string(name: 'UPLOAD_ASSET_URL', value: "${env.RELEASE_UPLOAD_ASSET_URL}")

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -40,11 +40,11 @@ pipeline {
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
 
         CHROME_EXTENSION__routerTargetOrigin = 'https://apache.github.io'
-        CHROME_EXTENSION__routerRelativePath = "incubator-kie-kogito-online/chrome-extension/${params.TAG}"
+        CHROME_EXTENSION__routerRelativePath = "incubator-kie-kogito-online/chrome-extension/${params.RELEASE_VERSION}"
         CHROME_EXTENSION__manifestFile = 'manifest.prod.json'
         CHROME_EXTENSION__onlineEditorUrl = 'https://apache.github.io/incubator-kie-kogito-online'
         SWF_CHROME_EXTENSION__routerTargetOrigin = 'https://apache.github.io'
-        SWF_CHROME_EXTENSION__routerRelativePath = "kogito-online/swf-chrome-extension/${params.TAG}"
+        SWF_CHROME_EXTENSION__routerRelativePath = "kogito-online/swf-chrome-extension/${params.RELEASE_VERSION}"
         SWF_CHROME_EXTENSION__manifestFile = 'manifest.prod.json'
 
         PNPM_FILTER_STRING = '-F chrome-extension-pack-kogito-kie-editors... -F chrome-extension-serverless-workflow-editor...'
@@ -142,8 +142,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.TAG}.zip",
-                        "chrome_extension_kogito_kie_editors_${params.TAG}.zip",
+                        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip",
+                        "chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -158,8 +158,8 @@ pipeline {
             steps {
                 dir('kogito-online') {
                     script {
-                        EDITORS_DIR = "editors/${params.TAG}"
-                        CHROME_EXTENSION_DIR = "chrome-extension/${params.TAG}"
+                        EDITORS_DIR = "editors/${params.RELEASE_VERSION}"
+                        CHROME_EXTENSION_DIR = "chrome-extension/${params.RELEASE_VERSION}"
 
                         sh """#!/bin/bash -el
                         git config user.email asf-ci-kie@jenkins.kie.apache.org
@@ -177,7 +177,7 @@ pipeline {
 
                         echo "Commit changes and push"
                         git add .
-                        git commit -m "Deploy ${params.TAG} (Chrome Extension for Kogito KIE Editors)"
+                        git commit -m "Deploy ${params.RELEASE_VERSION} (Chrome Extension for Kogito KIE Editors)"
                         """.trim()
 
                         githubUtils.pushObject('origin', 'gh-pages', "${pipelineVars.asfGithubPushCredentialsId}")
@@ -195,7 +195,7 @@ pipeline {
                     env.CHROME_EXTESION_KIE_EDITORS_UPLOAD_STATUS = chromeStoreUtils.uploadExtension(
                         "${pipelineVars.chromeStoreCredentialsId}",
                         "${pipelineVars.chromeStoreRefreshTokenCredentialsId}",
-                        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.TAG}.zip",
+                        "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip",
                         "${pipelineVars.chromeExtensionIdCredentialsId}"
                     )
                 }
@@ -247,8 +247,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.TAG}.zip",
-                        "chrome_extension_serverless_workflow_editor_${params.TAG}.zip",
+                        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip",
+                        "chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -263,7 +263,7 @@ pipeline {
             steps {
                 dir('kogito-online') {
                     script {
-                        DEPLOYMENT_DIR = "swf-chrome-extension/${params.TAG}"
+                        DEPLOYMENT_DIR = "swf-chrome-extension/${params.RELEASE_VERSION}"
 
                         sh """#!/bin/bash -el
                         git config user.email asf-ci-kie@jenkins.kie.apache.org
@@ -278,7 +278,7 @@ pipeline {
 
                         echo "Commit changes and push"
                         git add .
-                        git commit -m "Deploy ${params.TAG} (Chrome Extension for Serverless Workflow Editor)"
+                        git commit -m "Deploy ${params.RELEASE_VERSION} (Chrome Extension for Serverless Workflow Editor)"
                         """.trim()
 
                         githubUtils.pushObject('origin', 'gh-pages', "${pipelineVars.asfGithubPushCredentialsId}")
@@ -296,7 +296,7 @@ pipeline {
                     env.CHROME_EXTESION_SERVERLESS_WORKFLOW_EDITOR_UPLOAD_STATUS = chromeStoreUtils.uploadExtension(
                         "${pipelineVars.chromeStoreCredentialsId}",
                         "${pipelineVars.chromeStoreRefreshTokenCredentialsId}",
-                        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.TAG}.zip",
+                        "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip",
                         "${pipelineVars.swfChromeExtensionIdCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -45,7 +45,7 @@ pipeline {
         CORS_PROXY_IMAGE__imageRegistry = 'quay.io'
         CORS_PROXY_IMAGE__imageAccount = 'kie-tools'
         CORS_PROXY_IMAGE__imageName = 'cors-proxy-image'
-        CORS_PROXY_IMAGE__imageBuildTags = "latest ${params.TAG}"
+        CORS_PROXY_IMAGE__imageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -148,8 +148,8 @@ pipeline {
                     openShiftUtils.createOrUpdateApp(
                         "${env.OPENSHIFT_NAMESPACE}",
                         "${env.OPENSHIFT_APP_NAME}",
-                        "${params.TAG}",
-                        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${params.TAG}",
+                        "${params.RELEASE_VERSION}",
+                        "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${params.RELEASE_VERSION}",
                         "${env.OPENSHIFT_PART_OF}",
                         'nodejs',
                         "${pipelineVars.openshiftCredentialsId}"

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         DASHBUILDER__viewerImageRegistry = 'quay.io'
         DASHBUILDER__viewerImageAccount = 'kie-tools'
         DASHBUILDER__viewerImageName = 'dashbuilder-viewer-image'
-        DASHBUILDER__viewerImageBuildTags = "latest ${params.TAG}"
+        DASHBUILDER__viewerImageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         DEV_DEPLOYMENT_BASE_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_BASE_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_BASE_IMAGE__name = 'dev-deployment-base-image'
-        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "latest ${params.TAG}"
+        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name = 'dev-deployment-dmn-form-webapp-image'
-        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "latest ${params.TAG}"
+        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name = 'dev-deployment-kogito-quarkus-blank-app-image'
-        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "latest ${params.TAG}"
+        DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -116,64 +116,64 @@ pipeline {
                     // macOS - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.TAG}.tar.gz",
-                        "dev-deployment-upload-service-darwin-amd64-${params.TAG}.tar.gz",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // macOS - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.TAG}.tar.gz.sha256",
-                        "dev-deployment-upload-service-darwin-amd64-${params.TAG}.tar.gz.sha256",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // macOS - arm64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.TAG}.tar.gz",
-                        "dev-deployment-upload-service-darwin-arm64-${params.TAG}.tar.gz",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz",
+                        "dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // macOS - arm64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.TAG}.tar.gz.sha256",
-                        "dev-deployment-upload-service-darwin-arm64-${params.TAG}.tar.gz.sha256",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // linux - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.TAG}.tar.gz",
-                        "dev-deployment-upload-service-linux-amd64-${params.TAG}.tar.gz",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // linux - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.TAG}.tar.gz.sha256",
-                        "dev-deployment-upload-service-linux-amd64-${params.TAG}.tar.gz.sha256",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // windows - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.TAG}.tar.gz",
-                        "dev-deployment-upload-service-windows-amd64-${params.TAG}.tar.gz",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
                     // windows - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.TAG}.tar.gz.sha256",
-                        "dev-deployment-upload-service-windows-amd64-${params.TAG}.tar.gz.sha256",
+                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -116,7 +116,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz',
-                        "kie_sandbox_extended_services_linux_${params.TAG}.tar.gz",
+                        "kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Kie Sandbox Extendend Services Url', name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL')
         string(description: 'Kie Sandbox Cors Proxy Url', name: 'KIE_SANDBOX_CORS_PROXY_URL')
@@ -47,20 +47,20 @@ pipeline {
         KIE_SANDBOX__imageRegistry = 'quay.io'
         KIE_SANDBOX__imageAccount = 'kie-tools'
         KIE_SANDBOX__imageName = 'kie-sandbox-image'
-        KIE_SANDBOX__imageBuildTags = "latest ${params.TAG}"
-        ONLINE_EDITOR__buildInfo = "${params.TAG}"
-        ONLINE_EDITOR__extendedServicesDownloadUrlLinux = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_linux_${params.TAG}.tar.gz"
-        ONLINE_EDITOR__extendedServicesDownloadUrlMacOs = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_macos_${params.TAG}.dmg"
-        ONLINE_EDITOR__extendedServicesDownloadUrlWindows = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_windows_${params.TAG}.exe"
-        ONLINE_EDITOR__extendedServicesCompatibleVersion = "${params.TAG}"
+        KIE_SANDBOX__imageBuildTags = "latest ${params.RELEASE_VERSION}"
+        ONLINE_EDITOR__buildInfo = "${params.RELEASE_VERSION}"
+        ONLINE_EDITOR__extendedServicesDownloadUrlLinux = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz"
+        ONLINE_EDITOR__extendedServicesDownloadUrlMacOs = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_macos_${params.RELEASE_VERSION}.dmg"
+        ONLINE_EDITOR__extendedServicesDownloadUrlWindows = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_windows_${params.RELEASE_VERSION}.exe"
+        ONLINE_EDITOR__extendedServicesCompatibleVersion = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__devDeploymentBaseImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentBaseImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentBaseImageName = 'dev-deployment-base-image'
-        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.TAG}"
+        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageName = 'dev-deployment-dmn-form-webapp-image'
-        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.TAG}"
+        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__gtmId = 'GTM-PQGMKNW'
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
@@ -176,8 +176,8 @@ pipeline {
                     openShiftUtils.createOrUpdateApp(
                         "${env.OPENSHIFT_NAMESPACE}",
                         "${env.OPENSHIFT_APP_NAME}",
-                        "${params.TAG}",
-                        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${params.TAG}",
+                        "${params.RELEASE_VERSION}",
+                        "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${params.RELEASE_VERSION}",
                         "${env.OPENSHIFT_PART_OF}",
                         'js',
                         "${pipelineVars.openshiftCredentialsId}",

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -45,7 +45,7 @@ pipeline {
         KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry = 'quay.io'
         KIE_SANDBOX_EXTENDED_SERVICES__imageAccount = 'kie-tools'
         KIE_SANDBOX_EXTENDED_SERVICES__imageName = 'kie-sandbox-extended-services-image'
-        KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags = "latest ${params.TAG}"
+        KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -148,8 +148,8 @@ pipeline {
                     openShiftUtils.createOrUpdateApp(
                         "${env.OPENSHIFT_NAMESPACE}",
                         "${env.OPENSHIFT_APP_NAME}",
-                        "${params.TAG}",
-                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${params.TAG}",
+                        "${params.RELEASE_VERSION}",
+                        "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${params.RELEASE_VERSION}",
                         "${env.OPENSHIFT_PART_OF}",
                         'golang',
                         "${pipelineVars.openshiftCredentialsId}"

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KIE_SANDBOX_HELM_CHART__registry = 'quay.io'
         KIE_SANDBOX_HELM_CHART__account = 'kie-tools'
         KIE_SANDBOX_HELM_CHART__name = 'kie-sandbox-helm-chart'
-        KIE_SANDBOX_HELM_CHART__tag = "${params.TAG}"
+        KIE_SANDBOX_HELM_CHART__tag = "${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -112,7 +112,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'packages/kn-plugin-workflow/dist/kn-workflow-linux-amd64',
-                        "kn-workflow-linux-amd64-${params.TAG}",
+                        "kn-workflow-linux-amd64-${params.RELEASE_VERSION}",
                         'application/octet-stream',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -129,7 +129,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'packages/kn-plugin-workflow/dist/kn-workflow-darwin-amd64',
-                        "kn-workflow-darwin-amd64-${params.TAG}",
+                        "kn-workflow-darwin-amd64-${params.RELEASE_VERSION}",
                         'application/octet-stream',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -146,7 +146,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'packages/kn-plugin-workflow/dist/kn-workflow-darwin-arm64',
-                        "kn-workflow-darwin-arm64-${params.TAG}",
+                        "kn-workflow-darwin-arm64-${params.RELEASE_VERSION}",
                         'application/octet-stream',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -163,7 +163,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'packages/kn-plugin-workflow/dist/kn-workflow-windows-amd64.exe',
-                        "kn-workflow-windows-amd64-${params.TAG}.exe",
+                        "kn-workflow-windows-amd64-${params.RELEASE_VERSION}.exe",
                         'application/octet-stream',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KOGITO_MANAGEMENT_CONSOLE__registry = 'quay.io'
         KOGITO_MANAGEMENT_CONSOLE__account = 'kie-tools'
         KOGITO_MANAGEMENT_CONSOLE__name = 'kogito-management-console'
-        KOGITO_MANAGEMENT_CONSOLE__buildTags = "latest ${params.TAG}"
+        KOGITO_MANAGEMENT_CONSOLE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KOGITO_SERVERLESS_OPERATOR__registry = 'quay.io'
         KOGITO_SERVERLESS_OPERATOR__account = 'kiegroup'
         KOGITO_SERVERLESS_OPERATOR__name = 'kogito-serverless-operator'
-        KOGITO_SERVERLESS_OPERATOR__buildTag = "${params.TAG}"
+        KOGITO_SERVERLESS_OPERATOR__buildTag = "${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -127,7 +127,7 @@ pipeline {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
                         'kie-tools/packages/kogito-serverless-operator/operator.yaml',
-                        "operator_${params.TAG}.yaml",
+                        "operator_${params.RELEASE_VERSION}.yaml",
                         'application/yaml',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KOGITO_SWF_BUILDER_IMAGE__registry = 'quay.io'
         KOGITO_SWF_BUILDER_IMAGE__account = 'kiegroup'
         KOGITO_SWF_BUILDER_IMAGE__name = 'kogito-swf-builder'
-        KOGITO_SWF_BUILDER_IMAGE__buildTag = "${params.TAG}"
+        KOGITO_SWF_BUILDER_IMAGE__buildTag = "${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KOGITO_SWF_DEVMODE_IMAGE__registry = 'quay.io'
         KOGITO_SWF_DEVMODE_IMAGE__account = 'kiegroup'
         KOGITO_SWF_DEVMODE_IMAGE__name = 'kogito-swf-devmode'
-        KOGITO_SWF_DEVMODE_IMAGE__buildTag = "${params.TAG}"
+        KOGITO_SWF_DEVMODE_IMAGE__buildTag = "${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         KOGITO_TASK_CONSOLE__registry = 'quay.io'
         KOGITO_TASK_CONSOLE__account = 'kie-tools'
         KOGITO_TASK_CONSOLE__name = 'kogito-task-console'
-        KOGITO_TASK_CONSOLE__buildTags = "latest ${params.TAG}"
+        KOGITO_TASK_CONSOLE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -122,7 +122,7 @@ pipeline {
                     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
                     PNPM_FILTER_STRING_FOR_PUBLISHING=\$(pnpm -r exec 'bash' '-c' 'PKG_NAME=\$(jq -r ".name" package.json) PKG_IS_PVT=\$(jq -r ".private" package.json); if [[ "\$PKG_IS_PVT" != "true" ]]; then echo "-F \$PKG_NAME"; fi')
                     echo \$PNPM_FILTER_STRING_FOR_PUBLISHING
-                    pnpm \$PNPM_FILTER_STRING_FOR_PUBLISHING exec 'bash' '-c' 'PKG_NAME=\$(jq -r ".name" package.json); NPM_PKG_INFO=\$(npm view \$PKG_NAME@${params.TAG} name || echo ""); if [[ -z \$NPM_PKG_INFO ]]; then pnpm publish --no-git-checks --access public; fi'
+                    pnpm \$PNPM_FILTER_STRING_FOR_PUBLISHING exec 'bash' '-c' 'PKG_NAME=\$(jq -r ".name" package.json); NPM_PKG_INFO=\$(npm view \$PKG_NAME@${params.RELEASE_VERSION} name || echo ""); if [[ -z \$NPM_PKG_INFO ]]; then pnpm publish --no-git-checks --access public; fi'
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -38,29 +38,29 @@ pipeline {
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
 
-        ONLINE_EDITOR__buildInfo = "${params.TAG}"
-        ONLINE_EDITOR__extendedServicesDownloadUrlLinux = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_linux_${params.TAG}.tar.gz"
-        ONLINE_EDITOR__extendedServicesDownloadUrlMacOs = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_macos_${params.TAG}.dmg"
-        ONLINE_EDITOR__extendedServicesDownloadUrlWindows = "https://github.com/apache/incubator-kie-tools/releases/download/${params.TAG}/kie_sandbox_extended_services_windows_${params.TAG}.exe"
-        ONLINE_EDITOR__extendedServicesCompatibleVersion = "${params.TAG}"
+        ONLINE_EDITOR__buildInfo = "${params.RELEASE_VERSION}"
+        ONLINE_EDITOR__extendedServicesDownloadUrlLinux = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz"
+        ONLINE_EDITOR__extendedServicesDownloadUrlMacOs = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_macos_${params.RELEASE_VERSION}.dmg"
+        ONLINE_EDITOR__extendedServicesDownloadUrlWindows = "https://github.com/apache/incubator-kie-tools/releases/download/${params.RELEASE_VERSION}/kie_sandbox_extended_services_windows_${params.RELEASE_VERSION}.exe"
+        ONLINE_EDITOR__extendedServicesCompatibleVersion = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__devDeploymentBaseImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentBaseImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentBaseImageName = 'dev-deployment-base-image'
-        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.TAG}"
+        ONLINE_EDITOR__devDeploymentBaseImageTag = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageRegistry = 'quay.io'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageAccount = 'kie-tools'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageName = 'dev-deployment-dmn-form-webapp-image'
-        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.TAG}"
+        ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__gtmId = 'GTM-PQGMKNW'
         ONLINE_EDITOR__corsProxyUrl = 'https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud'
         DEV_DEPLOYMENT_BASE_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_BASE_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_BASE_IMAGE__name = 'dev-deployment-base-image'
-        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "latest ${params.TAG}"
+        DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry = 'quay.io'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account = 'kie-tools'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name = 'dev-deployment-dmn-form-webapp-image'
-        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "latest ${params.TAG}"
+        DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
 
         PNPM_FILTER_STRING = '-F @kie-tools/online-editor...'
     }
@@ -155,12 +155,12 @@ pipeline {
             steps {
                 dir('kogito-online') {
                     script {
-                        EDITORS_DIR = "editors/${params.TAG}"
+                        EDITORS_DIR = "editors/${params.RELEASE_VERSION}"
 
                         sh """#!/bin/bash -el
                         git config user.email asf-ci-kie@jenkins.kie.apache.org
                         git config user.name asf-ci-kie
-                        
+
                         git checkout gh-pages
 
                         echo "Reset deployment dir"
@@ -174,7 +174,7 @@ pipeline {
                         cp -RL ${WORKSPACE}/kie-tools/packages/stunner-editors/dist/bpmn ${EDITORS_DIR}
                         cp -RL ${WORKSPACE}/kie-tools/packages/stunner-editors/dist/scesim ${EDITORS_DIR}
                         rm -rf ./editors/latest
-                        ln -s ${params.TAG} ./editors/latest
+                        ln -s ${params.RELEASE_VERSION} ./editors/latest
 
                         echo "Copy Online Editor resources"
                         rm -rf ./gwt-editors
@@ -184,7 +184,7 @@ pipeline {
 
                         echo "Commit changes and push"
                         git add .
-                        git commit -m "Deploy ${params.TAG} (Editors + Online Editor)"
+                        git commit -m "Deploy ${params.RELEASE_VERSION} (Editors + Online Editor)"
                         """.trim()
 
                         githubUtils.pushObject('origin', 'gh-pages', "${pipelineVars.asfGithubPushCredentialsId}")

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -38,25 +38,25 @@ pipeline {
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
 
-        SERVERLESS_LOGIC_WEB_TOOLS__version = "${params.TAG}"
-        SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef = "${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__version = "${params.RELEASE_VERSION}"
+        SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef = "${params.RELEASE_VERSION}"
         SERVERLESS_LOGIC_WEB_TOOLS__buildInfo = ''
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName = 'serverless-logic-web-tools-swf-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag = "${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag = "${params.RELEASE_VERSION}"
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName = 'serverless-logic-web-tools-base-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageTag = "${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageTag = "${params.RELEASE_VERSION}"
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName = 'serverless-logic-web-tools-swf-dev-mode-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag = "${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag = "${params.RELEASE_VERSION}"
         DASHBUILDER__viewerImageRegistry = 'quay.io'
         DASHBUILDER__viewerImageAccount = 'kie-tools'
         DASHBUILDER__viewerImageName = 'dashbuilder-viewer-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__dashbuilderViewerImageTag = "${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__dashbuilderViewerImageTag = "${params.RELEASE_VERSION}"
         SERVERLESS_LOGIC_WEB_TOOLS__corsProxyUrl = 'https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud'
 
         PNPM_FILTER_STRING = '-F @kie-tools/serverless-logic-web-tools...'

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName = 'serverless-logic-web-tools-base-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags = "latest ${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName = 'serverless-logic-web-tools-swf-builder-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags = "latest ${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -41,7 +41,7 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry = 'quay.io'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount = 'kie-tools'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName = 'serverless-logic-web-tools-swf-dev-mode-image'
-        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags = "latest ${params.TAG}"
+        SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags = "latest ${params.RELEASE_VERSION}"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
     }
 
@@ -131,7 +131,7 @@ pipeline {
             steps {
                 dir('kogito-online') {
                     script {
-                        STANDALONE_EDITORS_DIR = "standalone/${params.TAG}"
+                        STANDALONE_EDITORS_DIR = "standalone/${params.RELEASE_VERSION}"
 
                         sh """#!/bin/bash -el
                         git config user.email asf-ci-kie@jenkins.kie.apache.org
@@ -148,13 +148,13 @@ pipeline {
                         rm -f ./standalone/bpmn/index.js
                         rm -f ./standalone/dmn/index.js
                         rm -f ./standalone/swf/index.js
-                        ln -s ../${params.TAG}/bpmn/index.js ./standalone/bpmn/index.js
-                        ln -s ../${params.TAG}/dmn/index.js ./standalone/dmn/index.js
-                        ln -s ../${params.TAG}/swf/index.js ./standalone/swf/index.js
+                        ln -s ../${params.RELEASE_VERSION}/bpmn/index.js ./standalone/bpmn/index.js
+                        ln -s ../${params.RELEASE_VERSION}/dmn/index.js ./standalone/dmn/index.js
+                        ln -s ../${params.RELEASE_VERSION}/swf/index.js ./standalone/swf/index.js
 
                         echo "Commit changes and push"
                         git add .
-                        git commit -m "Deploy ${params.TAG} (Standalone Editors)"
+                        git commit -m "Deploy ${params.RELEASE_VERSION} (Standalone Editors)"
                         """.trim()
 
                         githubUtils.pushObject('origin', 'gh-pages', "${pipelineVars.asfGithubPushCredentialsId}")

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-dev
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-dev
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -111,8 +111,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/kie-editors-dev-vscode-extension/dist/kie_editors_dev_vscode_extension_${params.TAG}.vsix",
-                        "vscode_extension_dev_${params.TAG}.vsix",
+                        "packages/kie-editors-dev-vscode-extension/dist/kie_editors_dev_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                        "vscode_extension_dev_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
-        string(description: 'Tag', name: 'TAG', defaultValue: '0.0.0')
+        string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
     }
@@ -122,8 +122,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/bpmn-vscode-extension/dist/bpmn_vscode_extension_${params.TAG}.vsix",
-                        "bpmn_vscode_extension_${params.TAG}.vsix",
+                        "packages/bpmn-vscode-extension/dist/bpmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                        "bpmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -139,8 +139,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.TAG}.vsix",
-                        "dmn_vscode_extension_${params.TAG}.vsix",
+                        "packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                        "dmn_vscode_extension_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -156,8 +156,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.TAG}.vsix",
-                        "pmml_vscode_extension_${params.TAG}.vsix",
+                        "packages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                        "pmml_vscode_extension_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -173,8 +173,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.TAG}.vsix",
-                        "vscode_extension_kogito_bundle_${params.TAG}.vsix",
+                        "packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix",
+                        "vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -190,8 +190,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.TAG}.vsix",
-                        "vscode_extension_kie_ba_bundle_${params.TAG}.vsix",
+                        "packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix",
+                        "vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -207,8 +207,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.TAG}.vsix",
-                        "serverless_workflow_vscode_extension_${params.TAG}.vsix",
+                        "packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                        "serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )
@@ -224,8 +224,8 @@ pipeline {
                 script {
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.TAG}.vsix",
-                        "vscode_extension_dashbuilder_editor_${params.TAG}.vsix",
+                        "packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix",
+                        "vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix",
                         'application/zip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                     )


### PR DESCRIPTION
In this PR:

- Replace `TAG` parameters / env vars to `RELEASE_VERSION`
- Build all packages in a single command in the staging job
- Change tag suffix from `-prerelease` to `-staging` in the staging job