### PR TITLE
NO-ISSUE: Prettier configuration for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   },
   "files.associations": {
     "*.yaml.helm": "helm"
-  }
+  },
+  "prettier.configPath": "prettier.config.mjs"
 }


### PR DESCRIPTION
By default, the Prettier VS Code Extension will look for a configuration file at the home directory, doing this makes it work for everyone importing `kie-tools` on VS Code.