### PR TITLE
kie-issues#1285: Remove unnecessary base image from quarkus examples (quay.io/kiegroup/kogito-runtime-jvm:latest)

### DIFF
--- a/examples/sonataflow-greeting-quarkus-example/src/main/resources/application.properties
+++ b/examples/sonataflow-greeting-quarkus-example/src/main/resources/application.properties
@@ -28,5 +28,5 @@ quarkus.native.native-image-xmx=8g
 %container.quarkus.container-image.registry=dev.local
 %container.quarkus.container-image.tag=1.0-SNAPSHOT
 %container.quarkus.jib.jvm-entrypoint=/home/kogito/kogito-app-launch.sh
-%container.quarkus.jib.base-jvm-image=quay.io/kiegroup/kogito-runtime-jvm:latest
+%container.quarkus.jib.base-jvm-image=registry.access.redhat.com/ubi9/openjdk-17:1.20
 %container.quarkus.jib.working-directory=/home/kogito/bin

--- a/packages/sonataflow-operator/bddframework/pkg/framework/util.go
+++ b/packages/sonataflow-operator/bddframework/pkg/framework/util.go
@@ -51,7 +51,7 @@ const (
 	// defaultBuilderImage Builder Image for Kogito
 	defaultBuilderImage = "kogito-s2i-builder"
 	// defaultRuntimeJVM Runtime Image for Kogito with  JRE
-	defaultRuntimeJVM = "kogito-runtime-jvm"
+	defaultRuntimeJVM = "registry.access.redhat.com/ubi9/openjdk-17"
 	//defaultRuntimeNative Runtime Image for Kogito for Native Quarkus Application
 	defaultRuntimeNative = "kogito-runtime-native"
 	// imageRegistryEnvVar ...
@@ -292,7 +292,11 @@ func AppendImageDefaultValues(image *api.Image) {
 	}
 
 	if len(image.Tag) == 0 {
-		image.Tag = GetKogitoImageVersion(version.GetTagVersion())
+		if image.Name == defaultRuntimeJVM {
+			image.Tag = GetKogitoImageVersion(version.GetOpenJDKImageVersion())
+		} else {
+			image.Tag = GetKogitoImageVersion(version.GetTagVersion())
+		}
 	}
 }
 

--- a/packages/sonataflow-operator/bddframework/pkg/framework/util.go
+++ b/packages/sonataflow-operator/bddframework/pkg/framework/util.go
@@ -293,7 +293,7 @@ func AppendImageDefaultValues(image *api.Image) {
 
 	if len(image.Tag) == 0 {
 		if image.Name == defaultRuntimeJVM {
-			image.Tag = GetKogitoImageVersion(version.GetOpenJDKImageVersion())
+			image.Tag = GetKogitoImageVersion(version.GetOpenJDKImageTagVersion())
 		} else {
 			image.Tag = GetKogitoImageVersion(version.GetTagVersion())
 		}

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -38,7 +38,7 @@ const (
 )
 
 // GetOpenJDKImageVersion gets the current OpenJDK image version.
-func GetOpenJDKImageVersion() string {
+func GetOpenJDKImageTagVersion() string {
 	return openJDKImageVersion
 }
 

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -33,13 +33,13 @@ const (
 	tagVersion = "main"
 	// Kogito images tag version. Used for data-index and jobs-service images.
 	kogitoImagesTagVersion = "999-20240623"
-	// OpenJDK image version
+	// OpenJDK image tag version
 	openJDKImageTagVersion = "1.20"
 )
 
-// GetOpenJDKImageVersion gets the current OpenJDK image version.
+// GetOpenJDKImageTagVersion gets the current OpenJDK image version.
 func GetOpenJDKImageTagVersion() string {
-	return openJDKImageVersion
+	return openJDKImageTagVersion
 }
 
 // GetOperatorVersion gets the current binary version of the operator. Do not use it to compose image tags!

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -34,7 +34,7 @@ const (
 	// Kogito images tag version. Used for data-index and jobs-service images.
 	kogitoImagesTagVersion = "999-20240623"
 	// OpenJDK image version
-	openJDKImageVersion = "1.20"
+	openJDKImageTagVersion = "1.20"
 )
 
 // GetOpenJDKImageVersion gets the current OpenJDK image version.

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -33,7 +33,14 @@ const (
 	tagVersion = "main"
 	// Kogito images tag version. Used for data-index and jobs-service images.
 	kogitoImagesTagVersion = "999-20240623"
+	// OpenJDK image version
+	openJDKImageVersion = "1.20"
 )
+
+// GetOpenJDKImageVersion gets the current OpenJDK image version.
+func GetOpenJDKImageVersion() string {
+	return openJDKImageVersion
+}
 
 // GetOperatorVersion gets the current binary version of the operator. Do not use it to compose image tags!
 func GetOperatorVersion() string {


### PR DESCRIPTION
**Closes:** https://github.com/apache/incubator-kie-issues/issues/1285

This PR is related to:
- https://github.com/apache/incubator-kie-kogito-examples/pull/1978
