### PR TITLE
NO-ISSUE: Removing an Included Model should remove all references of it on the current model

### DIFF
--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -563,14 +563,14 @@ function IncludedModelCard({
                   {extension === "dmn" && (
                     <>
                       Removing an included DMN will erase all its imported nodes and connected edges from your model.
-                      The references to item definitions, BKMs functions, and Decision expressions will remain,
-                      requiring to be manually removed.
+                      The references to item definitions, Business Knowledge Model functions, and Decision expressions
+                      will remain, requiring to be manually removed.
                     </>
                   )}
                   {extension === "pmml" && (
                     <>
-                      Removing an included PMML will not erase references on BKM functions, requiring it to be manually
-                      removed.
+                      Removing an included PMML will not erase references on Boxed Function expressions, requiring it to
+                      be manually removed.
                     </>
                   )}
                 </Alert>

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -456,23 +456,13 @@ function IncludedModelCard({
   const remove = useCallback(
     (index: number) => {
       dmnEditorStoreApi.setState((state) => {
-        const drgEdges = state.computed(state).getDiagramData(externalModelsByNamespace).drgEdges;
         const externalModelTypesByNamespace = state
           .computed(state)
           .getExternalModelTypesByNamespace(externalModelsByNamespace);
-        const externalEdgesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalEdgesByNamespace;
-        const externalNodesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
         deleteImport({
           definitions: state.dmn.model.definitions,
           index,
-          drgEdges,
-          externalDmnsIndex: externalModelTypesByNamespace.dmns,
-          externalEdgesByNamespace,
-          externalNodesByNamespace,
+          externalModelTypesByNamespace,
         });
       });
     },
@@ -607,23 +597,13 @@ function UnknownIncludedModelCard({
   const remove = useCallback(
     (index: number) => {
       dmnEditorStoreApi.setState((state) => {
-        const drgEdges = state.computed(state).getDiagramData(externalModelsByNamespace).drgEdges;
-        const externalDmnsIndex = state
+        const externalModelTypesByNamespace = state
           .computed(state)
-          .getExternalModelTypesByNamespace(externalModelsByNamespace).dmns;
-        const externalEdgesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalEdgesByNamespace;
-        const externalNodesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
+          .getExternalModelTypesByNamespace(externalModelsByNamespace);
         deleteImport({
           definitions: state.dmn.model.definitions,
           index,
-          drgEdges,
-          externalDmnsIndex,
-          externalEdgesByNamespace,
-          externalNodesByNamespace,
+          externalModelTypesByNamespace,
         });
       });
     },

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -50,13 +50,15 @@ import { allPmmlImportNamespaces, getPmmlNamespace } from "../pmml/pmml";
 import { allDmnImportNamespaces } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
 import { getNamespaceOfDmnImport } from "./importNamespaces";
 import { Alert, AlertVariant } from "@patternfly/react-core/dist/js/components/Alert/Alert";
-import { Dropdown, DropdownItem, KebabToggle } from "@patternfly/react-core/dist/js/components/Dropdown";
+import { KebabToggle } from "@patternfly/react-core/dist/js/components/Dropdown";
 import { TrashIcon } from "@patternfly/react-icons/dist/js/icons/trash-icon";
 import { useInViewSelect } from "../responsiveness/useInViewSelect";
 import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancelableEffect";
 import { State } from "../store/Store";
 import "./IncludedModels.css";
 import { Normalized } from "../normalization/normalize";
+import { Popover, PopoverPosition } from "@patternfly/react-core/dist/js/components/Popover";
+import { AlertActionCloseButton, AlertActionLink } from "@patternfly/react-core/dist/js/components/Alert";
 
 export const EMPTY_IMPORT_NAME_NAMESPACE_IDENTIFIER = "<Default>";
 
@@ -394,10 +396,11 @@ export function IncludedModels() {
                   (!isModalOpen && index === thisDmnsImports.length - 1 ? selectedModel : undefined); // Use the selected model to avoid showing the "unknown included model" card.
 
                 return !externalModel ? (
-                  <UnknownIncludedModelCard
+                  <IncludedModelCard
                     key={dmnImport["@_id"]}
                     _import={dmnImport}
                     index={index}
+                    externalModel={undefined}
                     isReadonly={false}
                   />
                 ) : (
@@ -444,7 +447,7 @@ function IncludedModelCard({
   isReadonly,
 }: {
   _import: Normalized<DMN15__tImport>;
-  externalModel: ExternalModel;
+  externalModel: ExternalModel | undefined;
   index: number;
   isReadonly: boolean;
 }) {
@@ -455,6 +458,7 @@ function IncludedModelCard({
 
   const remove = useCallback(
     (index: number) => {
+      setRemovePopoverOpen(false);
       dmnEditorStoreApi.setState((state) => {
         const externalModelTypesByNamespace = state
           .computed(state)
@@ -495,179 +499,115 @@ function IncludedModelCard({
   }, [_import]);
 
   const title = useMemo(() => {
+    if (externalModel === undefined) {
+      return "";
+    }
     if (externalModel.type === "dmn") {
       return externalModel.model.definitions["@_name"];
     } else if (externalModel.type === "pmml") {
       return "";
     }
-  }, [externalModel.model, externalModel.type]);
+  }, [externalModel]);
 
-  const pathDisplayed = useMemo(
-    () =>
-      onRequestToResolvePath?.(externalModel.normalizedPosixPathRelativeToTheOpenFile) ??
-      externalModel.normalizedPosixPathRelativeToTheOpenFile,
-    [onRequestToResolvePath, externalModel.normalizedPosixPathRelativeToTheOpenFile]
-  );
-
-  const [isCardActionsOpen, setCardActionsOpen] = useState(false);
-
-  return (
-    <Card isHoverable={true} isCompact={false}>
-      <CardHeader>
-        <CardActions>
-          <Dropdown
-            toggle={<KebabToggle id={"toggle-kebab-top-level"} onToggle={setCardActionsOpen} />}
-            onSelect={() => setCardActionsOpen(false)}
-            isOpen={isCardActionsOpen}
-            menuAppendTo={document.body}
-            isPlain={true}
-            position={"right"}
-            dropdownItems={[
-              <React.Fragment key={"remove-fragment"}>
-                {!isReadonly && (
-                  <DropdownItem
-                    style={{ minWidth: "240px" }}
-                    icon={<TrashIcon />}
-                    onClick={() => {
-                      if (isReadonly) {
-                        return;
-                      }
-
-                      remove(index);
-                    }}
-                  >
-                    Remove
-                  </DropdownItem>
-                )}
-              </React.Fragment>,
-            ]}
-          />
-        </CardActions>
-        <CardTitle>
-          <InlineFeelNameInput
-            placeholder={EMPTY_IMPORT_NAME_NAMESPACE_IDENTIFIER}
-            isPlain={true}
-            allUniqueNames={useCallback((s) => s.computed(s).getAllFeelVariableUniqueNames(), [])}
-            id={_import["@_id"]!}
-            name={_import["@_name"]}
-            isReadonly={false}
-            shouldCommitOnBlur={true}
-            onRenamed={rename}
-            validate={DMN15_SPEC.IMPORT.name.isValid}
-          />
-          <br />
-          <br />
-          <ExternalModelLabel extension={extension} />
-          <br />
-          <br />
-        </CardTitle>
-      </CardHeader>
-      <CardBody>
-        {`${title}`}
-        <br />
-        <br />
-        <small>
-          <Button
-            variant={ButtonVariant.link}
-            style={{ paddingLeft: 0, whiteSpace: "break-spaces", textAlign: "left" }}
-            onClick={() => {
-              onRequestToJumpToPath?.(externalModel.normalizedPosixPathRelativeToTheOpenFile);
-            }}
-          >
-            <i>{pathDisplayed}</i>
-          </Button>
-        </small>
-      </CardBody>
-    </Card>
-  );
-}
-
-function UnknownIncludedModelCard({
-  _import,
-  index,
-  isReadonly,
-}: {
-  _import: Normalized<DMN15__tImport>;
-  index: number;
-  isReadonly: boolean;
-}) {
-  const dmnEditorStoreApi = useDmnEditorStoreApi();
-  const { externalModelsByNamespace } = useExternalModels();
-
-  const remove = useCallback(
-    (index: number) => {
-      dmnEditorStoreApi.setState((state) => {
-        const externalModelTypesByNamespace = state
-          .computed(state)
-          .getExternalModelTypesByNamespace(externalModelsByNamespace);
-        deleteImport({
-          definitions: state.dmn.model.definitions,
-          __readonly_index: index,
-          __readonly_externalModelTypesByNamespace: externalModelTypesByNamespace,
-        });
-      });
-    },
-    [dmnEditorStoreApi, externalModelsByNamespace]
-  );
-
-  const rename = useCallback<OnInlineFeelNameRenamed>(
-    (newName) => {
-      dmnEditorStoreApi.setState((state) => {
-        renameImport({
-          definitions: state.dmn.model.definitions,
-          index,
-          newName,
-          allTopLevelDataTypesByFeelName: state.computed(state).getDataTypes(externalModelsByNamespace)
-            .allTopLevelDataTypesByFeelName,
-        });
-      });
-    },
-    [dmnEditorStoreApi, externalModelsByNamespace, index]
-  );
-
-  const extension = useMemo(() => {
-    if (allDmnImportNamespaces.has(_import["@_importType"])) {
-      return "dmn";
-    } else if (allPmmlImportNamespaces.has(_import["@_importType"])) {
-      return "pmml";
-    } else {
-      return "Unknwon";
+  const pathDisplayed = useMemo(() => {
+    if (externalModel !== undefined) {
+      return (
+        onRequestToResolvePath?.(externalModel.normalizedPosixPathRelativeToTheOpenFile) ??
+        externalModel.normalizedPosixPathRelativeToTheOpenFile
+      );
     }
-  }, [_import]);
+  }, [onRequestToResolvePath, externalModel]);
 
-  const [isCardActionsOpen, setCardActionsOpen] = useState(false);
+  const [isRemovePopoverOpen, setRemovePopoverOpen] = useState(false);
+  const [isConfirmationPopoverOpen, setConfirmationPopoverOpen] = useState(false);
+  const shouldRenderConfirmationMessage = useMemo(
+    () => isRemovePopoverOpen && isConfirmationPopoverOpen,
+    [isConfirmationPopoverOpen, isRemovePopoverOpen]
+  );
 
   return (
     <Card isHoverable={true} isCompact={false}>
       <CardHeader>
         <CardActions>
-          <Dropdown
-            toggle={<KebabToggle id={"toggle-kebab-top-level"} onToggle={setCardActionsOpen} />}
-            onSelect={() => setCardActionsOpen(false)}
-            isOpen={isCardActionsOpen}
-            menuAppendTo={document.body}
-            isPlain={true}
-            position={"right"}
-            dropdownItems={[
-              <React.Fragment key={"remove-fragment"}>
-                {!isReadonly && (
-                  <DropdownItem
-                    style={{ minWidth: "240px" }}
-                    icon={<TrashIcon />}
-                    onClick={() => {
-                      if (isReadonly) {
-                        return;
-                      }
-
-                      remove(index);
-                    }}
-                  >
-                    Remove
-                  </DropdownItem>
-                )}
-              </React.Fragment>,
-            ]}
-          />
+          <Popover
+            bodyContent={
+              shouldRenderConfirmationMessage ? (
+                <Alert
+                  isInline
+                  variant={AlertVariant.warning}
+                  title={"This action have major impact to your model"}
+                  actionClose={
+                    <AlertActionCloseButton
+                      onClose={() => {
+                        setRemovePopoverOpen(false);
+                        setConfirmationPopoverOpen(false);
+                      }}
+                    />
+                  }
+                  actionLinks={
+                    <>
+                      <AlertActionLink
+                        onClick={(ev) => {
+                          remove(index);
+                          ev.stopPropagation();
+                          ev.preventDefault();
+                        }}
+                        variant={"link"}
+                        style={{ color: "var(--pf-global--danger-color--200)", fontWeight: "bold" }}
+                      >
+                        {`Yes, remove included ${extension.toUpperCase()}`}
+                      </AlertActionLink>
+                    </>
+                  }
+                >
+                  {extension === "dmn" && (
+                    <>
+                      Removing a included DMN will erase all its imported nodes and connected edges from your model. The
+                      references to item definitions, BKMs functions and Decision expressions will remain, requiring to
+                      be manually removed.
+                    </>
+                  )}
+                </Alert>
+              ) : (
+                <Button
+                  variant={"plain"}
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    if (isReadonly) {
+                      return;
+                    }
+                    setConfirmationPopoverOpen(true);
+                  }}
+                >
+                  <TrashIcon />
+                  {"  "}
+                  Remove
+                </Button>
+              )
+            }
+            hasNoPadding={shouldRenderConfirmationMessage}
+            maxWidth={shouldRenderConfirmationMessage ? "300px" : "150px"}
+            minWidth={shouldRenderConfirmationMessage ? "300px" : "150px"}
+            isVisible={isRemovePopoverOpen}
+            showClose={false}
+            shouldClose={() => {
+              setRemovePopoverOpen(false);
+              setConfirmationPopoverOpen(false);
+            }}
+            position={PopoverPosition.bottom}
+            shouldOpen={() => setRemovePopoverOpen(true)}
+          >
+            <Button
+              variant={"plain"}
+              onClick={(ev) => {
+                ev.stopPropagation();
+                ev.preventDefault();
+              }}
+            >
+              <KebabToggle />
+            </Button>
+          </Popover>
         </CardActions>
         <CardTitle>
           <InlineFeelNameInput
@@ -688,18 +628,38 @@ function UnknownIncludedModelCard({
           <br />
         </CardTitle>
       </CardHeader>
-      <CardBody>
-        <Alert title={"External model not found."} isInline={true} variant={AlertVariant.danger}>
-          <Divider style={{ marginTop: "16px" }} />
+      {externalModel ? (
+        <CardBody>
+          {`${title}`}
           <br />
-          <p>
-            <b>Namespace:</b>&nbsp;{_import["@_namespace"]}
-          </p>
-          <p>
-            <b>URI:</b>&nbsp;{_import["@_locationURI"] ?? <i>None</i>}
-          </p>
-        </Alert>
-      </CardBody>
+          <br />
+          <small>
+            <Button
+              variant={ButtonVariant.link}
+              style={{ paddingLeft: 0, whiteSpace: "break-spaces", textAlign: "left" }}
+              onClick={() => {
+                onRequestToJumpToPath?.(externalModel.normalizedPosixPathRelativeToTheOpenFile);
+              }}
+            >
+              <i>{pathDisplayed}</i>
+            </Button>
+          </small>
+        </CardBody>
+      ) : (
+        // unknown
+        <CardBody>
+          <Alert title={"External model not found."} isInline={true} variant={AlertVariant.danger}>
+            <Divider style={{ marginTop: "16px" }} />
+            <br />
+            <p>
+              <b>Namespace:</b>&nbsp;{_import["@_namespace"]}
+            </p>
+            <p>
+              <b>URI:</b>&nbsp;{_import["@_locationURI"] ?? <i>None</i>}
+            </p>
+          </Alert>
+        </CardBody>
+      )}
     </Card>
   );
 }

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -54,11 +54,9 @@ import { Dropdown, DropdownItem, KebabToggle } from "@patternfly/react-core/dist
 import { TrashIcon } from "@patternfly/react-icons/dist/js/icons/trash-icon";
 import { useInViewSelect } from "../responsiveness/useInViewSelect";
 import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancelableEffect";
-import { defaultStaticState, State } from "../store/Store";
+import { State } from "../store/Store";
 import "./IncludedModels.css";
 import { Normalized } from "../normalization/normalize";
-import { computeDiagramData } from "../store/computed/computeDiagramData";
-import { computeIndexedDrd } from "../store/computed/computeIndexes";
 
 export const EMPTY_IMPORT_NAME_NAMESPACE_IDENTIFIER = "<Default>";
 

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -562,9 +562,15 @@ function IncludedModelCard({
                 >
                   {extension === "dmn" && (
                     <>
-                      Removing a included DMN will erase all its imported nodes and connected edges from your model. The
-                      references to item definitions, BKMs functions and Decision expressions will remain, requiring to
-                      be manually removed.
+                      Removing an included DMN will erase all its imported nodes and connected edges from your model.
+                      The references to item definitions, BKMs functions, and Decision expressions will remain,
+                      requiring to be manually removed.
+                    </>
+                  )}
+                  {extension === "pmml" && (
+                    <>
+                      Removing an included PMML will not erase references on BKM functions, requiring it to be manually
+                      removed.
                     </>
                   )}
                 </Alert>

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -459,19 +459,22 @@ function IncludedModelCard({
     (index: number) => {
       dmnEditorStoreApi.setState((state) => {
         const drgEdges = state.computed(state).getDiagramData(externalModelsByNamespace).drgEdges;
-        const externalNodesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
         const externalModelTypesByNamespace = state
           .computed(state)
           .getExternalModelTypesByNamespace(externalModelsByNamespace);
-
+        const externalEdgesByNamespace = state
+          .computed(state)
+          .getDiagramData(externalModelsByNamespace).externalEdgesByNamespace;
+        const externalNodesByNamespace = state
+          .computed(state)
+          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
         deleteImport({
           definitions: state.dmn.model.definitions,
           index,
           drgEdges,
-          externalNodesByNamespace,
           externalDmnsIndex: externalModelTypesByNamespace.dmns,
+          externalEdgesByNamespace,
+          externalNodesByNamespace,
         });
       });
     },
@@ -607,18 +610,22 @@ function UnknownIncludedModelCard({
     (index: number) => {
       dmnEditorStoreApi.setState((state) => {
         const drgEdges = state.computed(state).getDiagramData(externalModelsByNamespace).drgEdges;
-        const externalNodesByNamespace = state
-          .computed(state)
-          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
         const externalDmnsIndex = state
           .computed(state)
           .getExternalModelTypesByNamespace(externalModelsByNamespace).dmns;
+        const externalEdgesByNamespace = state
+          .computed(state)
+          .getDiagramData(externalModelsByNamespace).externalEdgesByNamespace;
+        const externalNodesByNamespace = state
+          .computed(state)
+          .getDiagramData(externalModelsByNamespace).externalNodesByNamespace;
         deleteImport({
           definitions: state.dmn.model.definitions,
           index,
           drgEdges,
-          externalNodesByNamespace,
           externalDmnsIndex,
+          externalEdgesByNamespace,
+          externalNodesByNamespace,
         });
       });
     },

--- a/packages/dmn-editor/src/includedModels/IncludedModels.tsx
+++ b/packages/dmn-editor/src/includedModels/IncludedModels.tsx
@@ -461,8 +461,8 @@ function IncludedModelCard({
           .getExternalModelTypesByNamespace(externalModelsByNamespace);
         deleteImport({
           definitions: state.dmn.model.definitions,
-          index,
-          externalModelTypesByNamespace,
+          __readonly_index: index,
+          __readonly_externalModelTypesByNamespace: externalModelTypesByNamespace,
         });
       });
     },
@@ -602,8 +602,8 @@ function UnknownIncludedModelCard({
           .getExternalModelTypesByNamespace(externalModelsByNamespace);
         deleteImport({
           definitions: state.dmn.model.definitions,
-          index,
-          externalModelTypesByNamespace,
+          __readonly_index: index,
+          __readonly_externalModelTypesByNamespace: externalModelTypesByNamespace,
         });
       });
     },

--- a/packages/dmn-editor/src/mutations/deleteImport.ts
+++ b/packages/dmn-editor/src/mutations/deleteImport.ts
@@ -31,48 +31,48 @@ import { TypeOrReturnType } from "../store/ComputedStateCache";
 
 export function deleteImport({
   definitions,
-  index,
-  externalModelTypesByNamespace,
+  __readonly_index,
+  __readonly_externalModelTypesByNamespace,
 }: {
   definitions: Normalized<DMN15__tDefinitions>;
-  index: number;
-  externalModelTypesByNamespace: TypeOrReturnType<Computed["getExternalModelTypesByNamespace"]>;
+  __readonly_index: number;
+  __readonly_externalModelTypesByNamespace: TypeOrReturnType<Computed["getExternalModelTypesByNamespace"]>;
 }) {
   definitions.import ??= [];
-  const [deleted] = definitions.import.splice(index, 1);
+  const [deletedImport] = definitions.import.splice(__readonly_index, 1);
 
   const namespaceName = getXmlNamespaceDeclarationName({
     rootElement: definitions,
-    namespace: deleted["@_namespace"],
+    namespace: deletedImport["@_namespace"],
   });
 
   // Delete from all DRDs
   const defaultDiagram = defaultStaticState().diagram;
   definitions["dmndi:DMNDI"]?.["dmndi:DMNDiagram"]?.forEach((_, i) => {
     const indexedDrd = computeIndexedDrd(definitions["@_namespace"], definitions, i);
-    const diagramData = computeDiagramData(
+    const { externalNodesByNamespace, drgEdges, edgesFromExternalNodesByNamespace } = computeDiagramData(
       defaultDiagram,
       definitions,
-      externalModelTypesByNamespace,
+      __readonly_externalModelTypesByNamespace,
       indexedDrd,
       false
     );
 
-    diagramData.externalNodesByNamespace.get(deleted["@_namespace"])?.forEach((node) => {
+    externalNodesByNamespace.get(deletedImport["@_namespace"])?.forEach((node) => {
       deleteNode({
         definitions,
-        drgEdges: diagramData.drgEdges,
+        drgEdges: drgEdges,
         drdIndex: 0,
         nodeNature: nodeNatures[node.type! as NodeType],
         dmnObjectId: node.data.dmnObject?.["@_id"],
         dmnObjectQName: node.data.dmnObjectQName,
-        dmnObjectNamespace: node.data.dmnObjectNamespace!, // ?? state.dmn.model.definitions["@_namespace"],
-        externalDmnsIndex: externalModelTypesByNamespace.dmns,
+        dmnObjectNamespace: node.data.dmnObjectNamespace!,
+        externalDmnsIndex: __readonly_externalModelTypesByNamespace.dmns,
         mode: NodeDeletionMode.FROM_DRG_AND_ALL_DRDS,
       });
     });
 
-    diagramData.externalEdgesByNamespace.get(deleted["@_namespace"])?.forEach((edge) => {
+    edgesFromExternalNodesByNamespace.get(deletedImport["@_namespace"])?.forEach((edge) => {
       deleteEdge({
         definitions,
         drdIndex: 0,

--- a/packages/dmn-editor/src/mutations/deleteImport.ts
+++ b/packages/dmn-editor/src/mutations/deleteImport.ts
@@ -25,6 +25,7 @@ import { deleteNode, NodeDeletionMode } from "./deleteNode";
 import { nodeNatures } from "./NodeNature";
 import { NodeType } from "../diagram/connections/graphStructure";
 import { ExternalDmnsIndex } from "../DmnEditor";
+import { deleteEdge, EdgeDeletionMode } from "./deleteEdge";
 
 export function deleteImport({
   definitions,
@@ -32,12 +33,14 @@ export function deleteImport({
   drgEdges,
   externalNodesByNamespace,
   externalDmnsIndex,
+  externalEdgesByNamespace,
 }: {
   definitions: Normalized<DMN15__tDefinitions>;
   index: number;
   drgEdges: ReturnType<typeof computeDiagramData>["drgEdges"];
-  externalNodesByNamespace: ReturnType<typeof computeDiagramData>["externalNodesByNamespace"];
   externalDmnsIndex: ExternalDmnsIndex;
+  externalEdgesByNamespace: ReturnType<typeof computeDiagramData>["externalEdgesByNamespace"];
+  externalNodesByNamespace: ReturnType<typeof computeDiagramData>["externalNodesByNamespace"];
 }) {
   definitions.import ??= [];
   const [deleted] = definitions.import.splice(index, 1);
@@ -58,6 +61,15 @@ export function deleteImport({
       dmnObjectNamespace: node.data.dmnObjectNamespace!, // ?? state.dmn.model.definitions["@_namespace"],
       externalDmnsIndex,
       mode: NodeDeletionMode.FROM_DRG_AND_ALL_DRDS,
+    });
+  });
+
+  externalEdgesByNamespace.get(deleted["@_namespace"])?.forEach((edge) => {
+    deleteEdge({
+      definitions,
+      drdIndex: 0,
+      edge: { id: edge.id, dmnObject: edge.data!.dmnObject },
+      mode: EdgeDeletionMode.FROM_DRG_AND_ALL_DRDS,
     });
   });
 

--- a/packages/dmn-editor/src/store/computed/computeDiagramData.ts
+++ b/packages/dmn-editor/src/store/computed/computeDiagramData.ts
@@ -115,12 +115,10 @@ export function computeDiagramData(
     };
 
     if (sourceNamespace && sourceNamespace !== KIE_UNKNOWN_NAMESPACE) {
-      const externalEdges = externalEdgesByNamespace.get(sourceNamespace) ?? [];
-      externalEdgesByNamespace.set(sourceNamespace, [...externalEdges, edge]);
+      externalEdgesByNamespace.set(sourceNamespace, [...(externalEdgesByNamespace.get(sourceNamespace) ?? []), edge]);
     }
     if (sourceNamespace !== targetNamespace && targetNamespace && targetNamespace !== KIE_UNKNOWN_NAMESPACE) {
-      const externalEdges = externalEdgesByNamespace.get(targetNamespace) ?? [];
-      externalEdgesByNamespace.set(targetNamespace, [...externalEdges, edge]);
+      externalEdgesByNamespace.set(targetNamespace, [...(externalEdgesByNamespace.get(targetNamespace) ?? []), edge]);
     }
 
     edgesById.set(edge.id, edge);
@@ -241,8 +239,10 @@ export function computeDiagramData(
     }
 
     if (dmnObjectNamespace && dmnObjectNamespace !== KIE_UNKNOWN_NAMESPACE) {
-      const externalNamespaceNodes = externalNodesByNamespace.get(dmnObjectNamespace) ?? [];
-      externalNodesByNamespace.set(dmnObjectNamespace, [...externalNamespaceNodes, newNode]);
+      externalNodesByNamespace.set(dmnObjectNamespace, [
+        ...(externalNodesByNamespace.get(dmnObjectNamespace) ?? []),
+        newNode,
+      ]);
     }
 
     nodesById.set(newNode.id, newNode);

--- a/packages/dmn-editor/src/store/computed/computeDiagramData.ts
+++ b/packages/dmn-editor/src/store/computed/computeDiagramData.ts
@@ -37,6 +37,7 @@ import { TypeOrReturnType } from "../ComputedStateCache";
 import { Computed, State } from "../Store";
 import { getDecisionServicePropertiesRelativeToThisDmn } from "../../mutations/addExistingDecisionServiceToDrd";
 import { Normalized } from "../../normalization/normalize";
+import { KIE_UNKNOWN_NAMESPACE } from "../../kie/kie";
 
 export const NODE_LAYERS = {
   GROUP_NODE: 0,
@@ -78,6 +79,7 @@ export function computeDiagramData(
   const nodesById = new Map<string, RF.Node<DmnDiagramNodeData>>();
   const edgesById = new Map<string, RF.Edge<DmnDiagramEdgeData>>();
   const parentIdsById = new Map<string, DmnDiagramNodeData>();
+  const externalNodesByNamespace = new Map<string, Array<RF.Node<DmnDiagramNodeData>>>();
 
   const { selectedNodes, draggingNodes, resizingNodes, selectedEdges } = {
     selectedNodes: new Set(diagram._selectedNodes),
@@ -224,6 +226,11 @@ export function computeDiagramData(
       }
     }
 
+    if (dmnObjectNamespace && dmnObjectNamespace !== KIE_UNKNOWN_NAMESPACE) {
+      const externalNamespaceNodes = externalNodesByNamespace.get(dmnObjectNamespace) ?? [];
+      externalNodesByNamespace.set(dmnObjectNamespace, [...externalNamespaceNodes, newNode]);
+    }
+
     nodesById.set(newNode.id, newNode);
     if (newNode.selected) {
       selectedNodesById.set(newNode.id, newNode);
@@ -360,6 +367,7 @@ export function computeDiagramData(
     nodes: sortedNodes,
     edges: sortedEdges,
     edgesById,
+    externalNodesByNamespace,
     nodesById,
     selectedNodeTypes,
     selectedNodesById,

--- a/packages/dmn-editor/src/store/computed/computeDiagramData.ts
+++ b/packages/dmn-editor/src/store/computed/computeDiagramData.ts
@@ -380,7 +380,7 @@ export function computeDiagramData(
     edges: sortedEdges,
     edgesById,
     externalNodesByNamespace,
-    externalEdgesByNamespace: edgesFromExternalNodesByNamespace,
+    edgesFromExternalNodesByNamespace,
     nodesById,
     selectedNodeTypes,
     selectedNodesById,


### PR DESCRIPTION
This PR adds two new maps on the diagram data. The `externalNodesByNamespace` collects a list of external nodes that are present on the DRD, and the `externalEdgesByNamespace` has a list of edges that reference external nodes. The `deleteImport` now iterates over the nodes and edges lists erasing all references.