### PR TITLE
NO-ISSUE: Differentiate artifacts being uploaded on CI builds depending on the partition

### DIFF
--- a/.github/actions/upload-ci-reports-and-artifacts/action.yml
+++ b/.github/actions/upload-ci-reports-and-artifacts/action.yml
@@ -2,10 +2,9 @@ name: "Upload CI reports and artifacts"
 description: ""
 
 inputs:
-  working_dir:
-    description: "Dir path of kie-tools"
-    required: false
-    default: "."
+  partition_index:
+    description: "Index of the partition whose artifacts are being uploaded."
+    required: true
 
 runs:
   using: "composite"
@@ -44,7 +43,7 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: ${{ runner.os }}__tests-reports
+        name: ${{ runner.os }}_${{ inputs.partition_index }}__tests-reports
         path: |
           ${{ runner.temp }}/tests-reports.zip
 
@@ -52,7 +51,7 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: ${{ runner.os }}__end-to-end-tests-reports
+        name: ${{ runner.os }}_${{ inputs.partition_index }}__end-to-end-tests-reports
         path: |
           ${{ runner.temp }}/end-to-end-tests-reports.zip
 
@@ -60,7 +59,7 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: ${{ runner.os }}__end-to-end-tests-artifacts
+        name: ${{ runner.os }}_${{ inputs.partition_index }}__end-to-end-tests-artifacts
         path: |
           ${{ runner.temp }}/end-to-end-tests-artifacts.zip
 
@@ -68,6 +67,6 @@ runs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: ${{ runner.os }}__build-artifacts
+        name: ${{ runner.os }}_${{ inputs.partition_index }}__build-artifacts
         path: |
           ${{ runner.temp }}/build-artifacts.zip

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -169,6 +169,8 @@ jobs:
       - name: "Upload reports and artifacts"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none'
         uses: ./.github/actions/upload-ci-reports-and-artifacts
+        with:
+          partition_index: ${{ matrix.partition }}
 
       - name: "Upload end-to-end tests results to Buildkite (`main` only)"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none' && !github.event.pull_request


### PR DESCRIPTION
Not doing so was causing the artifacts to be overwritten, together with concurrency errors happening due to uploads being done under the same name. 

The `working_dir` input was not being used by the changed action.