### PR TITLE
NO-ISSUE: Be more specific when registering SVG commands on the `bpmn-vscode-extension`

### DIFF
--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -124,14 +124,14 @@
       "commandPalette": [
         {
           "command": "extension.kogito.getPreviewSvgBpmn",
-          "when": "resourceLangId =~ /bpmn|bpmn2/"
+          "when": "resourceLangId =~ /bpmn|bpmn2/ && activeCustomEditorId == 'kieKogitoWebviewEditorsBpmn'"
         }
       ],
       "editor/title": [
         {
           "command": "extension.kogito.getPreviewSvgBpmn",
           "group": "navigation",
-          "when": "resourceLangId =~ /bpmn|bpmn2/"
+          "when": "resourceLangId =~ /bpmn|bpmn2/ && activeCustomEditorId == 'kieKogitoWebviewEditorsBpmn'"
         }
       ]
     }


### PR DESCRIPTION
Prevents making these commands available when the BPMN file is open but not using the custom editor contributed by the extension.