### PR TITLE
NO-ISSUE: Script for updating Kogito version

### DIFF
--- a/KOGITO_UPGRADE_PROCESS.md
+++ b/KOGITO_UPGRADE_PROCESS.md
@@ -73,7 +73,6 @@ You can find an example of the Java / Maven versions upgrade in [this PR](https:
 
 The Quarkus version is present in the following file categories:
 
-- `install.js` files
 - `root-env/env/index.js` file
 - go test files
 
@@ -87,16 +86,7 @@ You can find an example of the Quarkus upgrade in [this PR](https://github.com/a
 
 # Upgrading Kogito
 
-The Kogito version is present in the following file categories:
-
-- `install.js` files
-- `root-env/env/index.js` file
-- `package.json` files (eg. jit-executor reference in `extended-service`)
-
-The best (and fastest) way to catch all the Kogito versions is to perform a search a grep (or the IDE integrated search) and replace it with the new version. So, as a key, you can use:
-
-- The version number: `X.Y.Z` or `X.Y.Z-YYYYMMDD-SNAPSHOT` format (eg. `10.0.0` or `10.1.0-20240424-SNAPSHOT`);
-- Images references: `main-YYYY-MM-DD` (Daily builds) or `X.Y.Z-YYYYMMDD` (Weekly builds) format (eg. `main-2024-04-24` or `10.1.0-20240424` in case of snapshot version)
+In the root directory, run `pnpm update-kogito-version-to --maven [version] --images-tag [tag]`.
 
 Of course, a new Kogito version may lead to incompatibilities in the code and with other dependencies. In such a case, an investigation and evetually a fix is required to complete the process.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write . '**/*.xml'",
     "format:check": "prettier --check . '**/*.xml'",
     "prepare": "husky install",
+    "update-kogito-version-to": "kie-tools--update-kogito-version-to",
     "update-version-to": "kie-tools--update-version-to"
   },
   "devDependencies": {
@@ -18,6 +19,7 @@
     "@kie-tools-scripts/check-junit-report-results": "workspace:*",
     "@kie-tools-scripts/run-script-if": "workspace:*",
     "@kie-tools-scripts/sparse-checkout": "workspace:*",
+    "@kie-tools-scripts/update-kogito-version": "workspace:*",
     "@kie-tools-scripts/update-version": "workspace:*",
     "@nice-move/prettier-plugin-package-json": "^0.6.1",
     "@prettier/plugin-xml": "^2",

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -54,10 +54,12 @@ module.exports = composeEnv([], {
       default: "3.8.4",
       description: "Quarkus version to be used on dependency declaration.",
     },
+    /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
       default: "999-20240509-SNAPSHOT",
       description: "Kogito version to be used on dependency declaration.",
     },
+    /* (end) */
   }),
   get env() {
     return {

--- a/packages/serverless-logic-web-tools-base-builder-image/env/index.js
+++ b/packages/serverless-logic-web-tools-base-builder-image/env/index.js
@@ -31,10 +31,12 @@ module.exports = composeEnv(
         default: "v1.27.3",
         description: "",
       },
+      /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
       SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderKogitoImageTag: {
         default: "999-20240509",
         description: "",
       },
+      /* end */
     }),
     get env() {
       return {

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/env/index.js
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/env/index.js
@@ -27,10 +27,12 @@ module.exports = composeEnv(
         default: "latest",
         description: "",
       },
+      /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
       SERVERLESS_LOGIC_WEB_TOOLS_DEVMODE_IMAGE__kogitoBaseBuilderImageTag: {
         default: "999-20240509",
         description: "",
       },
+      /* end */
     }),
     get env() {
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       "@kie-tools-scripts/sparse-checkout":
         specifier: workspace:*
         version: link:scripts/sparse-checkout
+      "@kie-tools-scripts/update-kogito-version":
+        specifier: workspace:*
+        version: link:scripts/update-kogito-version
       "@kie-tools-scripts/update-version":
         specifier: workspace:*
         version: link:scripts/update-version
@@ -13460,6 +13463,8 @@ importers:
       graph-data-structure:
         specifier: ^2.0.0
         version: 2.0.0
+
+  scripts/update-kogito-version: {}
 
   scripts/update-version: {}
 

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -7,6 +7,7 @@ digraph G {
   "@kie-tools-scripts/check-junit-report-results" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools-scripts/run-script-if" [ color = "blue", fontcolor = "blue", style = "rounded" ];
   "@kie-tools-scripts/sparse-checkout" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
+  "@kie-tools-scripts/update-kogito-version" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools-scripts/update-version" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools-examples/base64png-editor" [ color = "orange", fontcolor = "orange", style = "dashed, rounded" ];
   "@kie-tools-core/editor" [ color = "purple", fontcolor = "purple", style = "rounded" ];
@@ -189,6 +190,7 @@ digraph G {
   "kie-tools-root" -> "@kie-tools-scripts/check-junit-report-results" [ style = "dashed", color = "black" ];
   "kie-tools-root" -> "@kie-tools-scripts/run-script-if" [ style = "dashed", color = "black" ];
   "kie-tools-root" -> "@kie-tools-scripts/sparse-checkout" [ style = "dashed", color = "black" ];
+  "kie-tools-root" -> "@kie-tools-scripts/update-kogito-version" [ style = "dashed", color = "black" ];
   "kie-tools-root" -> "@kie-tools-scripts/update-version" [ style = "dashed", color = "black" ];
   "@kie-tools-examples/base64png-editor" -> "@kie-tools-core/editor" [ style = "solid", color = "orange" ];
   "@kie-tools-examples/base64png-editor-chrome-extension" -> "@kie-tools-core/chrome-extension" [ style = "solid", color = "orange" ];

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -6,6 +6,7 @@
       { "id": "@kie-tools-scripts/check-junit-report-results" },
       { "id": "@kie-tools-scripts/run-script-if" },
       { "id": "@kie-tools-scripts/sparse-checkout" },
+      { "id": "@kie-tools-scripts/update-kogito-version" },
       { "id": "@kie-tools-scripts/update-version" },
       { "id": "@kie-tools-scripts/build-env" },
       { "id": "@kie-tools-examples/base64png-editor" },
@@ -190,6 +191,7 @@
       { "source": "kie-tools-root", "target": "@kie-tools-scripts/check-junit-report-results", "weight": 1 },
       { "source": "kie-tools-root", "target": "@kie-tools-scripts/run-script-if", "weight": 1 },
       { "source": "kie-tools-root", "target": "@kie-tools-scripts/sparse-checkout", "weight": 1 },
+      { "source": "kie-tools-root", "target": "@kie-tools-scripts/update-kogito-version", "weight": 1 },
       { "source": "kie-tools-root", "target": "@kie-tools-scripts/update-version", "weight": 1 },
       { "source": "@kie-tools-scripts/bootstrap", "target": "@kie-tools-scripts/build-env", "weight": 1 },
       { "source": "@kie-tools-examples/base64png-editor", "target": "@kie-tools-core/editor", "weight": 1 },
@@ -1383,6 +1385,7 @@
     ["@kie-tools-scripts/check-junit-report-results", "scripts/check-junit-report-results"],
     ["@kie-tools-scripts/run-script-if", "scripts/run-script-if"],
     ["@kie-tools-scripts/sparse-checkout", "scripts/sparse-checkout"],
+    ["@kie-tools-scripts/update-kogito-version", "scripts/update-kogito-version"],
     ["@kie-tools-scripts/update-version", "scripts/update-version"]
   ]
 }

--- a/scripts/update-kogito-version/package.json
+++ b/scripts/update-kogito-version/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@kie-tools-scripts/update-kogito-version",
+  "version": "0.0.0",
+  "keywords": [],
+  "bin": {
+    "kie-tools--update-kogito-version-to": "update_kogito_version.js"
+  }
+}

