### PR TITLE
NO-ISSUE: Fix CI partitioning by matching package dirs with path separator

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -184,8 +184,9 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
       }
 
       const changedSourcePathsInPartition = changedSourcePaths.filter((path) =>
-        [...partition.dirs].some((partitionDir) => path.startsWith(partitionDir))
+        [...partition.dirs].some((partitionDir) => path.startsWith(`${partitionDir}/`))
       );
+
       if (changedSourcePathsInPartition.length === 0) {
         console.log(`[build-partitioning] 'None' build of '${partition.name}'.`);
         console.log(`[build-partitioning] Building 0/${partition.dirs.size}/${allPackageDirs.size} packages.`);
@@ -203,7 +204,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
       );
 
       const relevantPackageNamesInPartition = new Set(
-        [...(await getDirsOfDependencies(affectedPackageNamesInPartition))].map(
+        [...(await getDirsOfDependencies(affectedPackageNamesInPartition, partition.name))].map(
           (pkgDir) => packageNamesByDir.get(pkgDir)!
         )
       );

--- a/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
+++ b/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
@@ -13,3 +13,4 @@ repo
 .idea
 .github/CODEOWNERS
 .github/supporting-files/ci/build-partitioning
+.github/supporting-files/ci/patterns

--- a/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
+++ b/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
@@ -12,3 +12,4 @@ repo
 .vscode
 .idea
 .github/CODEOWNERS
+.github/supporting-files/ci/build-partitioning

--- a/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
+++ b/.github/supporting-files/ci/patterns/non-source-files-patterns.txt
@@ -12,5 +12,3 @@ repo
 .vscode
 .idea
 .github/CODEOWNERS
-.github/supporting-files/ci/build-partitioning
-.github/supporting-files/ci/patterns


### PR DESCRIPTION
We have packages with similar names, like `workspace` and `workspaces-git-fs`. When string matching via `startsWith`, both packages would match with `workspace`, which is unwanted.

This fix appends a path separator to the package name so that when matching package dirs to changed file paths we guarantee that the full package name is compared.