### PR TITLE
NO-ISSUE: Bump `express` version to `4.19.2`

### DIFF
--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "node-fetch": "^3.3.1"
   },
   "devDependencies": {

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -81,7 +81,7 @@
     "css-minimizer-webpack-plugin": "^5.0.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
     "https-browserify": "^1.0.0",

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -95,7 +95,7 @@
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^5.0.1",
     "cypress": "^13.5.1",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "file-loader": "^6.2.0",
     "filemanager-webpack-plugin": "^7.0.0",
     "graphql": "14.3.1",

--- a/packages/runtime-tools-task-console-webapp/package.json
+++ b/packages/runtime-tools-task-console-webapp/package.json
@@ -82,7 +82,7 @@
     "css-minimizer-webpack-plugin": "^5.0.1",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
     "https-browserify": "^1.0.0",

--- a/packages/serverless-workflow-dev-ui-webapp/package.json
+++ b/packages/serverless-workflow-dev-ui-webapp/package.json
@@ -83,7 +83,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "cors": "^2.8.5",
     "css-loader": "^5.2.6",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "file-loader": "^6.2.0",
     "filemanager-webpack-plugin": "^7.0.0",
     "graphql": "14.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1456,8 +1456,8 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       express:
-        specifier: ^4.18.2
-        version: 4.18.2
+        specifier: ^4.19.2
+        version: 4.19.2
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.1
@@ -7433,7 +7433,7 @@ importers:
         version: 0.8.0(enzyme@3.11.0)(react-dom@17.0.2)(react@17.0.2)
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(express@4.18.2)(graphql@14.3.1)
+        version: 3.13.0(express@4.19.2)(graphql@14.3.1)
       babel-jest:
         specifier: ^25.5.1
         version: 25.5.1(@babel/core@7.23.9)
@@ -7465,8 +7465,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(enzyme@3.11.0)
       express:
-        specifier: ^4.18.2
-        version: 4.18.2
+        specifier: ^4.19.2
+        version: 4.19.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.88.2)
@@ -7734,7 +7734,7 @@ importers:
         version: 4.41.38
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(express@4.18.2)(graphql@14.3.1)
+        version: 3.13.0(express@4.19.2)(graphql@14.3.1)
       babel-jest:
         specifier: ^25.5.1
         version: 25.5.1(@babel/core@7.23.9)
@@ -7763,8 +7763,8 @@ importers:
         specifier: ^13.5.1
         version: 13.5.1
       express:
-        specifier: ^4.18.2
-        version: 4.18.2
+        specifier: ^4.19.2
+        version: 4.19.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.88.2)
@@ -7827,7 +7827,7 @@ importers:
         version: 8.0.0(webpack@5.88.2)
       swagger-ui-express:
         specifier: ^5.0.0
-        version: 5.0.0(express@4.18.2)
+        version: 5.0.0(express@4.19.2)
       ts-jest:
         specifier: ^26.5.6
         version: 26.5.6(jest@26.6.3)(typescript@4.8.4)
@@ -9033,7 +9033,7 @@ importers:
         version: 0.8.0(enzyme@3.11.0)(react-dom@17.0.2)(react@17.0.2)
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(express@4.18.2)(graphql@14.3.1)
+        version: 3.13.0(express@4.19.2)(graphql@14.3.1)
       babel-jest:
         specifier: ^25.5.1
         version: 25.5.1(@babel/core@7.23.9)
@@ -9056,8 +9056,8 @@ importers:
         specifier: ^3.6.2
         version: 3.6.2(enzyme@3.11.0)
       express:
-        specifier: ^4.18.2
-        version: 4.18.2
+        specifier: ^4.19.2
+        version: 4.19.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.88.2)
@@ -10108,7 +10108,7 @@ importers:
         version: 8.3.0
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(express@4.18.2)(graphql@14.3.1)
+        version: 3.13.0(express@4.19.2)(graphql@14.3.1)
       body-parser:
         specifier: ^1.20.2
         version: 1.20.2
@@ -10125,8 +10125,8 @@ importers:
         specifier: ^5.2.6
         version: 5.2.7(webpack@5.88.2)
       express:
-        specifier: ^4.18.2
-        version: 4.18.2
+        specifier: ^4.19.2
+        version: 4.19.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.88.2)
@@ -10180,7 +10180,7 @@ importers:
         version: 8.0.0(webpack@5.88.2)
       swagger-ui-express:
         specifier: ^5.0.0
-        version: 5.0.0(express@4.18.2)
+        version: 5.0.0(express@4.19.2)
       ts-jest:
         specifier: ^26.5.6
         version: 26.5.6(jest@26.6.3)(typescript@4.8.4)
@@ -27077,7 +27077,7 @@ packages:
       ejs: 3.1.9
       esbuild: 0.18.20
       esbuild-plugin-alias: 0.2.1
-      express: 4.18.2
+      express: 4.19.2
       find-cache-dir: 3.3.1
       fs-extra: 11.1.1
       process: 0.11.10
@@ -27102,7 +27102,7 @@ packages:
       ejs: 3.1.9
       esbuild: 0.18.20
       esbuild-plugin-alias: 0.2.1
-      express: 4.18.2
+      express: 4.19.2
       find-cache-dir: 3.3.1
       fs-extra: 11.1.1
       process: 0.11.10
