### PR TITLE
kie-issues#1245: Adapt KIE Tools release jobs to sign and upload release candidate artifacts to https://dist.apache.org/repos/dist/dev/incubator/kie

### DIFF
--- a/.ci/incubator-kie-tools-ci-build.Dockerfile
+++ b/.ci/incubator-kie-tools-ci-build.Dockerfile
@@ -43,6 +43,7 @@ unzip \
 bzip2 \
 xvfb \
 fluxbox && \
+subversion && \
 apt-get clean autoclean && apt-get autoremove --yes && \
 rm -rf /var/lib/{apt,dpkg,cache,log}/
 

--- a/.ci/jenkins/Jenkinsfile.release-build
+++ b/.ci/jenkins/Jenkinsfile.release-build
@@ -37,6 +37,7 @@ pipeline {
         string(description: 'Upload asset url', name: 'UPLOAD_ASSET_URL', defaultValue: '')
         string(description: 'Runners', name: 'RUNNERS', defaultValue: '{"dev_deployment_base_image":"false","dev_deployment_kogito_quakus_blank_app_image":"false","dev_deployment_dmn_form_webapp_image":"false","dev_deployment_upload_service":"false","kie_sandbox_image":"false","kie_sandbox_extended_services_image":"false","cors_proxy_image":"false","online_editor":"false", "chrome_extensions":"false","vscode_extensions_dev":"false","vscode_extensions_prod":"false","npm_packages":"false","standalone_editors_cdn":"false","extended_services":"false","serverless_logic_web_tools":"false","serverless_logic_web_tools_swf_builder_image":"false","serverless_logic_web_tools_base_builder_image":"false","serverless_logic_web_tools_swf_dev_mode_image":"false","dashbuilder_viewer_image":"false","kn_plugin_workflow":"false","kie_sandbox_helm_chart":"false","kogito_task_console":"false","kogito_management_console":"false","kogito_swf_builder":"false","kogito_swf_devmode":"false","kogito_serverless_operator":"false","jbpm_quarkus_devui":"false","sonataflow_quarkus_devui":"false"}')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -156,7 +157,9 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -177,7 +180,8 @@ pipeline {
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                     string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -197,8 +201,7 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
                                 ]
                             ).result
                         }
@@ -219,7 +222,8 @@ pipeline {
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                     string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -239,7 +243,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -260,7 +265,8 @@ pipeline {
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                     string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -280,7 +286,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -300,7 +307,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -320,7 +328,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -340,7 +349,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -359,8 +369,7 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
                                 ]
                             ).result
                         }
@@ -380,7 +389,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -400,7 +410,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -420,7 +431,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -440,7 +452,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -460,7 +473,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                 ]
                             ).result
                         }
@@ -559,7 +573,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -579,7 +594,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -600,7 +616,8 @@ pipeline {
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -620,7 +637,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -641,7 +659,8 @@ pipeline {
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                             string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -661,7 +680,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }
@@ -685,7 +705,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
 
@@ -707,7 +728,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
 
@@ -731,7 +753,8 @@ pipeline {
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                             string(name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL', value: "${env.KIE_SANDBOX_EXTENDED_SERVICES_URL}"),
                                             string(name: 'KIE_SANDBOX_CORS_PROXY_URL', value: "${env.KIE_SANDBOX_CORS_PROXY_URL}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
 
@@ -753,7 +776,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}"),
+                                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}")
                                         ]
                                     ).result
                                 }

--- a/.ci/jenkins/Jenkinsfile.release-build
+++ b/.ci/jenkins/Jenkinsfile.release-build
@@ -36,6 +36,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Upload asset url', name: 'UPLOAD_ASSET_URL', defaultValue: '')
         string(description: 'Runners', name: 'RUNNERS', defaultValue: '{"dev_deployment_base_image":"false","dev_deployment_kogito_quakus_blank_app_image":"false","dev_deployment_dmn_form_webapp_image":"false","dev_deployment_upload_service":"false","kie_sandbox_image":"false","kie_sandbox_extended_services_image":"false","cors_proxy_image":"false","online_editor":"false", "chrome_extensions":"false","vscode_extensions_dev":"false","vscode_extensions_prod":"false","npm_packages":"false","standalone_editors_cdn":"false","extended_services":"false","serverless_logic_web_tools":"false","serverless_logic_web_tools_swf_builder_image":"false","serverless_logic_web_tools_base_builder_image":"false","serverless_logic_web_tools_swf_dev_mode_image":"false","dashbuilder_viewer_image":"false","kn_plugin_workflow":"false","kie_sandbox_helm_chart":"false","kogito_task_console":"false","kogito_management_console":"false","kogito_swf_builder":"false","kogito_swf_devmode":"false","kogito_serverless_operator":"false","jbpm_quarkus_devui":"false","sonataflow_quarkus_devui":"false"}')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -154,7 +155,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -174,7 +176,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -194,7 +197,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -214,7 +218,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -233,7 +238,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -253,7 +259,8 @@ pipeline {
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                    string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -272,7 +279,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -291,7 +299,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -310,7 +319,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -329,7 +339,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -348,7 +359,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -367,7 +379,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -386,7 +399,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -405,7 +419,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -424,7 +439,8 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -443,7 +459,47 @@ pipeline {
                                 parameters: [
                                     booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                     string(name: 'BASE_REF', value: "${params.BASE_REF}"),
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
+                                ]
+                            ).result
+                        }
+                    }
+                }
+
+                stage('JBPM Quarkus Dev UI') {
+                    when {
+                        expression { env.JBPM_QUARKUS_DEVUI == 'true' }
+                    }
+                    steps {
+                        script {
+                            env.JBPM_QUARKUS_DEVUI_JOB_RESULT = build(
+                                wait: true,
+                                job: 'KIE/kie-tools/kie-tools-release-jobs/jbpm-quarkus-devui',
+                                parameters: [
+                                    booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
+                                    string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                     string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                ]
+                            ).result
+                        }
+                    }
+                }
+
+                stage('Sonataflow Quarkus Dev UI') {
+                    when {
+                        expression { env.SONATAFLOW_QUARKUS_DEVUI == 'true' }
+                    }
+                    steps {
+                        script {
+                            env.SONATAFLOW_QUARKUS_DEVUI_JOB_RESULT = build(
+                                wait: true,
+                                job: 'KIE/kie-tools/kie-tools-release-jobs/sonataflow-quarkus-devui',
+                                parameters: [
+                                    booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
+                                    string(name: 'BASE_REF', value: "${params.BASE_REF}"),
+                                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                    booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                 ]
                             ).result
                         }
@@ -502,7 +558,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -521,7 +578,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -541,7 +599,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                            string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -560,7 +619,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -580,7 +640,8 @@ pipeline {
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
-                                            string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}")
+                                            string(name: 'UPLOAD_ASSET_URL', value: "${params.UPLOAD_ASSET_URL}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -599,7 +660,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }
@@ -622,7 +684,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
 
@@ -643,7 +706,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
 
@@ -666,7 +730,8 @@ pipeline {
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
                                             string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                                             string(name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL', value: "${env.KIE_SANDBOX_EXTENDED_SERVICES_URL}"),
-                                            string(name: 'KIE_SANDBOX_CORS_PROXY_URL', value: "${env.KIE_SANDBOX_CORS_PROXY_URL}")
+                                            string(name: 'KIE_SANDBOX_CORS_PROXY_URL', value: "${env.KIE_SANDBOX_CORS_PROXY_URL}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
 
@@ -687,7 +752,8 @@ pipeline {
                                         parameters: [
                                             booleanParam(name: 'DRY_RUN', value: "${params.DRY_RUN}"),
                                             string(name: 'BASE_REF', value: "${params.BASE_REF}"),
-                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}")
+                                            string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                            booleanParam(name: 'RELEASE_CANDIDATE', value: "${params.RELEASE_CANDIDATE}")
                                         ]
                                     ).result
                                 }

--- a/.ci/jenkins/Jenkinsfile.release-candidate
+++ b/.ci/jenkins/Jenkinsfile.release-candidate
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        docker {
+            image 'quay.io/kie-tools/kie-tools-ci-build:latest'
+            args '--shm-size=2g --privileged --group-add docker'
+            label util.avoidFaultyNodes()
+        }
+    }
+
+    options {
+        timeout(time: 180, unit: 'MINUTES')
+    }
+
+    parameters {
+        string(name: 'BRANCH_NAME', defaultValue: 'main', description: 'Set the Git branch to checkout', trim: true)
+        string(name: 'TAG_NAME', description: 'Tag to create', trim: true)
+    }
+
+    environment {
+        KIE_TOOLS_BUILD__runLinters = 'false'
+        KIE_TOOLS_BUILD__runTests = 'false'
+        KIE_TOOLS_BUILD__runEndToEndTests = 'false'
+        KIE_TOOLS_BUILD__buildContainerImages = 'true'
+    }
+
+    stages {
+        stage('Load local shared scripts') {
+            steps {
+                script {
+                    pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
+                    buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
+                    githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                }
+            }
+        }
+
+        stage('Clean workspace before build') {
+            steps {
+                cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+            }
+        }
+
+        stage('Checkout kie-tools') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        githubUtils.checkoutRepo(
+                            "http://github.com/${pipelineVars.githubRepositorySlug}.git",
+                            "${params.BRANCH_NAME}",
+                            "${pipelineVars.kieToolsBotGithubCredentialsId}"
+                        )
+                    }
+                }
+            }
+        }
+
+        stage('Setup PNPM') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.setupPnpm()
+                    }
+                }
+            }
+        }
+
+        stage('PNPM Bootstrap') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.pnpmBootstrap("${env.PNPM_FILTER_STRING}")
+                    }
+                }
+            }
+        }
+
+        stage('Setup Git repository') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        sh """#!/bin/bash -el
+                        git config user.email asf-ci-kie@jenkins.kie.apache.org
+                        git config user.name asf-ci-kie
+                        git checkout ${params.BRANCH_NAME}
+                        """.trim()
+                    }
+                }
+            }
+        }
+
+        stage('Update project version') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.pnpmUpdateProjectVersion(params.TAG_NAME)
+                    }
+                }
+            }
+        }
+
+        stage('Update kogito version') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.pnpmUpdateKogitoVersion(params.TAG_NAME, params.TAG_NAME)
+                    }
+                }
+            }
+        }
+
+        stage('Commit and Push changes') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        sh """#!/bin/bash -el
+                        git add .
+                        git commit --allow-empty -am "Update project version to ${params.TAG_NAME}"
+                        """.trim()
+                        githubUtils.pushObject('origin', "${params.NEW_BRANCH_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                    }
+                }
+            }
+        }
+
+        stage('Create a new tag') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        githubUtils.createTag("${params.TAG_NAME}")
+                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                    }
+                }
+            }
+        }
+
+        stage('Build') {
+            steps {
+                dir('kie-tools') {
+                    sh '''#!/bin/bash -el
+                    pnpm -r --workspace-concurrency=1 build:prod
+                    '''.trim()
+                }
+            }
+        }
+
+        stage('Upload images zip') {
+            steps {
+                dir('kie-tools') {
+                    sh """#!/#!/bin/bash -el
+                    docker save "quay.io/${QUAY_ORGANIZATION}/canvas:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_CANVAS}"
+                    docker save "quay.io/${QUAY_ORGANIZATION}/extended-services:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_EXTENDED_SERVICES}"
+                    docker save "quay.io/${QUAY_ORGANIZATION}/cors-proxy:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_CORS_PROXY}"
+                    """.trim()
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs(deleteDirs: true)
+        }
+    }
+}

