### PR TITLE
NO-ISSUE: Unable to copy and paste nodes in the new DMN Editor

### DIFF
--- a/packages/dmn-editor/src/diagram/DiagramCommands.tsx
+++ b/packages/dmn-editor/src/diagram/DiagramCommands.tsx
@@ -225,7 +225,7 @@ export function DiagramCommands(props: {}) {
             type: "KIE__tComponentsWidthsExtension",
             attr: "kie:ComponentWidths",
           })
-          .randomize();
+          .randomize({ skipAlreadyAttributedIds: false });
 
         dmnEditorStoreApi.setState((state) => {
           state.dmn.model.definitions.drgElement ??= [];


### PR DESCRIPTION
Attempting to copy and paste a node in the editor resulted in a node being added to the DRG nodes menu, but not to the editor. The problem was that a new ID was never being generated. 
This fix resolves that by using the randomize function similarly to how we use it in the BEE.
And ensures that the pasted nodes have a new ID and that the copied nodes retain their original IDs.

https://github.com/apache/incubator-kie-tools/assets/92726146/6893eae9-3cdc-42a5-a581-cae0ff884fe4

