### PR TITLE
kie-issues#1188: DMN Runner shows an error message instead of empty state for empty DMNs

### DIFF
--- a/packages/dmn-language-service/package.json
+++ b/packages/dmn-language-service/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@kie-tools/dmn-feel-antlr4-parser": "workspace:*",
     "@kie-tools/dmn-marshaller": "workspace:*",
-    "antlr4": "^4.13.0"
+    "antlr4": "^4.13.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -37,6 +38,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/jest": "^26.0.23",
+    "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",
     "jest-junit": "^14.0.0",
     "rimraf": "^3.0.2",

--- a/packages/dmn-language-service/src/DmnLanguageService.ts
+++ b/packages/dmn-language-service/src/DmnLanguageService.ts
@@ -22,6 +22,9 @@ import { DmnDecision } from "./DmnDecision";
 import * as path from "path";
 import { getMarshaller } from "@kie-tools/dmn-marshaller";
 import { DMN15__tDefinitions } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
+import { ns as dmn15ns } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/meta";
+import { DMN15_SPEC } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
+import { v4 as uuid } from "uuid";
 
 const INPUT_DATA = "inputData";
 const XML_MIME = "text/xml";
@@ -30,6 +33,21 @@ const NAMESPACE = "namespace";
 const DMN_NAME = "name";
 const DECISION = "decision";
 const DEFINITIONS = "definitions";
+
+// FIXME: This was duplicated from boxed-expression-editor
+const generateUuid = () => {
+  return `_${uuid()}`.toLocaleUpperCase();
+};
+
+// FIXME: This was duplicated from dmn-editor-envelope
+const EMPTY_DMN = () => `<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="${dmn15ns.get("")}"
+  expressionLanguage="${DMN15_SPEC.expressionLanguage.default}"
+  namespace="https://kie.org/dmn/${generateUuid()}"
+  id="${generateUuid()}"
+  name="DMN${generateUuid()}">
+</definitions>`;
 
 /**
  * The normalized posix path relative to the workspace root is a string
@@ -195,7 +213,7 @@ export class DmnLanguageService {
             r.normalizedPosixPathRelativeToTheWorkspaceRoot,
             {
               xml: r.content,
-              definitions: getMarshaller(r.content, { upgradeTo: "latest" }).parser.parse().definitions,
+              definitions: getMarshaller(r.content || EMPTY_DMN(), { upgradeTo: "latest" }).parser.parse().definitions,
             },
           ])
         ),

--- a/packages/dmn-language-service/tests/buildImportIndex.test.ts
+++ b/packages/dmn-language-service/tests/buildImportIndex.test.ts
@@ -63,10 +63,7 @@ describe("invalid inputs", () => {
 
     const error: Error = await getError(async () => await dmnLs.buildImportIndex(emptyResource));
 
-    expect(error.message).toEqual(`
-DMN LANGUAGE SERVICE - buildImportIndex: Error while getting imported models from model resources.
-Tried to use the following model resources: ${JSON.stringify(emptyResource)}
-Error details: SyntaxError: about:blank:1:0: document must contain a root element.`);
+    expect(error.message).toEqual("");
   });
 
   it("invalid dmn", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3805,6 +3805,9 @@ importers:
       antlr4:
         specifier: ^4.13.0
         version: 4.13.0
+      uuid:
+        specifier: ^8.3.2
+        version: 8.3.2
     devDependencies:
       "@babel/core":
         specifier: ^7.16.0
@@ -3827,6 +3830,9 @@ importers:
       "@types/jest":
         specifier: ^26.0.23
         version: 26.0.23
+      "@types/uuid":
+        specifier: ^8.3.0
+        version: 8.3.0
       jest:
         specifier: ^26.6.3
         version: 26.6.3


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1188

Using the marshaller on an empty string will throw an error. This PR adds an empty DMN as a fallback.

The `EMPTY_DMN` was copied from the `dmn-editor-envelope` as the `dmn-language-service` shouldn't depend on it. The same happens which the `generateUuid` function. I've created this [issue](https://github.com/apache/incubator-kie-tools/issues/3947) so we could address this tech debt.