### PR TITLE
NO-ISSUE: Adding `maven-m2-repo-via-http-image` to allow Maven projects to be built inside container image builds while referring to JARs built/downloaded in the host environment

### DIFF
--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
@@ -27,12 +27,11 @@ ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_EXTRACT_TO_DIR=$HOME_PATH/app/src/main/resour
 ENV DEV_DEPLOYMENT__UPLOAD_SERVICE_PORT=8080
 
 COPY --chown=$USER_ID:$USER_ID dist-dev/quarkus-app $HOME_PATH/app/
-# This copies the jbpm-quarkus-devui dependencies to the m2 repository.
-# Commented out for now as it still requires docker to run. https://github.com/apache/incubator-kie-issues/issues/1272
-# COPY --chown=$USER_ID:$USER_ID dist-dev/quarkus-app-m2 /tmp/kogito/.m2/repository
+COPY --chown=$USER_ID:$USER_ID dist-dev/settings.xml /tmp/kogito/.m2/settings.xml
 
-RUN ./mvnw clean package -B -ntp -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
-  && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2
+# Pre-populate local Maven repository for faster startup
+RUN ./mvnw clean package -B --settings /tmp/kogito/.m2/settings.xml -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
+  && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2 && rm /tmp/kogito/.m2/settings.xml
 
 USER $USER_ID
 

--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/env/index.js
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/env/index.js
@@ -20,16 +20,21 @@
 const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
 
 const rootEnv = require("@kie-tools/root-env/env");
-const devDeploymentBaseImageEnv = require("@kie-tools/dev-deployment-base-image/env");
 
