### PR TITLE
kie-issues#1271: Retrieve process definitions from data index instead of openapi.json

### DIFF
--- a/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListContextProvider.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListContextProvider.tsx
@@ -20,19 +20,20 @@ import React, { useMemo } from "react";
 import { DevUIAppContext, useDevUIAppContext } from "../../components/contexts/DevUIAppContext";
 import ProcessDefinitionListContext from "./ProcessDefinitionListContext";
 import { ProcessDefinitionListGatewayApiImpl } from "./ProcessDefinitionListGatewayApi";
+import { ApolloClient } from "apollo-client";
+import { GraphQLProcessDefinitionListQueries } from "./ProcessDefinitionListQueries";
 
 interface ProcessDefinitionListContextProviderProps {
+  apolloClient: ApolloClient<any>;
   children;
 }
 
-const ProcessDefinitionListContextProvider: React.FC<ProcessDefinitionListContextProviderProps> = ({ children }) => {
-  const runtimeToolsApi: DevUIAppContext = useDevUIAppContext();
-
+const ProcessDefinitionListContextProvider: React.FC<ProcessDefinitionListContextProviderProps> = ({
+  apolloClient,
+  children,
+}) => {
   const gatewayApiImpl = useMemo(() => {
-    return new ProcessDefinitionListGatewayApiImpl(
-      runtimeToolsApi.getRemoteKogitoAppUrl() ?? runtimeToolsApi.getDevUIUrl(),
-      runtimeToolsApi.getOpenApiPath()
-    );
+    return new ProcessDefinitionListGatewayApiImpl(new GraphQLProcessDefinitionListQueries(apolloClient));
   }, []);
 
   return (

--- a/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListGatewayApi.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListGatewayApi.ts
@@ -18,7 +18,7 @@
  */
 
 import { ProcessDefinition } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
-import { getProcessDefinitionList } from "@kie-tools/runtime-tools-process-gateway-api/dist/gatewayApi";
+import { ProcessDefinitionListQueries } from "./ProcessDefinitionListQueries";
 
 export interface ProcessDefinitionListGatewayApi {
   getProcessDefinitionFilter: () => Promise<string[]>;
@@ -46,13 +46,11 @@ export class ProcessDefinitionListGatewayApiImpl implements ProcessDefinitionLis
   private readonly onOpenProcessListeners: OnOpenProcessFormListener[] = [];
   private readonly onOpenTriggerCloudEventListeners: OnOpenTriggerCloudEventListener[] = [];
 
-  private readonly kogitoAppUrl: string;
-  private readonly openApiPath: string;
+  private readonly queries: ProcessDefinitionListQueries;
   private processDefinitionFilter: string[] = [];
 
-  constructor(url: string, path: string) {
-    this.kogitoAppUrl = url;
-    this.openApiPath = path;
+  constructor(queries: ProcessDefinitionListQueries) {
+    this.queries = queries;
   }
 
   getProcessDefinitionFilter(): Promise<string[]> {
@@ -100,7 +98,7 @@ export class ProcessDefinitionListGatewayApiImpl implements ProcessDefinitionLis
   }
 
   getProcessDefinitionsQuery(): Promise<ProcessDefinition[]> {
-    return getProcessDefinitionList(this.kogitoAppUrl, this.openApiPath);
+    return this.queries.getProcessDefinitions();
   }
 
   openTriggerCloudEvent(): void {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListQueries.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListQueries.ts
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ApolloClient } from "apollo-client";
+import { ProcessDefinition } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
+import { getProcessDefinitions } from "@kie-tools/runtime-tools-process-gateway-api/dist/gatewayApi";
+import { OperationType } from "@kie-tools/runtime-tools-shared-gateway-api/dist/types";
+
+export interface ProcessDefinitionListQueries {
+  getProcessDefinitions(): Promise<ProcessDefinition[]>;
+}
+
+export class GraphQLProcessDefinitionListQueries implements ProcessDefinitionListQueries {
+  private readonly client: ApolloClient<any>;
+
+  constructor(client: ApolloClient<any>) {
+    this.client = client;
+  }
+
+  getProcessDefinitions(): Promise<ProcessDefinition[]> {
+    return getProcessDefinitions(this.client);
+  }
+}

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
@@ -90,7 +90,7 @@ const DevUILayout: React.FC<IOwnProps> = ({
             <ProcessListContextProvider apolloClient={apolloClient}>
               <ProcessDetailsContextProvider apolloClient={apolloClient}>
                 <JobsManagementContextProvider apolloClient={apolloClient}>
-                  <ProcessDefinitionListContextProvider>
+                  <ProcessDefinitionListContextProvider apolloClient={apolloClient}>
                     <FormsListContextProvider>
                       <FormDetailsContextProvider>
                         <ProcessFormContextProvider>

--- a/packages/runtime-tools-process-enveloped-components/src/processDetails/envelope/components/ProcessDetails/ProcessDetails.tsx
+++ b/packages/runtime-tools-process-enveloped-components/src/processDetails/envelope/components/ProcessDetails/ProcessDetails.tsx
@@ -320,7 +320,7 @@ const ProcessDetails: React.FC<ProcessDetailsProps> = ({
   const renderProcessVariables = (): JSX.Element => {
     return (
       <Flex direction={{ default: "column" }} flex={{ default: "flex_1" }}>
-        {Object.keys(updateJson).length > 0 && (
+        {updateJson && Object.keys(updateJson).length > 0 && (
           <FlexItem>
             <ProcessVariables
               displayLabel={displayLabel}

--- a/packages/runtime-tools-process-gateway-api/src/graphql/types.tsx
+++ b/packages/runtime-tools-process-gateway-api/src/graphql/types.tsx
@@ -1425,6 +1425,15 @@ export namespace GraphQL {
 
   export type HandleJobRescheduleMutation = { __typename?: "Mutation"; JobReschedule?: string | null };
 
+  export const GetProcessDefinitionsDocument = gql`
+    query getProcessDefinitions {
+      ProcessDefinitions {
+        id
+        endpoint
+      }
+    }
+  `;
+
   export const GetProcessInstancesDocument = gql`
     query getProcessInstances(
       $where: ProcessInstanceArgument


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1271

@pefernan I've replicated the change done for workflow definitions list. I've tried the jBPM Dev UI extension locally and it seems all good.