### PR TITLE
kie-issue#1134: Autocomplete and colorize should support local variable in iterator expressions (for, every, some)

### DIFF
--- a/packages/dmn-feel-antlr4-parser/src/parser/FeelSyntacticSymbolNature.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/FeelSyntacticSymbolNature.ts
@@ -42,4 +42,9 @@ export enum FeelSyntacticSymbolNature {
    * Parameters of functions.
    */
   Parameter,
+
+  /**
+   * Variables which the parser currently doesn't know if it is valid or not because they are validated at runtime.
+   */
+  DynamicVariable,
 }

--- a/packages/dmn-feel-antlr4-parser/src/parser/FeelVariablesParser.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/FeelVariablesParser.ts
@@ -132,7 +132,8 @@ export class FeelVariablesParser {
         context.variable.value,
         context.variable.typeRef ? this.createType(context.variable.typeRef) : undefined,
         context.variable.feelSyntacticSymbolNature,
-        context.variable
+        context.variable,
+        context.allowDynamicVariables
       );
     }
   }

--- a/packages/dmn-feel-antlr4-parser/src/parser/VariableContext.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/VariableContext.ts
@@ -54,4 +54,9 @@ export interface VariableContext {
    * Input nodes that define variables.
    */
   inputVariables: Array<string>;
+
+  /**
+   * Dynamic variables are variables only validated during runtime.
+   */
+  allowDynamicVariables?: boolean;
 }

--- a/packages/dmn-feel-antlr4-parser/src/parser/grammar/Scope.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/grammar/Scope.ts
@@ -84,4 +84,10 @@ export interface Scope {
   getSymbols(): Map<string, Symbol>;
 
   getType(): Type | undefined;
+
+  /**
+   * Allow the scope to accept variables that are validate during the runtime (dynamic variables),
+   * without marking them as invalid or valid variables.
+   */
+  allowDynamicVariables: boolean | undefined;
 }

--- a/packages/dmn-feel-antlr4-parser/src/parser/grammar/VariableSymbol.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/grammar/VariableSymbol.ts
@@ -22,16 +22,24 @@ import { Type } from "./Type";
 
 import { FeelSyntacticSymbolNature } from "../FeelSyntacticSymbolNature";
 import { Variable } from "../Variable";
+import { Scope } from "./Scope";
 
 export class VariableSymbol extends BaseSymbol {
   private readonly _symbolType: FeelSyntacticSymbolNature | undefined;
-
   private readonly _variableSource: Variable | undefined;
+  private readonly _allowDynamicVariables: boolean | undefined;
 
-  constructor(id?: string, type?: Type, variableType?: FeelSyntacticSymbolNature, variableSource?: Variable) {
+  constructor(
+    id?: string,
+    type?: Type,
+    variableType?: FeelSyntacticSymbolNature,
+    variableSource?: Variable,
+    allowDynamicVariables?: boolean
+  ) {
     super(id, type);
     this._symbolType = variableType;
     this._variableSource = variableSource;
+    this._allowDynamicVariables = allowDynamicVariables;
   }
 
   get symbolType(): FeelSyntacticSymbolNature | undefined {
@@ -40,5 +48,9 @@ export class VariableSymbol extends BaseSymbol {
 
   get variableSource(): Variable | undefined {
     return this._variableSource;
+  }
+
+  get allowDynamicVariables(): boolean | undefined {
+    return this._allowDynamicVariables;
   }
 }

--- a/packages/feel-input-component/src/FeelConfigs.ts
+++ b/packages/feel-input-component/src/FeelConfigs.ts
@@ -35,10 +35,11 @@ export const feelTheme = (): Monaco.editor.IStandaloneThemeData => {
       { token: Element[Element.FeelBoolean], foreground: "#26268D", fontStyle: "bold" },
       { token: Element[Element.FeelString], foreground: "#067D17" },
       { token: Element[Element.FeelFunction], foreground: "#00627A" },
-      { token: Element[Element.InputDataVariable], foreground: "#917632", fontStyle: "underline" },
+      { token: Element[Element.Variable], foreground: "#917632", fontStyle: "underline" },
       { token: Element[Element.FunctionCall], foreground: "#917632", fontStyle: "underline italic" },
       { token: Element[Element.UnknownVariable], foreground: "#ff0000", fontStyle: "underline bold" },
       { token: Element[Element.FunctionParameterVariable], foreground: "#036e9b", fontStyle: "italic" },
+      { token: Element[Element.DynamicVariable], foreground: "#8b97a2", fontStyle: "underline" },
     ],
     colors: {
       "editorLineNumber.foreground": "#000000",

--- a/packages/feel-input-component/src/FeelInput.tsx
+++ b/packages/feel-input-component/src/FeelInput.tsx
@@ -81,7 +81,9 @@ function getTokenTypeIndex(symbolType: FeelSyntacticSymbolNature) {
     default:
     case FeelSyntacticSymbolNature.LocalVariable:
     case FeelSyntacticSymbolNature.GlobalVariable:
-      return Element.InputDataVariable;
+      return Element.Variable;
+    case FeelSyntacticSymbolNature.DynamicVariable:
+      return Element.DynamicVariable;
     case FeelSyntacticSymbolNature.Unknown:
       return Element.UnknownVariable;
     case FeelSyntacticSymbolNature.Invocable:

--- a/packages/feel-input-component/src/themes/Element.ts
+++ b/packages/feel-input-component/src/themes/Element.ts
@@ -23,8 +23,9 @@ export enum Element {
   FeelBoolean,
   FeelString,
   FeelFunction,
-  InputDataVariable,
+  Variable,
   FunctionCall,
   UnknownVariable,
   FunctionParameterVariable,
+  DynamicVariable,
 }


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1134
Closes: https://github.com/apache/incubator-kie-issues/issues/1135

This PR adds autocomplete and color for variables declared in the new expressions `for`, `every` and `some` and for the new reserved word `item` in the `filter` expression.

Since currently it is not viable in terms of time to introduce type inference for those variables, if the user types something after the dot (.) when using one of those variables we mark it in grayscale, to show that that name is not "valid or invalid".

See the image below for more clear example:
![image](https://github.com/apache/incubator-kie-tools/assets/7305741/3ddc8e45-d5b7-487e-851a-5688b40fa584)
![image](https://github.com/apache/incubator-kie-tools/assets/7305741/e797e257-e4f8-43c0-a6a6-3cc10578876d)
![image](https://github.com/apache/incubator-kie-tools/assets/7305741/38883a46-b463-4014-ad17-7c771cbaf070)