--- a/scripts/update-kogito-version/update_kogito_version.js
+++ b/scripts/update-kogito-version/update_kogito_version.js
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const execSync = require("child_process").execSync;
+
+const newMavenVersion = process.argv[3];
+const newImagesTag = process.argv[5];
+if (!newMavenVersion) {
+  console.error("Usage 'node update_kogito_version.js --maven [version] --images-tag [tag]'");
+  return 1;
+}
+
+if (process.argv[2] !== "--maven" || process.argv[4] !== "--images-tag") {
+  console.error("Arguments need to be passed in the correct order.");
+  console.error(`Argv: ${process.argv.join(", ")}`);
+  console.error("Usage 'node update_kogito_version.js --maven [version] --images-tag [tag]'");
+  process.exit(1);
+}
+
+const execOpts = { stdio: "inherit" };
+
+try {
+  console.info("[update-kogito-version] Updating 'packages/root-env/env/index.js'...");
+  const rootEnvPath = path.resolve(__dirname, "../../packages/root-env/env/index.js");
+  fs.writeFileSync(
+    rootEnvPath,
+    fs
+      .readFileSync(rootEnvPath, "utf-8")
+      .replace(
+        /KOGITO_RUNTIME_version:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
+        `KOGITO_RUNTIME_version: {\n      default: "${newMavenVersion}"`
+      )
+  );
+
+  console.info("[update-kogito-version] Updating 'serverless-logic-web-tools-base-builder-image/env/index.js'...");
+  const serverlessLogicWebToolsBaseBuilderImageEnvPath = path.resolve(
+    __dirname,
+    "../../packages/serverless-logic-web-tools-base-builder-image/env/index.js"
+  );
+  fs.writeFileSync(
+    serverlessLogicWebToolsBaseBuilderImageEnvPath,
+    fs
+      .readFileSync(serverlessLogicWebToolsBaseBuilderImageEnvPath, "utf-8")
+      .replace(
+        /SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderKogitoImageTag:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
+        `SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderKogitoImageTag: {\n      default: "${newImagesTag}"`
+      )
+  );
+
+  console.info(
+    "[update-kogito-version] Updating 'packages/serverless-logic-web-tools-swf-dev-mode-image/env/index.js'..."
+  );
+  const serverlessLogicWebToolsSwfDevModeImageEnvPath = path.resolve(
+    __dirname,
+    "../../packages/serverless-logic-web-tools-swf-dev-mode-image/env/index.js"
+  );
+  fs.writeFileSync(
+    serverlessLogicWebToolsSwfDevModeImageEnvPath,
+    fs
+      .readFileSync(serverlessLogicWebToolsSwfDevModeImageEnvPath, "utf-8")
+      .replace(
+        /SERVERLESS_LOGIC_WEB_TOOLS_DEVMODE_IMAGE__kogitoBaseBuilderImageTag:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
+        `SERVERLESS_LOGIC_WEB_TOOLS_DEVMODE_IMAGE__kogitoBaseBuilderImageTag: {\n      default: "${newImagesTag}"`
+      )
+  );
+
+  console.info(`[update-kogito-version] Bootstrapping with updated Kogito version...`);
+  execSync(`pnpm bootstrap`, execOpts);
+
+  console.info(`[update-kogito-version] Formatting files...`);
+  execSync(`pnpm pretty-quick`, execOpts);
+
+  console.info(
+    `[update-kogito-version] Updated Kogito to '${newMavenVersion}' (Maven) and '${newImagesTag}' (Images tag).`
+  );
+  console.info(`[update-kogito-version] Done.`);
+} catch (error) {
+  console.error(error);
+  console.error("");
+  console.error(`[update-kogito-version] Error updating Kogito version. There might be undesired unstaged changes.`);
+}


### PR DESCRIPTION
In the root directory, we can now run `pnpm update-kogito-version-to --maven [version] --images-tag [tag]` for example.

NOTE: I'm ignoring the @kie-tools/jitexecutor-native because our consumption strategy will change from NPM to Maven. We'll be able to use `KOGITO_RUNTIME_version` then.

Just waiting for 
- https://github.com/apache/incubator-kie-issues/issues/1191