### PR TITLE
NO-ISSUE: Add range and enum DMN Runner validation for the time, date, date-time and duration types of the new Type Constraint property

### DIFF
--- a/packages/dmn-runner/src/ajv.ts
+++ b/packages/dmn-runner/src/ajv.ts
@@ -26,20 +26,24 @@ import {
   DATE_AND_TIME_FEEL_REGEXP,
   DATE_ENUM_REGEXP,
   DATE_FEEL_REGEXP,
-  DAYS_AND_TIME_DURATION_FORMAT,
-  DAYS_AND_TIME_DURATION_REGEXP,
-  RECURSION_KEYWORD,
-  RECURSION_REF_KEYWORD,
-  X_DMN_ALLOWED_VALUES_KEYWORD,
-  X_DMN_DESCRIPTIONS_KEYWORD,
-  X_DMN_TYPE_KEYWORD,
   DURATION_ENUM_REGEXP,
   DURATION_FEEL_REGEXP,
   TIME_ENUM_REGEXP,
   TIME_FEEL_REGEXP,
+} from "./dmnRegExp";
+import {
+  X_DMN_ALLOWED_VALUES_KEYWORD,
+  X_DMN_DESCRIPTIONS_KEYWORD,
+  X_DMN_TYPE_CONSTRAINTS_KEYWORD,
+  X_DMN_TYPE_KEYWORD,
+} from "./jitExecutorKeywords";
+import { RECURSION_KEYWORD, RECURSION_REF_KEYWORD } from "./jsonSchemaConstants";
+import {
+  DAYS_AND_TIME_DURATION_FORMAT,
+  DAYS_AND_TIME_DURATION_REGEXP,
   YEARS_AND_MONTHS_DURATION_FORMAT,
   YEARS_AND_MONTHS_DURATION_REGEXP,
-} from "./constants";
+} from "./dmnFormats";
 
 /**
  * Please notice this is enum is slightly different from DMN built in types.
@@ -61,11 +65,11 @@ export enum DmnAjvSchemaFormat {
 export class DmnRunnerAjv {
   private ajv;
 
-  private parseRangeFromAllowedValues = (xDmnAllowedValues: string, type: DmnAjvSchemaFormat) => {
+  private parseRangeFromConstraints = (constraint: string, type: DmnAjvSchemaFormat) => {
     if (
-      (xDmnAllowedValues.startsWith("[") || xDmnAllowedValues.startsWith("(")) &&
-      (xDmnAllowedValues.endsWith("]") || xDmnAllowedValues.endsWith(")")) &&
-      xDmnAllowedValues.includes("..")
+      (constraint.startsWith("[") || constraint.startsWith("(")) &&
+      (constraint.endsWith("]") || constraint.endsWith(")")) &&
+      constraint.includes("..")
     ) {
       //It is a range
       let feelFunction: string;
@@ -89,19 +93,19 @@ export class DmnRunnerAjv {
           regExp = DURATION_FEEL_REGEXP;
           break;
       }
-      const matches = xDmnAllowedValues.match(regExp);
+      const matches = constraint.match(regExp);
       if (matches) {
         const minAllowed = matches[0].replace(`${feelFunction}("`, "").replace('")', "");
-        const minAllowedIncluded = xDmnAllowedValues.startsWith("[");
+        const minAllowedIncluded = constraint.startsWith("[");
         const maxAllowed = matches[1].replace(`${feelFunction}("`, "").replace('")', "");
-        const maxAllowedIncluded = xDmnAllowedValues.endsWith("]");
+        const maxAllowedIncluded = constraint.endsWith("]");
         return { minAllowed, minAllowedIncluded, maxAllowed, maxAllowedIncluded };
       }
     }
     return {};
   };
 
-  private parseEnumerationFromAllowedValues = (xDmnAllowedValues: string, type: DmnAjvSchemaFormat) => {
+  private parseEnumerationFromConstraints = (constraint: string, type: DmnAjvSchemaFormat) => {
     // try to check if it is enumeration
     let feelFunction: string;
     let regExp;
@@ -124,7 +128,7 @@ export class DmnRunnerAjv {
         regExp = DURATION_ENUM_REGEXP;
         break;
     }
-    const matches = xDmnAllowedValues.match(regExp);
+    const matches = constraint.match(regExp);
     if (matches) {
       return [
         ...matches.map((matchedString) =>
@@ -134,6 +138,82 @@ export class DmnRunnerAjv {
     }
     return [];
   };
+
+  private constraintCompiler() {
+    return (schema: any, parentSchema: { format?: DmnAjvSchemaFormat }, it: any) => {
+      if (!parentSchema.format) {
+        return (data: string) => true;
+      }
+      const { minAllowed, minAllowedIncluded, maxAllowed, maxAllowedIncluded } = this.parseRangeFromConstraints(
+        schema ?? "",
+        parentSchema.format
+      );
+      const enumeratedValues = this.parseEnumerationFromConstraints(schema ?? "", parentSchema.format);
+      const isUnderTheMinBoundary: (value: Date | String | number, minBoundary: Date | String | number) => boolean =
+        minAllowedIncluded ? (value, minBoundary) => value < minBoundary : (value, minBoundary) => value <= minBoundary;
+      const isOverTheMaxBoundary: (value: Date | String | number, maxBoundary: Date | String | number) => boolean =
+        maxAllowedIncluded ? (value, maxBoundary) => value > maxBoundary : (value, maxBoundary) => value >= maxBoundary;
+
+      return (data: string) => {
+        if (data.includes(".") && data.endsWith("Z")) {
+          // adjusting from "2023-06-01T10:42:00.000Z" to "2023-06-01T10:42:00"
+          data = data.substring(0, data.lastIndexOf("."));
+        }
+        if (minAllowed && maxAllowed) {
+          // It is a Range constraint
+          if (parentSchema.format === "time") {
+            if (isUnderTheMinBoundary(data, minAllowed) || isOverTheMaxBoundary(data, maxAllowed)) {
+              return false;
+            }
+          } else if (parentSchema.format?.includes("duration")) {
+            const actualDuration = duration(data).asMilliseconds();
+            const minDuration = duration(minAllowed).asMilliseconds();
+            const maxDuration = duration(maxAllowed).asMilliseconds();
+            if (
+              isUnderTheMinBoundary(actualDuration, minDuration) ||
+              isOverTheMaxBoundary(actualDuration, maxDuration)
+            ) {
+              return false;
+            }
+          } else if (parentSchema.format?.includes("date")) {
+            const actualDate = new Date(data);
+            if (actualDate.toString() === "Invalid Date") {
+              return false;
+            }
+            const minAllowedDate = new Date(minAllowed);
+            if (minAllowedDate && isUnderTheMinBoundary(actualDate, minAllowedDate)) {
+              return false;
+            }
+            const maxAllowedDate = new Date(maxAllowed);
+            if (maxAllowedDate && isOverTheMaxBoundary(actualDate, maxAllowedDate)) {
+              return false;
+            }
+          }
+        } else if (enumeratedValues) {
+          if (parentSchema.format === "time") {
+            return enumeratedValues.includes(data);
+          } else if (parentSchema.format?.includes("duration")) {
+            const actualDuration = duration(data).asMilliseconds();
+            return enumeratedValues.some((value) => {
+              const enumeratedDurationValue = duration(value).asMilliseconds();
+              return enumeratedDurationValue === actualDuration;
+            });
+          } else if (parentSchema.format?.includes("date")) {
+            const actualDate = new Date(data);
+            if (actualDate.toString() === "Invalid Date") {
+              return false;
+            }
+            return enumeratedValues.some((value) => {
+              const enumeratedDateValue = new Date(value);
+              return !(enumeratedDateValue < actualDate) && !(enumeratedDateValue > actualDate);
+            });
+          }
+        }
+
+        return true;
+      };
+    };
+  }
 
   constructor() {
     this.ajv = new Ajv({
@@ -146,83 +226,10 @@ export class DmnRunnerAjv {
     this.ajv.addMetaSchema(metaSchemaDraft04);
     this.ajv.addKeyword(X_DMN_TYPE_KEYWORD, {});
     this.ajv.addKeyword(X_DMN_ALLOWED_VALUES_KEYWORD, {
-      compile: (schema, parentSchema: { format?: DmnAjvSchemaFormat }, it) => {
-        if (!parentSchema.format) {
-          return (data: string) => true;
-        }
-        const { minAllowed, minAllowedIncluded, maxAllowed, maxAllowedIncluded } = this.parseRangeFromAllowedValues(
-          schema ?? "",
-          parentSchema.format
-        );
-        const enumeratedValues = this.parseEnumerationFromAllowedValues(schema ?? "", parentSchema.format);
-        const isUnderTheMinBoundary: (value: Date | String | number, minBoundary: Date | String | number) => boolean =
-          minAllowedIncluded
-            ? (value, minBoundary) => value < minBoundary
-            : (value, minBoundary) => value <= minBoundary;
-        const isOverTheMaxBoundary: (value: Date | String | number, maxBoundary: Date | String | number) => boolean =
-          maxAllowedIncluded
-            ? (value, maxBoundary) => value > maxBoundary
-            : (value, maxBoundary) => value >= maxBoundary;
-
-        return (data: string) => {
-          if (data.includes(".") && data.endsWith("Z")) {
-            // adjusting from "2023-06-01T10:42:00.000Z" to "2023-06-01T10:42:00"
-            data = data.substring(0, data.lastIndexOf("."));
-          }
-          if (minAllowed && maxAllowed) {
-            // It is a Range constraint
-            if (parentSchema.format === "time") {
-              if (isUnderTheMinBoundary(data, minAllowed) || isOverTheMaxBoundary(data, maxAllowed)) {
-                return false;
-              }
-            } else if (parentSchema.format?.includes("duration")) {
-              const actualDuration = duration(data).asMilliseconds();
-              const minDuration = duration(minAllowed).asMilliseconds();
-              const maxDuration = duration(maxAllowed).asMilliseconds();
-              if (
-                isUnderTheMinBoundary(actualDuration, minDuration) ||
-                isOverTheMaxBoundary(actualDuration, maxDuration)
-              ) {
-                return false;
-              }
-            } else if (parentSchema.format?.includes("date")) {
-              const actualDate = new Date(data);
-              if (actualDate.toString() === "Invalid Date") {
-                return false;
-              }
-              const minAllowedDate = new Date(minAllowed);
-              if (minAllowedDate && isUnderTheMinBoundary(actualDate, minAllowedDate)) {
-                return false;
-              }
-              const maxAllowedDate = new Date(maxAllowed);
-              if (maxAllowedDate && isOverTheMaxBoundary(actualDate, maxAllowedDate)) {
-                return false;
-              }
-            }
-          } else if (enumeratedValues) {
-            if (parentSchema.format === "time") {
-              return enumeratedValues.includes(data);
-            } else if (parentSchema.format?.includes("duration")) {
-              const actualDuration = duration(data).asMilliseconds();
-              return enumeratedValues.some((value) => {
-                const enumeratedDurationValue = duration(value).asMilliseconds();
-                return enumeratedDurationValue === actualDuration;
-              });
-            } else if (parentSchema.format?.includes("date")) {
-              const actualDate = new Date(data);
-              if (actualDate.toString() === "Invalid Date") {
-                return false;
-              }
-              return enumeratedValues.some((value) => {
-                const enumeratedDateValue = new Date(value);
-                return !(enumeratedDateValue < actualDate) && !(enumeratedDateValue > actualDate);
-              });
-            }
-          }
-
-          return true;
-        };
-      },
+      compile: this.constraintCompiler(),
+    });
+    this.ajv.addKeyword(X_DMN_TYPE_CONSTRAINTS_KEYWORD, {
+      compile: this.constraintCompiler(),
     });
     this.ajv.addKeyword(X_DMN_DESCRIPTIONS_KEYWORD, {});
     this.ajv.addKeyword(RECURSION_KEYWORD, {});

--- a/packages/dmn-runner/src/ajv.ts
+++ b/packages/dmn-runner/src/ajv.ts
@@ -154,7 +154,8 @@ export class DmnRunnerAjv {
       const isOverTheMaxBoundary: (value: Date | String | number, maxBoundary: Date | String | number) => boolean =
         maxAllowedIncluded ? (value, maxBoundary) => value > maxBoundary : (value, maxBoundary) => value >= maxBoundary;
 
-      return (data: string) => {
+      return (rawData: string | Date) => {
+        let data = rawData instanceof Date ? rawData.toISOString() : rawData;
         if (data.includes(".") && data.endsWith("Z")) {
           // adjusting from "2023-06-01T10:42:00.000Z" to "2023-06-01T10:42:00"
           data = data.substring(0, data.lastIndexOf("."));

--- a/packages/dmn-runner/src/dmnFormats.ts
+++ b/packages/dmn-runner/src/dmnFormats.ts
@@ -17,30 +17,9 @@
  * under the License.
  */
 
