### PR TITLE
NO-ISSUE: Update `JDT.LS` to `1.34`

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -41,7 +41,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/apache/incubator-kie-tools.git</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.30.1.20231207151730</jdt.ls.version>
+    <jdt.ls.version>1.34.0.20240403125844</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
@@ -56,7 +56,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.30.1/repository/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.34.0/repository/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>


### PR DESCRIPTION
Like 1.30.x, this is like an "LTS" version that relies on a fixed repo.

It's crucial to keep it updated and synchronized with the `Language Support for Java(TM) by Red Hat` VSCode extension.

<img width="1648" alt="Screenshot 2024-06-05 at 17 40 15" src="https://github.com/apache/incubator-kie-tools/assets/16005046/900b695f-985f-47be-9209-51572fe5dc0d">