--- a/.ci/jenkins/Jenkinsfile.release-candidate
+++ b/.ci/jenkins/Jenkinsfile.release-candidate
@@ -31,15 +31,8 @@ pipeline {
     }
 
     parameters {
-        string(name: 'BRANCH_NAME', defaultValue: 'main', description: 'Set the Git branch to checkout', trim: true)
-        string(name: 'TAG_NAME', description: 'Tag to create', trim: true)
-    }
-
-    environment {
-        KIE_TOOLS_BUILD__runLinters = 'false'
-        KIE_TOOLS_BUILD__runTests = 'false'
-        KIE_TOOLS_BUILD__runEndToEndTests = 'false'
-        KIE_TOOLS_BUILD__buildContainerImages = 'true'
+        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.x)', trim: true)
+        string(name: 'RELEASE_CANDIDATE_VERSION', description: 'Release Candidate version', trim: true)
     }
 
     stages {
@@ -111,7 +104,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildUtils.pnpmUpdateProjectVersion(params.TAG_NAME)
+                        buildUtils.pnpmUpdateProjectVersion(params.RELEASE_CANDIDATE_VERSION)
                     }
                 }
             }
@@ -121,7 +114,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildUtils.pnpmUpdateKogitoVersion(params.TAG_NAME, params.TAG_NAME)
+                        buildUtils.pnpmUpdateKogitoVersion(params.RELEASE_CANDIDATE_VERSION, params.RELEASE_CANDIDATE_VERSION)
                     }
                 }
             }
@@ -133,9 +126,22 @@ pipeline {
                     script {
                         sh """#!/bin/bash -el
                         git add .
-                        git commit --allow-empty -am "Update project version to ${params.TAG_NAME}"
+                        git commit --allow-empty -am "Update project version to ${params.RELEASE_CANDIDATE_VERSION}"
                         """.trim()
                         githubUtils.pushObject('origin', "${params.NEW_BRANCH_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                    }
+                }
+            }
+        }
+
+        stage('Check `tag` against `package.json.version`') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        packageVersion = sh(returnStdout: true, script: "#!/bin/bash -el \n node -p \"require('./package.json').version\"").trim()
+                        sh """#!/bin/bash -el
+                        [[ "${params.RELEASE_CANDIDATE_VERSION}" == "${packageVersion}" ]]
+                        """.trim()
                     }
                 }
             }
@@ -145,32 +151,23 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        githubUtils.createTag("${params.TAG_NAME}")
-                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                        githubUtils.createTag("${params.RELEASE_CANDIDATE_VERSION}")
+                        githubUtils.pushObject('origin', "${params.RELEASE_CANDIDATE_VERSION}", "${pipelineVars.asfGithubPushCredentialsId}")
                     }
                 }
             }
         }
 
-        stage('Build') {
+        stage('Build and Publish release candidate artifacts') {
             steps {
-                dir('kie-tools') {
-                    sh '''#!/bin/bash -el
-                    pnpm -r --workspace-concurrency=1 build:prod
-                    '''.trim()
-                }
-            }
-        }
-
-        stage('Upload images zip') {
-            steps {
-                dir('kie-tools') {
-                    sh """#!/#!/bin/bash -el
-                    docker save "quay.io/${QUAY_ORGANIZATION}/canvas:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_CANVAS}"
-                    docker save "quay.io/${QUAY_ORGANIZATION}/extended-services:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_EXTENDED_SERVICES}"
-                    docker save "quay.io/${QUAY_ORGANIZATION}/cors-proxy:${BAMOE_VERSION_IMAGES}" | gzip >"${ZIP_FILE_NAME_CORS_PROXY}"
-                    """.trim()
-                }
+                build job: 'KIE/kie-tools/kie-tools-release-build', parameters: [
+                    booleanParam(name: 'DRY_RUN', value: false),
+                    string(name: 'BASE_REF', value: "${env.BRANCH_NAME}"),
+                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}"),
+                    string(name: 'UPLOAD_ASSET_URL', value: "${env.RELEASE_UPLOAD_ASSET_URL}"),
+                    string(name: 'RUNNERS', value: "${params.RUNNERS}"),
+                    booleanParam(name: 'RELEASE_CANDIDATE', value: true)
+                ]
             }
         }
     }

--- a/.ci/jenkins/Jenkinsfile.release-candidate
+++ b/.ci/jenkins/Jenkinsfile.release-candidate
@@ -31,8 +31,9 @@ pipeline {
     }
 
     parameters {
-        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.x)', trim: true)
-        string(name: 'RELEASE_CANDIDATE_VERSION', description: 'Release Candidate version', trim: true)
+        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.X)', trim: true)
+        string(name: 'RELEASE_VERSION', description: 'Release version', trim: true)
+        string(name: 'TAG_NAME', description: 'Tag name to be created', trim: true)
     }
 
     stages {
@@ -104,7 +105,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildUtils.pnpmUpdateProjectVersion(params.RELEASE_CANDIDATE_VERSION)
+                        buildUtils.pnpmUpdateProjectVersion(params.RELEASE_VERSION)
                     }
                 }
             }
@@ -114,7 +115,17 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildUtils.pnpmUpdateKogitoVersion(params.RELEASE_CANDIDATE_VERSION, params.RELEASE_CANDIDATE_VERSION)
+                        buildUtils.pnpmUpdateKogitoVersion(params.RELEASE_VERSION, params.RELEASE_VERSION)
+                    }
+                }
+            }
+        }
+
+        stage('Update stream name') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.pnpmUpdateStreamName(params.BRANCH_NAME)
                     }
                 }
             }
@@ -126,7 +137,7 @@ pipeline {
                     script {
                         sh """#!/bin/bash -el
                         git add .
-                        git commit --allow-empty -am "Update project version to ${params.RELEASE_CANDIDATE_VERSION}"
+                        git commit --allow-empty -am "Apache KIE ${params.RELEASE_VERSION} release"
                         """.trim()
                         githubUtils.pushObject('origin', "${params.NEW_BRANCH_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
                     }
@@ -134,13 +145,13 @@ pipeline {
             }
         }
 
-        stage('Check `tag` against `package.json.version`') {
+        stage('Check `release version` against `package.json.version`') {
             steps {
                 dir('kie-tools') {
                     script {
                         packageVersion = sh(returnStdout: true, script: "#!/bin/bash -el \n node -p \"require('./package.json').version\"").trim()
                         sh """#!/bin/bash -el
-                        [[ "${params.RELEASE_CANDIDATE_VERSION}" == "${packageVersion}" ]]
+                        [[ "${params.RELEASE_VERSION}" == "${packageVersion}" ]]
                         """.trim()
                     }
                 }
@@ -151,8 +162,8 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        githubUtils.createTag("${params.RELEASE_CANDIDATE_VERSION}")
-                        githubUtils.pushObject('origin', "${params.RELEASE_CANDIDATE_VERSION}", "${pipelineVars.asfGithubPushCredentialsId}")
+                        githubUtils.createTag("${params.TAG_NAME}")
+                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
                     }
                 }
             }
@@ -163,10 +174,11 @@ pipeline {
                 build job: 'KIE/kie-tools/kie-tools-release-build', parameters: [
                     booleanParam(name: 'DRY_RUN', value: false),
                     string(name: 'BASE_REF', value: "${env.BRANCH_NAME}"),
-                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_CANDIDATE_VERSION}"),
+                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
                     string(name: 'UPLOAD_ASSET_URL', value: "${env.RELEASE_UPLOAD_ASSET_URL}"),
                     string(name: 'RUNNERS', value: "${params.RUNNERS}"),
-                    booleanParam(name: 'RELEASE_CANDIDATE', value: true)
+                    booleanParam(name: 'RELEASE_CANDIDATE', value: true),
+                    string(name: 'RELEASE_CANDIDATE_VERSION', value: "${TAG_NAME}")
                 ]
             }
         }

--- a/.ci/jenkins/Jenkinsfile.release-candidate
+++ b/.ci/jenkins/Jenkinsfile.release-candidate
@@ -125,7 +125,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        buildUtils.pnpmUpdateStreamName(params.BRANCH_NAME)
+                        buildUtils.pnpmUpdateStreamName(params.RELEASE_VERSION)
                     }
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -145,6 +145,16 @@ pipeline {
             }
         }
 
