### PR TITLE
NO-ISSUE: Update kie-sandbox-quarkus-accelerator setup-branch Jenkins job to use new credentials

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch.quarkus-accelerator
+++ b/.ci/jenkins/Jenkinsfile.setup-branch.quarkus-accelerator
@@ -100,7 +100,7 @@ pipeline {
                         git add .
                         git commit --allow-empty -am "Update kogito version to ${params.KOGITO_VERSION}"
                         """.trim()
-                        githubUtils.pushObject('origin', "${params.NEW_BRANCH_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                        githubUtils.pushObject('origin', "${params.NEW_BRANCH_NAME}", "${pipelineVars.asfCIGithubCredentialsId}")
                     }
                 }
             }

--- a/.ci/jenkins/shared-scripts/pipelineVars.groovy
+++ b/.ci/jenkins/shared-scripts/pipelineVars.groovy
@@ -31,7 +31,7 @@ class PipelineVars implements Serializable {
     String swfChromeExtensionIdCredentialsId = 'kie-tools-swf-chrome-extension-id'
     String npmTokenCredentialsId = 'kie-tools-npm-token'
     String buildKiteTokenCredentialsId = 'kie-tools-build-kite-token'
-    String asfCIGithubCredentialsId = 'asf-ci'
+    String asfCIGithubCredentialsId = '399061d0-5ab5-4142-a186-a52081fef742'
     String asfGithubPushCredentialsId = '84811880-2025-45b6-a44c-2f33bef30ad2'
     String asfGithubTokenPushCredentialsId = '41128c14-bb63-4708-9074-d20a318ee630'
     String mavenSettingsConfigFileId = 'kie-release-settings'

--- a/.ci/jenkins/shared-scripts/pipelineVars.groovy
+++ b/.ci/jenkins/shared-scripts/pipelineVars.groovy
@@ -31,6 +31,7 @@ class PipelineVars implements Serializable {
     String swfChromeExtensionIdCredentialsId = 'kie-tools-swf-chrome-extension-id'
     String npmTokenCredentialsId = 'kie-tools-npm-token'
     String buildKiteTokenCredentialsId = 'kie-tools-build-kite-token'
+    String asfCIGithubCredentialsId = 'asf-ci'
     String asfGithubPushCredentialsId = '84811880-2025-45b6-a44c-2f33bef30ad2'
     String asfGithubTokenPushCredentialsId = '41128c14-bb63-4708-9074-d20a318ee630'
     String mavenSettingsConfigFileId = 'kie-release-settings'


### PR DESCRIPTION
In order to be able to push new branches to the http://github.com/apache/incubator-kie-sandbox-quarkus-accelerator repository from a Jenkins job we need to use a new Jenkins credential that was created by the ASF Infra team.

This PR updates the setup-branch Jenkins job to use the new credential.