### PR TITLE
kie-issues#1143: DMN Editor throws an error when deleting Unknown nodes

### DIFF
--- a/packages/dmn-editor/src/mutations/deleteNode.ts
+++ b/packages/dmn-editor/src/mutations/deleteNode.ts
@@ -131,7 +131,7 @@ export function deleteNode({
       throw new Error(`DMN MUTATION: Unknown node nature '${nodeNature}'.`);
     }
 
-    if (!dmnObject) {
+    if (!dmnObject && nodeNature !== NodeNature.UNKNOWN) {
       throw new Error(`DMN MUTATION: Can't delete DMN object that doesn't exist: ID=${dmnObjectId}`);
     }
   }

--- a/packages/dmn-editor/src/mutations/deleteNode.ts
+++ b/packages/dmn-editor/src/mutations/deleteNode.ts
@@ -132,6 +132,11 @@ export function deleteNode({
     }
 
     if (!dmnObject && nodeNature !== NodeNature.UNKNOWN) {
+      /**
+       * We do not want to throw error in case of `nodeNature` equals to `NodeNature.UNKNOWN`.
+       * In such scenario it is expected `dmnObject` is undefined as we can not pair `dmnObject` with the `DMNShape`.
+       * However we are still able to delete at least the selected `DMNShape` from the diagram.
+       */
       throw new Error(`DMN MUTATION: Can't delete DMN object that doesn't exist: ID=${dmnObjectId}`);
     }
   }


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1143

This PR was tried with different kind of scenarios and always **x**, **backspace** and **delete** keys were checked.

[unknown-node.dmn.txt](https://github.com/apache/incubator-kie-tools/files/15197312/unknown-node.dmn.txt)
here was the `Shape` originally referring to input data

[unknown-node-artifact.dmn.txt](https://github.com/apache/incubator-kie-tools/files/15197307/unknown-node-artifact.dmn.txt)
here was the `Shape` originally referring to an artifact

[unknown-node-in-decision-service.dmn.txt](https://github.com/apache/incubator-kie-tools/files/15197311/unknown-node-in-decision-service.dmn.txt)
here was the `Shape` originally referring to a node contained by Decision Service node

[unknown-node-in-drd-but-known-in-drg.dmn.txt](https://github.com/apache/incubator-kie-tools/files/15197309/unknown-node-in-drd-but-known-in-drg.dmn.txt)
here was the `Shape` originally referring to a node used in secondary DRD


[unknown-node-in-drg-but-known-in-drd.dmn.txt](https://github.com/apache/incubator-kie-tools/files/15197310/unknown-node-in-drg-but-known-in-drd.dmn.txt)
here was the `Shape` originally referring to a node used in primary DRD


Playwright tests were not added as part of this PR as currently the test suite has no tests that would allow opening an existing dmn file.
