### PR TITLE
NO-ISSUE: DMN Editor: Validate knowledge source node name to be unique

### DIFF
--- a/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
+++ b/packages/dmn-editor/src/diagram/nodes/Nodes.tsx
@@ -728,7 +728,6 @@ export const KnowledgeSourceNode = React.memo(
             setEditing={setEditingLabel}
             value={knowledgeSource["@_label"] ?? knowledgeSource["@_name"]}
             onChange={setName}
-            skipValidation={true}
             onGetAllUniqueNames={getAllFeelVariableUniqueNames}
             shouldCommitOnBlur={true}
             fontCssProperties={fontCssProperties}


### PR DESCRIPTION
The knowledge source node name validation is needed due to DMN Runner because it produces similar messages:
```
Message [id=0, level=ERROR, path=KnowledgeSource.dmn, line=1657, column=-1
   text=DMN: Duplicate node name 'Credit officer' in the model (DMN id: _a3e9ef24-5b34-4e56-8a24-e8c02afb4587, The referenced name is not unique with its scope) ]
Message [id=0, level=ERROR, path=KnowledgeSource.dmn, line=1658, column=-1
   text=DMN: Duplicate node name 'Credit officer' in the model (DMN id: _aa1bfb73-ae57-4e53-ac32-3d5f7906f21e, The referenced name is not unique with its scope) ]
```

where `Credit officer` is:
```
...
<dmn:knowledgeSource id="_a3e9ef24-5b34-4e56-8a24-e8c02afb4587" name="Credit officer"/>
<dmn:knowledgeSource id="_aa1bfb73-ae57-4e53-ac32-3d5f7906f21e" name="Credit officer"/>
...
```

### Before
![Screenshot 2024-05-23 140906](https://github.com/apache/incubator-kie-tools/assets/8044780/0a98e072-488a-4e5f-b1fe-5dd88cf78333)


### After
![Screenshot 2024-05-23 140902](https://github.com/apache/incubator-kie-tools/assets/8044780/abf6a360-f83b-408b-b46e-d5f0e78f2b98)
