### PR TITLE
[10.0.x] incubator-kie-tools#2475: Include the bump of variable tagVersion in version.go via the bump-version.sh script

### DIFF
--- a/packages/sonataflow-operator/hack/bump-version.sh
+++ b/packages/sonataflow-operator/hack/bump-version.sh
@@ -59,6 +59,7 @@ node -p "require('replace-in-file').sync({ from: /docker\.io\/apache\/incubator-
 node -p "require('replace-in-file').sync({ from: /sonataflow-operator-system\/sonataflow-operator:[\w\.]*/g, to: 'sonataflow-operator-system/sonataflow-operator:${imageTag}', files: ['**/*.yaml'] });"
 
 node -p "require('replace-in-file').sync({ from: /\bOperatorVersion = .*/g, to: 'OperatorVersion = \"${version}\"', files: ['version/version.go'] });"
+node -p "require('replace-in-file').sync({ from: /\btagVersion = .*/g, to: 'tagVersion = \"${imageTag}\"', files: ['version/version.go'] });"
 node -p "require('replace-in-file').sync({ from: /\bcontainerImage:.*\b/g, to: 'containerImage: ${targetSonataflowOperatorImage}', files: ['$(getCsvFile)'] });"
 
 make generate-all

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -30,7 +30,7 @@ const (
 	// This tag must reflect an existing tag in the registry. In development, must follow the git branch naming.
 	// When released, this version should reflect the `major.minor` version in the registry.
 	// For example, docker.io/apache/incubator-kie-sonataflow-operator:10.0.x -> 10.0
-	tagVersion = "main"
+	tagVersion = "10.0.x"
 	// Kogito images tag version. Used for data-index and jobs-service images.
 	kogitoImagesTagVersion = "10.0.999-20240717"
 	// OpenJDK image tag version


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/2475