### PR TITLE
NO-ISSUE: sonataflow-operator: generate stable names for workflow resources

### DIFF
--- a/packages/sonataflow-operator/workflowproj/workflowproj_test.go
+++ b/packages/sonataflow-operator/workflowproj/workflowproj_test.go
@@ -85,7 +85,7 @@ func Test_Handler_WorkflowMinimalAndPropsAndSpec(t *testing.T) {
 	assert.Equal(t, "hello-props", proj.Properties.Name)
 	assert.NotEmpty(t, proj.Properties.Data)
 	assert.Equal(t, 1, len(proj.Resources))
-	assert.Equal(t, "01-hello-resources", proj.Resources[0].Name)
+	assert.Equal(t, "01-hello-resources-specs", proj.Resources[0].Name)
 	assert.Equal(t, proj.Workflow.Spec.Resources.ConfigMaps[0].ConfigMap.Name, proj.Resources[0].Name)
 
 }
@@ -114,8 +114,8 @@ func Test_Handler_WorkflowMinimalAndPropsAndSpecAndGeneric(t *testing.T) {
 	assert.Equal(t, "hello-props", proj.Properties.Name)
 	assert.NotEmpty(t, proj.Properties.Data)
 	assert.Equal(t, 2, len(proj.Resources))
-	assert.Equal(t, "01-hello-resources", proj.Resources[0].Name)
-	assert.Equal(t, "02-hello-resources", proj.Resources[1].Name)
+	assert.Equal(t, "01-hello-resources-files", proj.Resources[0].Name)
+	assert.Equal(t, "02-hello-resources-specs", proj.Resources[1].Name)
 	assert.Equal(t, proj.Workflow.Spec.Resources.ConfigMaps[0].ConfigMap.Name, proj.Resources[0].Name)
 	assert.Equal(t, proj.Workflow.Spec.Resources.ConfigMaps[1].ConfigMap.Name, proj.Resources[1].Name)
 	data, err := getResourceDataWithFileName(proj.Resources, "myopenapi.json")
@@ -158,8 +158,8 @@ func Test_Handler_WorklflowServiceAndPropsAndSpec_SaveAs(t *testing.T) {
 
 	expectedFiles := []string{
 		"01-configmap_service-props.yaml",
-		"02-configmap_01-service-resources.yaml",
-		"03-configmap_02-service-resources.yaml",
+		"02-configmap_01-service-resources-files.yaml",
+		"03-configmap_02-service-resources-specs.yaml",
 		"04-sonataflow_service.yaml",
 	}
 	expectedKinds := []schema.GroupVersionKind{


### PR DESCRIPTION
Motivation:
Workflowproj generates a configmap per schema or subflow or specs in a
separate file for each one, however the name is not deterministic. In
one iteration you can get the specs in
01-configmap-FLOWNAME-resources.yaml and in the next iteration the same
content will go in 02-configmap-FLOWNAME-resources.yaml.

While the flow spec file will be updated accordingly and stay correct,
the behaviour generates lots of changes when tracking changes in git.

Modification:
This fix will make the generation behaviour deterministic by sorting the
resources iteration prior to generating them and also add the related
schemas|specs/subflows to the generated file name:

Result:
old schema configmap manifest:
0x-configmap-FLOWNAME-resources.yaml

new schema configmap manifest:
01-configmap-FLOWNAME-resources-schemas.yaml

old specs config map manifest:
0x-configmap-FLOWNAME-resources.yaml

new specs configmap manifest:
02-configmap-FLOWNAME-resources-specs.yaml

old subflows config map manifest:
0x-configmap-FLOWNAME-resources.yaml

new subflows configmap manifest:
01-configmap-FLOWNAME-resources-subflows.yaml

Also the name of the config map itself will get the name related to the
content like: '03-FLOWNAME-resources-schemas'

Signed-off-by: Roy Golan <rgolan@redhat.com>
