### PR TITLE
NO-ISSUE: Holding alt and navigating away from the page locks the editor

### DIFF
--- a/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
@@ -393,11 +393,10 @@ export class DmnEditorRoot extends React.Component<DmnEditorRootProps, DmnEditor
       "Navigate | Reset position to origin",
       async () => commands.resetPosition()
     );
-    const pan = this.props.keyboardShortcutsService?.registerKeyDownThenUp(
-      "Alt",
+    const pan = this.props.keyboardShortcutsService?.registerKeyPress(
+      "Right Mouse Button",
       "Navigate | Hold and drag to Pan",
-      async () => commands.panDown(),
-      async () => commands.panUp()
+      async () => {}
     );
     const zoom = this.props.keyboardShortcutsService?.registerKeyPress(
       "Ctrl",

--- a/packages/dmn-editor/src/commands/CommandsContextProvider.tsx
+++ b/packages/dmn-editor/src/commands/CommandsContextProvider.tsx
@@ -26,8 +26,6 @@ export interface Commands {
   togglePropertiesPanel: () => void;
   createGroup: () => void;
   selectAll: () => void;
-  panDown: () => void;
-  panUp: () => void;
   paste: () => void;
   copy: () => void;
   cut: () => void;
@@ -60,12 +58,6 @@ export function CommandsContextProvider(props: React.PropsWithChildren<{}>) {
     },
     selectAll: () => {
       throw new Error("DMN EDITOR: selectAll command not implemented.");
-    },
-    panDown: () => {
-      throw new Error("DMN EDITOR: panDown command not implemented.");
-    },
-    panUp: () => {
-      throw new Error("DMN EDITOR: panUp command not implemented.");
     },
     paste: () => {
       throw new Error("DMN EDITOR: paste command not implemented.");

--- a/packages/dmn-editor/src/diagram/Diagram.tsx
+++ b/packages/dmn-editor/src/diagram/Diagram.tsx
@@ -1154,7 +1154,6 @@ export const Diagram = React.forwardRef<DiagramRef, { container: React.RefObject
             preventScrolling={true}
             selectionOnDrag={true}
             panOnDrag={PAN_ON_DRAG}
-            panActivationKeyCode={"Alt"}
             selectionMode={RF.SelectionMode.Full} // For selections happening inside Groups/DecisionServices it's better to leave it as "Full"
             isValidConnection={isValidConnection}
             connectionLineComponent={ConnectionLine}

--- a/packages/dmn-editor/src/diagram/DiagramCommands.tsx
+++ b/packages/dmn-editor/src/diagram/DiagramCommands.tsx
@@ -422,28 +422,5 @@ export function DiagramCommands(props: {}) {
       });
     };
   }, [dmnEditorStoreApi, externalModelsByNamespace, commandsRef, rf]);
-
-  useEffect(() => {
-    if (!commandsRef.current) {
-      return;
-    }
-    commandsRef.current.panDown = async () => {
-      console.debug("DMN DIAGRAM: COMMANDS: Panning down");
-      rfStoreApi.setState({
-        nodesDraggable: false,
-        nodesConnectable: false,
-        elementsSelectable: false,
-      });
-    };
-    commandsRef.current.panUp = async () => {
-      console.debug("DMN DIAGRAM: COMMANDS: Panning up");
-      rfStoreApi.setState({
-        nodesDraggable: true,
-        nodesConnectable: true,
-        elementsSelectable: true,
-      });
-    };
-  }, [commandsRef, rfStoreApi]);
-
   return <></>;
 }


### PR DESCRIPTION
Adding alt to pan was done to simulate the "Pan" action of the legacy DMN Editor, but it isn't ideal when pressing alt and navigating away from the page locks the editor, with e.g. alt+tab, ctrl+alt+delete, holding alt and clicking to a new tab.

Removing this shortcut as using the middle mouse button or the right mouse button allows one to pan around easily.