-module.exports = composeEnv([rootEnv, devDeploymentBaseImageEnv], {
+const {
+  env: { devDeploymentBaseImage: devDedevDeploymentBaseImageEnv },
+} = require("@kie-tools/dev-deployment-base-image/env");
+
+const {
+  env: { mavenM2RepoViaHttpImage: mavenM2RepoViaHttpImageEnv },
+} = require("@kie-tools/maven-m2-repo-via-http-image/env");
+
+module.exports = composeEnv([rootEnv], {
   vars: varsWithName({
     DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__builderImage: {
-      default: `${devDeploymentBaseImageEnv.env.devDeploymentBaseImage.registry}/${
-        devDeploymentBaseImageEnv.env.devDeploymentBaseImage.account
-      }/${devDeploymentBaseImageEnv.env.devDeploymentBaseImage.name}:${
-        devDeploymentBaseImageEnv.env.devDeploymentBaseImage.tags.split(" ")[0]
-      }`,
+      default: `${devDedevDeploymentBaseImageEnv.registry}/${devDedevDeploymentBaseImageEnv.account}/${
+        devDedevDeploymentBaseImageEnv.name
+      }:${devDedevDeploymentBaseImageEnv.tags.split(" ")[0]}`,
       description: "The image used in the FROM import.",
     },
     DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__registry: {
@@ -48,6 +53,10 @@ module.exports = composeEnv([rootEnv, devDeploymentBaseImageEnv], {
       default: rootEnv.env.root.streamName,
       description: "The image tag.",
     },
+    DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__mavenM2RepoViaHttpImage: {
+      default: `${mavenM2RepoViaHttpImageEnv.registry}/${mavenM2RepoViaHttpImageEnv.account}/${mavenM2RepoViaHttpImageEnv.name}:${mavenM2RepoViaHttpImageEnv.tag}`,
+      description: "The image tag for the Maven M2 Repo via HTTP. Used during the build only.",
+    },
   }),
   get env() {
     return {
@@ -58,6 +67,12 @@ module.exports = composeEnv([rootEnv, devDeploymentBaseImageEnv], {
         name: getOrDefault(this.vars.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__name),
         tags: getOrDefault(this.vars.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__buildTags),
         version: require("../package.json").version,
+        dev: {
+          mavenM2RepoViaHttpImage: getOrDefault(
+            this.vars.DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE__mavenM2RepoViaHttpImage
+          ),
+          mavenM2RepoViaHttpImagePort: 8008,
+        },
       },
     };
   },

--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/package.json
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/package.json
@@ -13,20 +13,25 @@
     "url": "https://github.com/apache/incubator-kie-tools/issues"
   },
   "scripts": {
-    "build:dev": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy:assets\" \"pnpm image:docker:build\"",
-    "build:prod": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy:assets\" \"pnpm image:docker:build\"",
-    "copy:assets": "rimraf dist-dev && mkdir -p ./dist-dev && pnpm copy:quarkus-app",
-    "copy:m2-for-jbpm-quarkus-devui": "mvn dependency:copy-dependencies -Dmdep.useRepositoryLayout=true -Dmdep.copyPom=true -DexcludeTransitive=true -DoutputDirectory=./dist-dev/quarkus-app-m2",
+    "build": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm copy:assets\" \"pnpm m2-repo-via-http:container:run\" \"pnpm image:docker:build\" --finally \"pnpm m2-repo-via-http:container:kill\"",
+    "build:dev": "pnpm build",
+    "build:prod": "pnpm build",
+    "copy:assets": "rimraf dist-dev && mkdir -p ./dist-dev && pnpm copy:quarkus-app && pnpm copy:maven-m2-repo-via-http-image--settings-xml",
+    "copy:maven-m2-repo-via-http-image--settings-xml": "run-script-os",
+    "copy:maven-m2-repo-via-http-image--settings-xml:linux:darwin": "M2_REPO_VIA_HTTP_PORT=$(build-env devDeploymentKogitoQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImagePort) envsubst < ./node_modules/@kie-tools/maven-m2-repo-via-http-image/settings.xml.envsubst > dist-dev/settings.xml",
+    "copy:maven-m2-repo-via-http-image--settings-xml:win32": "pnpm powershell \"(Get-Content ./node_modules/@kie-tools/maven-m2-repo-via-http-image/settings.xml.envsubst) -replace '$M2_REPO_VIA_HTTP_PORT', $(build-env devDeploymentKogitoQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImagePort) | Set-Content ./dist-dev/settings.xml\"",
     "copy:quarkus-app": "run-script-os",
     "copy:quarkus-app:linux:darwin": " cp -R ./node_modules/@kie-tools/dev-deployment-kogito-quarkus-blank-app/ ./dist-dev/quarkus-app && rm -rf ./dist-dev/quarkus-app/node_modules ./dist-dev/quarkus-app/install.js ./dist-dev/quarkus-app/env ./dist-dev/quarkus-app/package.json",
     "copy:quarkus-app:win32": "pnpm powershell \"New-Item -ItemType Directory -Force -Path ./dist-dev/quarkus-app; Copy-Item -R ./node_modules/@kie-tools/dev-deployment-kogito-quarkus-blank-app/* ./dist-dev/quarkus-app -Exclude @('node_modules')\"",
-    "create-test-image:build-only": "kie-tools--image-builder build -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
+    "create-test-image:build-only": "kie-tools--image-builder build --allowHostNetworkAccess -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
     "create-test-image:kind": "kie-tools--image-builder kind -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/ --kind-cluster-name kie-sandbox-dev-cluster",
     "create-test-image:minikube": "kie-tools--image-builder minikube -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
     "create-test-image:openshift": "kie-tools--image-builder openshift -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
-    "image:docker:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
-    "image:podman:build": "kie-tools--image-builder build -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/ -e podman",
+    "image:docker:build": "kie-tools--image-builder build --allowHostNetworkAccess -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/",
+    "image:podman:build": "kie-tools--image-builder build --allowHostNetworkAccess -r \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.tags)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentKogitoQuarkusBlankAppImage.builderImage)\" --build-arg ROOT_PATH=/ -e podman",
     "install": "node install.js",
+    "m2-repo-via-http:container:kill": "(docker container kill m2-repo-via-http || true) && (docker container rm m2-repo-via-http || true)",
+    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && docker run --name m2-repo-via-http -v ~/.m2/repository:/var/www/html -dit -p \"$(build-env devDeploymentKogitoQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImagePort):80\" $(build-env devDeploymentKogitoQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImage)",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command"
   },
   "dependencies": {
@@ -36,6 +41,7 @@
   "devDependencies": {
     "@kie-tools/image-builder": "workspace:*",
     "@kie-tools/maven-config-setup-helper": "workspace:*",
+    "@kie-tools/maven-m2-repo-via-http-image": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6"

--- a/packages/image-builder/README.md
+++ b/packages/image-builder/README.md
@@ -8,17 +8,18 @@ Commands:
   @kie-tools/image-builder openshift  Builds the image on the OpenShift cluster in an ImageStream
 
 Options:
-  -r, --registry       The string for the image registry  [string]
-  -a, --account        The string for the image account  [string]
-  -n, --name           The string for the image name  [string] [required]
-  -t, --tags           The string for the image tags  [array] [required]
-  -e, --engine         The build engine to be used  [string] [choices: "docker", "podman"] [default: "docker"]
-  -p, --push           Push the image to the registry  [boolean] [default: false]
-  -f, --containerfile  Path to the Containerfile/Dockerfile  [string] [default: "Containerfile"]
-  -c, --context        Path to the build context  [string] [default: "./"]
-      --build-arg      Build args for the builder in the format '<arg>=<value>', where <value> is a string (Can be used multiple times)  [array] [default: []]
-      --arch           The target build architecture. If not provided will default to the native architecture  [string] [choices: "amd64", "arm64", "native"] [default: "native"]
-  -h, --help           Show help  [boolean]
+  -r, --registry                The string for the image registry  [string]
+  -a, --account                 The string for the image account  [string]
+  -n, --name                    The string for the image name  [string] [required]
+  -t, --tags                    The string for the image tags  [array] [required]
+  -e, --engine                  The build engine to be used  [string] [choices: "docker", "podman"] [default: "docker"]
+  -p, --push                    Push the image to the registry  [boolean] [default: false]
+      --allowHostNetworkAccess  Allows host network access during build  [boolean] [default: false]
+  -f, --containerfile           Path to the Containerfile/Dockerfile  [string] [default: "Containerfile"]
+  -c, --context                 Path to the build context  [string] [default: "./"]
+      --build-arg               Build args for the builder in the format '<arg>=<value>', where <value> is a string (Can be used multiple times)  [array] [default: []]
+      --arch                    The target build architecture. If not provided will default to the native architecture  [string] [choices: "amd64", "arm64", "native"] [default: "native"]
+  -h, --help                    Show help  [boolean]
 
 Examples:
   $ image-builder --registry "$(build-env myCustomEnv.registry)" --account "$(build-env myCustomEnv.account)" --name "$(build-env myCustomEnv.name)" --tags "$(build-env myCustomEnv.buildTags)" --engine docker --push  Build an image using parameters from your myCustomEnv build env variables

--- a/packages/maven-m2-repo-via-http-image/Containerfile
+++ b/packages/maven-m2-repo-via-http-image/Containerfile
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.4
+
+# Argument for configuring the port
+ARG PORT=80
+
+# Install required packages: httpd and unzip, clean up after installation
+RUN microdnf --disableplugin=subscription-manager -y install httpd \
+ && microdnf --disableplugin=subscription-manager clean all
+
+# Apache configuration adjustments
+RUN echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
+ && sed -i "s/Listen 80/Listen $PORT/g" /etc/httpd/conf/httpd.conf \
+ && sed -i "s/#ServerName www.example.com:80/ServerName 127.0.0.1:$PORT/g" /etc/httpd/conf/httpd.conf \
+ && sed -i "/ServerName 127.0.0.1:$PORT/a Header set Content-Security-Policy \"frame-ancestors 'self';\"" /etc/httpd/conf/httpd.conf \
+ && sed -i "s/Options Indexes FollowSymLinks/Options +Indexes +FollowSymLinks/" /etc/httpd/conf/httpd.conf \
+ && sed -i "$ a ServerTokens Prod" /etc/httpd/conf/httpd.conf \
+ && sed -i "$ a ServerSignature Off" /etc/httpd/conf/httpd.conf \
+ && sed -i "\$ a <Directory \"/var/www/html\">\n    Options +Indexes +FollowSymLinks\n    AllowOverride None\n    Require all granted\n    IndexOptions FancyIndexing SuppressDescription SuppressHTMLPreamble SuppressLastModified SuppressSize NameWidth=* SuppressColumnSorting SuppressIcon SuppressRules\n    HeaderName /header.html\n    ReadmeName /readme.html\n</Directory>" /etc/httpd/conf/httpd.conf
+
+VOLUME /var/www/html/
+
+# Remove the default welcome page to avoid conflicts
+RUN rm -rf /etc/httpd/conf.d/welcome.conf
+
+# Expose the configured port
+EXPOSE $PORT
+
+HEALTHCHECK --interval=1s --timeout=60s CMD curl -f http://localhost:"$PORT" || exit 1
+
+# Start httpd when the container launches
+CMD ["httpd", "-D", "FOREGROUND"]

--- a/packages/maven-m2-repo-via-http-image/README.md
+++ b/packages/maven-m2-repo-via-http-image/README.md
@@ -1,0 +1,26 @@
+## (private) Apache KIE™ :: Tools :: Maven M2 repo via HTTP
+
+Used to expose the local Maven repository (E.g., ~/.m2/repository) via HTTP, so it can be used inside other container builds. This is important so that containers can include applications that depend on locally-built Maven artifacts.
+
+Containers referencing this must make use of `settings.xml.envsubst` so that:
+
+1. The default Maven blocker for repositories exposed via HTTP without TSL is disabled.
+1. The exposed Maven repository via HTTP is accessible from within the container image build.
+
+> NOTE: Host network access is not enabled by default during image builds. Use the `--allowHostNetworkAccess` option of `@kie-tools/image-builder` to enable it.
+
+### Usage
+
+Running the container:
+
+- `docker run --name m2-repo-via-http -v ~/.m2/repository:/var/www/html -dit -p 8008:80 docker.io/apache/incubator-kie-tools-maven-m2-repo-via-http:main`
+
+Interpolating settings.xml
+
+- Linux and macOS:
+
+  `M2_REPO_VIA_HTTP_PORT=8008 envsubst < settings.xml.envsubst > /tmp/settings.xml`
+
+- Windows (PowerShell):
+
+  `(Get-Content settings.xml.envsubst) -replace '$M2_REPO_VIA_HTTP_PORT', 8008 | Set-Content /tmp/settings.xml`

--- a/packages/maven-m2-repo-via-http-image/env/index.js
+++ b/packages/maven-m2-repo-via-http-image/env/index.js
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
+
+const rootEnv = require("@kie-tools/root-env/env");
+
+module.exports = composeEnv([rootEnv], {
+  vars: varsWithName({
+    MAVEN_M2_REPO_VIA_HTTP_IMAGE__registry: {
+      default: "docker.io",
+      description: "The image registry.",
+    },
+    MAVEN_M2_REPO_VIA_HTTP_IMAGE__account: {
+      default: "apache",
+      description: "The image registry account.",
+    },
+    MAVEN_M2_REPO_VIA_HTTP_IMAGE__name: {
+      default: "incubator-kie-tools-maven-m2-repo-via-http",
+      description: "The image name.",
+    },
+    MAVEN_M2_REPO_VIA_HTTP_IMAGE__buildTag: {
+      default: rootEnv.env.root.streamName,
+      description: "The image tag.",
+    },
+  }),
+  get env() {
+    return {
+      mavenM2RepoViaHttpImage: {
+        registry: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__registry),
+        account: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__account),
+        name: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__name),
+        tag: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__buildTag),
+        version: require("../package.json").version,
+        dev: {
+          port: 8008,
+        },
+      },
+    };
+  },
+});

--- a/packages/maven-m2-repo-via-http-image/env/index.js
+++ b/packages/maven-m2-repo-via-http-image/env/index.js
@@ -47,10 +47,6 @@ module.exports = composeEnv([rootEnv], {
         account: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__account),
         name: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__name),
         tag: getOrDefault(this.vars.MAVEN_M2_REPO_VIA_HTTP_IMAGE__buildTag),
-        version: require("../package.json").version,
-        dev: {
-          port: 8008,
-        },
       },
     };
   },

--- a/packages/maven-m2-repo-via-http-image/package.json
+++ b/packages/maven-m2-repo-via-http-image/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "name": "@kie-tools/maven-m2-repo-via-http-image",
+  "version": "0.0.0",
+  "description": "",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/apache/incubator-kie-tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apache/incubator-kie-tools.git"
+  },
+  "bugs": {
+    "url": "https://github.com/apache/incubator-kie-tools/issues"
+  },
+  "scripts": {
+    "build": "run-script-if --bool \"$(build-env containerImages.build)\" --then \"pnpm image:docker:build\"",
+    "build:dev": "pnpm build",
+    "build:prod": "pnpm build",
+    "image:docker:build": "kie-tools--image-builder build -r \"$(build-env mavenM2RepoViaHttpImage.registry)\" -a \"$(build-env mavenM2RepoViaHttpImage.account)\" -n \"$(build-env mavenM2RepoViaHttpImage.name)\" -t \"$(build-env mavenM2RepoViaHttpImage.tag)\""
+  },
+  "devDependencies": {
+    "@kie-tools/image-builder": "workspace:*",
+    "@kie-tools/root-env": "workspace:*",
+    "run-script-os": "^1.1.6"
+  }
+}

