### PR TITLE
NO-ISSUE: Boxed Expression Editor in DMN Editor produces non unique IDs for BKM node

### DIFF
--- a/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
@@ -413,7 +413,7 @@ export function drgElementToBoxedExpression(
         }
       : {
           __$$element: "functionDefinition",
-          "@_id": expressionHolder.variable?.["@_id"] ?? generateUuid(),
+          "@_id": generateUuid(),
           "@_kind": "FEEL",
           expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
           formalParameter: [],


### PR DESCRIPTION
1. Add a Business Knowledge Model (BKM) in the DMN Editor
2.  Click on "Edit" to open the Boxed Expression Editor
3. Add an expression
4. Download the XML
![image](https://github.com/apache/incubator-kie-tools/assets/7305741/0facf00d-ba80-42e3-bdcd-8c9f32ffa4d9)

You'll notice that the  ID of the `encaspulatedLogic` is the same as the `variable` node.

This PR fixes this behavior, generating a new ID for `encapsulatedLogic` when `encapsulatedLogic` is not present.