### PR TITLE
[DO NTO MERGE] Move jbpm-quarkus-devui-bom to project root

### DIFF
--- a/examples/jbpm-compact-architecture-example/pom.xml
+++ b/examples/jbpm-compact-architecture-example/pom.xml
@@ -39,6 +39,18 @@
     <kogito.task-console.image>docker.io/apache/incubator-kie-kogito-task-console:main</kogito.task-console.image>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-quarkus-devui-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -144,17 +156,6 @@
       <properties>
         <quarkus.profile>dev</quarkus.profile>
       </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>org.jbpm</groupId>
-            <artifactId>jbpm-quarkus-devui-bom</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
       <dependencies>
         <dependency>
           <groupId>org.jbpm</groupId>


### PR DESCRIPTION
verified the changes as:
- `KIE_TOOLS_BUILD__buildExamples=true pnpm -F @kie-tools-examples/jbpm-compact-architecture-example... build:prod`
- `cd examples/jbpm-compact-architecture-example`
- `mvn quarkus:dev -Pdevelopment`
- open `http://localhost:8080/q/dev-ui/extensions`