--- a/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
+++ b/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
@@ -1,0 +1,56 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>kie-tools--maven-m2-repo-via-http-allowed</id>
+      <mirrorOf>kie-tools--maven-m2-repo-via-http</mirrorOf>
+      <name>Mirror to override default blocking mirror that blocks http.</name>
+      <url>http://localhost:$M2_REPO_VIA_HTTP_PORT</url>
+    </mirror>
+  </mirrors>
+
+  <profiles>
+    <profile>
+      <id>kie-tools--maven-m2-repo-via-http-allowed-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>kie-tools--maven-m2-repo-via-http</id>
+          <name>KIE Tools :: Maven M2 Repo via HTTP</name>
+          <url>http://localhost:$M2_REPO_VIA_HTTP_PORT/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+
+      <pluginRepositories>
+        <pluginRepository>
+          <id>kie-tools--maven-m2-repo-via-http</id>
+          <name>KIE Tools :: Maven M2 Repo via HTTP</name>
+          <url>http://localhost:$M2_REPO_VIA_HTTP_PORT/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+
+</settings>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3363,6 +3363,9 @@ importers:
       "@kie-tools/maven-config-setup-helper":
         specifier: workspace:*
         version: link:../maven-config-setup-helper
+      "@kie-tools/maven-m2-repo-via-http-image":
+        specifier: workspace:*
+        version: link:../maven-m2-repo-via-http-image
       "@kie-tools/root-env":
         specifier: workspace:*
         version: link:../root-env