-export const TIME_FEEL_REGEXP = /time\("([^.,\s]*)"\)/g;
-export const TIME_ENUM_REGEXP = /time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
-
-export const DATE_FEEL_REGEXP = /date\("([^.,\s]*)"\)/g;
-export const DATE_ENUM_REGEXP = /date\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
-
-export const DATE_AND_TIME_FEEL_REGEXP = /date and time\("([^.,\s]*)"\)/g;
-export const DATE_AND_TIME_ENUM_REGEXP = /date and time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
-
-export const DURATION_FEEL_REGEXP = /duration\("([^.,\s]*)"\)/g;
-export const DURATION_ENUM_REGEXP = /duration\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
-
 export const DAYS_AND_TIME_DURATION_FORMAT = "days and time duration";
 export const DAYS_AND_TIME_DURATION_REGEXP =
   /^(-|\+)?P(?:([-+]?[0-9]*)D)?(?:T(?:([-+]?[0-9]*)H)?(?:([-+]?[0-9]*)M)?(?:([-+]?[0-9]*)S)?)?$/;
 
 export const YEARS_AND_MONTHS_DURATION_FORMAT = "years and months duration";
 export const YEARS_AND_MONTHS_DURATION_REGEXP = /^(-|\+)?P(?:([-+]?[0-9]*)Y)?(?:([-+]?[0-9]*)M)?$/;
