### PR TITLE
kie-issue#1149: DMN Editor produces invalid typeRef attributes

### DIFF
--- a/packages/boxed-expression-component/src/BoxedExpressionEditor.tsx
+++ b/packages/boxed-expression-component/src/BoxedExpressionEditor.tsx
@@ -20,7 +20,7 @@
 import "@patternfly/react-styles/css/components/Drawer/drawer.css";
 import { I18nDictionariesProvider } from "@kie-tools-core/i18n/dist/react-components";
 import * as React from "react";
-import { BeeGwtService, DmnDataType, BoxedExpression, PmmlDocument } from "./api";
+import { BeeGwtService, BoxedExpression, DmnDataType, PmmlDocument } from "./api";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -42,7 +42,7 @@ export interface BoxedExpressionEditorProps {
   /** Name of the Decision or BKM containing `expression` */
   expressionHolderName: string;
   /** TypeRef of the Decision or BKM containing `expression` */
-  expressionHolderTypeRef: string;
+  expressionHolderTypeRef: string | undefined;
   /** The boxed expression itself */
   expression: BoxedExpression | undefined;
   /** Called every time something changes on the expression */

--- a/packages/boxed-expression-component/src/api/BeeGwtService.ts
+++ b/packages/boxed-expression-component/src/api/BeeGwtService.ts
@@ -25,7 +25,7 @@ import { BoxedExpression } from "./BoxedExpression";
 export interface BeeGwtService {
   getDefaultExpressionDefinition(
     logicType: BoxedExpression["__$$element"] | undefined,
-    typeRef: string,
+    typeRef: string | undefined,
     isRoot?: boolean
   ): { expression: BoxedExpression; widthsById: Map<string, number[]> };
 

--- a/packages/boxed-expression-component/src/expressionVariable/DataTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/DataTypeSelector.tsx
@@ -19,18 +19,18 @@
 
 import { Select, SelectGroup, SelectOption, SelectVariant } from "@patternfly/react-core/dist/js/components/Select";
 import * as React from "react";
-import { useCallback, useState, useRef, useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useBoxedExpressionEditorI18n } from "../i18n";
 import * as _ from "lodash";
-import { DmnDataType } from "../api";
+import { DmnBuiltInDataType, DmnDataType } from "../api";
 import { useBoxedExpressionEditor } from "../BoxedExpressionEditorContext";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 
 export interface DataTypeSelectorProps {
   /** The pre-selected data type */
-  value: string;
+  value: string | undefined;
   /** On DataType selection callback */
-  onChange: (dataType: string) => void;
+  onChange: (dataType: string | undefined) => void;
   /** By default the menu will be appended inline, but it is possible to append on the parent or on other elements */
   /** Callback for toggle select behavior */
   onToggle?: (isOpen: boolean) => void;
@@ -64,7 +64,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       /* this setTimeout keeps the context menu open after type selection changes. Without this Popover component thinks there has been a click outside the context menu, after DataTypeSelector has changed. This because the Select component has been removed from the html*/
       setTimeout(() => setOpen(false), 0);
 
-      onChange(selection);
+      onChange(selection === DmnBuiltInDataType.Undefined ? undefined : selection);
 
       // Because Select leave the focus to the detached btn, give back the focus to the selectWrapperRef
       (selectContainerRef.current?.querySelector("button") as HTMLInputElement)?.focus();
@@ -108,7 +108,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
       return buildSelectGroups().reduce((acc, group) => {
         const filteredGroup = React.cloneElement(group, {
           children: group.props?.children?.filter((item: React.ReactElement) =>
-            item.props.value.toLowerCase().includes(textInput.toLowerCase())
+            (item.props.value ?? DmnBuiltInDataType.Undefined).toLowerCase().includes(textInput.toLowerCase())
           ),
         });
 
@@ -157,7 +157,7 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
         onSelect={onSelect}
         onFilter={onFilter}
         isOpen={isOpen}
-        selections={value}
+        selections={value ?? DmnBuiltInDataType.Undefined}
         isGrouped={true}
         hasInlineFilter={true}
         inlineFilterPlaceholderText={i18n.choose}

--- a/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableCell.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableCell.tsx
@@ -49,7 +49,7 @@ export const ExpressionVariableCell: React.FunctionComponent<
   const { expression, variable, index } = data[rowIndex];
 
   const onVariableUpdated = useCallback<OnExpressionVariableUpdated>(
-    ({ name = DEFAULT_EXPRESSION_VARIABLE_NAME, typeRef = DmnBuiltInDataType.Undefined }) => {
+    ({ name = DEFAULT_EXPRESSION_VARIABLE_NAME, typeRef = undefined }) => {
       onExpressionWithVariableUpdated(index, {
         // `expression` and `variable` must always have the same `typeRef` and `name/label`, as those are dictated by `variable`.
         expression: expression
@@ -99,7 +99,7 @@ export const ExpressionVariableCell: React.FunctionComponent<
     rowIndex,
     columnIndex,
     undefined,
-    useCallback(() => `${variable["@_name"]} (${variable["@_typeRef"] ?? DmnBuiltInDataType.Undefined}})`, [variable])
+    useCallback(() => `${variable["@_name"]} (${variable["@_typeRef"]}})`, [variable])
   );
 
   const { beeGwtService } = useBoxedExpressionEditor();

--- a/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableMenu.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableMenu.tsx
@@ -18,10 +18,9 @@
  */
 
 import * as React from "react";
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { PopoverMenu, PopoverMenuRef } from "../contextMenu/PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../i18n";
-import { DmnBuiltInDataType, BoxedExpression } from "../api";
 import { useBoxedExpressionEditor } from "../BoxedExpressionEditorContext";
 import { DataTypeSelector } from "./DataTypeSelector";
 import { CogIcon } from "@patternfly/react-icons/dist/js/icons/cog-icon";
@@ -30,7 +29,7 @@ import { NavigationKeysUtils } from "../keysUtils/keyUtils";
 import { PopoverPosition } from "@patternfly/react-core/dist/js/components/Popover";
 import "./ExpressionVariableMenu.css";
 
-export type OnExpressionVariableUpdated = (args: { name: string; typeRef: string }) => void;
+export type OnExpressionVariableUpdated = (args: { name: string; typeRef: string | undefined }) => void;
 
 export interface ExpressionVariableMenuProps {
   /** Optional children element to be considered for triggering the edit expression menu */
@@ -62,7 +61,7 @@ export function ExpressionVariableMenu({
   arrowPlacement,
   nameField,
   dataTypeField,
-  selectedDataType = DmnBuiltInDataType.Undefined,
+  selectedDataType = undefined,
   selectedExpressionName,
   onVariableUpdated,
   position,
@@ -92,7 +91,7 @@ export function ExpressionVariableMenu({
     setExpressionName(event.target.value);
   }, []);
 
-  const onDataTypeChange = useCallback((dataType: DmnBuiltInDataType) => {
+  const onDataTypeChange = useCallback((dataType: string | undefined) => {
     setDataType(dataType);
   }, []);
 

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -35,11 +35,11 @@ import {
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";
 import { NestedExpressionContainerContext } from "../../resizing/NestedExpressionContainerContext";
-import { ResizerStopBehavior, ResizingWidth, useResizingWidths } from "../../resizing/ResizingWidthsContext";
+import { ResizerStopBehavior, ResizingWidth } from "../../resizing/ResizingWidthsContext";
 import {
   CONTEXT_ENTRY_EXPRESSION_MIN_WIDTH,
-  CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
   CONTEXT_ENTRY_VARIABLE_COLUMN_WIDTH_INDEX,
+  CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
   CONTEXT_EXPRESSION_EXTRA_WIDTH,
 } from "../../resizing/WidthConstants";
 import { useBeeTableCoordinates, useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
@@ -49,12 +49,10 @@ import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/Expre
 import { ContextEntryExpressionCell } from "./ContextEntryExpressionCell";
 import { ExpressionVariableCell, ExpressionWithVariable } from "../../expressionVariable/ExpressionVariableCell";
 import { ContextResultExpressionCell } from "./ContextResultExpressionCell";
-import { getExpressionMinWidth, getExpressionTotalMinWidth } from "../../resizing/WidthMaths";
+import { getExpressionTotalMinWidth } from "../../resizing/WidthMaths";
 import { DMN15__tContextEntry } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import { findAllIdsDeep } from "../../ids/ids";
 import "./ContextExpression.css";
-
-const CONTEXT_ENTRY_DEFAULT_DATA_TYPE = DmnBuiltInDataType.Undefined;
 
 export type ROWTYPE = ExpressionWithVariable & { index: number };
 
@@ -156,7 +154,7 @@ export function ContextExpression({
         accessor: expressionHolderId as any, // FIXME: https://github.com/apache/incubator-kie-issues/issues/169
         label: contextExpression["@_label"] ?? DEFAULT_EXPRESSION_VARIABLE_NAME,
         isRowIndexColumn: false,
-        dataType: contextExpression["@_typeRef"] ?? CONTEXT_ENTRY_DEFAULT_DATA_TYPE,
+        dataType: contextExpression["@_typeRef"] ?? DmnBuiltInDataType.Undefined,
         width: undefined,
         columns: [
           {
@@ -286,7 +284,7 @@ export function ContextExpression({
         variable: {
           "@_id": generateUuid(),
           "@_name": variableName,
-          "@_typeRef": DmnBuiltInDataType.Undefined,
+          "@_typeRef": undefined,
           description: { __$$text: "" },
         },
       };

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -62,7 +62,6 @@ import {
   DMN15__tInputClause,
   DMN15__tLiteralExpression,
   DMN15__tOutputClause,
-  DMN15__tRuleAnnotation,
   DMN15__tRuleAnnotationClause,
   DMN15__tUnaryTests,
 } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
@@ -728,7 +727,7 @@ export function DecisionTableExpression({
                 "@_id": generateUuid(),
                 inputExpression: {
                   "@_id": generateUuid(),
-                  "@_typeRef": DmnBuiltInDataType.Undefined,
+                  "@_typeRef": undefined,
                   text: { __$$text: newName },
                 },
               });
@@ -768,7 +767,7 @@ export function DecisionTableExpression({
               outputColumnsToAdd.push({
                 "@_id": generateUuid(),
                 "@_name": name,
-                "@_typeRef": DmnBuiltInDataType.Undefined,
+                "@_typeRef": undefined,
               });
             }
 

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
@@ -20,7 +20,7 @@
 import * as React from "react";
 import { useCallback, useEffect, useRef } from "react";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
-import { BoxedExpression, DmnBuiltInDataType, generateUuid } from "../../api";
+import { BoxedExpression, generateUuid } from "../../api";
 import { findAllIdsDeep } from "../../ids/ids";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
 import { useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
@@ -65,11 +65,7 @@ export const ExpressionContainer: React.FunctionComponent<ExpressionContainerPro
   const onLogicTypeSelected = useCallback(
     (logicType: BoxedExpression["__$$element"] | undefined) => {
       const { expression: defaultExpression, widthsById: defaultWidthsById } =
-        beeGwtService!.getDefaultExpressionDefinition(
-          logicType,
-          parentElementTypeRef ?? expressionTypeRef ?? DmnBuiltInDataType.Undefined,
-          !isNested
-        );
+        beeGwtService!.getDefaultExpressionDefinition(logicType, parentElementTypeRef ?? expressionTypeRef, !isNested);
 
       setExpression((prev: BoxedExpression) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector.tsx
@@ -101,10 +101,10 @@ export function ExpressionDefinitionLogicTypeSelector({
       "invocation",
       ...(isNested ? (["functionDefinition"] as const) : []),
       ...(!hideDmn14BoxedExpressions ? (["conditional"] as const) : []),
-      "for",
-      "every",
-      "some",
-      "filter",
+      ...(!hideDmn14BoxedExpressions ? (["for"] as const) : []),
+      ...(!hideDmn14BoxedExpressions ? (["every"] as const) : []),
+      ...(!hideDmn14BoxedExpressions ? (["some"] as const) : []),
+      ...(!hideDmn14BoxedExpressions ? (["filter"] as const) : []),
     ],
     [hideDmn14BoxedExpressions, isNested]
   );

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
@@ -25,7 +25,7 @@ import "./ExpressionDefinitionRoot.css";
 
 export interface ExpressionDefinitionRootProps {
   expressionHolderId: string;
-  expressionHolderTypeRef: string;
+  expressionHolderTypeRef: string | undefined;
   expression?: BoxedExpression;
   isResetSupported: boolean | undefined;
   expressionHolderName?: string;

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
@@ -27,10 +27,10 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   BeeTableProps,
-  DmnBuiltInDataType,
   BoxedExpression,
   BoxedFunction,
   BoxedFunctionKind,
+  DmnBuiltInDataType,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
@@ -20,15 +20,15 @@
 import _ from "lodash";
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind, generateUuid } from "../../api";
+import { BoxedFunction, BoxedFunctionKind, generateUuid } from "../../api";
 import { PopoverMenu } from "../../contextMenu/PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
-import { FeelFunctionExpression, BoxedFunctionFeel } from "./FeelFunctionExpression";
+import { BoxedFunctionFeel, FeelFunctionExpression } from "./FeelFunctionExpression";
 import { FunctionKindSelector } from "./FunctionKindSelector";
-import { JavaFunctionExpression, BoxedFunctionJava } from "./JavaFunctionExpression";
+import { BoxedFunctionJava, JavaFunctionExpression } from "./JavaFunctionExpression";
 import { ParametersPopover } from "./ParametersPopover";
-import { PmmlFunctionExpression, BoxedFunctionPmml } from "./PmmlFunctionExpression";
+import { BoxedFunctionPmml, PmmlFunctionExpression } from "./PmmlFunctionExpression";
 import {
   DMN15__tFunctionDefinition,
   DMN15__tFunctionKind,
@@ -86,11 +86,11 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
             "@_label": prev["@_label"],
             "@_id": generateUuid(),
             "@_kind": BoxedFunctionKind.Feel,
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
             expression: {
               __$$element: "literalExpression",
               "@_id": generateUuid(),
-              "@_typeRef": DmnBuiltInDataType.Undefined,
+              "@_typeRef": undefined,
             },
             formalParameter: [],
           };
@@ -108,7 +108,7 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
               "@_id": generateUuid(),
             },
             "@_kind": BoxedFunctionKind.Java,
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
             formalParameter: [],
           };
           return retJava;
@@ -123,7 +123,7 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
               "@_id": generateUuid(),
             },
             "@_kind": BoxedFunctionKind.Pmml,
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
             formalParameter: [],
           };
           return retPmml;

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
@@ -20,7 +20,7 @@
 import _ from "lodash";
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { BoxedFunction, BoxedFunctionKind, generateUuid } from "../../api";
+import { BoxedFunction, BoxedFunctionKind, DmnBuiltInDataType, generateUuid } from "../../api";
 import { PopoverMenu } from "../../contextMenu/PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
@@ -167,7 +167,9 @@ export function useFunctionExpressionParametersColumnHeader(
                   <React.Fragment key={i}>
                     <span>{parameter["@_name"]}</span>
                     <span>{": "}</span>
-                    <span className={"expression-info-data-type"}>({parameter["@_typeRef"]})</span>
+                    <span className={"expression-info-data-type"}>
+                      ({parameter["@_typeRef"] ?? DmnBuiltInDataType.Undefined})
+                    </span>
                     {i < (formalParameters ?? []).length - 1 && <span>{", "}</span>}
                   </React.Fragment>
                 ))}

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -29,10 +29,10 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   BeeTableProps,
-  DmnBuiltInDataType,
-  BoxedFunctionKind,
-  generateUuid,
   BoxedFunction,
+  BoxedFunctionKind,
+  DmnBuiltInDataType,
+  generateUuid,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
@@ -24,7 +24,7 @@ import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { OutlinedTrashAltIcon } from "@patternfly/react-icons/dist/js/icons/outlined-trash-alt-icon";
 import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
-import { BoxedFunction, generateUuid, getNextAvailablePrefixedName } from "../../api";
+import { BoxedFunction, DmnBuiltInDataType, generateUuid, getNextAvailablePrefixedName } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
 import { DMN15__tInformationItem } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
@@ -24,7 +24,7 @@ import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { OutlinedTrashAltIcon } from "@patternfly/react-icons/dist/js/icons/outlined-trash-alt-icon";
 import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
-import { DmnBuiltInDataType, BoxedFunction, generateUuid, getNextAvailablePrefixedName } from "../../api";
+import { BoxedFunction, generateUuid, getNextAvailablePrefixedName } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
 import { DMN15__tInformationItem } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
@@ -51,7 +51,7 @@ export const ParametersPopover: React.FunctionComponent<ParametersPopoverProps> 
               (prev.formalParameter ?? []).map((p) => p["@_name"]),
               "p"
             ),
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
           },
         ];
 
@@ -120,7 +120,7 @@ function ParameterEntry({ parameter, index }: { parameter: DMN15__tInformationIt
   );
 
   const onDataTypeChange = useCallback(
-    (typeRef: string) => {
+    (typeRef: string | undefined) => {
       setExpression((prev: BoxedFunction) => {
         const newParameters = [...(prev.formalParameter ?? [])];
         newParameters[index] = {
@@ -166,11 +166,7 @@ function ParameterEntry({ parameter, index }: { parameter: DMN15__tInformationIt
         placeholder={"Parameter Name"}
         defaultValue={parameter["@_name"]}
       />
-      <DataTypeSelector
-        value={parameter["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
-        onChange={onDataTypeChange}
-        menuAppendTo="parent"
-      />
+      <DataTypeSelector value={parameter["@_typeRef"]} onChange={onDataTypeChange} menuAppendTo="parent" />
       <Button
         variant="danger"
         className="delete-parameter"

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
@@ -30,6 +30,7 @@ import {
   BeeTableProps,
   BoxedFunction,
   BoxedFunctionKind,
+  DmnBuiltInDataType,
   generateUuid,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
@@ -89,7 +90,7 @@ export function PmmlFunctionExpression({
       {
         accessor: expressionHolderId as any, // FIXME: https://github.com/apache/incubator-kie-issues/issues/169
         label: functionExpression["@_label"] ?? DEFAULT_EXPRESSION_VARIABLE_NAME,
-        dataType: functionExpression["@_typeRef"] ?? "",
+        dataType: functionExpression["@_typeRef"] ?? DmnBuiltInDataType.Undefined,
         isRowIndexColumn: false,
         width: undefined,
         columns: [

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useMemo, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import * as ReactTable from "react-table";
 import {
   BeeTableContextMenuAllowedOperationsConditions,
@@ -26,21 +26,21 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   BeeTableProps,
+  BoxedExpression,
+  BoxedInvocation,
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
-  BoxedInvocation,
-  BoxedExpression,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { NestedExpressionContainerContext } from "../../resizing/NestedExpressionContainerContext";
 import { ResizerStopBehavior, ResizingWidth } from "../../resizing/ResizingWidthsContext";
 import {
   CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
-  INVOCATION_PARAMETER_MIN_WIDTH,
   INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH,
   INVOCATION_EXTRA_WIDTH,
   INVOCATION_PARAMETER_INFO_COLUMN_WIDTH_INDEX,
+  INVOCATION_PARAMETER_MIN_WIDTH,
 } from "../../resizing/WidthConstants";
 import { BeeTable, BeeTableColumnUpdate } from "../../table/BeeTable";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
@@ -57,7 +57,6 @@ import "./InvocationExpression.css";
 export type ROWTYPE = ExpressionWithVariable & { index: number };
 
 export const INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME = "p-1";
-export const INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE = DmnBuiltInDataType.Undefined;
 
 export function InvocationExpression({
   isNested,
@@ -203,7 +202,7 @@ export function InvocationExpression({
                 accessor: "parameter" as any,
                 label: "parameter",
                 isRowIndexColumn: false,
-                dataType: INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
+                dataType: DmnBuiltInDataType.Undefined,
                 isWidthPinned: true,
                 minWidth: CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
                 width: parametersWidth,
@@ -213,7 +212,7 @@ export function InvocationExpression({
                 accessor: "expression" as any,
                 label: "expression",
                 isRowIndexColumn: false,
-                dataType: INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
+                dataType: DmnBuiltInDataType.Undefined,
                 minWidth: INVOCATION_ARGUMENT_EXPRESSION_MIN_WIDTH,
                 width: undefined,
               },
@@ -333,7 +332,7 @@ export function InvocationExpression({
       return {
         parameter: {
           "@_id": generateUuid(),
-          "@_typeRef": DmnBuiltInDataType.Undefined,
+          "@_typeRef": undefined,
           "@_name":
             name ||
             getNextAvailablePrefixedName(

--- a/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionComponent.tsx
+++ b/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionComponent.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../api";
 import { BeeTable, BeeTableColumnUpdate, BeeTableRef } from "../../table/BeeTable";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
   DMN15__tChildExpression,
   DMN15__tTypedChildExpression,
@@ -47,7 +47,6 @@ import {
   ITERATOR_EXPRESSION_LABEL_COLUMN_WIDTH,
 } from "../../resizing/WidthConstants";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
-import { useBeeTableCoordinates, useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
 import { IteratorExpressionVariableCell } from "./IteratorExpressionVariableCell";
 
 type ROWTYPE = IteratorClause;

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
@@ -27,10 +27,9 @@ import {
   BeeTableOperation,
   BeeTableOperationConfig,
   BeeTableProps,
-  DmnBuiltInDataType,
-  InsertRowColumnsDirection,
-  BoxedList,
   BoxedExpression,
+  BoxedList,
+  DmnBuiltInDataType,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";

--- a/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
@@ -24,8 +24,8 @@ import {
   BeeTableContextMenuAllowedOperationsConditions,
   BeeTableHeaderVisibility,
   BeeTableOperation,
-  DmnBuiltInDataType,
   BoxedLiteral,
+  DmnBuiltInDataType,
 } from "../../api";
 import { useNestedExpressionContainer } from "../../resizing/NestedExpressionContainerContext";
 import {
@@ -85,11 +85,13 @@ export function LiteralExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression(() => ({
-        ...literalExpression,
-        "@_label": name,
-        "@_typeRef": typeRef,
-      }));
+      setExpression(
+        (): BoxedLiteral => ({
+          ...literalExpression,
+          "@_label": name,
+          "@_typeRef": typeRef,
+        })
+      );
     },
     [literalExpression, setExpression]
   );

--- a/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
@@ -26,11 +26,10 @@ import {
   BeeTableHeaderVisibility,
   BeeTableOperation,
   BeeTableOperationConfig,
+  BoxedRelation,
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
-  InsertRowColumnsDirection,
-  BoxedRelation,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
@@ -44,7 +43,7 @@ import {
 import { BeeTable, BeeTableCellUpdate, BeeTableColumnUpdate, BeeTableRef } from "../../table/BeeTable";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
-import { DMN15__tList, DMN15__tLiteralExpression } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
+import { DMN15__tList } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import "./RelationExpression.css";
 
 type ROWTYPE = any; // FIXME: https://github.com/kiegroup/kie-issues/issues/169
@@ -326,7 +325,7 @@ export function RelationExpression({
           newItems.push({
             "@_id": generateUuid(),
             "@_name": name,
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
           });
         }
 

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -21,7 +21,7 @@ import _ from "lodash";
 import * as React from "react";
 import { useCallback } from "react";
 import * as ReactTable from "react-table";
-import { BeeTableHeaderVisibility, DmnBuiltInDataType, BoxedExpression, InsertRowColumnsDirection } from "../../api";
+import { BeeTableHeaderVisibility, BoxedExpression, InsertRowColumnsDirection } from "../../api";
 import { BeeTableTh } from "./BeeTableTh";
 import { BeeTableThResizable } from "./BeeTableThResizable";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
@@ -32,7 +32,7 @@ import { InlineEditableTextInput } from "./InlineEditableTextInput";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
 
 export interface BeeTableColumnUpdate<R extends object> {
-  typeRef: string;
+  typeRef: string | undefined;
   name: string;
   column: ReactTable.ColumnInstance<R>;
   columnIndex: number;
@@ -120,10 +120,7 @@ export function BeeTableHeader<R extends object>({
     ) => (args: Pick<BoxedExpression, "@_label" | "@_typeRef">) => void
   >(
     (column, columnIndex) => {
-      return ({
-        "@_label": name = DEFAULT_EXPRESSION_VARIABLE_NAME,
-        "@_typeRef": typeRef = DmnBuiltInDataType.Undefined,
-      }) => {
+      return ({ "@_label": name = DEFAULT_EXPRESSION_VARIABLE_NAME, "@_typeRef": typeRef = undefined }) => {
         onColumnUpdates?.([
           {
             // Subtract one because of the rowIndex column.

--- a/packages/boxed-expression-component/stories/boxedExpressionStoriesWrapper.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressionStoriesWrapper.tsx
@@ -71,7 +71,7 @@ export const dataTypes = [
 ];
 
 export const beeGwtService: BeeGwtService = {
-  getDefaultExpressionDefinition(logicType: BoxedExpression["__$$element"] | undefined, dataType: string) {
+  getDefaultExpressionDefinition(logicType: BoxedExpression["__$$element"] | undefined, dataType: string | undefined) {
     const widthsById = new Map();
     const expression = getDefaultBoxedExpressionForStories({ logicType, typeRef: dataType, widthsById });
     return {
@@ -167,9 +167,7 @@ export function BoxedExpressionEditorStory(props?: Partial<BoxedExpressionEditor
         expressionHolderName={
           props?.expressionHolderName ?? args?.expressionHolderName ?? DEFAULT_EXPRESSION_VARIABLE_NAME
         }
-        expressionHolderTypeRef={
-          props?.expressionHolderTypeRef ?? args?.expressionHolderTypeRef ?? DmnBuiltInDataType.Undefined
-        }
+        expressionHolderTypeRef={props?.expressionHolderTypeRef ?? args?.expressionHolderTypeRef}
         expression={expressionState}
         onExpressionChange={setExpressionState}
         onWidthsChange={onWidthsChange}

--- a/packages/boxed-expression-component/stories/boxedExpressions/Context/Context.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Context/Context.stories.tsx
@@ -43,13 +43,13 @@ export const Base: Story = {
       __$$element: "context",
       "@_id": "_35255561-88FA-4A78-9C3F-61855213EE0F",
       "@_label": "Expression Name",
-      "@_typeRef": DmnBuiltInDataType.Undefined,
+      "@_typeRef": undefined,
       contextEntry: [
         {
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
           },
           expression: undefined!,
         },

--- a/packages/boxed-expression-component/stories/boxedExpressions/DecisionTable/DecisionTable.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/DecisionTable/DecisionTable.stories.tsx
@@ -60,7 +60,7 @@ export const Base: Story = {
           inputExpression: {
             "@_id": generateUuid(),
             text: { __$$text: "input-1" },
-            "@_typeRef": DmnBuiltInDataType.Undefined,
+            "@_typeRef": undefined,
           },
         },
       ],
@@ -68,7 +68,7 @@ export const Base: Story = {
         {
           "@_id": generateUuid(),
           "@_label": "output-1",
-          "@_typeRef": DmnBuiltInDataType.Undefined,
+          "@_typeRef": undefined,
         },
       ],
       annotation: [

--- a/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
+++ b/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
@@ -34,10 +34,7 @@ import {
   BoxedEvery,
   BoxedFilter,
 } from "../../src/api";
-import {
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-} from "../../src/expressions/InvocationExpression/InvocationExpression";
+import { INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME } from "../../src/expressions/InvocationExpression/InvocationExpression";
 import {
   DECISION_TABLE_INPUT_DEFAULT_VALUE,
   DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
@@ -110,7 +107,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
           parameter: {
             "@_id": generateUuid(),
             "@_name": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-            "@_typeRef": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
+            "@_typeRef": undefined,
           },
         },
       ],

--- a/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
+++ b/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
@@ -45,7 +45,7 @@ import {
 
 export function getDefaultBoxedExpressionForDevWebapp(
   logicType: BoxedExpression["__$$element"] | undefined,
-  typeRef: string
+  typeRef: string | undefined
 ): BoxedExpression {
   if (logicType === "literalExpression") {
     const literalExpression: BoxedLiteral = {

--- a/packages/boxed-expression-component/stories/features/Resizing/Resizing.stories.tsx
+++ b/packages/boxed-expression-component/stories/features/Resizing/Resizing.stories.tsx
@@ -89,7 +89,7 @@ const expression: BoxedExpression = {
         "@_kind": BoxedFunctionKind.Feel,
         expression: {
           "@_id": "_C1F325BF-D812-4192-AA90-B820C892EA9A",
-          "@_typeRef": DmnBuiltInDataType.Undefined,
+          "@_typeRef": undefined,
           __$$element: "context",
           contextEntry: [
             {
@@ -149,7 +149,7 @@ const expression: BoxedExpression = {
                         {
                           "@_id": "_64AA2820-EC4F-4A5B-9045-A474983CC86E",
                           "@_name": "Result Expression",
-                          "@_typeRef": DmnBuiltInDataType.Undefined,
+                          "@_typeRef": undefined,
                         },
                       ],
                       annotation: [

--- a/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
+++ b/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
@@ -64,7 +64,7 @@ export function getDefaultBoxedExpressionForStories({
   widthsById,
 }: {
   logicType: BoxedExpression["__$$element"] | undefined;
-  typeRef: string;
+  typeRef: string | undefined;
   widthsById: Map<string, number[]>;
 }): BoxedExpression {
   if (logicType === "literalExpression") {
@@ -166,7 +166,7 @@ export function getDefaultBoxedExpressionForStories({
         {
           "@_id": generateUuid(),
           "@_name": "column-1",
-          "@_typeRef": DmnBuiltInDataType.Undefined,
+          "@_typeRef": undefined,
         },
       ],
     };
@@ -179,11 +179,11 @@ export function getDefaultBoxedExpressionForStories({
   } else if (logicType === "decisionTable") {
     const singleOutputColumn = {
       name: "output-1",
-      typeRef: DmnBuiltInDataType.Undefined,
+      typeRef: undefined,
     };
     const singleInputColumn = {
       name: "input-1",
-      typeRef: DmnBuiltInDataType.Undefined,
+      typeRef: undefined,
     };
 
     const input = [
@@ -192,7 +192,7 @@ export function getDefaultBoxedExpressionForStories({
         inputExpression: {
           "@_id": generateUuid(),
           text: { __$$text: singleInputColumn.name },
-          "@_typeRef": singleInputColumn.typeRef ?? DmnBuiltInDataType.Undefined,
+          "@_typeRef": singleInputColumn.typeRef,
         },
       },
     ];

--- a/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
+++ b/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
@@ -18,7 +18,6 @@
  */
 
 import {
-  DMN15__tContextEntry,
   DMN15__tItemDefinition,
   DMN15__tOutputClause,
 } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
@@ -27,22 +26,17 @@ import {
   BoxedDecisionTable,
   BoxedExpression,
   BoxedFunction,
-  BoxedFunctionKind,
   BoxedInvocation,
   BoxedList,
   BoxedLiteral,
   BoxedRelation,
-  DmnBuiltInDataType,
   generateUuid,
 } from "../src/api";
 import {
   DECISION_TABLE_INPUT_DEFAULT_VALUE,
   DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
 } from "../src/expressions/DecisionTableExpression/DecisionTableExpression";
-import {
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-} from "../src/expressions/InvocationExpression/InvocationExpression";
+import { INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME } from "../src/expressions/InvocationExpression/InvocationExpression";
 import {
   BEE_TABLE_ROW_INDEX_COLUMN_WIDTH,
   CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
@@ -132,7 +126,7 @@ export function getDefaultBoxedExpressionForStories({
           parameter: {
             "@_id": generateUuid(),
             "@_name": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-            "@_typeRef": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
+            "@_typeRef": undefined,
           },
           expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
         },

--- a/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
@@ -385,11 +385,7 @@ export function BoxedExpressionScreen({ container }: { container: React.RefObjec
             isResetSupportedOnRootExpression={isResetSupportedOnRootExpression}
             expressionHolderId={activeDrgElementId!}
             expressionHolderName={drgElement?.variable?.["@_name"] ?? drgElement?.["@_name"] ?? ""}
-            expressionHolderTypeRef={
-              drgElement?.variable?.["@_typeRef"] ??
-              expression?.boxedExpression?.["@_typeRef"] ??
-              DmnBuiltInDataType.Undefined
-            }
+            expressionHolderTypeRef={drgElement?.variable?.["@_typeRef"] ?? expression?.boxedExpression?.["@_typeRef"]}
             expression={expression?.boxedExpression}
             onExpressionChange={onExpressionChange}
             dataTypes={dataTypes}
@@ -432,7 +428,9 @@ export function drgElementToBoxedExpression(
             expressionHolder?.variable?.["@_name"] ??
             expressionHolder.expression["@_label"] ??
             expressionHolder?.["@_name"],
-          "@_typeRef": expressionHolder?.variable?.["@_typeRef"] ?? expressionHolder.expression["@_typeRef"],
+          "@_typeRef": expressionHolder?.variable
+            ? expressionHolder?.variable["@_typeRef"]
+            : expressionHolder.expression["@_typeRef"],
         }
       : undefined;
   } else {

--- a/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
@@ -18,30 +18,30 @@
  */
 
 import {
-  DmnBuiltInDataType,
-  BoxedExpression,
-  generateUuid,
-  BoxedLiteral,
-  BoxedFunction,
-  BoxedContext,
-  BoxedList,
-  BoxedInvocation,
-  BoxedRelation,
-  BoxedDecisionTable,
   BoxedConditional,
-  BoxedFor,
-  BoxedSome,
+  BoxedContext,
+  BoxedDecisionTable,
   BoxedEvery,
+  BoxedExpression,
   BoxedFilter,
+  BoxedFor,
+  BoxedFunction,
+  BoxedInvocation,
+  BoxedList,
+  BoxedLiteral,
+  BoxedRelation,
+  BoxedSome,
+  DmnBuiltInDataType,
+  generateUuid,
 } from "@kie-tools/boxed-expression-component/dist/api";
 import {
-  LITERAL_EXPRESSION_MIN_WIDTH,
+  BEE_TABLE_ROW_INDEX_COLUMN_WIDTH,
   CONTEXT_ENTRY_VARIABLE_MIN_WIDTH,
+  DECISION_TABLE_ANNOTATION_DEFAULT_WIDTH,
   DECISION_TABLE_INPUT_DEFAULT_WIDTH,
   DECISION_TABLE_OUTPUT_DEFAULT_WIDTH,
-  DECISION_TABLE_ANNOTATION_DEFAULT_WIDTH,
+  LITERAL_EXPRESSION_MIN_WIDTH,
   RELATION_EXPRESSION_COLUMN_DEFAULT_WIDTH,
-  BEE_TABLE_ROW_INDEX_COLUMN_WIDTH,
 } from "@kie-tools/boxed-expression-component/dist/resizing/WidthConstants";
 import {
   DECISION_TABLE_INPUT_DEFAULT_VALUE,
@@ -71,7 +71,7 @@ export function getDefaultBoxedExpression({
   getDefaultColumnWidth?: (args: { name: string; typeRef: string | undefined }) => number | undefined;
   widthsById: Map<string, number[]>;
 }): BoxedExpression {
-  const dataType = allTopLevelDataTypesByFeelName.get(typeRef ?? "<Undefined>");
+  const dataType = allTopLevelDataTypesByFeelName.get(typeRef ?? DmnBuiltInDataType.Undefined);
 
   if (logicType === "literalExpression") {
     const literalExpression: BoxedLiteral = {

--- a/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
@@ -47,10 +47,7 @@ import {
   DECISION_TABLE_INPUT_DEFAULT_VALUE,
   DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
 } from "@kie-tools/boxed-expression-component/dist/expressions/DecisionTableExpression/DecisionTableExpression";
-import {
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-  INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
-} from "@kie-tools/boxed-expression-component/dist/expressions/InvocationExpression/InvocationExpression";
+import { INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME } from "@kie-tools/boxed-expression-component/dist/expressions/InvocationExpression/InvocationExpression";
 import { RELATION_EXPRESSION_DEFAULT_VALUE } from "@kie-tools/boxed-expression-component/dist/expressions/RelationExpression/RelationExpression";
 import { DataTypeIndex } from "../dataTypes/DataTypes";
 import { isStruct } from "../dataTypes/DataTypeSpec";
@@ -68,13 +65,13 @@ export function getDefaultBoxedExpression({
   getDefaultColumnWidth,
 }: {
   logicType: BoxedExpression["__$$element"] | undefined;
-  typeRef: string;
+  typeRef: string | undefined;
   allTopLevelDataTypesByFeelName: DataTypeIndex;
   getInputs?: () => { name: string; typeRef: string | undefined }[] | undefined;
   getDefaultColumnWidth?: (args: { name: string; typeRef: string | undefined }) => number | undefined;
   widthsById: Map<string, number[]>;
 }): BoxedExpression {
-  const dataType = allTopLevelDataTypesByFeelName.get(typeRef);
+  const dataType = allTopLevelDataTypesByFeelName.get(typeRef ?? "<Undefined>");
 
   if (logicType === "literalExpression") {
     const literalExpression: BoxedLiteral = {
@@ -109,7 +106,6 @@ export function getDefaultBoxedExpression({
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",
-            "@_typeRef": DmnBuiltInDataType.Undefined,
           },
           expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
         },
@@ -117,7 +113,7 @@ export function getDefaultBoxedExpression({
     } else {
       contextEntries = (dataType.itemDefinition.itemComponent ?? []).map((ic) => {
         const name = ic["@_name"];
-        const typeRef = isStruct(ic) ? DmnBuiltInDataType.Any : ic.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined;
+        const typeRef = isStruct(ic) ? DmnBuiltInDataType.Any : ic.typeRef?.__$$text;
         maxWidthBasedOnEntryNames = Math.max(
           maxWidthBasedOnEntryNames,
           getDefaultColumnWidth?.({ name, typeRef }) ?? CONTEXT_ENTRY_VARIABLE_MIN_WIDTH
@@ -169,7 +165,7 @@ export function getDefaultBoxedExpression({
           parameter: {
             "@_id": generateUuid(),
             "@_name": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME,
-            "@_typeRef": INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
+            "@_typeRef": undefined,
           },
           expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
         },
@@ -206,14 +202,12 @@ export function getDefaultBoxedExpression({
             {
               "@_id": generateUuid(),
               "@_name": dataType?.itemDefinition["@_name"] ?? "column-1",
-              "@_typeRef": dataType?.feelName ?? DmnBuiltInDataType.Undefined,
+              "@_typeRef": dataType?.feelName,
             },
           ]
         : (dataType.itemDefinition.itemComponent ?? []).map((ic) => {
             const name = ic["@_name"];
-            const typeRef = isStruct(ic)
-              ? DmnBuiltInDataType.Any
-              : ic.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined;
+            const typeRef = isStruct(ic) ? DmnBuiltInDataType.Any : ic.typeRef?.__$$text;
             return {
               "@_id": generateUuid(),
               "@_name": name,
@@ -236,11 +230,11 @@ export function getDefaultBoxedExpression({
   } else if (logicType === "decisionTable") {
     const singleOutputColumn = {
       name: "Output-1",
-      typeRef: dataType?.feelName ?? DmnBuiltInDataType.Undefined,
+      typeRef: dataType?.feelName,
     };
     const singleInputColumn = {
       name: "Input-1",
-      typeRef: DmnBuiltInDataType.Undefined,
+      typeRef: undefined,
     };
 
     const input = getInputs?.()?.map((input) => ({
@@ -248,7 +242,7 @@ export function getDefaultBoxedExpression({
       inputExpression: {
         "@_id": generateUuid(),
         text: { __$$text: input.name },
-        "@_typeRef": input.typeRef ?? DmnBuiltInDataType.Undefined,
+        "@_typeRef": input.typeRef,
       },
     })) ?? [
       {
@@ -256,7 +250,7 @@ export function getDefaultBoxedExpression({
         inputExpression: {
           "@_id": generateUuid(),
           text: { __$$text: singleInputColumn.name },
-          "@_typeRef": singleInputColumn.typeRef ?? DmnBuiltInDataType.Undefined,
+          "@_typeRef": singleInputColumn.typeRef,
         },
       },
     ];
@@ -273,7 +267,7 @@ export function getDefaultBoxedExpression({
         : (dataType.itemDefinition.itemComponent ?? []).map((ic) => ({
             "@_id": generateUuid(),
             "@_name": ic["@_name"],
-            "@_typeRef": isStruct(ic) ? DmnBuiltInDataType.Any : ic.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined,
+            "@_typeRef": isStruct(ic) ? DmnBuiltInDataType.Any : ic.typeRef?.__$$text,
           }));
 
     const decisionTableExpression: BoxedDecisionTable = {

--- a/packages/dmn-editor/src/boxedExpressions/getDefaultColumnWidth.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/getDefaultColumnWidth.tsx
@@ -29,7 +29,7 @@ export function getDefaultColumnWidth({ name, typeRef }: { name: string; typeRef
       DEFAULT_MIN_WIDTH,
       getTextWidth(name, "700 11.2px Menlo, monospace"),
       getTextWidth(
-        `(${typeRef ?? DmnBuiltInDataType.Undefined})`,
+        `(${typeRef ?? "<Undefined>"})`,
         "700 11.6667px RedHatText, Overpass, overpass, helvetica, arial, sans-serif"
       )
     )

--- a/packages/dmn-editor/src/boxedExpressions/getDefaultColumnWidth.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/getDefaultColumnWidth.tsx
@@ -29,7 +29,7 @@ export function getDefaultColumnWidth({ name, typeRef }: { name: string; typeRef
       DEFAULT_MIN_WIDTH,
       getTextWidth(name, "700 11.2px Menlo, monospace"),
       getTextWidth(
-        `(${typeRef ?? "<Undefined>"})`,
+        `(${typeRef ?? DmnBuiltInDataType.Undefined})`,
         "700 11.6667px RedHatText, Overpass, overpass, helvetica, arial, sans-serif"
       )
     )

--- a/packages/dmn-editor/src/dataTypes/Constraints.tsx
+++ b/packages/dmn-editor/src/dataTypes/Constraints.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from "react";
-import { useMemo, useCallback, useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ConstraintsExpression } from "./ConstraintsExpression";
 import {
   DMN15__tItemDefinition,
@@ -86,8 +86,7 @@ export function recursivelyGetRootItemDefinition(
   allDataTypesById: DataTypeIndex,
   allTopLevelItemDefinitionUniqueNames: UniqueNameIndex
 ): DMN15__tItemDefinition {
-  const typeRef: DmnBuiltInDataType =
-    (itemDefinition.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined;
+  const typeRef: DmnBuiltInDataType = itemDefinition.typeRef?.__$$text as DmnBuiltInDataType;
 
   if (builtInFeelTypeNames.has(typeRef) === false) {
     const parentDataType = allDataTypesById.get(allTopLevelItemDefinitionUniqueNames.get(typeRef) ?? "");
@@ -422,7 +421,7 @@ export function ConstraintsFromAllowedValuesAttribute({
 
   const allowedValues = useMemo(() => itemDefinition?.allowedValues, [itemDefinition?.allowedValues]);
   const itemDefinitionId = itemDefinition["@_id"]!;
-  const typeRef = (itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined;
+  const typeRef = itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType;
   const typeRefConstraintTypeHelper = useMemo(
     () => constraintTypeHelper(itemDefinition, allDataTypesById, allTopLevelItemDefinitionUniqueNames),
     [allDataTypesById, allTopLevelItemDefinitionUniqueNames, itemDefinition]
@@ -569,7 +568,7 @@ export function ConstraintsFromTypeConstraintAttribute({
     [defaultsToAllowedValues, itemDefinition?.allowedValues, itemDefinition?.typeConstraint]
   );
 
-  const typeRef = (itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined;
+  const typeRef = itemDefinition?.typeRef?.__$$text as DmnBuiltInDataType;
   const typeRefConstraintTypeHelper = useMemo(
     () => constraintTypeHelper(itemDefinition, allDataTypesById, allTopLevelItemDefinitionUniqueNames),
     [allDataTypesById, allTopLevelItemDefinitionUniqueNames, itemDefinition]
@@ -587,9 +586,7 @@ export function ConstraintsFromTypeConstraintAttribute({
     if (isCollection(rootItemDefinition)) {
       return ["expression"] as KIE__tConstraintType[];
     }
-    return constrainableBuiltInFeelTypes.get(
-      (rootItemDefinition.typeRef?.__$$text as DmnBuiltInDataType) ?? DmnBuiltInDataType.Undefined
-    );
+    return constrainableBuiltInFeelTypes.get(rootItemDefinition.typeRef?.__$$text as DmnBuiltInDataType);
   }, [rootItemDefinition]);
 
   const {

--- a/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
@@ -135,7 +135,7 @@ export function DataTypeName({
           />
           {!isEditingLabel && (
             <TypeRefLabel
-              typeRef={itemDefinition.typeRef?.__$$text}
+              typeRef={itemDefinition.typeRef?.__$$text ?? "<Undefined>"}
               isCollection={itemDefinition["@_isCollection"]}
               relativeToNamespace={relativeToNamespace}
             />

--- a/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
@@ -30,6 +30,7 @@ import { buildFeelQNameFromNamespace } from "../feel/buildFeelQName";
 import { InlineFeelNameInput, OnInlineFeelNameRenamed } from "../feel/InlineFeelNameInput";
 import { useExternalModels } from "../includedModels/DmnEditorDependenciesContext";
 import { State } from "../store/Store";
+import { DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
 
 export function DataTypeName({
   isReadonly,
@@ -135,7 +136,7 @@ export function DataTypeName({
           />
           {!isEditingLabel && (
             <TypeRefLabel
-              typeRef={itemDefinition.typeRef?.__$$text ?? "<Undefined>"}
+              typeRef={itemDefinition.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined}
               isCollection={itemDefinition["@_isCollection"]}
               relativeToNamespace={relativeToNamespace}
             />

--- a/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypePanel.tsx
@@ -123,7 +123,7 @@ export function DataTypePanel({
       }
 
       editItemDefinition(dataType.itemDefinition["@_id"]!, (itemDefinition) => {
-        itemDefinition.typeRef = { __$$text: typeRef };
+        itemDefinition.typeRef = typeRef ? { __$$text: typeRef } : undefined;
         const originalItemDefinition = original(itemDefinition);
         if (originalItemDefinition?.typeRef?.__$$text !== typeRef) {
           itemDefinition.typeConstraint = undefined;

--- a/packages/dmn-editor/src/dataTypes/DataTypes.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypes.tsx
@@ -171,7 +171,7 @@ export function DataTypes() {
     <>
       {(dataTypesTree.length <= 0 && (
         <DataTypesEmptyState
-          onAdd={() => addTopLevelItemDefinition({ typeRef: { __$$text: DmnBuiltInDataType.Undefined } })}
+          onAdd={() => addTopLevelItemDefinition({ typeRef: undefined })}
           onPaste={pasteTopLevelItemDefinition}
         />
       )) || (
@@ -203,9 +203,7 @@ export function DataTypes() {
                               {...extraPropsForDropdownToggleAction}
                               key="add-data-type-action"
                               aria-label="Add Data Type"
-                              onClick={() =>
-                                addTopLevelItemDefinition({ typeRef: { __$$text: DmnBuiltInDataType.Undefined } })
-                              }
+                              onClick={() => addTopLevelItemDefinition({ typeRef: undefined })}
                             >
                               <PlusCircleIcon />
                             </DropdownToggleAction>,

--- a/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
+++ b/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
@@ -39,16 +39,16 @@ import { AngleDownIcon } from "@patternfly/react-icons/dist/js/icons/angle-down-
 import { AngleRightIcon } from "@patternfly/react-icons/dist/js/icons/angle-right-icon";
 import { EyeIcon } from "@patternfly/react-icons/dist/js/icons/eye-icon";
 import { TrashIcon } from "@patternfly/react-icons/dist/js/icons/trash-icon";
-import { DataType, EditItemDefinition, AddItemComponent, DataTypeIndex } from "./DataTypes";
+import { AddItemComponent, DataType, DataTypeIndex, EditItemDefinition } from "./DataTypes";
 import { DataTypeName } from "./DataTypeName";
-import { isStruct, canHaveConstraints, getNewItemDefinition } from "./DataTypeSpec";
+import { canHaveConstraints, getNewItemDefinition, isStruct } from "./DataTypeSpec";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { UniqueNameIndex } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
 import {
+  buildClipboardFromDataType,
   DMN_EDITOR_DATA_TYPES_CLIPBOARD_MIME_TYPE,
   DmnEditorDataTypesClipboard,
-  buildClipboardFromDataType,
   getClipboard,
 } from "../clipboard/Clipboard";
 import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
@@ -110,6 +110,7 @@ export function ItemComponentsTable({
 
   const flatTree = useMemo(() => {
     const ret: { dataType: DataType; allUniqueNamesAtLevel: UniqueNameIndex }[] = [];
+
     function traverse(dataType: DataType[], allUniqueNamesAtLevel: UniqueNameIndex) {
       for (let i = 0; i < (dataType?.length ?? 0); i++) {
         ret.push({ dataType: dataType[i], allUniqueNamesAtLevel });
@@ -162,7 +163,7 @@ export function ItemComponentsTable({
                 onClick={() =>
                   addItemComponent(parent.itemDefinition["@_id"]!, "unshift", {
                     "@_name": "New property",
-                    typeRef: { __$$text: DmnBuiltInDataType.Undefined },
+                    typeRef: undefined,
                   })
                 }
               >
@@ -376,7 +377,7 @@ export function ItemComponentsTable({
                                 onClick={() => {
                                   addItemComponent(dt.itemDefinition["@_id"]!, "unshift", {
                                     "@_name": "New property",
-                                    typeRef: { __$$text: DmnBuiltInDataType.Undefined },
+                                    typeRef: undefined,
                                   });
                                   dmnEditorStoreApi.setState((state) => {
                                     state.dataTypesEditor.expandedItemComponentIds.push(dt.itemDefinition["@_id"]!);
@@ -434,11 +435,11 @@ export function ItemComponentsTable({
                             })}
                             onChange={(newDataType) => {
                               editItemDefinition(dt.itemDefinition["@_id"]!, (itemDefinition, items) => {
-                                itemDefinition.typeRef = { __$$text: newDataType };
                                 if (itemDefinition.typeRef?.__$$text !== newDataType) {
                                   itemDefinition.typeConstraint = undefined;
                                   itemDefinition.allowedValues = undefined;
                                 }
+                                itemDefinition.typeRef = newDataType ? { __$$text: newDataType } : undefined;
                               });
                             }}
                           />
@@ -640,7 +641,7 @@ export function ItemComponentsTable({
                     onClick={() =>
                       addItemComponent(parent.itemDefinition["@_id"]!, "push", {
                         "@_name": "New property",
-                        typeRef: { __$$text: DmnBuiltInDataType.Undefined },
+                        typeRef: undefined,
                       })
                     }
                     style={{ paddingLeft: 0 }}

--- a/packages/dmn-editor/src/dataTypes/TypeRefLabel.tsx
+++ b/packages/dmn-editor/src/dataTypes/TypeRefLabel.tsx
@@ -18,9 +18,9 @@
  */
 
 import * as React from "react";
+import { useMemo } from "react";
 import { DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
 import { buildFeelQNameFromXmlQName } from "../feel/buildFeelQName";
-import { useMemo } from "react";
 import { buildXmlQName, parseXmlQName } from "@kie-tools/xml-parser-ts/dist/qNames";
 import { useDmnEditorStore } from "../store/StoreContext";
 import { getXmlNamespaceDeclarationName } from "../xml/xmlNamespaceDeclarations";

--- a/packages/dmn-editor/src/dataTypes/TypeRefSelector.tsx
+++ b/packages/dmn-editor/src/dataTypes/TypeRefSelector.tsx
@@ -133,13 +133,13 @@ export function TypeRefSelector({
         className={!exists && typeRef ? "kie-dmn-editor--type-ref-selector-invalid-value" : undefined}
         isDisabled={isDisabled}
         variant={SelectVariant.typeahead}
-        typeAheadAriaLabel={"<Undefined>"}
+        typeAheadAriaLabel={DmnBuiltInDataType.Undefined}
         onToggle={_onToggle}
         onSelect={(e, v) => {
           _onToggle(false);
-          onChange(v === "<Undefined>" ? undefined : (v as string));
+          onChange(v === DmnBuiltInDataType.Undefined ? undefined : (v as string));
         }}
-        selections={typeRef ?? "<Undefined>"}
+        selections={typeRef ?? DmnBuiltInDataType.Undefined}
         isOpen={isOpen}
         aria-labelledby={"Data types selector"}
         placeholderText={"Select a data type..."}

--- a/packages/dmn-editor/src/dataTypes/TypeRefSelector.tsx
+++ b/packages/dmn-editor/src/dataTypes/TypeRefSelector.tsx
@@ -32,11 +32,9 @@ import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { useInViewSelect } from "../responsiveness/useInViewSelect";
 import { useExternalModels } from "../includedModels/DmnEditorDependenciesContext";
 
-export type OnTypeRefChange = (newDataType: DmnBuiltInDataType) => void;
+export type OnTypeRefChange = (newDataType: string | undefined) => void;
 export type OnCreateDataType = (newDataTypeName: string) => void;
 export type OnToggle = (isExpanded: boolean) => void;
-
-export const typeRefSelectorLimitedSpaceStyle = { maxHeight: "600px", boxShadow: "none", overflowY: "scroll" };
 
 export function TypeRefSelector({
   zoom,
@@ -132,16 +130,16 @@ export function TypeRefSelector({
       )}
       <Select
         toggleRef={toggleRef}
-        className={!exists ? "kie-dmn-editor--type-ref-selector-invalid-value" : undefined}
+        className={!exists && typeRef ? "kie-dmn-editor--type-ref-selector-invalid-value" : undefined}
         isDisabled={isDisabled}
         variant={SelectVariant.typeahead}
-        typeAheadAriaLabel={DmnBuiltInDataType.Undefined}
+        typeAheadAriaLabel={"<Undefined>"}
         onToggle={_onToggle}
         onSelect={(e, v) => {
           _onToggle(false);
-          onChange(v as DmnBuiltInDataType);
+          onChange(v === "<Undefined>" ? undefined : (v as string));
         }}
-        selections={typeRef}
+        selections={typeRef ?? "<Undefined>"}
         isOpen={isOpen}
         aria-labelledby={"Data types selector"}
         placeholderText={"Select a data type..."}

--- a/packages/dmn-editor/src/dataTypes/useResolvedTypeRef.ts
+++ b/packages/dmn-editor/src/dataTypes/useResolvedTypeRef.ts
@@ -28,7 +28,7 @@ export function useResolvedTypeRef(typeRef: string | undefined, relativeToNamesp
   return useDmnEditorStore((s) => {
     const thisDmnsNamespace = s.dmn.model.definitions["@_namespace"];
     return resolveTypeRef({
-      typeRef: typeRef || DmnBuiltInDataType.Undefined,
+      typeRef: typeRef,
       namespace: relativeToNamespace || thisDmnsNamespace,
       allTopLevelDataTypesByFeelName: s.computed(s).getDataTypes(externalModelsByNamespace)
         .allTopLevelDataTypesByFeelName,

--- a/packages/dmn-editor/src/diagram/Diagram.tsx
+++ b/packages/dmn-editor/src/diagram/Diagram.tsx
@@ -1251,7 +1251,7 @@ function DmnDiagramEmptyState({
                   const defaultExpression = getDefaultBoxedExpression({
                     logicType: "decisionTable",
                     allTopLevelDataTypesByFeelName: new Map(),
-                    typeRef: DmnBuiltInDataType.Undefined,
+                    typeRef: undefined,
                     getDefaultColumnWidth,
                     widthsById: defaultWidthsById,
                   });

--- a/packages/dmn-editor/src/diagram/nodes/DataTypeNodePanel.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/DataTypeNodePanel.tsx
@@ -45,10 +45,7 @@ export function DataTypeNodePanel(props: {
 
   const { dmnEditorRootElementRef } = useDmnEditor();
 
-  const resolvedTypeRef = useResolvedTypeRef(
-    props.variable?.["@_typeRef"] ?? DmnBuiltInDataType.Undefined,
-    props.dmnObjectNamespace
-  );
+  const resolvedTypeRef = useResolvedTypeRef(props.variable?.["@_typeRef"], props.dmnObjectNamespace);
 
   const isExternalNode = !!props.dmnObjectNamespace;
 

--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -1475,7 +1475,7 @@ export function useDataTypeCreationCallbackForNodes(index: number, drgElementNam
         drgElement.variable["@_typeRef"] = newDataTypeName;
         const newItemDefinition = addTopLevelItemDefinition({
           definitions: state.dmn.model.definitions,
-          partial: { "@_name": newDataTypeName, typeRef: { __$$text: DmnBuiltInDataType.Undefined } },
+          partial: { "@_name": newDataTypeName, typeRef: undefined },
         });
         state.dataTypesEditor.activeItemDefinitionId = newItemDefinition["@_id"];
         state.navigation.tab = DmnEditorTab.DATA_TYPES;

--- a/packages/dmn-editor/src/mutations/addConnectedNode.ts
+++ b/packages/dmn-editor/src/mutations/addConnectedNode.ts
@@ -62,7 +62,7 @@ export function addConnectedNode({
     definitions.drgElement ??= [];
     const variableBase = {
       "@_id": generateUuid(),
-      "@_typeRef": DmnBuiltInDataType.Undefined,
+      "@_typeRef": undefined,
     };
     definitions.drgElement?.push(
       switchExpression(newNode.type as Exclude<NodeType, "node_group" | "node_textAnnotation" | "node_unknown">, {

--- a/packages/dmn-editor/src/mutations/addStandaloneNode.ts
+++ b/packages/dmn-editor/src/mutations/addStandaloneNode.ts
@@ -44,7 +44,7 @@ export function addStandaloneNode({
     definitions.drgElement ??= [];
     const variableBase = {
       "@_id": generateUuid(),
-      "@_typeRef": DmnBuiltInDataType.Undefined,
+      "@_typeRef": undefined,
     };
     definitions.drgElement?.push(
       switchExpression(newNode.type as Exclude<NodeType, "node_group" | "node_textAnnotation" | "node_unknown">, {

--- a/packages/dmn-editor/src/mutations/updateExpression.ts
+++ b/packages/dmn-editor/src/mutations/updateExpression.ts
@@ -46,7 +46,7 @@ export function updateExpression({
 
   if (drgElement?.__$$element === "decision") {
     drgElement.expression = expression;
-    drgElement.variable!["@_typeRef"] = expression?.["@_typeRef"] ?? drgElement.variable!["@_typeRef"];
+    drgElement.variable!["@_typeRef"] = expression ? expression["@_typeRef"] : drgElement.variable!["@_typeRef"];
   } else if (drgElement?.__$$element === "businessKnowledgeModel") {
     if (expression.__$$element !== "functionDefinition") {
       throw new Error("DMN MUTATION: Can't have an expression on a BKM that is not a Function.");

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
@@ -110,7 +110,7 @@ export function DecisionTableInputHeaderCell(props: {
             <TypeRefField
               isReadonly={props.isReadonly}
               dmnEditorRootElementRef={dmnEditorRootElementRef}
-              typeRef={inputExpression?.["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
+              typeRef={inputExpression?.["@_typeRef"]}
               onChange={(newTypeRef) =>
                 updater((dmnObject) => {
                   dmnObject.inputExpression ??= {};

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
@@ -119,7 +119,7 @@ export function DecisionTableOutputHeaderCell(props: {
             alternativeFieldName={`${alternativeFieldName} Type`}
             isReadonly={true}
             dmnEditorRootElementRef={dmnEditorRootElementRef}
-            typeRef={root?.["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
+            typeRef={root?.["@_typeRef"]}
           />
         </>
       )}
@@ -139,7 +139,7 @@ export function DecisionTableOutputHeaderCell(props: {
         alternativeFieldName={root?.output.length === 1 ? "Column Type" : undefined}
         isReadonly={props.isReadonly}
         dmnEditorRootElementRef={dmnEditorRootElementRef}
-        typeRef={cell?.["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
+        typeRef={cell?.["@_typeRef"]}
         onChange={(newTypeRef) =>
           updater((dmnObject) => {
             dmnObject["@_typeRef"] = newTypeRef;

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/Fields.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/Fields.tsx
@@ -91,7 +91,7 @@ export function NameField(props: {
 
 export function TypeRefField(props: {
   alternativeFieldName?: string;
-  typeRef: string;
+  typeRef?: string;
   isReadonly: boolean;
   dmnEditorRootElementRef: React.RefObject<HTMLElement>;
   onChange?: (newTypeRef: string) => void;

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/FunctionDefinitionParametersCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/FunctionDefinitionParametersCell.tsx
@@ -156,7 +156,7 @@ function FunctionDefinitionParameterTypeRef(props: {
       <TypeRefField
         isReadonly={props.isReadonly}
         dmnEditorRootElementRef={dmnEditorRootElementRef}
-        typeRef={props.parameter["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
+        typeRef={props.parameter["@_typeRef"]}
         onChange={props.onTypeRefChange}
       />
       {itemDefinition && (

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/InformationItemCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/InformationItemCell.tsx
@@ -76,7 +76,7 @@ export function InformationItemCell(props: {
       />
       <TypeRefField
         isReadonly={props.isReadonly}
-        typeRef={cell["@_typeRef"] ?? DmnBuiltInDataType.Undefined}
+        typeRef={cell["@_typeRef"]}
         dmnEditorRootElementRef={dmnEditorRootElementRef}
         onChange={props.onTypeRefChange}
       />

--- a/packages/dmn-editor/tests/e2e/drgElements/addBkm.spec.ts
+++ b/packages/dmn-editor/tests/e2e/drgElements/addBkm.spec.ts
@@ -44,7 +44,6 @@ test.describe("Add node - BKM", () => {
           variable: {
             "@_id": bkm.variable?.["@_id"],
             "@_name": DefaultNodeName.BKM,
-            "@_typeRef": DataType.Undefined,
           },
         });
         expect(await jsonModel.drd.getDrgElementBoundsOnDrd({ drgElementIndex: 0, drdIndex: 0 })).toEqual({

--- a/packages/dmn-editor/tests/e2e/drgElements/addDecision.spec.ts
+++ b/packages/dmn-editor/tests/e2e/drgElements/addDecision.spec.ts
@@ -44,7 +44,6 @@ test.describe("Add node - Decision", () => {
           variable: {
             "@_id": decision.variable?.["@_id"],
             "@_name": DefaultNodeName.DECISION,
-            "@_typeRef": DataType.Undefined,
           },
         });
         expect(await jsonModel.drd.getDrgElementBoundsOnDrd({ drgElementIndex: 0, drdIndex: 0 })).toEqual({
@@ -89,7 +88,6 @@ test.describe("Add node - Decision", () => {
           variable: {
             "@_id": inputData.variable?.["@_id"],
             "@_name": DefaultNodeName.INPUT_DATA,
-            "@_typeRef": DataType.Undefined,
           },
         });
         const decision = await jsonModel.drgElements.getDecision({ drgElementIndex: 1, drdIndex: 0 });
@@ -108,7 +106,6 @@ test.describe("Add node - Decision", () => {
           variable: {
             "@_id": decision.variable?.["@_id"],
             "@_name": DefaultNodeName.DECISION,
-            "@_typeRef": DataType.Undefined,
           },
         });
       });

--- a/packages/dmn-editor/tests/e2e/drgElements/addDecisionService.spec.ts
+++ b/packages/dmn-editor/tests/e2e/drgElements/addDecisionService.spec.ts
@@ -46,7 +46,6 @@ test.describe("Add node - Decision Service", () => {
           variable: {
             "@_id": decisionService.variable?.["@_id"],
             "@_name": DefaultNodeName.DECISION_SERVICE,
-            "@_typeRef": DataType.Undefined,
           },
         });
         expect(await jsonModel.drd.getDrgElementBoundsOnDrd({ drgElementIndex: 0, drdIndex: 0 })).toEqual({

--- a/packages/dmn-editor/tests/e2e/drgElements/addInputData.spec.ts
+++ b/packages/dmn-editor/tests/e2e/drgElements/addInputData.spec.ts
@@ -43,7 +43,6 @@ test.describe("Add node - Input Data", () => {
           variable: {
             "@_id": inputData.variable?.["@_id"],
             "@_name": DefaultNodeName.INPUT_DATA,
-            "@_typeRef": DataType.Undefined,
           },
         });
         expect(await jsonModel.drd.getDrgElementBoundsOnDrd({ drgElementIndex: 0, drdIndex: 0 })).toEqual({

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -98,7 +98,7 @@ const BoxedExpressionEditorWrapper: React.FunctionComponent<BoxedExpressionEdito
   const beeGwtService: BeeGwtService = {
     getDefaultExpressionDefinition(logicType, dataType, isRoot) {
       const defaultExpression = gwtExpressionToDmnExpression(
-        window.beeApiWrapper?.getDefaultExpressionDefinition(gwtLogicType(logicType), dataType ?? "<Undefined>")
+        window.beeApiWrapper?.getDefaultExpressionDefinition(gwtLogicType(logicType), dataType)
       );
       if (isRoot === false) {
         defaultExpression.expression["@_label"] = undefined;

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -98,7 +98,7 @@ const BoxedExpressionEditorWrapper: React.FunctionComponent<BoxedExpressionEdito
   const beeGwtService: BeeGwtService = {
     getDefaultExpressionDefinition(logicType, dataType, isRoot) {
       const defaultExpression = gwtExpressionToDmnExpression(
-        window.beeApiWrapper?.getDefaultExpressionDefinition(gwtLogicType(logicType), dataType)
+        window.beeApiWrapper?.getDefaultExpressionDefinition(gwtLogicType(logicType), dataType ?? "<Undefined>")
       );
       if (isRoot === false) {
         defaultExpression.expression["@_label"] = undefined;

--- a/packages/stunner-editors-dmn-loader/src/types.ts
+++ b/packages/stunner-editors-dmn-loader/src/types.ts
@@ -25,7 +25,7 @@ declare global {
     // It requests to the GWT layer the default GwtExpressionDefinition given a selected logic type and a data type.
     getDefaultExpressionDefinition: (
       logicType: GwtExpressionDefinitionLogicType,
-      dataType: string
+      dataType: string | undefined
     ) => GwtExpressionDefinition;
 
     // It Navigates to "Data Type" tab page


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1149

Some places related to the user interface are using "<Undefined>".
The places where the data is marshaled are using `undefined`.

The "<Undefined>" value is still present in `DmnBuiltInDataType` because it is still a "valid value".