@@ -27149,7 +27149,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.88.2)
-      express: 4.18.2
+      express: 4.19.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.8.4)(webpack@5.88.2)
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
@@ -27218,7 +27218,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.88.2)
-      express: 4.18.2
+      express: 4.19.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.8.4)(webpack@5.88.2)
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
@@ -27278,7 +27278,7 @@ packages:
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.88.2)
       es-module-lexer: 1.4.1
-      express: 4.18.2
+      express: 4.19.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.8.4)(webpack@5.88.2)
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.88.2)
@@ -27357,7 +27357,7 @@ packages:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.18.2
+      express: 4.19.2
       find-up: 5.0.0
       fs-extra: 11.1.1
       get-npm-tarball-url: 2.0.3
@@ -27410,7 +27410,7 @@ packages:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.18.2
+      express: 4.19.2
       find-up: 5.0.0
       fs-extra: 11.1.1
       get-npm-tarball-url: 2.0.3
@@ -27696,7 +27696,7 @@ packages:
       cli-table3: 0.6.1
       compression: 1.7.4
       detect-port: 1.5.1
-      express: 4.18.2
+      express: 4.19.2
       fs-extra: 11.1.1
       globby: 11.1.0
       ip: 2.0.0
@@ -27748,7 +27748,7 @@ packages:
       cli-table3: 0.6.1
       compression: 1.7.4
       detect-port: 1.5.1
-      express: 4.18.2
+      express: 4.19.2
       fs-extra: 11.1.1
       globby: 11.1.0
       ip: 2.0.0
@@ -31858,7 +31858,7 @@ packages:
       graphql: 14.3.1
     dev: true
 
-  /apollo-server-express@3.13.0(express@4.18.2)(graphql@14.3.1):
+  /apollo-server-express@3.13.0(express@4.19.2)(graphql@14.3.1):
     resolution:
       { integrity: sha512-iSxICNbDUyebOuM8EKb3xOrpIwOQgKxGbR2diSr4HP3IW8T3njKFOoMce50vr+moOCe1ev8BnLcw9SNbuUtf7g== }
     engines: { node: ">=12.0" }
@@ -31876,7 +31876,7 @@ packages:
       apollo-server-types: 3.8.0(graphql@14.3.1)
       body-parser: 1.20.2
       cors: 2.8.5
-      express: 4.18.2
+      express: 4.19.2
       graphql: 14.3.1
       parseurl: 1.3.3
     transitivePeerDependencies:
@@ -33130,6 +33130,7 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /body-parser@1.20.2:
     resolution:
@@ -33150,7 +33151,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /body-scroll-lock@4.0.0-beta.0:
     resolution:
@@ -34568,11 +34568,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
-  /content-type@1.0.4:
-    resolution:
-      { integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA== }
-    engines: { node: ">= 0.6" }
-
   /content-type@1.0.5:
     resolution:
       { integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA== }
@@ -34602,6 +34597,12 @@ packages:
   /cookie@0.5.0:
     resolution:
       { integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw== }
+    engines: { node: ">= 0.6" }
+    dev: true
+
+  /cookie@0.6.0:
+    resolution:
+      { integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw== }
     engines: { node: ">= 0.6" }
 
   /cookiejar@2.1.4:
@@ -38163,8 +38164,48 @@ packages:
       array-flatten: 1.1.1
       body-parser: 1.20.1
       content-disposition: 0.5.4
-      content-type: 1.0.4
+      content-type: 1.0.5
       cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /express@4.19.2:
+    resolution:
+      { integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q== }
+    engines: { node: ">= 0.10.0" }
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.2
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -47338,6 +47379,7 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+    dev: true
 
   /raw-body@2.5.2:
     resolution:
@@ -47348,7 +47390,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
   /raw-loader@4.0.2(webpack@5.88.2):
     resolution:
@@ -50889,14 +50930,14 @@ packages:
       { integrity: sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A== }
     dev: true
 
-  /swagger-ui-express@5.0.0(express@4.18.2):
+  /swagger-ui-express@5.0.0(express@4.19.2):
     resolution:
       { integrity: sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA== }
     engines: { node: ">= v0.10.32" }
     peerDependencies:
       express: ">=4.0.0 || >=5.0.0-beta"
     dependencies:
-      express: 4.18.2
+      express: 4.19.2
       swagger-ui-dist: 5.11.2
     dev: true
 
@@ -53241,7 +53282,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.18.2
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.17)
@@ -53345,7 +53386,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.18.2
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.17)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34594,12 +34594,6 @@ packages:
     engines: { node: ">= 0.6" }
     dev: true
 
-  /cookie@0.5.0:
-    resolution:
-      { integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw== }
-    engines: { node: ">= 0.6" }
-    dev: true
-
   /cookie@0.6.0:
     resolution:
       { integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw== }
@@ -38153,46 +38147,6 @@ packages:
       jest-matcher-utils: 26.6.2
       jest-message-util: 26.6.2
       jest-regex-util: 26.0.0
-    dev: true
-
-  /express@4.18.2:
-    resolution:
-      { integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ== }
-    engines: { node: ">= 0.10.0" }
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.1
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.5.0
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.2.0
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.1
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.7
-      proxy-addr: 2.0.7
-      qs: 6.11.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /express@4.19.2:
@@ -53333,7 +53287,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.18.2
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.17)


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-rv95-896h-c2vc 