-
-export const X_DMN_DESCRIPTIONS_KEYWORD = "x-dmn-descriptions";
-export const X_DMN_ALLOWED_VALUES_KEYWORD = "x-dmn-allowed-values";
-export const X_DMN_TYPE_KEYWORD = "x-dmn-type";
-export const RECURSION_KEYWORD = "recursion";
-export const RECURSION_REF_KEYWORD = "recursionRef";
-
-export const SCHEMA_DRAFT4 = "http://json-schema.org/draft-04/schema#";
-export const JSON_SCHEMA_INPUT_SET_PATH = "definitions.InputSet.properties";

--- a/packages/dmn-runner/src/dmnRegExp.ts
+++ b/packages/dmn-runner/src/dmnRegExp.ts
@@ -17,17 +17,14 @@
  * under the License.
  */
 
-import { defaultDmnRunnerAutoFieldValue } from "@kie-tools/dmn-runner/dist/uniforms";
-import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
-import { Context, GuaranteedProps } from "uniforms/esm";
-import FormDmnNotSupportedField from "./FormDmnNotSupportedField";
+export const TIME_FEEL_REGEXP = /time\("([^.,\s]*)"\)/g;
+export const TIME_ENUM_REGEXP = /time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
 
-export function formDmnRunnerAutoFieldValue(
-  props: GuaranteedProps<unknown>,
-  uniforms: Context<Record<string, unknown>>
-) {
-  if (props.field?.[`${RECURSION_KEYWORD}`]) {
-    return FormDmnNotSupportedField;
-  }
-  return defaultDmnRunnerAutoFieldValue(props, uniforms);
-}
+export const DATE_FEEL_REGEXP = /date\("([^.,\s]*)"\)/g;
+export const DATE_ENUM_REGEXP = /date\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
+export const DATE_AND_TIME_FEEL_REGEXP = /date and time\("([^.,\s]*)"\)/g;
+export const DATE_AND_TIME_ENUM_REGEXP = /date and time\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;
+
+export const DURATION_FEEL_REGEXP = /duration\("([^.,\s]*)"\)/g;
+export const DURATION_ENUM_REGEXP = /duration\("([^.,\s]*)"\)[,]{0,1}[\s]*/g;

