### PR TITLE
NO-ISSUE: DMN Editor: Invocation function name and Annotation column name are copied twice

### DIFF
--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
@@ -169,10 +169,12 @@ export function BeeTableTh<R extends object>({
     useCallback(() => {
       if (column.dataType) {
         return `${column.label} (${column.dataType})`;
-      } else {
+      } else if (!column.isInlineEditable) {
         return column.label;
+      } else {
+        return "";
       }
-    }, [column.dataType, column.label])
+    }, [column.dataType, column.isInlineEditable, column.label])
   );
 
   const coordinates = useMemo<BeeTableCellCoordinates>(


### PR DESCRIPTION
When users copied the name of an Invocation function or the column name of the Annotation column in a Decision Table, the name was copied twice to memory.