+        stage('Update stream name') {
+            steps {
+                dir('kie-tools') {
+                    script {
+                        buildUtils.pnpmUpdateStreamName(params.NEW_BRANCH_NAME)
+                    }
+                }
+            }
+        }
+
         stage('Replace CI image tag') {
             steps {
                 dir('kie-tools/.ci/jenkins') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -356,8 +356,8 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    cp "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip" ${env.RELEASE_ARTIFACTS_DIR}/${CHROME_EXTENSION_RELEASE_ZIP_FILE}
-                    cp "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip" ${env.RELEASE_ARTIFACTS_DIR}/${SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}
+                    cp "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip" "${env.RELEASE_ARTIFACTS_DIR}/${CHROME_EXTENSION_RELEASE_ZIP_FILE}"
+                    cp "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip" "${env.RELEASE_ARTIFACTS_DIR}/${SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -386,7 +386,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -350,9 +350,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-chrome-extension.zip"
-                    env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-chrome-extension.zip"
+                    env.CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-chrome-extension.zip"
+                    env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-chrome-extension.zip"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -385,7 +384,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -47,6 +48,8 @@ pipeline {
         SWF_CHROME_EXTENSION__routerRelativePath = "kogito-online/swf-chrome-extension/${params.RELEASE_VERSION}"
         SWF_CHROME_EXTENSION__manifestFile = 'manifest.prod.json'
 
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
+
         PNPM_FILTER_STRING = '-F chrome-extension-pack-kogito-kie-editors... -F chrome-extension-serverless-workflow-editor...'
     }
 
@@ -58,6 +61,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     chromeStoreUtils = load '.ci/jenkins/shared-scripts/chromeStoreUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -153,7 +157,7 @@ pipeline {
 
         stage('Deploy Chrome Extension for KIE Editors to GitHub Pages (kogito-online)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kogito-online') {
@@ -188,7 +192,7 @@ pipeline {
 
         stage('Upload Chrome Extension for KIE Editors to the Chrome Store') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -204,7 +208,7 @@ pipeline {
 
         stage('Check Upload - Chrome Extension for KIE Editors') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 sh """#!/bin/bash -el
@@ -215,7 +219,7 @@ pipeline {
 
         stage('Publish Chrome Extension for KIE Editors for users') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -230,7 +234,7 @@ pipeline {
 
         stage('Check Publish - Chrome Extension for KIE Editors') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 sh """#!/bin/bash -el
@@ -241,7 +245,7 @@ pipeline {
 
         stage('Upload Chrome Extension for Serverless Workflow Editor') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -258,7 +262,7 @@ pipeline {
 
         stage('Deploy Chrome Extension for Serverless Workflow Editor to GitHub Pages (kogito-online)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kogito-online') {
@@ -289,7 +293,7 @@ pipeline {
 
         stage('Upload Chrome Extension for Serverless Workflow Editor to the Chrome Store') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -305,7 +309,7 @@ pipeline {
 
         stage('Check Upload - Chrome Extension for Serverless Workflow Editor') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 sh """#!/bin/bash -el
@@ -316,7 +320,7 @@ pipeline {
 
         stage('Publish Chrome Extension for Serverless Workflow Editor for users') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -331,12 +335,60 @@ pipeline {
 
         stage('Check Publish - Chrome Extension for Serverless Workflow Editor') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 sh """#!/bin/bash -el
                 [[ "${env.CHROME_EXTESION_SERVERLESS_WORKFLOW_EDITOR_PUBLISH_STATUS}" == "OK" ]] || [[ "${env.CHROME_EXTESION_SERVERLESS_WORKFLOW_EDITOR_PUBLISH_STATUS}" == "PUBLISHED_WITH_FRICTION_WARNING" ]]
                 """.trim()
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-chrome-extension.zip"
+                    env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-chrome-extension.zip"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    cp "kie-tools/packages/chrome-extension-pack-kogito-kie-editors/dist/chrome_extension_kogito_kie_editors_${params.RELEASE_VERSION}.zip" ${env.RELEASE_ARTIFACTS_DIR}/${CHROME_EXTENSION_RELEASE_ZIP_FILE}
+                    cp "kie-tools/packages/chrome-extension-serverless-workflow-editor/dist/chrome_extension_serverless_workflow_editor_${params.RELEASE_VERSION}.zip" ${env.RELEASE_ARTIFACTS_DIR}/${SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.CHROME_EXTENSION_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
+                }
             }
         }
     }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -350,8 +351,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-chrome-extension.zip"
-                    env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-chrome-extension.zip"
+                    env.CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-business-automation-chrome-extension.zip"
+                    env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-chrome-extension.zip"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -384,7 +385,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -370,8 +370,8 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.CHROME_EXTENSION_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.CHROME_EXTENSION_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -168,8 +168,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.CORS_PROXY_IMAGE__imageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.CORS_PROXY_IMAGE__imageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -200,7 +199,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -186,7 +186,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -168,7 +169,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.CORS_PROXY_IMAGE__imageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${env.CORS_PROXY_IMAGE__imageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -199,7 +200,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -84,6 +84,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -173,7 +173,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -211,7 +211,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -47,6 +48,8 @@ pipeline {
         CORS_PROXY_IMAGE__imageName = 'incubator-kie-cors-proxy'
         CORS_PROXY_IMAGE__imageBuildTags = "latest ${params.RELEASE_VERSION}"
 
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
+
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
         PNPM_FILTER_STRING = '-F @kie-tools/cors-proxy-image...'
@@ -61,6 +64,7 @@ pipeline {
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     openShiftUtils = load '.ci/jenkins/shared-scripts/openShiftUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -125,7 +129,7 @@ pipeline {
 
         stage('Push cors-proxy-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -141,7 +145,7 @@ pipeline {
 
         stage('Deploy cors-proxy-image to OpenShift') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -153,6 +157,51 @@ pipeline {
                         "${env.OPENSHIFT_PART_OF}",
                         'nodejs',
                         "${pipelineVars.openshiftCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.CORS_PROXY_IMAGE__imageName}.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.CORS_PROXY_IMAGE__imageRegistry}/${env.CORS_PROXY_IMAGE__imageAccount}/${env.CORS_PROXY_IMAGE__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         DASHBUILDER__viewerImageAccount = 'apache'
         DASHBUILDER__viewerImageName = 'incubator-kie-dashbuilder-viewer'
         DASHBUILDER__viewerImageBuildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push dashbuilder-viewer-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.DASHBUILDER__viewerImageName}",
                         "${env.DASHBUILDER__viewerImageBuildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.DASHBUILDER__viewerImageName}.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.DASHBUILDER__viewerImageRegistry}/${env.DASHBUILDER__viewerImageAccount}/${env.DASHBUILDER__viewerImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.DASHBUILDER__viewerImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.DASHBUILDER__viewerImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.DASHBUILDER__viewerImageRegistry}/${env.DASHBUILDER__viewerImageAccount}/${env.DASHBUILDER__viewerImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.DASHBUILDER__viewerImageRegistry}/${env.DASHBUILDER__viewerImageAccount}/${env.DASHBUILDER__viewerImageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.DASHBUILDER__viewerImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${env.DASHBUILDER__viewerImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.DEV_DEPLOYMENT_BASE_IMAGE__registry}/${env.DEV_DEPLOYMENT_BASE_IMAGE__account}/${env.DEV_DEPLOYMENT_BASE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.DEV_DEPLOYMENT_BASE_IMAGE__registry}/${env.DEV_DEPLOYMENT_BASE_IMAGE__account}/${env.DEV_DEPLOYMENT_BASE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${penv.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-base-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-base-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-base-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-base-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         DEV_DEPLOYMENT_BASE_IMAGE__account = 'apache'
         DEV_DEPLOYMENT_BASE_IMAGE__name = 'incubator-kie-sandbox-dev-deployment-base'
         DEV_DEPLOYMENT_BASE_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push dev-deployment-base-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -134,6 +138,50 @@ pipeline {
             }
         }
 
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${penv.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-base-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.DEV_DEPLOYMENT_BASE_IMAGE__registry}/${env.DEV_DEPLOYMENT_BASE_IMAGE__account}/${env.DEV_DEPLOYMENT_BASE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
+                }
+            }
+        }
     }
 
     post {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account = 'apache'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name = 'incubator-dev-deployment-dmn-form-webapp'
         DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push dev-deployment-dmn-form-webapp-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}",
                         "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__buildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-dmn-form-webapp-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-dmn-form-webapp-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-dmn-form-webapp-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-dmn-form-webapp-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-dmn-form-webapp-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__registry}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__account}/${env.DEV_DEPLOYMENT_DMN_FORM_WEBAPP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account = 'apache'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name = 'incubator-dev-deployment-kogito-quarkus-blank-app'
         DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push dev-deployment-kogito-quarkus-blank-app-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -134,6 +138,50 @@ pipeline {
             }
         }
 
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-quarkus-blank-app-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
+                }
+            }
+        }
     }
 
     post {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-quarkus-blank-app-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-quarkus-blank-app-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__account}/${env.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-quarkus-blank-app-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-quarkus-blank-app-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -199,10 +199,10 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}
-                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}
-                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}
-                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz" "${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}"
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz" "${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}"
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz" "${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}"
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz" "${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -191,10 +192,10 @@ pipeline {
             }
             steps {
                 script {
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-arm64.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-x86.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-linux-x86.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-windows-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-upload-service-macOS-arm64.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-upload-service-macOS-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-upload-service-linux-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-dev-deployment-upload-service-windows-x86.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -231,7 +232,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -38,6 +39,8 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         PNPM_FILTER_STRING = '-F @kie-tools/dev-deployment-upload-service...'
     }
@@ -49,6 +52,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -109,14 +113,14 @@ pipeline {
 
         stage('Upload Dev Deployment Upload Service assets') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
                     // macOS - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz",
                         "dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -124,7 +128,7 @@ pipeline {
                     // macOS - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         "dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -132,7 +136,7 @@ pipeline {
                     // macOS - arm64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz",
                         "dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -140,7 +144,7 @@ pipeline {
                     // macOS - arm64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         "dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -148,7 +152,7 @@ pipeline {
                     // linux - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz",
                         "dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -156,7 +160,7 @@ pipeline {
                     // linux - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         "dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -164,7 +168,7 @@ pipeline {
                     // windows - amd64 - tar.gz
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz",
                         "dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz",
                         'application/tar+gzip',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
@@ -172,10 +176,64 @@ pipeline {
                     // windows - amd64 - tar.gz.sha256
                     githubUtils.uploadReleaseAsset(
                         "${params.UPLOAD_ASSET_URL}",
-                        "packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
+                        "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         "dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz.sha256",
                         'text/plain',
                         "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-arm64.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE = "incubator-kie-${penv.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-linux-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-windows-x86.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-darwin-arm64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-linux-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}
+                    cp "kie-tools/packages/dev-deployment-upload-service/dist/dev-deployment-upload-service-windows-amd64-${params.RELEASE_VERSION}.tar.gz" ${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${params.RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -215,10 +215,10 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -233,7 +233,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -191,11 +191,10 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-arm64.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE = "incubator-kie-${penv.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-x86.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-linux-x86.tar.gz"
-                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-dev-deployment-upload-service-windows-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-arm64.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-macOS-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-linux-x86.tar.gz"
+                    env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-dev-deployment-upload-service-windows-x86.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -169,7 +169,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -136,7 +137,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-extended-services-linux-x86.tar.gz"
+                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-extended-services-linux-x86.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -167,7 +168,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -141,7 +141,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    cp kie-tools/packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                    cp kie-tools/packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz "${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -38,6 +39,8 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         PNPM_FILTER_STRING = '-F @kie-tools/extended-services...'
     }
@@ -49,6 +52,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -109,16 +113,63 @@ pipeline {
 
         stage('Upload Extended Services for Linux') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
+            }
+            steps {
+                dir('kie-tools') {
+                    script {
+                        githubUtils.uploadReleaseAsset(
+                            "${params.UPLOAD_ASSET_URL}",
+                            'packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz',
+                            "kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz",
+                            'application/tar+gzip',
+                            "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
+                        )
+                    }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
-                    githubUtils.uploadReleaseAsset(
-                        "${params.UPLOAD_ASSET_URL}",
-                        'packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz',
-                        "kie_sandbox_extended_services_linux_${params.RELEASE_VERSION}.tar.gz",
-                        'application/tar+gzip',
-                        "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-extended-services-linux-x86.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    cp kie-tools/packages/extended-services/dist/linux/kie_sandbox_extended_services.tar.gz ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -154,7 +154,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -136,8 +136,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-extended-services-linux-x86.tar.gz"
+                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-extended-services-linux-x86.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -168,7 +167,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -33,6 +33,7 @@ pipeline {
         string(description: 'Kie Sandbox Extendend Services Url', name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL')
         string(description: 'Kie Sandbox Cors Proxy Url', name: 'KIE_SANDBOX_CORS_PROXY_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -197,7 +198,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-webapp-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-webapp-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -228,7 +229,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -100,6 +100,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -240,7 +240,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Kie Sandbox Extendend Services Url', name: 'KIE_SANDBOX_EXTENDED_SERVICES_URL')
         string(description: 'Kie Sandbox Cors Proxy Url', name: 'KIE_SANDBOX_CORS_PROXY_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -63,6 +64,8 @@ pipeline {
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.RELEASE_VERSION}"
         ONLINE_EDITOR__gtmId = 'GTM-PQGMKNW'
 
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
+
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
         PNPM_FILTER_STRING = '-F @kie-tools/kie-sandbox-webapp-image...'
@@ -77,6 +80,7 @@ pipeline {
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
                     openShiftUtils = load '.ci/jenkins/shared-scripts/openShiftUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -157,7 +161,7 @@ pipeline {
 
         stage('Prepare environment variables for OpenShift deployment') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 sh """#!/bin/bash -el
@@ -169,7 +173,7 @@ pipeline {
 
         stage('Deploy kie-sandbox-image to OpenShift') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -182,6 +186,51 @@ pipeline {
                         'js',
                         "${pipelineVars.openshiftCredentialsId}",
                         './deployment.env'
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-webapp-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -215,7 +215,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -202,7 +202,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KIE_SANDBOX__imageRegistry}/${env.KIE_SANDBOX__imageAccount}/${env.KIE_SANDBOX__imageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -197,8 +197,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-webapp-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-webapp-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -229,7 +228,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -186,7 +186,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -84,6 +84,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -47,6 +48,8 @@ pipeline {
         KIE_SANDBOX_EXTENDED_SERVICES__imageName = 'incubator-kie-sandbox-extended-services'
         KIE_SANDBOX_EXTENDED_SERVICES__imageBuildTags = "latest ${params.RELEASE_VERSION}"
 
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
+
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
         PNPM_FILTER_STRING = '-F @kie-tools/kie-sandbox-extended-services-image...'
@@ -61,6 +64,7 @@ pipeline {
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
                     openShiftUtils = load '.ci/jenkins/shared-scripts/openShiftUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -125,7 +129,7 @@ pipeline {
 
         stage('Push kie-sandbox-extended-services-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -141,7 +145,7 @@ pipeline {
 
         stage('Deploy kie-sandbox-extended-services-image to OpenShift') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -153,6 +157,51 @@ pipeline {
                         "${env.OPENSHIFT_PART_OF}",
                         'golang',
                         "${pipelineVars.openshiftCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-extended-services-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -211,7 +211,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -168,8 +168,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-extended-services-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-extended-services-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -200,7 +199,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -168,7 +169,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-extended-services-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-extended-services-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -199,7 +200,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -173,7 +173,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KIE_SANDBOX_EXTENDED_SERVICES__imageRegistry}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageAccount}/${env.KIE_SANDBOX_EXTENDED_SERVICES__imageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -145,8 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-helm-chart.tar.gz"
+                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-helm-chart.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -177,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -163,7 +163,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -150,7 +150,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    cp kie-tools/packages/kie-sandbox-helm-chart/dist/${env.KIE_SANDBOX_HELM_CHART__name}-${env.KIE_SANDBOX_HELM_CHART__tag}.tgz ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                    cp "kie-tools/packages/kie-sandbox-helm-chart/dist/${env.KIE_SANDBOX_HELM_CHART__name}-${env.KIE_SANDBOX_HELM_CHART__tag}.tgz" "${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -188,7 +188,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -145,7 +146,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-helm-chart.tar.gz"
+                    env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-helm-chart.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +177,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         KIE_SANDBOX_HELM_CHART__account = 'apache'
         KIE_SANDBOX_HELM_CHART__name = 'incubator-kie-sandbox-helm-chart'
         KIE_SANDBOX_HELM_CHART__tag = "${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     helmUtils = load '.ci/jenkins/shared-scripts/helmUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push kie-sandbox-helm-chart to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE  }
             }
             steps {
                 dir('kie-tools') {
@@ -131,6 +135,51 @@ pipeline {
                             "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
                         )
                     }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-helm-chart.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    cp kie-tools/packages/kie-sandbox-helm-chart/dist/${env.KIE_SANDBOX_HELM_CHART__name}-${env.KIE_SANDBOX_HELM_CHART__tag}.tgz ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -220,10 +220,10 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -198,10 +199,10 @@ pipeline {
             }
             steps {
                 script {
-                    env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-linux-x86.zip"
-                    env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-macOS-arm64.zip"
-                    env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-macOS-x86.zip"
-                    env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-windows-x86.zip"
+                    env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-knative-plugin-linux-x86.zip"
+                    env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-knative-plugin-macOS-arm64.zip"
+                    env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-knative-plugin-macOS-x86.zip"
+                    env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-knative-plugin-windows-x86.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-linux-amd64')
@@ -236,7 +237,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -198,11 +198,10 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-linux-x86.zip"
-                    env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-macOS-arm64.zip"
-                    env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-macOS-x86.zip"
-                    env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-windows-x86.zip"
+                    env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-linux-x86.zip"
+                    env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-macOS-arm64.zip"
+                    env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-macOS-x86.zip"
+                    env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-knative-plugin-windows-x86.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-linux-amd64')
@@ -237,7 +236,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -38,6 +39,8 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         PNPM_FILTER_STRING = '-F @kie-tools/kn-plugin-workflow...'
     }
@@ -49,6 +52,8 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
                 }
             }
         }
@@ -113,7 +118,7 @@ pipeline {
 
         stage('Upload Knative CLI Workflow Plugin for Linux') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -132,7 +137,7 @@ pipeline {
 
         stage('Upload Knative CLI Workflow Plugin for macOS') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -151,7 +156,7 @@ pipeline {
 
         stage('Upload Knative CLI Workflow Plugin for macOS M1') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -170,7 +175,7 @@ pipeline {
 
         stage('Upload Knative CLI Workflow Plugin for Windows') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -183,6 +188,58 @@ pipeline {
                             "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                         )
                     }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-linux-x86.zip"
+                    env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-macOS-arm64.zip"
+                    env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-macOS-x86.zip"
+                    env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-knative-plugin-windows-x86.zip"
+
+                    sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-linux-amd64')
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-darwin-arm64')
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-darwin-amd64')
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}", 'kie-tools/packages/kn-plugin-workflow/dist/kn-workflow-windows-amd64.exe')
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -238,7 +238,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${KOGITO_MANAGEMENT_CONSOLE__name}-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${KOGITO_MANAGEMENT_CONSOLE__name}-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KOGITO_MANAGEMENT_CONSOLE__registry}/${env.KOGITO_MANAGEMENT_CONSOLE__account}/${env.KOGITO_MANAGEMENT_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KOGITO_MANAGEMENT_CONSOLE__registry}/${env.KOGITO_MANAGEMENT_CONSOLE__account}/${env.KOGITO_MANAGEMENT_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${KOGITO_MANAGEMENT_CONSOLE__name}-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${KOGITO_MANAGEMENT_CONSOLE__name}-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         KOGITO_MANAGEMENT_CONSOLE__account = 'apache'
         KOGITO_MANAGEMENT_CONSOLE__name = 'incubator-kie-kogito-management-console'
         KOGITO_MANAGEMENT_CONSOLE__buildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push kogito-management-console to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.KOGITO_MANAGEMENT_CONSOLE__name}",
                         "${env.KOGITO_MANAGEMENT_CONSOLE__buildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${KOGITO_MANAGEMENT_CONSOLE__name}-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KOGITO_MANAGEMENT_CONSOLE__registry}/${env.KOGITO_MANAGEMENT_CONSOLE__account}/${env.KOGITO_MANAGEMENT_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SONATAFLOW_OPERATOR__account = 'apache'
         SONATAFLOW_OPERATOR__name = 'incubator-kie-sonataflow-operator'
         SONATAFLOW_OPERATOR__buildTag = "${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -150,7 +154,7 @@ pipeline {
 
         stage('Push sonataflow-operator to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE  }
             }
             steps {
                 script {
@@ -159,6 +163,55 @@ pipeline {
                         "${env.SONATAFLOW_OPERATOR__name}",
                         "${env.SONATAFLOW_OPERATOR__buildTag} latest",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-operator-image.tar.gz"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}--sonataflow-operator.zip"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KOGITO_SERVERLESS_OPERATOR__registry}/${env.KOGITO_SERVERLESS_OPERATOR__account}/${env.KOGITO_SERVERLESS_OPERATOR__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", 'kie-tools/packages/kogito-serverless-operator/operator.yaml')
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -175,9 +175,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-operator-image.tar.gz"
-                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-operator.zip"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-operator-image.tar.gz"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-operator.zip"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -211,7 +210,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -60,6 +60,7 @@ pipeline {
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
                     releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -175,8 +176,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-operator-image.tar.gz"
-                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-operator.zip"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-operator-image.tar.gz"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-operator.zip"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -210,7 +211,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -176,11 +176,11 @@ pipeline {
                 script {
                     env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
                     env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-operator-image.tar.gz"
-                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}--sonataflow-operator.zip"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-operator.zip"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KOGITO_SERVERLESS_OPERATOR__registry}/${env.KOGITO_SERVERLESS_OPERATOR__account}/${env.KOGITO_SERVERLESS_OPERATOR__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.SONATAFLOW_OPERATOR__registry}/${env.SONATAFLOW_OPERATOR__account}/${env.SONATAFLOW_OPERATOR__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
                     """.trim()
 
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", 'kie-tools/packages/kogito-serverless-operator/operator.yaml')

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -80,6 +80,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -196,8 +196,8 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -181,7 +181,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.SONATAFLOW_OPERATOR__registry}/${env.SONATAFLOW_OPERATOR__account}/${env.SONATAFLOW_OPERATOR__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.SONATAFLOW_OPERATOR__registry}/${env.SONATAFLOW_OPERATOR__account}/${env.SONATAFLOW_OPERATOR__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
 
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", 'kie-tools/packages/kogito-serverless-operator/operator.yaml')

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -222,7 +222,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -175,7 +175,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SONATAFLOW_BUILDER_IMAGE__account = 'apache'
         SONATAFLOW_BUILDER_IMAGE__name = 'incubator-kie-sonataflow-builder'
         SONATAFLOW_BUILDER_IMAGE__buildTag = "${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -133,7 +137,7 @@ pipeline {
 
         stage('Push sonataflow-builder to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -142,6 +146,51 @@ pipeline {
                         "${env.SONATAFLOW_BUILDER_IMAGE__name}",
                         "${env.SONATAFLOW_BUILDER_IMAGE__buildTag} latest",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-builder-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KOGITO_SWF_BUILDER_IMAGE__registry}/${env.KOGITO_SWF_BUILDER_IMAGE__account}/${env.KOGITO_SWF_BUILDER_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -200,7 +200,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -157,7 +158,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-builder-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-builder-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -188,7 +189,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -162,7 +162,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KOGITO_SWF_BUILDER_IMAGE__registry}/${env.KOGITO_SWF_BUILDER_IMAGE__account}/${env.KOGITO_SWF_BUILDER_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KOGITO_SWF_BUILDER_IMAGE__registry}/${env.KOGITO_SWF_BUILDER_IMAGE__account}/${env.KOGITO_SWF_BUILDER_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -157,8 +157,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-builder-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-builder-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -189,7 +188,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -157,7 +158,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-devmode-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-devmode-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -188,7 +189,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -175,7 +175,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SONATAFLOW_DEVMODE_IMAGE__account = 'apache'
         SONATAFLOW_DEVMODE_IMAGE__name = 'incubator-kie-sonataflow-devmode'
         SONATAFLOW_DEVMODE_IMAGE__buildTag = "${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -133,7 +137,7 @@ pipeline {
 
         stage('Push sonataflow-devmode to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -142,6 +146,51 @@ pipeline {
                         "${env.SONATAFLOW_DEVMODE_IMAGE__name}",
                         "${env.SONATAFLOW_DEVMODE_IMAGE__buildTag} latest",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-devmode-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KOGITO_SWF_DEVMODE_IMAGE__registry}/${env.KOGITO_SWF_DEVMODE_IMAGE__account}/${env.KOGITO_SWF_DEVMODE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -200,7 +200,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -162,7 +162,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KOGITO_SWF_DEVMODE_IMAGE__registry}/${env.KOGITO_SWF_DEVMODE_IMAGE__account}/${env.KOGITO_SWF_DEVMODE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KOGITO_SWF_DEVMODE_IMAGE__registry}/${env.KOGITO_SWF_DEVMODE_IMAGE__account}/${env.KOGITO_SWF_DEVMODE_IMAGE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -157,8 +157,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-devmode-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-devmode-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -189,7 +188,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.KOGITO_TASK_CONSOLE__name}-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${env.KOGITO_TASK_CONSOLE__name}-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.KOGITO_TASK_CONSOLE__name}-image.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${env.KOGITO_TASK_CONSOLE__name}-image.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         KOGITO_TASK_CONSOLE__account = 'apache'
         KOGITO_TASK_CONSOLE__name = 'incubator-kie-kogito-task-console'
         KOGITO_TASK_CONSOLE__buildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push kogito-task-console to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.KOGITO_TASK_CONSOLE__name}",
                         "${env.KOGITO_TASK_CONSOLE__buildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${env.KOGITO_TASK_CONSOLE__name}-image.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.KOGITO_TASK_CONSOLE__registry}/${env.KOGITO_TASK_CONSOLE__account}/${env.KOGITO_TASK_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.KOGITO_TASK_CONSOLE__registry}/${env.KOGITO_TASK_CONSOLE__account}/${env.KOGITO_TASK_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.KOGITO_TASK_CONSOLE__registry}/${env.KOGITO_TASK_CONSOLE__account}/${env.KOGITO_TASK_CONSOLE__name}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -50,6 +51,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
                 }
             }
         }
@@ -151,13 +153,16 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-tools-npm-packages.tar.gz"
+                        env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-tools-npm-packages.zip"
+                        env.TMP_RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-tools-npm-packages"
 
                         sh """#!/bin/bash -el
-                        mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                        npm pack
-                        cp "kie-tools/kie-tools-root-${params.RELEASE_VERSION}.tgz" "${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}"
+                        mkdir ${env.TMP_RELEASE_ARTIFACTS_DIR} ${env.RELEASE_ARTIFACTS_DIR}
+                        PNPM_FILTER_STRING_FOR_PUBLISHING=\$(pnpm -r exec 'bash' '-c' 'PKG_NAME=\$(jq -r ".name" package.json) PKG_IS_PVT=\$(jq -r ".private" package.json); if [[ "\$PKG_IS_PVT" != "true" ]]; then echo "-F \$PKG_NAME"; fi')
+                        echo \$PNPM_FILTER_STRING_FOR_PUBLISHING
+                        pnpm \$PNPM_FILTER_STRING_FOR_PUBLISHING exec 'bash' '-c' 'pnpm pack --pack-destination ${env.TMP_RELEASE_ARTIFACTS_DIR}'
                         """.trim()
+                        zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", "${env.TMP_RELEASE_ARTIFACTS_DIR}")
                     }
                 }
             }
@@ -170,7 +175,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }
@@ -184,7 +189,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -37,6 +38,8 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
     }
 
     stages {
@@ -46,6 +49,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -124,7 +128,7 @@ pipeline {
 
         stage('Publish packages to the NPM registry') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -136,6 +140,54 @@ pipeline {
                         pnpm \$PNPM_FILTER_STRING_FOR_PUBLISHING exec 'bash' '-c' 'PKG_NAME=\$(jq -r ".name" package.json); NPM_PKG_INFO=\$(npm view \$PKG_NAME@${params.RELEASE_VERSION} name || echo ""); if [[ -z \$NPM_PKG_INFO ]]; then pnpm publish --no-git-checks --access public; fi'
                         """.trim()
                     }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                dir('kie-tools') {
+                    script {
+                        env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                        env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-tools-npm-packages.tar.gz"
+
+                        sh """#!/bin/bash -el
+                        mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                        npm pack
+                        cp "kie-tools/kie-tools-root-${params.RELEASE_VERSION}.tgz" ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                        """.trim()
+                    }
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -157,7 +157,7 @@ pipeline {
                         sh """#!/bin/bash -el
                         mkdir ${env.RELEASE_ARTIFACTS_DIR}
                         npm pack
-                        cp "kie-tools/kie-tools-root-${params.RELEASE_VERSION}.tgz" ${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}
+                        cp "kie-tools/kie-tools-root-${params.RELEASE_VERSION}.tgz" "${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}"
                         """.trim()
                     }
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -151,8 +151,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                        env.RELEASE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-tools-npm-packages.tar.gz"
+                        env.RELEASE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-tools-npm-packages.tar.gz"
 
                         sh """#!/bin/bash -el
                         mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -185,7 +184,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -190,7 +190,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -171,7 +171,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -68,6 +69,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -146,7 +148,7 @@ pipeline {
 
         stage('Deploy to GitHub Pages (kogito-online)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kogito-online') {
@@ -188,6 +190,50 @@ pipeline {
                 }
             }
         }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-webapp.zip"
+
+                    sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/online-editor/dist/')
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
+                }
+            }
+        }
+        
     }
 
     post {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -214,7 +214,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -234,7 +234,6 @@ pipeline {
                 }
             }
         }
-        
     }
 
     post {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -70,6 +70,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -198,8 +198,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sandbox-webapp.zip"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-webapp.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/online-editor/dist/')
@@ -228,7 +227,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -229,7 +229,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -198,7 +199,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sandbox-webapp.zip"
+                    env.RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sandbox-webapp.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/online-editor/dist/')
@@ -227,7 +228,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount = 'apache'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName = 'incubator-kie-serverless-logic-web-tools-base-builder'
         SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push serverless-logic-web-tools-base-builder-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}",
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageBuildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__baseBuilderImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount = 'apache'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName = 'incubator-serverless-logic-web-tools-swf-builder'
         SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push serverless-logic-web-tools-swf-builder-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}",
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageBuildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -79,6 +79,16 @@ pipeline {
             }
         }
 
+        stage('Load upstream images') {
+            steps {
+                script {
+                    upstreamReleaseArtifactsDir = "${WORKSPACE}/upstream-release-artifacts"
+                    releaseUtils.downloadReleaseArtifacts("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}")
+                    dockerUtils.loadImages(releaseUtils.getUpstreamImagesArtifactsList("${upstreamReleaseArtifactsDir}", "${params.RELEASE_CANDIDATE_VERSION}"))
+                }
+            }
+        }
+
         stage('Checkout kie-tools') {
             steps {
                 dir('kie-tools') {

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -187,7 +187,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -144,7 +145,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -175,7 +176,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -149,7 +149,7 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}:${params.RELEASE_VERSION}" | gzip > "${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -144,8 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}.tar.gz"
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${params.RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}.tar.gz"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -176,7 +175,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -162,7 +162,7 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -42,6 +43,8 @@ pipeline {
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount = 'apache'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName = 'incubator-kie-serverless-logic-web-tools-swf-dev-mode'
         SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags = "latest ${params.RELEASE_VERSION}"
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -56,6 +59,7 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     dockerUtils = load '.ci/jenkins/shared-scripts/dockerUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -120,7 +124,7 @@ pipeline {
 
         stage('Push serverless-logic-web-tools-swf-dev-mode-image to Docker Hub') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE  }
             }
             steps {
                 script {
@@ -129,6 +133,51 @@ pipeline {
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}",
                         "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageBuildTags}",
                         "${pipelineVars.dockerHubApacheKiePushCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.RELEASE_IMAGE_TAR_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-${SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}.tar.gz"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    docker save "${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount}/${env.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageName}:${params.RELEASE_VERSION}" | gzip > ${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifact for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -209,7 +209,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -175,9 +175,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-standalone-editors.zip"
-                    env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-standalone-editors.zip"
+                    env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-standalone-editors.zip"
+                    env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-standalone-editors.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/kie-editors-standalone/dist')
@@ -208,7 +207,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -30,6 +30,7 @@ pipeline {
         booleanParam(description: 'Dry run', name: 'DRY_RUN', defaultValue: true)
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -37,6 +38,8 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
         PNPM_FILTER_STRING = '-F @kie-tools/kie-editors-standalone... -F @kie-tools/serverless-workflow-standalone-editor...'
     }
@@ -48,6 +51,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -126,7 +130,7 @@ pipeline {
 
         stage('Deploy to GitHub Pages (kogito-online)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kogito-online') {
@@ -159,6 +163,52 @@ pipeline {
 
                         githubUtils.pushObject('origin', 'gh-pages', "${pipelineVars.asfGithubPushCredentialsId}")
                     }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-standalone-editors.zip"
+                    env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-standalone-editors.zip"
+
+                    sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/kie-editors-standalone/dist')
+                    zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/serverless-workflow-standalone-editor/dist')
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -193,8 +193,8 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -52,6 +52,8 @@ pipeline {
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
                     releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
+                    zipUtils = load '.ci/jenkins/shared-scripts/zipUtils.groovy'
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -175,8 +176,8 @@ pipeline {
             }
             steps {
                 script {
-                    env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-standalone-editors.zip"
-                    env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-standalone-editors.zip"
+                    env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-business-automation-standalone-editors.zip"
+                    env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-standalone-editors.zip"
 
                     sh "mkdir ${env.RELEASE_ARTIFACTS_DIR}"
                     zipUtils.zipArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}", 'kie-tools/packages/kie-editors-standalone/dist')
@@ -207,7 +208,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -307,14 +307,14 @@ pipeline {
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
-                    cp "kie-tools/packages/bpmn-vscode-extension/dist/bpmn_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "pkie-tools/ackages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/yard-vscode-extension/dist/yard_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}
-                    cp "kie-tools/packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/bpmn-vscode-extension/dist/bpmn_vscode_extension_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/ackages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/yard-vscode-extension/dist/yard_vscode_extension_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}"
+                    cp "kie-tools/packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix" "${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}"
                     """.trim()
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -31,6 +31,7 @@ pipeline {
         string(description: 'Release Version', name: 'RELEASE_VERSION', defaultValue: '0.0.0')
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
+        booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
     }
 
     environment {
@@ -38,6 +39,17 @@ pipeline {
         KIE_TOOLS_BUILD__runTests = 'false'
         KIE_TOOLS_BUILD__runEndToEndTests = 'false'
         KIE_TOOLS_BUILD__buildContainerImages = 'true'
+
+        RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
+
+        BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-bpmn-vscode-extension.vsix"
+        DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dmn-vscode-extension.vsix"
+        PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-pmml-vscode-extension.vsix"
+        DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
+        SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
+        YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-yard-vscode-extension.vsix"
+        KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
+        BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
     }
 
     stages {
@@ -47,6 +59,7 @@ pipeline {
                     pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
                     buildUtils = load '.ci/jenkins/shared-scripts/buildUtils.groovy'
                     githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                    releaseUtils = load '.ci/jenkins/shared-scripts/releaseUtils.groovy'
                 }
             }
         }
@@ -99,7 +112,8 @@ pipeline {
                     -F vscode-extension-kogito-bundle... \
                     -F swf-vscode-extension... \
                     -F vscode-extension-kie-ba-bundle... \
-                    -F vscode-extension-dashbuilder-editor...
+                    -F vscode-extension-dashbuilder-editor... \
+                    -F yard-vscode-extension...
                     '''.trim()
                 }
             }
@@ -116,6 +130,7 @@ pipeline {
                     -F swf-vscode-extension... \
                     -F vscode-extension-kie-ba-bundle... \
                     -F vscode-extension-dashbuilder-editor... \
+                    -F yard-vscode-extension... \
                     build:prod
                     '''.trim()
                 }
@@ -124,7 +139,7 @@ pipeline {
 
         stage('Upload VS Code Extension - BPMN Editor (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -143,7 +158,7 @@ pipeline {
 
         stage('Upload VS Code Extension - DMN Editor (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -162,7 +177,7 @@ pipeline {
 
         stage('Upload VS Code Extension - PMML Editor (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -181,7 +196,7 @@ pipeline {
 
         stage('Upload VS Code Extension - Kogito Bundle (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -200,7 +215,7 @@ pipeline {
 
         stage('Upload VS Code Extension - KIE Business Automation Bundle (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -219,7 +234,7 @@ pipeline {
 
         stage('Upload VS Code Extension - Serverless Workflow Editor - KIE (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -238,7 +253,7 @@ pipeline {
 
         stage('Upload VS Code Extension - Dashbuilder Editor (prod)') {
             when {
-                expression { !params.DRY_RUN }
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
             }
             steps {
                 dir('kie-tools') {
@@ -251,6 +266,91 @@ pipeline {
                             "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
                         )
                     }
+                }
+            }
+        }
+
+        stage('Upload VS Code Extension - Yard (prod)') {
+            when {
+                expression { !params.DRY_RUN && !params.RELEASE_CANDIDATE }
+            }
+            steps {
+                dir('kie-tools') {
+                    script {
+                        githubUtils.uploadReleaseAsset(
+                            "${params.UPLOAD_ASSET_URL}",
+                            "packages/yard-vscode-extension/dist/yard_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                            "yard_vscode_extension_${params.RELEASE_VERSION}.vsix",
+                            'application/zip',
+                            "${pipelineVars.kieToolsBotGithubTokenCredentialsId}"
+                        )
+                    }
+                }
+            }
+        }
+
+        stage('Setup release candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
+                    env.BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-bpmn-vscode-extension.vsix"
+                    env.DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-dmn-vscode-extension.vsix"
+                    env.PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-pmml-vscode-extension.vsix"
+                    env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
+                    env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
+                    env.YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-yard-vscode-extension.vsix"
+                    env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
+                    env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
+
+                    sh """#!/bin/bash -el
+                    mkdir ${env.RELEASE_ARTIFACTS_DIR}
+                    cp "kie-tools/packages/bpmn-vscode-extension/dist/bpmn_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/dmn-vscode-extension/dist/dmn_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "pkie-tools/ackages/pmml-vscode-extension/dist/pmml_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/vscode-extension-dashbuilder-editor/dist/vscode_extension_dashbuilder_editor_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/serverless-workflow-vscode-extension/dist/serverless_workflow_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/yard-vscode-extension/dist/yard_vscode_extension_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/vscode-extension-kogito-bundle/dist/vscode_extension_kogito_bundle_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}
+                    cp "kie-tools/packages/vscode-extension-kie-ba-bundle/dist/vscode_extension_kie_ba_bundle_${params.RELEASE_VERSION}.vsix" ${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}
+                    """.trim()
+                }
+            }
+        }
+
+        stage('Sign artifacts for Apache release') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
+                }
+            }
+        }
+
+        stage('Publish Release Candidate artifacts') {
+            when {
+                expression { !params.DRY_RUN && params.RELEASE_CANDIDATE }
+            }
+            steps {
+                script {
+                    releaseUtils.publishArtifacts(
+                        "${env.RELEASE_ARTIFACTS_DIR}",
+                        "${pipelineVars.asfReleaseStagingRepository}",
+                        "${env.FINAL_RELEASE_VERSION}",
+                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                    )
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -295,15 +295,14 @@ pipeline {
             }
             steps {
                 script {
-                    env.FINAL_RELEASE_VERSION = releaseUtils.getFinalReleaseVersion("${params.RELEASE_VERSION}")
-                    env.BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-bpmn-vscode-extension.vsix"
-                    env.DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-dmn-vscode-extension.vsix"
-                    env.PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-pmml-vscode-extension.vsix"
-                    env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
-                    env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
-                    env.YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-yard-vscode-extension.vsix"
-                    env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
-                    env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${env.FINAL_RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
+                    env.BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-bpmn-vscode-extension.vsix"
+                    env.DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dmn-vscode-extension.vsix"
+                    env.PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-pmml-vscode-extension.vsix"
+                    env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
+                    env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
+                    env.YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-yard-vscode-extension.vsix"
+                    env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
+                    env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -348,7 +347,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${env.FINAL_RELEASE_VERSION}",
+                        "${params.RELEASE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -349,7 +349,7 @@ pipeline {
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
                         "${params.RELEASE_CANDIDATE_VERSION}",
-                        "${pipelineVars.asfReleaseUserCredentialsId}"
+                        "${pipelineVars.asfReleaseSVNStagingCredentialsId}"
                     )
                 }
             }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -32,6 +32,7 @@ pipeline {
         string(description: 'Base Ref', name: 'BASE_REF')
         string(description: 'Upload Asset Url', name: 'UPLOAD_ASSET_URL')
         booleanParam(description: 'Release Candidate', name: 'RELEASE_CANDIDATE', defaultValue: false)
+        string(description: 'Release Candidate Version', name: 'RELEASE_CANDIDATE_VERSION', defaultValue: '')
     }
 
     environment {
@@ -42,14 +43,14 @@ pipeline {
 
         RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 
-        BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-bpmn-vscode-extension.vsix"
-        DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dmn-vscode-extension.vsix"
-        PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-pmml-vscode-extension.vsix"
-        DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
-        SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
-        YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-yard-vscode-extension.vsix"
-        KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
-        BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
+        BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-bpmn-vscode-extension.vsix"
+        DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-dmn-vscode-extension.vsix"
+        PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-pmml-vscode-extension.vsix"
+        DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-dashbuilder-vscode-extension.vsix"
+        SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-vscode-extension.vsix"
+        YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-yard-vscode-extension.vsix"
+        KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-kogito-bundle-vscode-extension.vsix"
+        BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-business-automation-bundle-vscode-extension.vsix"
     }
 
     stages {
@@ -295,14 +296,14 @@ pipeline {
             }
             steps {
                 script {
-                    env.BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-bpmn-vscode-extension.vsix"
-                    env.DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dmn-vscode-extension.vsix"
-                    env.PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-pmml-vscode-extension.vsix"
-                    env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-dashbuilder-vscode-extension.vsix"
-                    env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-sonataflow-vscode-extension.vsix"
-                    env.YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-yard-vscode-extension.vsix"
-                    env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-kogito-bundle-vscode-extension.vsix"
-                    env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_VERSION}-business-automation-bundle-vscode-extension.vsix"
+                    env.BPMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-bpmn-vscode-extension.vsix"
+                    env.DMN_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-dmn-vscode-extension.vsix"
+                    env.PMML_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-pmml-vscode-extension.vsix"
+                    env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-dashbuilder-vscode-extension.vsix"
+                    env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-sonataflow-vscode-extension.vsix"
+                    env.YARD_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-yard-vscode-extension.vsix"
+                    env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-kogito-bundle-vscode-extension.vsix"
+                    env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE = "incubator-kie-${params.RELEASE_CANDIDATE_VERSION}-business-automation-bundle-vscode-extension.vsix"
 
                     sh """#!/bin/bash -el
                     mkdir ${env.RELEASE_ARTIFACTS_DIR}
@@ -347,7 +348,7 @@ pipeline {
                     releaseUtils.publishArtifacts(
                         "${env.RELEASE_ARTIFACTS_DIR}",
                         "${pipelineVars.asfReleaseStagingRepository}",
-                        "${params.RELEASE_VERSION}",
+                        "${params.RELEASE_CANDIDATE_VERSION}",
                         "${pipelineVars.asfReleaseUserCredentialsId}"
                     )
                 }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -327,14 +327,14 @@ pipeline {
             steps {
                 script {
                     releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
+                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}", "${pipelineVars.asfReleaseGPGKeyPasswordCredentialsId}")
                 }
             }
         }

--- a/.ci/jenkins/shared-scripts/buildUtils.groovy
+++ b/.ci/jenkins/shared-scripts/buildUtils.groovy
@@ -103,6 +103,15 @@ def pnpmUpdateKogitoVersion(String kogitoVersion, String imagesTag) {
 }
 
 /**
+* PNPM update stream name to
+*/
+def pnpmUpdateStreamName(String streamName) {
+    sh """#!/bin/bash -el
+    pnpm update-stream-name-to ${streamName}
+    """.trim()
+}
+
+/**
 * Start KIE-Tools required services for build and test
 */
 def startRequiredServices() {

--- a/.ci/jenkins/shared-scripts/dockerUtils.groovy
+++ b/.ci/jenkins/shared-scripts/dockerUtils.groovy
@@ -50,4 +50,20 @@ def tagImage(String registry, String image, String oldTag, String newTag) {
     sh "docker tag ${registry}/${image}:${oldTag} ${registry}/${image}:${newTag}"
 }
 
+/**
+* Load an image
+*/
+def loadImage(String imageFile) {
+    sh "docker load < ${imageFile}"
+}
+
+/**
+* Load multiple images
+*/
+def loadImages(String... imagesFiles) {
+    for (imageFile in imagesFiles) {
+        loadImage(imageFile)
+    }
+}
+
 return this

--- a/.ci/jenkins/shared-scripts/pipelineVars.groovy
+++ b/.ci/jenkins/shared-scripts/pipelineVars.groovy
@@ -39,8 +39,8 @@ class PipelineVars implements Serializable {
     String defaultArtifactsTempDir = 'artifacts-tmp'
     String asfReleaseStagingRepository = 'https://dist.apache.org/repos/dist/dev/incubator/kie'
     String asfReleaseGPGKeyCredentialsId = 'asf-release-gpg-signing-key'
-    String asfReleaseGPGKeyPasswordCredentialsId = 'asf-release-gpg-signing-key-password'
-    String asfReleaseUserCredentialsId = 'asf-release-credentials'
+    String asfReleaseGPGKeyPasswordCredentialsId = 'asf-release-gpg-signing-key-passphrase'
+    String asfReleaseSVNStagingCredentialsId = 'asf-release-svn-staging'
 
 }
 

--- a/.ci/jenkins/shared-scripts/pipelineVars.groovy
+++ b/.ci/jenkins/shared-scripts/pipelineVars.groovy
@@ -40,6 +40,7 @@ class PipelineVars implements Serializable {
     String asfReleaseStagingRepository = 'https://dist.apache.org/repos/dist/dev/incubator/kie'
     String asfReleaseGPGKeyCredentialsId = 'asf-release-gpg-signing-key'
     String asfReleaseGPGKeyPasswordCredentialsId = 'asf-release-gpg-signing-key-password'
+    String asfReleaseUserCredentialsId = 'asf-release-credentials'
 
 }
 

--- a/.ci/jenkins/shared-scripts/pipelineVars.groovy
+++ b/.ci/jenkins/shared-scripts/pipelineVars.groovy
@@ -37,6 +37,7 @@ class PipelineVars implements Serializable {
     String mavenSettingsConfigFileId = 'kie-release-settings'
     String mavenDeployRepositoryCredentialsId = 'apache-nexus-kie-deploy-credentials'
     String defaultArtifactsTempDir = 'artifacts-tmp'
+    String asfReleaseStagingRepository = 'https://dist.apache.org/repos/dist/dev/incubator/kie'
     String asfReleaseGPGKeyCredentialsId = 'asf-release-gpg-signing-key'
     String asfReleaseGPGKeyPasswordCredentialsId = 'asf-release-gpg-signing-key-password'
 

--- a/.ci/jenkins/shared-scripts/releaseUtils.groovy
+++ b/.ci/jenkins/shared-scripts/releaseUtils.groovy
@@ -58,13 +58,3 @@ def publishArtifacts(String artifactsDir, String releaseRepository, String relea
         """.trim()
     }
 }
-
-/**
-* Return the final release version from a release candidate version (10.0.0-rc1 -> 10.0.0)
-*/
-def getFinalReleaseVersion(String releaseCandidateVersion) {
-    finalReleaseVersion = releaseCandidateVersion.replaceAll(/-rc\d{1,2}/, '')
-    return finalReleaseVersion
-}
-
-return this

--- a/.ci/jenkins/shared-scripts/releaseUtils.groovy
+++ b/.ci/jenkins/shared-scripts/releaseUtils.groovy
@@ -58,3 +58,27 @@ def publishArtifacts(String artifactsDir, String releaseRepository, String relea
         """.trim()
     }
 }
+
+/**
+* Download release artifacts from a specific release
+*/
+def downloadReleaseArtifacts(String artifactsDir, String releaseVersion) {
+    sh """#!/bin/bash -el
+    svn co "${releaseRepository}/${releaseVersion}" "${artifactsDir}/${releaseVersion}"
+    """.trim()
+}
+
+/**
+* Return a list of upstream images artifacts
+*/
+def getUpstreamImagesArtifactsList(String artifactsDir, String releaseVersion) {
+    return [
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-base-builder-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-data-index-ephemeral-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-data-index-postgresql-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-jit-runner-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-jobs-service-allinone-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-jobs-service-ephemeral-image.tar.gz",
+        "${artifactsDir}/incubator-kie-${releaseVersion}-kogito-jobs-service-postgresql-image.tar.gz"
+    ]
+}

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -118,9 +118,9 @@ jobs:
         if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
         shell: bash
         env:
-          RC_VERSION: ${{ inputs.release_candidate_version }}
+          PROJECT_VERSION: ${{ inputs.release_candidate_version }}
         run: |
-          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$RC_VERSION-sandbox-extended-services-macOS.zip"
+          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$PROJECT_VERSION-sandbox-extended-services-macOS.zip"
           echo "ARTIFACT_ZIP_FILE=$ARTIFACT_ZIP_FILE" >> "$GITHUB_OUTPUT"
           mkdir ./extended-services-release-artifacts
           zip $ARTIFACT_ZIP_FILE ./packages/extended-services/dist/darwin/Kogito.dmg
@@ -131,7 +131,6 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          RC_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.macos_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
           echo $GPG_KEY > ./signkey.gpg
@@ -147,14 +146,14 @@ jobs:
         env:
           ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
           ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
-          RC_VERSION: ${{ inputs.release_candidate_version }}
+          PROJECT_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.macos_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
           svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/kie svn-kie
-          cp ./extended-services-release-artifacts/* svn-kie/$RC_VERSION/
-          svn add "svn-kie/$RC_VERSION"
+          cp ./extended-services-release-artifacts/* svn-kie/$PROJECT_VERSION/
+          svn add "svn-kie/$PROJECT_VERSION"
           cd svn-kie
-          svn ci --non-interactive --no-auth-cache --username $ASF_USERNAME --password '$ASF_PASSWORD' -m "Apache KIE $RC_VERSION Extended Services for macOS artifact"
+          svn ci --non-interactive --no-auth-cache --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for macOS artifact"
           rm -rf svn-kie
 
       - name: "Setup Extended Services for Windows artifacts"
@@ -162,9 +161,9 @@ jobs:
         if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
         shell: pwsh
         env:
-          RC_VERSION: ${{ inputs.release_candidate_version }}
+          PROJECT_VERSION: ${{ inputs.release_candidate_version }}
         run: |
-          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$RC_VERSION-sandbox-extended-services-macOS.zip"
+          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$PROJECT_VERSION-sandbox-extended-services-macOS.zip"
           echo "ARTIFACT_ZIP_FILE=$ARTIFACT_ZIP_FILE" >> "$GITHUB_OUTPUT"
           mkdir ./extended-services-release-artifacts
           zip $ARTIFACT_ZIP_FILE ./packages/extended-services/dist/win32/kie_sandbox_extended_services.exe
@@ -175,7 +174,6 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          RC_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.windows_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
           echo $GPG_KEY > ./signkey.gpg
@@ -191,12 +189,12 @@ jobs:
         env:
           ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
           ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
-          RC_VERSION: ${{ inputs.release_candidate_version }}
+          PROJECT_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.windows_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
           svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/kie svn-kie
-          cp ./extended-services-release-artifacts/* svn-kie/$RC_VERSION/
-          svn add "svn-kie/$RC_VERSION"
+          cp ./extended-services-release-artifacts/* svn-kie/$PROJECT_VERSION/
+          svn add "svn-kie/$PROJECT_VERSION"
           cd svn-kie
-          svn ci --non-interactive --no-auth-cache --username $ASF_USERNAME --password '$ASF_PASSWORD' -m "Apache KIE $RC_VERSION Extended Services for Windows artifact"
+          svn ci --non-interactive --no-auth-cache --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for Windows artifact"
           rm -rf svn-kie

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -36,6 +36,14 @@ on:
         type: string
         required: false
         default: ""
+      release_candidate:
+        type: boolean
+        required: false
+        default: false
+      release_candidate_version:
+        type: string
+        required: false
+        default: ""
     secrets:
       gh_token:
         required: false
@@ -83,8 +91,8 @@ jobs:
         run: |
           pnpm ${{ steps.bootstrap.outputs.pnpm_filter_string }} build:prod
 
-      - name: "Upload Extended Services for macOS (macOS only)"
-        if: ${{ runner.os == 'macOS' && !inputs.dry_run }}
+      - name: "Upload Extended Services for macOS"
+        if: ${{ runner.os == 'macOS' && !inputs.dry_run && !inputs.release_candidate }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -94,8 +102,8 @@ jobs:
           asset_name: kie_sandbox_extended_services_macos_${{ inputs.tag }}.dmg
           asset_content_type: application/octet-stream
 
-      - name: "Upload Extended Services for Windows (Windows only)"
-        if: ${{ runner.os == 'Windows' && !inputs.dry_run }}
+      - name: "Upload Extended Services for Windows"
+        if: ${{ runner.os == 'Windows' && !inputs.dry_run && !inputs.release_candidate }}
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -104,3 +112,91 @@ jobs:
           asset_path: "./packages/extended-services/dist/win32/kie_sandbox_extended_services.exe"
           asset_name: "kie_sandbox_extended_services_windows_${{ inputs.tag }}.exe"
           asset_content_type: application/octet-stream
+
+      - name: "Setup Extended Services for macOS artifacts"
+        id: macos_setup_artifact
+        if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
+        shell: bash
+        env:
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+        run: |
+          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$RC_VERSION-sandbox-extended-services-macOS.zip"
+          echo "ARTIFACT_ZIP_FILE=$ARTIFACT_ZIP_FILE" >> "$GITHUB_OUTPUT"
+          mkdir ./extended-services-release-artifacts
+          zip $ARTIFACT_ZIP_FILE ./packages/extended-services/dist/darwin/Kogito.dmg
+
+      - name: "Sign Extended Services for macOS artifact"
+        if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
+        shell: bash
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+          ARTIFACT_ZIP_FILE: ${{ steps.macos_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
+        run: |
+          echo $GPG_KEY > ./signkey.gpg
+          gpg --list-keys
+          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --import ./signkey.gpg
+          rm ./signkey.gpg
+          echo $GPG_PASSPHRASE | gpg --no-tty --batch --sign --pinentry-mode loopback --passphrase-fd 0 --output $ARTIFACT_ZIP_FILE.asc --detach-sig $ARTIFACT_ZIP_FILE
+          shasum -a 512 $ARTIFACT_ZIP_FILE > $ARTIFACT_ZIP_FILE.sha512
+
+      - name: "Upload Extended Services for macOS artifact"
+        if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
+        shell: bash
+        env:
+          ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
+          ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+          ARTIFACT_ZIP_FILE: ${{ steps.macos_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
+        run: |
+          svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/kie svn-kie
+          cp ./extended-services-release-artifacts/* svn-kie/$RC_VERSION/
+          svn add "svn-kie/$RC_VERSION"
+          cd svn-kie
+          svn ci --non-interactive --no-auth-cache --username $ASF_USERNAME --password '$ASF_PASSWORD' -m "Apache KIE $RC_VERSION Extended Services for macOS artifact"
+          rm -rf svn-kie
+
+      - name: "Setup Extended Services for Windows artifacts"
+        id: windows_setup_artifact
+        if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
+        shell: pwsh
+        env:
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+        run: |
+          ARTIFACT_ZIP_FILE="./extended-services-release-artifacts/incubator-kie-$RC_VERSION-sandbox-extended-services-macOS.zip"
+          echo "ARTIFACT_ZIP_FILE=$ARTIFACT_ZIP_FILE" >> "$GITHUB_OUTPUT"
+          mkdir ./extended-services-release-artifacts
+          zip $ARTIFACT_ZIP_FILE ./packages/extended-services/dist/win32/kie_sandbox_extended_services.exe
+
+      - name: "Sign Extended Services for Windows artifact"
+        if: ${{ runner.os == 'Windows' && !inputs.dry_run && inputs.release_candidate }}
+        shell: pwsh
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+          ARTIFACT_ZIP_FILE: ${{ steps.windows_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
+        run: |
+          echo $GPG_KEY > ./signkey.gpg
+          gpg --list-keys
+          gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --import ./signkey.gpg
+          rm ./signkey.gpg
+          echo $GPG_PASSPHRASE | gpg --no-tty --batch --sign --pinentry-mode loopback --passphrase-fd 0 --output $ARTIFACT_ZIP_FILE.asc --detach-sig $ARTIFACT_ZIP_FILE
+          shasum -a 512 $ARTIFACT_ZIP_FILE > $ARTIFACT_ZIP_FILE.sha512
+
+      - name: "Upload Extended Services for Windows artifact"
+        if: ${{ runner.os == 'Windows' && !inputs.dry_run && inputs.release_candidate }}
+        shell: pwsh
+        env:
+          ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
+          ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
+          RC_VERSION: ${{ inputs.release_candidate_version }}
+          ARTIFACT_ZIP_FILE: ${{ steps.windows_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
+        run: |
+          svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/kie svn-kie
+          cp ./extended-services-release-artifacts/* svn-kie/$RC_VERSION/
+          svn add "svn-kie/$RC_VERSION"
+          cd svn-kie
+          svn ci --non-interactive --no-auth-cache --username $ASF_USERNAME --password '$ASF_PASSWORD' -m "Apache KIE $RC_VERSION Extended Services for Windows artifact"
+          rm -rf svn-kie

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -144,8 +144,8 @@ jobs:
         if: ${{ runner.os == 'macOS' && !inputs.dry_run && inputs.release_candidate }}
         shell: bash
         env:
-          ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
-          ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           PROJECT_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.macos_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
@@ -153,7 +153,7 @@ jobs:
           cp ./extended-services-release-artifacts/* svn-kie/$PROJECT_VERSION/
           svn add "svn-kie/$PROJECT_VERSION"
           cd svn-kie
-          svn ci --non-interactive --no-auth-cache --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for macOS artifact"
+          svn ci --non-interactive --no-auth-cache --username "$SVN_USERNAME" --password "$SVN_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for macOS artifact"
           rm -rf svn-kie
 
       - name: "Setup Extended Services for Windows artifacts"
@@ -187,8 +187,8 @@ jobs:
         if: ${{ runner.os == 'Windows' && !inputs.dry_run && inputs.release_candidate }}
         shell: pwsh
         env:
-          ASF_USERNAME: ${{ secrets.ASF_USERNAME }}
-          ASF_PASSWORD: ${{ secrets.ASF_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           PROJECT_VERSION: ${{ inputs.release_candidate_version }}
           ARTIFACT_ZIP_FILE: ${{ steps.windows_setup_artifact.outputs.ARTIFACT_ZIP_FILE }}
         run: |
@@ -196,5 +196,5 @@ jobs:
           cp ./extended-services-release-artifacts/* svn-kie/$PROJECT_VERSION/
           svn add "svn-kie/$PROJECT_VERSION"
           cd svn-kie
-          svn ci --non-interactive --no-auth-cache --username "$ASF_USERNAME" --password "$ASF_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for Windows artifact"
+          svn ci --non-interactive --no-auth-cache --username "$SVN_USERNAME" --password "$SVN_PASSWORD" -m "Apache KIE $PROJECT_VERSION Extended Services for Windows artifact"
           rm -rf svn-kie


### PR DESCRIPTION
This PR introduces a new Jenkins job to build, sign and publish release candidate artifacts to: https://dist.apache.org/repos/dist/dev/incubator/kie as part of the issue: [#1245](https://github.com/apache/incubator-kie-issues/issues/1245)