--- a/packages/dmn-runner/src/jitExecutorKeywords.ts
+++ b/packages/dmn-runner/src/jitExecutorKeywords.ts
@@ -17,17 +17,7 @@
  * under the License.
  */
 
-import { defaultDmnRunnerAutoFieldValue } from "@kie-tools/dmn-runner/dist/uniforms";
-import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
-import { Context, GuaranteedProps } from "uniforms/esm";
-import FormDmnNotSupportedField from "./FormDmnNotSupportedField";
-
-export function formDmnRunnerAutoFieldValue(
-  props: GuaranteedProps<unknown>,
-  uniforms: Context<Record<string, unknown>>
-) {
-  if (props.field?.[`${RECURSION_KEYWORD}`]) {
-    return FormDmnNotSupportedField;
-  }
-  return defaultDmnRunnerAutoFieldValue(props, uniforms);
-}
+export const X_DMN_DESCRIPTIONS_KEYWORD = "x-dmn-descriptions";
+export const X_DMN_ALLOWED_VALUES_KEYWORD = "x-dmn-allowed-values";
+export const X_DMN_TYPE_CONSTRAINTS_KEYWORD = "x-dmn-type-constraints";
+export const X_DMN_TYPE_KEYWORD = "x-dmn-type";

--- a/packages/dmn-runner/src/jsonSchema.ts
+++ b/packages/dmn-runner/src/jsonSchema.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { JSON_SCHEMA_INPUT_SET_PATH, RECURSION_KEYWORD, RECURSION_REF_KEYWORD, X_DMN_TYPE_KEYWORD } from "./constants";
+import { JSON_SCHEMA_INPUT_SET_PATH, RECURSION_KEYWORD, RECURSION_REF_KEYWORD } from "./jsonSchemaConstants";
 import { DmnAjvSchemaFormat, ValidateFunction } from "./ajv";
 import {
   ExtendedServicesDmnJsonSchema,
@@ -29,6 +29,7 @@ import cloneDeep from "lodash/cloneDeep";
 import getObjectValueByPath from "lodash/get";
 import setObjectValueByPath from "lodash/set";
 import unsetObjectValueByPath from "lodash/unset";
+import { X_DMN_TYPE_KEYWORD } from "./jitExecutorKeywords";
 
 function getFieldDefaultValue(dmnField: DmnInputFieldProperties): string | boolean | [] | object | undefined {
   if (dmnField?.type === "string" && dmnField?.format === undefined) {

--- a/packages/dmn-runner/src/jsonSchemaConstants.ts
+++ b/packages/dmn-runner/src/jsonSchemaConstants.ts
@@ -17,17 +17,7 @@
  * under the License.
  */
 
-import { defaultDmnRunnerAutoFieldValue } from "@kie-tools/dmn-runner/dist/uniforms";
-import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
-import { Context, GuaranteedProps } from "uniforms/esm";
-import FormDmnNotSupportedField from "./FormDmnNotSupportedField";
-
-export function formDmnRunnerAutoFieldValue(
-  props: GuaranteedProps<unknown>,
-  uniforms: Context<Record<string, unknown>>
-) {
-  if (props.field?.[`${RECURSION_KEYWORD}`]) {
-    return FormDmnNotSupportedField;
-  }
-  return defaultDmnRunnerAutoFieldValue(props, uniforms);
-}
+export const RECURSION_KEYWORD = "recursion";
+export const RECURSION_REF_KEYWORD = "recursionRef";
+export const SCHEMA_DRAFT4 = "http://json-schema.org/draft-04/schema#";
+export const JSON_SCHEMA_INPUT_SET_PATH = "definitions.InputSet.properties";

--- a/packages/form-dmn/src/FormDmnValidator.ts
+++ b/packages/form-dmn/src/FormDmnValidator.ts
@@ -62,7 +62,7 @@ export class FormDmnValidator extends Validator {
             return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnAllowedValues };
           }
           if (error.keyword === X_DMN_TYPE_CONSTRAINTS_KEYWORD) {
-            return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnAllowedValues };
+            return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnTypeConstraint };
           }
           return error;
         }),

