### PR TITLE
NO-ISSUE: Filter of affected packages of a partition should not include dependents

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -230,7 +230,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
         name: partition.name,
         bootstrapPnpmFilterString: [...relevantPackageNamesInPartition].map((p) => `-F '${p}'`).join(" "),
         upstreamPnpmFilterString: [...upstreamPackageNamesInPartition].map((p) => `-F '${p}'`).join(" "),
-        affectedPnpmFilterString: [...affectedPackageNamesInPartition].map((p) => `-F '...${p}'`).join(" "),
+        affectedPnpmFilterString: [...affectedPackageNamesInPartition].map((p) => `-F '${p}'`).join(" "),
       };
     })
   );


### PR DESCRIPTION
The assertion was being done correctly, though. BOOTSTRAPPED === UPSTREAM + AFFECTED