### PR TITLE
kie-issues#1358: Fix typo in the container image name (jppm -> jbpm)

### DIFF
--- a/examples/jbpm-compact-architecture-example/docker-compose/docker-compose.yml
+++ b/examples/jbpm-compact-architecture-example/docker-compose/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   jbpm-compact-architecture-example-service:
     container_name: jbpm-compact-architecture-example-service
-    image: dev.local/${USER}/jppm-compact-architecture-example-service:${PROJECT_VERSION}
+    image: dev.local/${USER}/jbpm-compact-architecture-example-service:${PROJECT_VERSION}
     profiles: ["example", "full"]
     ports:
       - "8080:8080"

--- a/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
+++ b/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.group=${USER}
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=${project.version}
-%container.quarkus.container-image.name=jppm-compact-architecture-example-service
+%container.quarkus.container-image.name=jbpm-compact-architecture-example-service
 
 %dev.jbpm.devui.users.jdoe.groups=admin,HR,IT
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1358