### PR TITLE
NO-ISSUE: DMN Editor: Blank screen with DMN models 1.1

### DIFF
--- a/packages/dmn-editor-envelope/package.json
+++ b/packages/dmn-editor-envelope/package.json
@@ -36,6 +36,7 @@
     "@kie-tools/dmn-marshaller": "workspace:*",
     "@kie-tools/pmml-editor-marshaller": "workspace:*",
     "@kie-tools/xml-parser-ts": "workspace:*",
+    "@patternfly/react-core": "^4.276.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/dmn-editor/src/DmnEditorErrorFallback.tsx
+++ b/packages/dmn-editor/src/DmnEditorErrorFallback.tsx
@@ -19,7 +19,6 @@
 
 import * as React from "react";
 import { useDmnEditor } from "./DmnEditorContext";
-import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 import {
   EmptyState,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3683,6 +3683,9 @@ importers:
       "@kie-tools/xml-parser-ts":
         specifier: workspace:*
         version: link:../xml-parser-ts
+      "@patternfly/react-core":
+        specifier: ^4.276.6
+        version: 4.276.6(react-dom@17.0.2)(react@17.0.2)
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -24049,7 +24052,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-dropzone: 11.7.1(react@17.0.2)
       tippy.js: 5.1.2
-      tslib: 2.5.0
+      tslib: 2.6.2
 
   /@patternfly/react-icons@4.93.6(react-dom@17.0.2)(react@17.0.2):
     resolution:


### PR DESCRIPTION
The new editor does not support opening old DMN 1.1 models. 

We now show an error/warning message to the user that models from 1.1 are not supported.

![image](https://github.com/apache/incubator-kie-tools/assets/7305741/29ae2d7e-d2d5-45b6-81ce-c74aa09d4bab)
