### PR TITLE
NO-ISSUE: Use offline m2 for dev-deployment-kogito-quarkus-blank-app-image

### DIFF
--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
@@ -31,7 +31,7 @@ COPY --chown=$USER_ID:$USER_ID dist-dev/settings.xml /tmp/kogito/.m2/settings.xm
 
 # Pre-populate local Maven repository for faster startup
 RUN ./mvnw clean package -B --settings /tmp/kogito/.m2/settings.xml -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
-  && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2 && rm /tmp/kogito/.m2/settings.xml
+  && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2
 
 USER $USER_ID
 
@@ -39,4 +39,4 @@ EXPOSE 8080
 
 ENTRYPOINT ["/bin/bash", "-c"]
 
-CMD ["dev-deployment-upload-service && cp -r $HOME_PATH/app/. /tmp/app && cd /tmp/app && ./mvnw quarkus:dev -Ddebug=false -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH}"]
+CMD ["dev-deployment-upload-service && cp -r $HOME_PATH/app/. /tmp/app && cd /tmp/app && ./mvnw quarkus:dev -o -s=/tmp/kogito/.m2/settings.xml -Dquarkus.analytics.disabled=true -Ddebug=false -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH}"]

--- a/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
+++ b/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
@@ -4,7 +4,7 @@
   <mirrors>
     <mirror>
       <id>kie-tools--maven-m2-repo-via-http-allowed</id>
-      <mirrorOf>*</mirrorOf>
+      <mirrorOf>kie-tools--maven-m2-repo-via-http</mirrorOf>
       <name>Mirror to override default blocking mirror that blocks http.</name>
       <url>http://localhost:$M2_REPO_VIA_HTTP_PORT</url>
     </mirror>

--- a/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
+++ b/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
@@ -4,7 +4,7 @@
   <mirrors>
     <mirror>
       <id>kie-tools--maven-m2-repo-via-http-allowed</id>
-      <mirrorOf>kie-tools--maven-m2-repo-via-http</mirrorOf>
+      <mirrorOf>*</mirrorOf>
       <name>Mirror to override default blocking mirror that blocks http.</name>
       <url>http://localhost:$M2_REPO_VIA_HTTP_PORT</url>
     </mirror>
@@ -28,7 +28,7 @@
           </releases>
           <snapshots>
             <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
+            <updatePolicy>never</updatePolicy>
           </snapshots>
         </repository>
       </repositories>
@@ -45,7 +45,7 @@
           </releases>
           <snapshots>
             <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
+            <updatePolicy>never</updatePolicy>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>


### PR DESCRIPTION
- Using -o for startup speed
- Disabling Quarkus telemetry on startup (saving 10s)
- Not deleting settings.xml anymore so Maven understands that the artifacts stored at /tmp/kogito/.m2 have been downloaded using the `kie-tools--maven-m2-repo-via-http` repository.
- Better logs to the `image-builder` package.
- Always allow host network access on `image-builder` when building using `buildx`