### PR TITLE
NO-ISSUE: Skip `BpmnPrTest` and `DmnPrTest` on Chrome Extension E2E tests

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/BpmnPrTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/BpmnPrTest.ts
@@ -31,9 +31,9 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   // TODO create PR in Apache KIE
-  const PR_WEB_PAGE = "https://github.com/tomasdavidorg/chrome-extension-pr-test/pull/2/files";
+  const PR_WEB_PAGE = "";
 
   // open PR and check that source is opened
   const gitHubPrPage: GitHubPrPage = await tools.openPage(GitHubPrPage, PR_WEB_PAGE);

--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnPrTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnPrTest.ts
@@ -31,9 +31,9 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   // TODO create PR in Apache KIE
-  const PR_WEB_PAGE = "https://github.com/tomasdavidorg/chrome-extension-pr-test/pull/3/files";
+  const PR_WEB_PAGE = "";
 
   // open PR and check that source is opened
   const gitHubPrPage: GitHubPrPage = await tools.openPage(GitHubPrPage, PR_WEB_PAGE);


### PR DESCRIPTION
Fixes #2326.

@jomarko Could you please take a look? 
The tests contains links to the separated repository.
- https://github.com/apache/incubator-kie-tools/blob/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnPrTest.ts#L36
- https://github.com/apache/incubator-kie-tools/blob/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/BpmnPrTest.ts#L36

I will close the referenced PRs and delete the repository soon:
- https://github.com/tomasdavidorg/chrome-extension-pr-test/pull/2
- https://github.com/tomasdavidorg/chrome-extension-pr-test/pull/3
- https://github.com/tomasdavidorg/chrome-extension-pr-test

To avoid test failures the tests needs to be skipped/removed or the testing PRs needs to be recreated somewhere. 