### PR TITLE
NO-ISSUE: DMN Editor: Add `label` and `typeRef` fallback values to Boxed Function Expression

### DIFF
--- a/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
@@ -410,6 +410,8 @@ export function drgElementToBoxedExpression(
     return expressionHolder.encapsulatedLogic
       ? {
           __$$element: "functionDefinition",
+          "@_label": expressionHolder.encapsulatedLogic["@_label"] ?? expressionHolder["@_name"],
+          "@_typeRef": expressionHolder.encapsulatedLogic["@_typeRef"] ?? expressionHolder.variable?.["@_typeRef"],
           ...expressionHolder.encapsulatedLogic,
         }
       : {


### PR DESCRIPTION
Using the `businessKnowledgeModel` `name` as fallback for the `encapsulatedLogic` `label` as the `name` isn't an optional property.

Using the `businessKnowledgeModel` `variable` `typeRef` as a fallback for the `encapsulatedLogic` `typeRef`. 