### PR TITLE
NO-ISSUE: Apache KIE™ names for VS Code and Chrome extensions

### DIFF
--- a/packages/bpmn-vscode-extension/README.md
+++ b/packages/bpmn-vscode-extension/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## BPMN Editor
+## Apache KIE™ (incubating) BPMN Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -53,7 +53,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE BPMN Editor",
+  "displayName": "Apache KIE™ BPMN Editor",
   "categories": [
     "Other"
   ],

--- a/packages/chrome-extension-pack-kogito-kie-editors/manifest.dev.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/manifest.dev.json
@@ -1,5 +1,5 @@
 {
-  "name": "BPMN, DMN & Test Scenario Editors for GitHub",
+  "name": "Apache KIE™ BPMN, DMN & Test Scenario Editors for GitHub",
   "version": "0.0.0",
   "manifest_version": 3,
   "description": "Visualize and edit BPMN, DMN and Test Scenario files using a graphical editor on GitHub",

--- a/packages/chrome-extension-pack-kogito-kie-editors/manifest.prod.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/manifest.prod.json
@@ -1,5 +1,5 @@
 {
-  "name": "BPMN, DMN & Test Scenario Editors for GitHub",
+  "name": "Apache KIE™ BPMN, DMN & Test Scenario Editors for GitHub",
   "version": "0.0.0",
   "manifest_version": 3,
   "description": "Visualize and edit BPMN, DMN and Test Scenario files using a graphical editor on GitHub",

--- a/packages/chrome-extension-serverless-workflow-editor/manifest.dev.json
+++ b/packages/chrome-extension-serverless-workflow-editor/manifest.dev.json
@@ -1,5 +1,5 @@
 {
-  "name": "Serverless Workflow Editor for GitHub",
+  "name": "Apache KIE™ Serverless Workflow Editor for GitHub",
   "version": "0.0.0",
   "manifest_version": 3,
   "description": "Visualize and edit Serverless Workflow files using a graphical editor on GitHub",

--- a/packages/chrome-extension-serverless-workflow-editor/manifest.prod.json
+++ b/packages/chrome-extension-serverless-workflow-editor/manifest.prod.json
@@ -1,5 +1,5 @@
 {
-  "name": "Serverless Workflow Editor for GitHub",
+  "name": "Apache KIE™ Serverless Workflow Editor for GitHub",
   "version": "0.0.0",
   "manifest_version": 3,
   "description": "Visualize and edit Serverless Workflow files using a graphical editor on GitHub",

--- a/packages/dmn-vscode-extension/README.md
+++ b/packages/dmn-vscode-extension/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## DMN Editor
+## Apache KIE™ DMN Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -56,7 +56,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE DMN Editor",
+  "displayName": "Apache KIE™ DMN Editor",
   "categories": [
     "Other"
   ],

--- a/packages/pmml-vscode-extension/README.md
+++ b/packages/pmml-vscode-extension/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## PMML Scorecard Editor
+## Apache KIE™ PMML Scorecard Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/pmml-vscode-extension/package.json
+++ b/packages/pmml-vscode-extension/package.json
@@ -53,7 +53,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE PMML Editor",
+  "displayName": "Apache KIE™ PMML Editor",
   "categories": [
     "Other"
   ],

--- a/packages/serverless-workflow-vscode-extension/README.md
+++ b/packages/serverless-workflow-vscode-extension/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## Kogito Serverless Workflow Editor
+## Apache KIE™ Serverless Workflow Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -219,7 +219,7 @@
           "type": "string"
         }
       },
-      "title": "Serverless Workflow Editor"
+      "title": "Apache KIE™ Serverless Workflow Editor"
     },
     "configurationDefaults": {
       "[json]": {

--- a/packages/vscode-extension-dashbuilder-editor/README.md
+++ b/packages/vscode-extension-dashbuilder-editor/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## Kogito Dashbuilder Editor
+## Apache KIE™ Dashbuilder Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/vscode-extension-dashbuilder-editor/package.json
+++ b/packages/vscode-extension-dashbuilder-editor/package.json
@@ -78,7 +78,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "Dashbuilder Editor",
+  "displayName": "Apache KIE™ Dashbuilder Editor",
   "contributes": {
     "capabilities": {
       "untrustedWorkspaces": {

--- a/packages/vscode-extension-kie-ba-bundle/README.md
+++ b/packages/vscode-extension-kie-ba-bundle/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## KIE Business Automation Bundle
+## Apache KIE™ Business Automation Bundle
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/vscode-extension-kie-ba-bundle/package.json
+++ b/packages/vscode-extension-kie-ba-bundle/package.json
@@ -38,7 +38,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE Business Automation Bundle",
+  "displayName": "Apache KIE™ Business Automation Bundle",
   "categories": [
     "Other"
   ],

--- a/packages/vscode-extension-kogito-bundle/README.md
+++ b/packages/vscode-extension-kogito-bundle/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## Kogito Bundle
+## Apache KIE™ Kogito Bundle
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/vscode-extension-kogito-bundle/package.json
+++ b/packages/vscode-extension-kogito-bundle/package.json
@@ -38,7 +38,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "Kogito Bundle",
+  "displayName": "Apache KIE™ Kogito Bundle",
   "categories": [
     "Other"
   ],

--- a/packages/yard-vscode-extension/README.md
+++ b/packages/yard-vscode-extension/README.md
@@ -15,7 +15,7 @@
    under the License.
 -->
 
-## Kogito yard Editor
+## Apache KIE™ YARD Editor
 
 ![vs-code-support](https://img.shields.io/badge/Visual%20Studio%20Code-1.67.0+-blue.svg)
 ![github-ci](https://github.com/apache/incubator-kie-tools/actions/workflows/ci_build.yml/badge.svg)

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -81,7 +81,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "Kogito yard Editor",
+  "displayName": "Apache KIE™ YARD Editor",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
The Chrome Extensions' descriptions need to be edited directly on the Chrome Web Store. 