### PR TITLE
NO-ISSUE: Add `url` package everywhere `stream-http` is used

### DIFF
--- a/packages/feel-input-component/showcase/webpack.config.js
+++ b/packages/feel-input-component/showcase/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = (env) =>
       rules: [
         {
           test: /\.ttf$/,
-          use: ["file-loader"],
+          use: [require.resolve("file-loader")],
         },
         ...patternflyBase.webpackModuleRules,
       ],

--- a/packages/import-java-classes-component/showcase/webpack.config.js
+++ b/packages/import-java-classes-component/showcase/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = (env) =>
       rules: [
         {
           test: /\.ttf$/,
-          use: ["file-loader"],
+          use: [require.resolve("file-loader")],
         },
         ...patternflyBase.webpackModuleRules,
       ],

--- a/packages/kie-editors-dev-vscode-extension/webpack.config.js
+++ b/packages/kie-editors-dev-vscode-extension/webpack.config.js
@@ -137,7 +137,7 @@ module.exports = async (env) => [
       rules: [
         {
           test: /\.ttf$/,
-          use: ["file-loader"],
+          use: [require.resolve("file-loader")],
         },
         ...patternflyBase.webpackModuleRules,
       ],

--- a/packages/monaco-editor/webpack.config.js
+++ b/packages/monaco-editor/webpack.config.js
@@ -34,15 +34,15 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: "ts-loader",
+        loader: require.resolve("ts-loader"),
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: [require.resolve("style-loader"), require.resolve("css-loader")],
       },
       {
         test: /\.ttf$/,
-        use: ["url-loader"],
+        use: [require.resolve("url-loader")],
       },
     ],
   },

--- a/packages/patternfly-base/index.js
+++ b/packages/patternfly-base/index.js
@@ -78,7 +78,7 @@ module.exports = {
       // this is primarily useful when applying a CSS background using an SVG
       include: (input) => input.indexOf(BG_IMAGES_DIRNAME) > -1,
       use: {
-        loader: "svg-url-loader",
+        loader: require.resolve("svg-url-loader"),
         options: {},
       },
     },

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -25,6 +25,7 @@
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",
     "style-loader": "^2.0.0",
+    "svg-url-loader": "^8.0.0",
     "url-loader": "^4.1.1",
     "webpack": "^5.88.2"
   }

--- a/packages/pmml-editor/dev-webapp/webpack.config.js
+++ b/packages/pmml-editor/dev-webapp/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = (env) =>
       rules: [
         {
           test: /\.ttf$/,
-          use: ["file-loader"],
+          use: [require.resolve("file-loader")],
         },
         ...patternflyBase.webpackModuleRules,
       ],