--- a/packages/form-dmn/src/FormDmnValidator.ts
+++ b/packages/form-dmn/src/FormDmnValidator.ts
@@ -20,14 +20,14 @@
 import { Validator } from "@kie-tools/form/dist/Validator";
 import { FormDmnI18n } from "./i18n";
 import { FormDmnJsonSchemaBridge } from "./uniforms";
+import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/dmnFormats";
 import {
-  DAYS_AND_TIME_DURATION_FORMAT,
   X_DMN_ALLOWED_VALUES_KEYWORD,
-  YEARS_AND_MONTHS_DURATION_FORMAT,
-} from "@kie-tools/dmn-runner/dist/constants";
+  X_DMN_TYPE_CONSTRAINTS_KEYWORD,
+} from "@kie-tools/dmn-runner/dist/jitExecutorKeywords";
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
-import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
+import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
 
 export class FormDmnValidator extends Validator {
   private dmnRunnerAjv = new DmnRunnerAjv();
@@ -59,6 +59,9 @@ export class FormDmnValidator extends Validator {
             }
           }
           if (error.keyword === X_DMN_ALLOWED_VALUES_KEYWORD) {
+            return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnAllowedValues };
+          }
+          if (error.keyword === X_DMN_TYPE_CONSTRAINTS_KEYWORD) {
             return { ...error, message: (this.i18n as FormDmnI18n).validation.xDmnAllowedValues };
           }
           return error;