@@ -6211,6 +6214,18 @@ importers:
         version: 1.1.6
 
   packages/maven-config-setup-helper: {}
+
+  packages/maven-m2-repo-via-http-image:
+    devDependencies:
+      "@kie-tools/image-builder":
+        specifier: workspace:*
+        version: link:../image-builder
+      "@kie-tools/root-env":
+        specifier: workspace:*
+        version: link:../root-env
+      run-script-os:
+        specifier: ^1.1.6
+        version: 1.1.6
 
   packages/monaco-editor:
     dependencies:

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -90,6 +90,7 @@ digraph G {
   "@kie-tools/dev-deployment-kogito-quarkus-blank-app" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools/maven-config-setup-helper" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
+  "@kie-tools/maven-m2-repo-via-http-image" [ color = "black", fontcolor = "black", style = "dashed, rounded" ];
   "@kie-tools/dmn-editor" [ color = "blue", fontcolor = "blue", style = "rounded" ];
   "@kie-tools-core/react-hooks" [ color = "purple", fontcolor = "purple", style = "rounded" ];
   "@kie-tools/pmml-editor-marshaller" [ color = "blue", fontcolor = "blue", style = "rounded" ];
@@ -311,6 +312,7 @@ digraph G {
   "@kie-tools/dev-deployment-kogito-quarkus-blank-app" -> "@kie-tools/root-env" [ style = "dashed", color = "black" ];
   "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image" -> "@kie-tools/dev-deployment-base-image" [ style = "solid", color = "black" ];
   "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image" -> "@kie-tools/dev-deployment-kogito-quarkus-blank-app" [ style = "solid", color = "black" ];
+  "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image" -> "@kie-tools/maven-m2-repo-via-http-image" [ style = "dashed", color = "black" ];
   "@kie-tools/dev-deployment-upload-service" -> "@kie-tools/root-env" [ style = "dashed", color = "black" ];
   "@kie-tools/dmn-editor" -> "@kie-tools-core/react-hooks" [ style = "solid", color = "blue" ];
   "@kie-tools/dmn-editor" -> "@kie-tools/boxed-expression-component" [ style = "solid", color = "blue" ];
@@ -410,6 +412,8 @@ digraph G {
   "@kie-tools-core/kubernetes-bridge" -> "@kie-tools/cors-proxy-api" [ style = "solid", color = "purple" ];
   "@kie-tools/maven-base" -> "@kie-tools/maven-config-setup-helper" [ style = "dashed", color = "black" ];
   "@kie-tools/maven-base" -> "@kie-tools/root-env" [ style = "dashed", color = "black" ];
+  "@kie-tools/maven-m2-repo-via-http-image" -> "@kie-tools/image-builder" [ style = "dashed", color = "black" ];
+  "@kie-tools/maven-m2-repo-via-http-image" -> "@kie-tools/root-env" [ style = "dashed", color = "black" ];
   "@kie-tools-core/monaco-editor" -> "@kie-tools/eslint" [ style = "dashed", color = "purple" ];
   "@kie-tools-core/monaco-editor" -> "@kie-tools/root-env" [ style = "dashed", color = "purple" ];
   "@kie-tools-core/monaco-editor" -> "@kie-tools/tsconfig" [ style = "dashed", color = "purple" ];

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -108,6 +108,7 @@
       { "id": "@kie-tools/dev-deployment-dmn-form-webapp-image" },
       { "id": "@kie-tools/dev-deployment-kogito-quarkus-blank-app" },
       { "id": "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image" },
+      { "id": "@kie-tools/maven-m2-repo-via-http-image" },
       { "id": "@kie-tools/dmn-editor" },
       { "id": "@kie-tools/dmn-editor-envelope" },
       { "id": "@kie-tools/dmn-feel-antlr4-parser" },
@@ -724,6 +725,13 @@
         "target": "@kie-tools/dev-deployment-kogito-quarkus-blank-app",
         "weight": 1
       },
+      {
+        "source": "@kie-tools/dev-deployment-kogito-quarkus-blank-app-image",
+        "target": "@kie-tools/maven-m2-repo-via-http-image",
+        "weight": 1
+      },
+      { "source": "@kie-tools/maven-m2-repo-via-http-image", "target": "@kie-tools/image-builder", "weight": 1 },
+      { "source": "@kie-tools/maven-m2-repo-via-http-image", "target": "@kie-tools/root-env", "weight": 1 },
       { "source": "@kie-tools/dmn-editor", "target": "@kie-tools-core/react-hooks", "weight": 1 },
       { "source": "@kie-tools/dmn-editor", "target": "@kie-tools/boxed-expression-component", "weight": 1 },
       { "source": "@kie-tools/dmn-editor", "target": "@kie-tools/pmml-editor-marshaller", "weight": 1 },
@@ -1273,6 +1281,7 @@
     ["@kie-tools-core/kubernetes-bridge", "packages/kubernetes-bridge"],
     ["@kie-tools/maven-base", "packages/maven-base"],
     ["@kie-tools/maven-config-setup-helper", "packages/maven-config-setup-helper"],
+    ["@kie-tools/maven-m2-repo-via-http-image", "packages/maven-m2-repo-via-http-image"],
     ["@kie-tools-core/monaco-editor", "packages/monaco-editor"],
     ["@kie-tools-core/notifications", "packages/notifications"],
     ["@kie-tools/online-editor", "packages/online-editor"],


### PR DESCRIPTION
This will allow `jbpm-quarkus-devui` to be used inside `dev-deployment-kogito-quarkus-blank-app`, for example, without manipulating pseudo-m2 dirs by hand.