### PR TITLE
NO-ISSUE Bump `org.xmlunit:xmlunit-core` from `2.9.0` to `2.10.0`

### DIFF
--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -276,7 +276,7 @@
     <version.com.google.gwt.gwtmockito>1.1.9</version.com.google.gwt.gwtmockito>
     <version.org.mockito>3.12.4</version.org.mockito>
     <version.powermock.api.mockito2>2.0.9</version.powermock.api.mockito2>
-    <version.org.xmlunit>2.9.0</version.org.xmlunit>
+    <version.org.xmlunit>2.10.0</version.org.xmlunit>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Required to fix CVE-2024-31573