--- a/packages/form-dmn/src/i18n/FormDmnI18n.ts
+++ b/packages/form-dmn/src/i18n/FormDmnI18n.ts
@@ -23,6 +23,7 @@ import { FormI18n } from "@kie-tools/form/dist/i18n/FormI18n";
 export interface FormDmnI18n extends FormI18n {
   validation: {
     xDmnAllowedValues: string;
+    xDmnTypeConstraint: string;
     daysAndTimeError: string;
     yearsAndMonthsError: string;
   };

--- a/packages/form-dmn/src/i18n/locales/de.ts
+++ b/packages/form-dmn/src/i18n/locales/de.ts
@@ -19,9 +19,9 @@
 
 import { de as de_common } from "@kie-tools/i18n-common-dictionary";
 import { FormDmnI18n } from "../FormDmnI18n";
-import { wrapped } from "@kie-tools-core/i18n/dist/core";
+import { TranslatedDictionary, wrapped } from "@kie-tools-core/i18n/dist/core";
 
-export const de: FormDmnI18n = {
+export const de: TranslatedDictionary<FormDmnI18n> = {
   ...de_common,
   form: {
     status: {

--- a/packages/form-dmn/src/i18n/locales/en.ts
+++ b/packages/form-dmn/src/i18n/locales/en.ts
@@ -46,6 +46,7 @@ export const en: FormDmnI18n = {
   },
   validation: {
     xDmnAllowedValues: "does not belong to set of allowed values",
+    xDmnTypeConstraint: "does not belong to set of type constraint",
     daysAndTimeError: "should match format P1D(ays)T2H(ours)3M(inutes)1S(econds)",
     yearsAndMonthsError: "should match format P1Y(ears)2M(onths)",
   },

--- a/packages/form-dmn/src/uniforms/FormDmnJsonSchemaBridge.ts
+++ b/packages/form-dmn/src/uniforms/FormDmnJsonSchemaBridge.ts
@@ -20,7 +20,7 @@
 import { FormJsonSchemaBridge } from "@kie-tools/form/dist/uniforms/FormJsonSchemaBridge";
 import { FormDmnI18n } from "../i18n";
 import { DmnInputFieldProperties, ExtendedServicesDmnJsonSchema, X_DMN_TYPE } from "@kie-tools/extended-services-api";
-import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/constants";
+import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/dmnFormats";
 
 export enum Duration {
   DaysAndTimeDuration,

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -42,7 +42,7 @@ import {
   ExtendedServicesModelPayload,
 } from "@kie-tools/extended-services-api";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
-import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
+import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
 import { useDmnRunnerPersistence } from "../dmnRunnerPersistence/DmnRunnerPersistenceHook";
 import { DmnLanguageService } from "@kie-tools/dmn-language-service";
 import { decoder } from "@kie-tools-core/workspaces-git-fs/dist/encoderdecoder/EncoderDecoder";

--- a/packages/unitables-dmn/src/DmnUnitablesValidator.ts
+++ b/packages/unitables-dmn/src/DmnUnitablesValidator.ts
@@ -19,11 +19,11 @@
 
 import { DmnUnitablesJsonSchemaBridge } from "./uniforms/DmnUnitablesJsonSchemaBridge";
 import { DmnUnitablesI18n } from "./i18n";
-import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/constants";
+import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/dmnFormats";
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 import { UnitablesValidator } from "@kie-tools/unitables/dist/UnitablesValidator";
 import { DmnRunnerAjv } from "@kie-tools/dmn-runner/dist/ajv";
-import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/constants";
+import { SCHEMA_DRAFT4 } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
 
 export class DmnUnitablesValidator extends UnitablesValidator {
   protected readonly dmnRunnerAjv = new DmnRunnerAjv();

--- a/packages/unitables-dmn/src/uniforms/DmnUnitablesJsonSchemaBridge.ts
+++ b/packages/unitables-dmn/src/uniforms/DmnUnitablesJsonSchemaBridge.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/constants";
+import { DAYS_AND_TIME_DURATION_FORMAT, YEARS_AND_MONTHS_DURATION_FORMAT } from "@kie-tools/dmn-runner/dist/dmnFormats";
 import { UnitablesJsonSchemaBridge } from "@kie-tools/unitables/dist/uniforms";
 import { DmnInputFieldProperties, ExtendedServicesDmnJsonSchema, X_DMN_TYPE } from "@kie-tools/extended-services-api";
 

--- a/packages/unitables/src/Unitables.tsx
+++ b/packages/unitables/src/Unitables.tsx
@@ -222,7 +222,7 @@ export const Unitables = ({
             style={{ display: "flex", flexDirection: "column" }}
           >
             <OutsideRowMenu height={63} isFirstChild={true}>{`#`}</OutsideRowMenu>
-            <OutsideRowMenu height={65} borderBottomSizeBasis={1}>{`#`}</OutsideRowMenu>
+            <OutsideRowMenu height={64} borderBottomSizeBasis={1}>{`#`}</OutsideRowMenu>
             {rows.map((_, rowIndex) => (
               <Tooltip key={rowIndex} content={`Open row ${rowIndex + 1} in the form view`}>
                 <OutsideRowMenu height={61} isLastChild={rowIndex === rows.length - 1}>

--- a/packages/unitables/src/uniforms/UnitablesDmnRunnerAutoFieldValue.ts
+++ b/packages/unitables/src/uniforms/UnitablesDmnRunnerAutoFieldValue.ts
@@ -22,7 +22,7 @@ import { Context, GuaranteedProps } from "uniforms/esm";
 import UnitablesListField from "./UnitablesListField";
 import UnitablesNestField from "./UnitablesNestField";
 import UnitablesNotSupportedField from "./UnitablesNotSupportedField";
-import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/constants";
+import { RECURSION_KEYWORD } from "@kie-tools/dmn-runner/dist/jsonSchemaConstants";
 
 export function unitablesDmnRunnerAutoFieldValue(
   props: GuaranteedProps<unknown>,


### PR DESCRIPTION
The new DMN editor uses the new `type constraints` property to set the Item Definition/Item Components constraint. This new property is mapped to the  JSON Schema `x-dmn-type-constraints` keyword. This PR adds the property to the AJV validator. This PR also break the file `constants` into multiple specific ones.

Before:
![image](https://github.com/apache/incubator-kie-tools/assets/24302289/fc0c7ce3-1259-439c-9e48-e57e2714a2d2)


After:
![image](https://github.com/apache/incubator-kie-tools/assets/24302289/45857b75-8c17-4ce2-94de-bbf0431f736a)