### PR TITLE
NO-ISSUE: DMN Editor: Context data type assignment menu is not well readable

### DIFF
--- a/packages/boxed-expression-component/src/expressionVariable/DataTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/DataTypeSelector.tsx
@@ -41,6 +41,7 @@ export interface DataTypeSelectorProps {
 
 /** This is the optimal height for the dropdown menu for the "Data Type" */
 const DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT = 500;
+const MININAL_SELECT_DATA_TYPE_MENU_HEIGHT = 70;
 
 /** This margin is the height of the status bar in the on-line editor because it can't be overlaped */
 const POPUP_BOTTOM_MARGIN = 46;
@@ -140,7 +141,10 @@ export const DataTypeSelector: React.FunctionComponent<DataTypeSelectorProps> = 
         DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT + yPos > availableHeight
       ) {
         const offset = DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT + yPos - availableHeight;
-        return DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT - offset - POPUP_BOTTOM_MARGIN;
+        const calculatedHeight = DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT - offset - POPUP_BOTTOM_MARGIN;
+        return calculatedHeight < MININAL_SELECT_DATA_TYPE_MENU_HEIGHT
+          ? MININAL_SELECT_DATA_TYPE_MENU_HEIGHT
+          : calculatedHeight;
       }
     }
     return DEFAULT_SELECT_DATA_TYPE_MENU_HEIGHT;


### PR DESCRIPTION
Add a minimal height for the select data type menu. Opening the menu close to the end of the window will automatically scroll down creating enough room to properly see an option.


https://github.com/apache/incubator-kie-tools/assets/24302289/28abae44-49c2-45a1-8edf-b5ebe9c03041

