### PR TITLE
NO-ISSUE: DMN Editor Boxed Expression Types help icon is not working as expected

### DIFF
--- a/packages/boxed-expression-component/src/contextMenu/MenuWithHelp/MenuItemWithHelp.tsx
+++ b/packages/boxed-expression-component/src/contextMenu/MenuWithHelp/MenuItemWithHelp.tsx
@@ -52,7 +52,10 @@ export function MenuItemWithHelp({
       actions={
         (isHovered || visibleHelp === menuItemHelp) && (
           <MenuItemAction
-            onClick={() => setVisibleHelp(menuItemHelp)}
+            onClick={(e) => {
+              e.stopPropagation();
+              setVisibleHelp(menuItemHelp);
+            }}
             icon={<HelpIcon aria-hidden />}
             actionId={menuItemKey + "-help"}
             aria-label={menuItemKey + "-help"}


### PR DESCRIPTION
Previously when the user clicked on the help icon the menu was being closed.

Fix:

https://github.com/apache/incubator-kie-tools/assets/7305741/cf510ff2-244a-429d-81ff-a55810d598ef