--- a/packages/pmml-vscode-extension/webpack.config.js
+++ b/packages/pmml-vscode-extension/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = async (env) => [
       rules: [
         {
           test: /\.ttf$/,
-          use: ["file-loader"],
+          use: [require.resolve("file-loader")],
         },
         ...patternflyBase.webpackModuleRules,
       ],

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -102,6 +102,7 @@
     "ts-loader": "^9.4.2",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.6.2",
+    "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "uuid": "^8.3.2",
     "waait": "^1.0.5",

--- a/packages/runtime-tools-management-console-webapp/webpack.config.js
+++ b/packages/runtime-tools-management-console-webapp/webpack.config.js
@@ -82,7 +82,7 @@ module.exports = async (env) => {
         {
           test: /\.(svg|ttf|eot|woff|woff2)$/,
           use: {
-            loader: "file-loader",
+            loader: require.resolve("file-loader"),
             options: {
               // Limit at 50k. larger files emited into separate files
               limit: 5000,
@@ -96,7 +96,7 @@ module.exports = async (env) => {
           include: (input) => input.indexOf("background-filter.svg") > 1,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "svgs",
@@ -109,7 +109,7 @@ module.exports = async (env) => {
           test: /\.svg$/,
           include: (input) => input.indexOf(BG_IMAGES_DIRNAME) > -1,
           use: {
-            loader: "svg-url-loader",
+            loader: require.resolve("svg-url-loader"),
             options: {},
           },
         },
@@ -117,7 +117,7 @@ module.exports = async (env) => {
           test: /\.(jpg|jpeg|png|gif)$/i,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "images",

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -121,6 +121,7 @@
     "ts-loader": "^9.4.2",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.6.2",
+    "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "waait": "^1.0.5",
     "webpack": "^5.88.2",

--- a/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
+++ b/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = async (env) => {
         {
           test: /\.(svg|ttf|eot|woff|woff2)$/,
           use: {
-            loader: "file-loader",
+            loader: require.resolve("file-loader"),
             options: {
               // Limit at 50k. larger files emited into separate files
               limit: 5000,
@@ -115,7 +115,7 @@ module.exports = async (env) => {
           include: (input) => input.indexOf("background-filter.svg") > 1,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "svgs",
@@ -128,7 +128,7 @@ module.exports = async (env) => {
           test: /\.svg$/,
           include: (input) => input.indexOf(BG_IMAGES_DIRNAME) > -1,
           use: {
-            loader: "svg-url-loader",
+            loader: require.resolve("svg-url-loader"),
             options: {},
           },
         },
@@ -136,7 +136,7 @@ module.exports = async (env) => {
           test: /\.(jpg|jpeg|png|gif)$/i,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "images",

--- a/packages/runtime-tools-task-console-webapp/package.json
+++ b/packages/runtime-tools-task-console-webapp/package.json
@@ -100,6 +100,7 @@
     "ts-loader": "^9.4.2",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.6.2",
+    "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "uuid": "^8.3.2",
     "waait": "^1.0.5",

--- a/packages/runtime-tools-task-console-webapp/webpack.config.js
+++ b/packages/runtime-tools-task-console-webapp/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = async (env) => {
         {
           test: /\.(svg|ttf|eot|woff|woff2)$/,
           use: {
-            loader: "file-loader",
+            loader: require.resolve("file-loader"),
             options: {
               // Limit at 50k. larger files emited into separate files
               limit: 5000,
@@ -97,7 +97,7 @@ module.exports = async (env) => {
           include: (input) => input.indexOf("background-filter.svg") > 1,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "svgs",
@@ -110,7 +110,7 @@ module.exports = async (env) => {
           test: /\.svg$/,
           include: (input) => input.indexOf(BG_IMAGES_DIRNAME) > -1,
           use: {
-            loader: "svg-url-loader",
+            loader: require.resolve("svg-url-loader"),
             options: {},
           },
         },
@@ -118,7 +118,7 @@ module.exports = async (env) => {
           test: /\.(jpg|jpeg|png|gif)$/i,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "images",

--- a/packages/serverless-workflow-dev-ui-webapp/package.json
+++ b/packages/serverless-workflow-dev-ui-webapp/package.json
@@ -104,6 +104,7 @@
     "swagger-ui-express": "^5.0.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.6.2",
+    "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.88.2",
     "webpack-cli": "^4.10.0",

--- a/packages/serverless-workflow-dev-ui-webapp/webpack.config.js
+++ b/packages/serverless-workflow-dev-ui-webapp/webpack.config.js
@@ -151,7 +151,7 @@ module.exports = async (env) =>
         {
           test: /\.(svg|ttf|eot|woff|woff2)$/,
           use: {
-            loader: "file-loader",
+            loader: require.resolve("file-loader"),
             options: {
               // Limit at 50k. larger files emited into separate files
               limit: 5000,
@@ -165,7 +165,7 @@ module.exports = async (env) =>
           include: (input) => input.indexOf("background-filter.svg") > 1,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "svgs",
@@ -178,7 +178,7 @@ module.exports = async (env) =>
           test: /\.svg$/,
           include: (input) => input.indexOf(BG_IMAGES_DIRNAME) > -1,
           use: {
-            loader: "svg-url-loader",
+            loader: require.resolve("svg-url-loader"),
             options: {},
           },
         },
@@ -186,7 +186,7 @@ module.exports = async (env) =>
           test: /\.(jpg|jpeg|png|gif)$/i,
           use: [
             {
-              loader: "url-loader",
+              loader: require.resolve("url-loader"),
               options: {
                 limit: 5000,
                 outputPath: "images",

--- a/packages/sonataflow-deployment-webapp/package.json
+++ b/packages/sonataflow-deployment-webapp/package.json
@@ -74,6 +74,7 @@
     "stream-http": "^3.2.0",
     "terser-webpack-plugin": "^5.3.9",
     "ts-jest": "^26.5.6",
+    "url": "^0.11.3",
     "webpack": "^5.88.2",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7518,6 +7518,9 @@ importers:
       typescript:
         specifier: ^4.6.2
         version: 4.8.4
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
       url-loader:
         specifier: ^4.1.1
         version: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -7825,6 +7828,9 @@ importers:
       typescript:
         specifier: ^4.6.2
         version: 4.8.4
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
       url-loader:
         specifier: ^4.1.1
         version: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -9085,6 +9091,9 @@ importers:
       typescript:
         specifier: ^4.6.2
         version: 4.8.4
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
       url-loader:
         specifier: ^4.1.1
         version: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -10160,6 +10169,9 @@ importers:
       typescript:
         specifier: ^4.6.2
         version: 4.8.4
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
       url-loader:
         specifier: ^4.1.1
         version: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -11148,6 +11160,9 @@ importers:
       ts-jest:
         specifier: ^26.5.6
         version: 26.5.6(jest@26.6.3)(typescript@4.8.4)
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
       webpack:
         specifier: ^5.88.2
         version: 5.88.2(webpack-cli@4.10.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6715,6 +6715,9 @@ importers:
       style-loader:
         specifier: ^2.0.0
         version: 2.0.0(webpack@5.88.2)
+      svg-url-loader:
+        specifier: ^8.0.0
+        version: 8.0.0(webpack@5.88.2)
       url-loader:
         specifier: ^4.1.1
         version: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
@@ -50831,7 +50834,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       file-loader: 6.2.0(webpack@5.88.2)
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.88.2
     dev: true
 
   /svgo@2.8.0:


### PR DESCRIPTION
So `stream-http` is used as a polyfill for `http` in the browser, but it doesn't declare a dependency to `url`. I tried adding it to  `pnpm.packageExtensions` at the root `package.json`, but it didn't work, so I'm resorting to installing it alongside `stream-http` everywhere.

This should fix the error we saw on the release dry run for `kogito-management-console`.