### PR TITLE
NO-ISSUE: Remove bin directory from kogito-serverless-operator before install

### DIFF
--- a/packages/kogito-serverless-operator/package.json
+++ b/packages/kogito-serverless-operator/package.json
@@ -26,7 +26,7 @@
     "image:build": "run-script-os",
     "image:build:darwin:win32": "echo 'Image build not supported on Windows and macOS'",
     "image:build:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --bool \"$(build-env containerImages.build)\" --then \"make container-build\"",
-    "install": "go mod tidy && pnpm bump-version && pnpm format",
+    "install": "rimraf bin && go mod tidy && pnpm bump-version && pnpm format",
     "test": "run-script-os",
     "test-e2e": "run-script-os",
     "test-e2e:darwin:win32": "echo 'E2E tests not supported on Windows and macOS'",


### PR DESCRIPTION
Why?

Installed binaries can have dependencies or references to old go versions and will break if go version changes.
This guarantees that binaries are added during bootstrap/install.