### PR TITLE
kie-issues#1182: Performing the `undo` operation after resetting the expressions crashes the new DMN Editor

### DIFF
--- a/packages/boxed-expression-component/src/BoxedExpressionEditor.tsx
+++ b/packages/boxed-expression-component/src/BoxedExpressionEditor.tsx
@@ -20,7 +20,7 @@
 import "@patternfly/react-styles/css/components/Drawer/drawer.css";
 import { I18nDictionariesProvider } from "@kie-tools-core/i18n/dist/react-components";
 import * as React from "react";
-import { BeeGwtService, BoxedExpression, DmnDataType, PmmlDocument } from "./api";
+import { BeeGwtService, BoxedExpression, DmnDataType, Normalized, PmmlDocument } from "./api";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -44,9 +44,9 @@ export interface BoxedExpressionEditorProps {
   /** TypeRef of the Decision or BKM containing `expression` */
   expressionHolderTypeRef: string | undefined;
   /** The boxed expression itself */
-  expression: BoxedExpression | undefined;
+  expression: Normalized<BoxedExpression> | undefined;
   /** Called every time something changes on the expression */
-  onExpressionChange: React.Dispatch<React.SetStateAction<BoxedExpression | undefined>>;
+  onExpressionChange: React.Dispatch<React.SetStateAction<Normalized<BoxedExpression> | undefined>>;
   /** KIE Extension to represent IDs of individual columns or expressions */
   widthsById: Map<string, number[]>;
   /** Called every time a width changes on the expression */

--- a/packages/boxed-expression-component/src/BoxedExpressionEditorContext.tsx
+++ b/packages/boxed-expression-component/src/BoxedExpressionEditorContext.tsx
@@ -18,9 +18,8 @@
  */
 
 import * as React from "react";
-import { useContext, useMemo } from "react";
-import { BeeGwtService, DmnDataType, BoxedExpression, PmmlDocument } from "./api";
-import { useRef, useState } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
+import { BeeGwtService, BoxedExpression, DmnDataType, Normalized, PmmlDocument } from "./api";
 import { BoxedExpressionEditorProps, OnRequestFeelVariables } from "./BoxedExpressionEditor";
 import "./BoxedExpressionEditorContext.css";
 
@@ -45,7 +44,7 @@ export interface BoxedExpressionEditorContextType {
 }
 
 export interface BoxedExpressionEditorDispatchContextType {
-  setExpression: React.Dispatch<React.SetStateAction<BoxedExpression>>;
+  setExpression: React.Dispatch<React.SetStateAction<Normalized<BoxedExpression>>>;
   setWidthsById: (mutation: ({ newMap }: { newMap: Map<string, number[]> }) => void) => void;
 }
 
@@ -131,7 +130,7 @@ export function BoxedExpressionEditorContextProvider({
 }
 
 export type OnSetExpression = (args: {
-  getNewExpression: (prev: BoxedExpression | undefined) => BoxedExpression | undefined;
+  getNewExpression: (prev: Normalized<BoxedExpression> | undefined) => Normalized<BoxedExpression> | undefined;
 }) => void;
 
 export function NestedExpressionDispatchContextProvider({
@@ -143,8 +142,8 @@ export function NestedExpressionDispatchContextProvider({
   const { setWidthsById } = useBoxedExpressionEditorDispatch();
   const nestedExpressionDispatch = useMemo<BoxedExpressionEditorDispatchContextType>(() => {
     return {
-      setExpression: (newExpressionAction: React.SetStateAction<BoxedExpression>) => {
-        function getNewExpression(prev: BoxedExpression) {
+      setExpression: (newExpressionAction: React.SetStateAction<Normalized<BoxedExpression>>) => {
+        function getNewExpression(prev: Normalized<BoxedExpression>) {
           return typeof newExpressionAction === "function" ? newExpressionAction(prev) : newExpressionAction;
         }
 

--- a/packages/boxed-expression-component/src/api/BeeGwtService.ts
+++ b/packages/boxed-expression-component/src/api/BeeGwtService.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedExpression } from "./BoxedExpression";
+import { BoxedExpression, Normalized } from "./BoxedExpression";
 
 /**
  * This interface defines all the API methods which BoxedExpressionEditor component can use to dialog with GWT Layer
@@ -27,7 +27,7 @@ export interface BeeGwtService {
     logicType: BoxedExpression["__$$element"] | undefined,
     typeRef: string | undefined,
     isRoot?: boolean
-  ): { expression: BoxedExpression; widthsById: Map<string, number[]> };
+  ): { expression: Normalized<BoxedExpression>; widthsById: Map<string, number[]> };
 
   openDataTypePage: () => void; // Just open the data types tab
 

--- a/packages/boxed-expression-component/src/api/BoxedExpression.ts
+++ b/packages/boxed-expression-component/src/api/BoxedExpression.ts
@@ -51,6 +51,16 @@ export enum BoxedFunctionKind {
   Pmml = "PMML",
 }
 
+export type Normalized<T> = WithRequiredDeep<T, "@_id">;
+
+type WithRequiredDeep<T, K extends keyof any> = T extends undefined
+  ? T
+  : T extends Array<infer U>
+    ? Array<WithRequiredDeep<U, K>>
+    : { [P in keyof T]: WithRequiredDeep<T[P], K> } & (K extends keyof T
+        ? { [P in K]-?: NonNullable<WithRequiredDeep<T[P], K>> }
+        : T);
+
 export type BoxedIterator = BoxedFor | BoxedEvery | BoxedSome;
 
 export type BoxedExpression =

--- a/packages/boxed-expression-component/src/clipboard/clipboard.ts
+++ b/packages/boxed-expression-component/src/clipboard/clipboard.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedExpression } from "../api";
+import { BoxedExpression, Normalized } from "../api";
 import { findAllIdsDeep } from "../ids/ids";
 
 export const DMN_BOXED_EXPRESSION_CLIPBOARD_MIME_TYPE =
@@ -25,12 +25,12 @@ export const DMN_BOXED_EXPRESSION_CLIPBOARD_MIME_TYPE =
 
 export type BoxedExpressionClipboard = {
   mimeType: typeof DMN_BOXED_EXPRESSION_CLIPBOARD_MIME_TYPE;
-  expression: BoxedExpression;
+  expression: Normalized<BoxedExpression>;
   widthsById: Record<string, number[]>;
 };
 
 export function buildClipboardFromExpression(
-  expression: BoxedExpression,
+  expression: Normalized<BoxedExpression>,
   widthsById: Map<string, number[]>
 ): BoxedExpressionClipboard {
   const originalIds = findAllIdsDeep(expression);

--- a/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableCell.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableCell.tsx
@@ -20,7 +20,7 @@
 import { DMN15__tInformationItem } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import * as React from "react";
 import { useCallback, useEffect, useMemo } from "react";
-import { BeeTableCellProps, BoxedExpression, DmnBuiltInDataType } from "../api";
+import { BeeTableCellProps, BoxedExpression, DmnBuiltInDataType, Normalized } from "../api";
 import { useCellWidthToFitDataRef } from "../resizing/BeeTableCellWidthToFitDataContext";
 import { getCanvasFont, getTextWidth } from "../resizing/WidthsToFitData";
 import { useBeeTableSelectableCellRef } from "../selection/BeeTableSelectionContext";
@@ -33,8 +33,8 @@ import {
 import "./ExpressionVariableCell.css";
 
 export interface ExpressionWithVariable {
-  expression: BoxedExpression | undefined;
-  variable: DMN15__tInformationItem;
+  expression: Normalized<BoxedExpression> | undefined;
+  variable: Normalized<DMN15__tInformationItem>;
 }
 
 export type OnExpressionWithVariableUpdated = (index: number, { expression, variable }: ExpressionWithVariable) => void;

--- a/packages/boxed-expression-component/src/expressions/ConditionalExpression/ConditionalExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ConditionalExpression/ConditionalExpression.tsx
@@ -24,6 +24,8 @@ import {
   BeeTableProps,
   BoxedConditional,
   DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
 } from "../../api";
 import { BeeTable, BeeTableColumnUpdate } from "../../table/BeeTable";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
@@ -43,7 +45,7 @@ import {
   CONDITIONAL_EXPRESSION_LABEL_COLUMN_WIDTH,
 } from "../../resizing/WidthConstants";
 
-export type ROWTYPE = ConditionalClause;
+export type ROWTYPE = Normalized<ConditionalClause>;
 
 export type ConditionalClause = {
   part: DMN15__tChildExpression;
@@ -55,7 +57,7 @@ export function ConditionalExpression({
   parentElementId,
   expression: conditionalExpression,
 }: {
-  expression: BoxedConditional;
+  expression: Normalized<BoxedConditional>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -169,26 +171,35 @@ export function ConditionalExpression({
 
   const onRowReset = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedConditional) => {
+      setExpression((prev: Normalized<BoxedConditional>) => {
         if (args.rowIndex === 0) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
-            if: { expression: undefined! }, // SPEC DISCREPANCY
+            if: {
+              "@_id": generateUuid(),
+              expression: undefined!,
+            }, // SPEC DISCREPANCY
           };
           return ret;
         } else if (args.rowIndex === 1) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
-            then: { expression: undefined! }, // SPEC DISCREPANCY
+            then: {
+              "@_id": generateUuid(),
+              expression: undefined!,
+            }, // SPEC DISCREPANCY
           };
           return ret;
         } else if (args.rowIndex === 2) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
-            else: { expression: undefined! }, // SPEC DISCREPANCY
+            else: {
+              "@_id": generateUuid(),
+              expression: undefined!,
+            }, // SPEC DISCREPANCY
           };
           return ret;
         } else {
@@ -201,9 +212,9 @@ export function ConditionalExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedConditional) => {
+      setExpression((prev: Normalized<BoxedConditional>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedConditional = {
+        const ret: Normalized<BoxedConditional> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,

--- a/packages/boxed-expression-component/src/expressions/ConditionalExpression/ConditionalExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ConditionalExpression/ConditionalExpressionCell.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BeeTableCellProps, BoxedConditional } from "../../api";
+import { BeeTableCellProps, BoxedConditional, Normalized } from "../../api";
 
 import {
   NestedExpressionDispatchContextProvider,
@@ -27,14 +27,7 @@ import {
 import * as React from "react";
 import { useCallback } from "react";
 import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionContainer";
-import { ConditionalClause, ROWTYPE } from "./ConditionalExpression";
-
-export interface ConditionalExpressionCellProps {
-  conditionalClause: ConditionalClause;
-  rowIndex: number;
-  columnIndex: number;
-  columnId: string;
-}
+import { ROWTYPE } from "./ConditionalExpression";
 
 export function ConditionalExpressionCell({
   data,
@@ -46,24 +39,24 @@ export function ConditionalExpressionCell({
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedConditional) => {
+      setExpression((prev: Normalized<BoxedConditional>) => {
         if (rowIndex === 0) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
             if: { ...prev.if, expression: getNewExpression(prev.if.expression)! },
           };
           return ret;
         } else if (rowIndex === 1) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
             then: { ...prev.then, expression: getNewExpression(prev.then.expression)! },
           };
           return ret;
         } else if (rowIndex === 2) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedConditional = {
+          const ret: Normalized<BoxedConditional> = {
             ...prev,
             else: { ...prev.else, expression: getNewExpression(prev.else.expression)! },
           };

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryExpressionCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useEffect } from "react";
-import { BeeTableCellProps, BoxedContext, BoxedExpression } from "../../api";
+import { BeeTableCellProps, BoxedContext, BoxedExpression, generateUuid, Normalized } from "../../api";
 import {
   NestedExpressionDispatchContextProvider,
   OnSetExpression,
@@ -49,7 +49,7 @@ export const ContextEntryExpressionCell: React.FunctionComponent<BeeTableCellPro
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const newContextEntries = [...(prev.contextEntry ?? [])];
         const newExpression = getNewExpression(newContextEntries[index]?.expression ?? undefined);
         newContextEntries[index] = {
@@ -57,13 +57,14 @@ export const ContextEntryExpressionCell: React.FunctionComponent<BeeTableCellPro
           expression: newExpression!, // SPEC DISCREPANCY: Accepting undefined expression
           variable: {
             ...newContextEntries[index].variable,
+            "@_id": newContextEntries[index]?.variable?.["@_id"] ?? generateUuid(),
             "@_name": newExpression?.["@_label"] ?? newContextEntries[index].variable!["@_name"],
             "@_typeRef": newExpression?.["@_typeRef"] ?? newContextEntries[index].variable!["@_typeRef"],
           },
         };
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: newContextEntries,
         };

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -31,6 +31,7 @@ import {
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";
@@ -61,7 +62,7 @@ export function ContextExpression({
   parentElementId,
   expression: contextExpression,
 }: {
-  expression: BoxedContext;
+  expression: Normalized<BoxedContext>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -182,9 +183,9 @@ export function ContextExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,
@@ -202,7 +203,7 @@ export function ContextExpression({
 
   const updateVariable = useCallback(
     (index: number, { expression, variable }: ExpressionWithVariable) => {
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const contextEntries = [...(prev.contextEntry ?? [])];
 
         contextEntries[index] = {
@@ -212,7 +213,7 @@ export function ContextExpression({
         };
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: contextEntries,
         };
@@ -271,7 +272,7 @@ export function ContextExpression({
   }, [contextExpression, parentElementId]);
 
   const getDefaultContextEntry = useCallback(
-    (name?: string): DMN15__tContextEntry => {
+    (name?: string): Normalized<DMN15__tContextEntry> => {
       const variableName =
         name ||
         getNextAvailablePrefixedName(
@@ -294,7 +295,7 @@ export function ContextExpression({
 
   const onRowAdded = useCallback(
     (args: { beforeIndex: number; rowsCount: number }) => {
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const newContextEntries = [...(prev.contextEntry ?? [])];
 
         const newEntries = [];
@@ -310,7 +311,7 @@ export function ContextExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: newContextEntries,
         };
@@ -323,9 +324,9 @@ export function ContextExpression({
 
   const onRowDeleted = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
+      let oldExpression: Normalized<BoxedExpression> | undefined;
 
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const newContextEntries = [...(prev.contextEntry ?? [])];
 
         const { isResultOperation: isDeletingResult, entryIndex } = solveResultAndEntriesIndex({
@@ -341,7 +342,7 @@ export function ContextExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: newContextEntries,
         };
@@ -360,9 +361,9 @@ export function ContextExpression({
 
   const onRowReset = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
+      let oldExpression: Normalized<BoxedExpression> | undefined;
 
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const newContextEntries = [...(prev.contextEntry ?? [])];
 
         const {
@@ -389,7 +390,7 @@ export function ContextExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: newContextEntries,
         };

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback } from "react";
-import { BoxedContext } from "../../api";
+import { BoxedContext, generateUuid, Normalized } from "../../api";
 import {
   NestedExpressionDispatchContextProvider,
   OnSetExpression,
@@ -29,7 +29,7 @@ import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionConta
 import { solveResultAndEntriesIndex } from "./ContextExpression";
 
 export function ContextResultExpressionCell(props: {
-  contextExpression: BoxedContext;
+  contextExpression: Normalized<BoxedContext>;
   rowIndex: number;
   columnIndex: number;
 }) {
@@ -42,13 +42,14 @@ export function ContextResultExpressionCell(props: {
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedContext) => {
+      setExpression((prev: Normalized<BoxedContext>) => {
         const newContextEntries = [...(prev.contextEntry ?? [])];
 
         const newExpression = getNewExpression(newContextEntries[resultIndex]?.expression);
 
         if (resultIndex <= -1) {
           newContextEntries.push({
+            "@_id": generateUuid(),
             expression: newExpression!, // SPEC DISCREPANCY:
           });
         } else if (newExpression) {
@@ -61,7 +62,7 @@ export function ContextResultExpressionCell(props: {
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedContext = {
+        const ret: Normalized<BoxedContext> = {
           ...prev,
           contextEntry: newContextEntries,
           "@_label": newExpression?.["@_label"] ?? prev["@_label"],

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -29,6 +29,7 @@ import {
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
@@ -80,21 +81,21 @@ export const DECISION_TABLE_INPUT_DEFAULT_VALUE = "-";
 export const DECISION_TABLE_OUTPUT_DEFAULT_VALUE = "";
 export const DECISION_TABLE_ANNOTATION_DEFAULT_VALUE = "";
 
-function createInputEntry(): Unpacked<DMN15__tDecisionRule["inputEntry"]> {
+function createInputEntry(): Unpacked<Normalized<DMN15__tDecisionRule["inputEntry"]>> {
   return {
     "@_id": generateUuid(),
     text: { __$$text: DECISION_TABLE_INPUT_DEFAULT_VALUE },
   };
 }
 
-function createOutputEntry(): Unpacked<DMN15__tDecisionRule["outputEntry"]> {
+function createOutputEntry(): Unpacked<Normalized<DMN15__tDecisionRule["outputEntry"]>> {
   return {
     "@_id": generateUuid(),
     text: { __$$text: DECISION_TABLE_OUTPUT_DEFAULT_VALUE },
   };
 }
 
-function createAnnotationEntry(): Unpacked<DMN15__tDecisionRule["annotationEntry"]> {
+function createAnnotationEntry(): Unpacked<Normalized<DMN15__tDecisionRule["annotationEntry"]>> {
   return {
     text: { __$$text: DECISION_TABLE_ANNOTATION_DEFAULT_VALUE },
   };
@@ -102,12 +103,10 @@ function createAnnotationEntry(): Unpacked<DMN15__tDecisionRule["annotationEntry
 
 export function DecisionTableExpression({
   isNested,
-  parentElementId,
   expression: decisionTableExpression,
 }: {
   expression: BoxedDecisionTable;
   isNested: boolean;
-  parentElementId: string;
 }) {
   const { i18n } = useBoxedExpressionEditorI18n();
   const { expressionHolderId, widthsById } = useBoxedExpressionEditor();
@@ -435,8 +434,8 @@ export function DecisionTableExpression({
 
   const onCellUpdates = useCallback(
     (cellUpdates: BeeTableCellUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedDecisionTable) => {
-        let previousExpression: BoxedDecisionTable = { ...prev };
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
+        let previousExpression: Normalized<BoxedDecisionTable> = { ...prev };
 
         cellUpdates.forEach((cellUpdate) => {
           const newRules = [...(previousExpression.rule ?? [])];
@@ -499,9 +498,9 @@ export function DecisionTableExpression({
 
   const onColumnUpdates = useCallback(
     (columnUpdates: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = { ...prev };
+        const ret: Normalized<BoxedDecisionTable> = { ...prev };
         for (const columnUpdate of columnUpdates) {
           // This is the Output column aggregator column, which represents the entire expression name and typeRef
           if (
@@ -571,9 +570,9 @@ export function DecisionTableExpression({
 
   const onHitPolicySelect = useCallback(
     (hitPolicy: string) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = {
+        const ret: Normalized<BoxedDecisionTable> = {
           ...prev,
           "@_hitPolicy": hitPolicy as DMN15__tHitPolicy,
           "@_aggregation": HIT_POLICIES_THAT_SUPPORT_AGGREGATION.includes(hitPolicy)
@@ -622,9 +621,9 @@ export function DecisionTableExpression({
 
   const onBuiltInAggregatorSelect = useCallback(
     (aggregation: DMN15__tBuiltinAggregator) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = {
+        const ret: Normalized<BoxedDecisionTable> = {
           ...prev,
           "@_aggregation": getAggregation(aggregation),
         };
@@ -649,9 +648,9 @@ export function DecisionTableExpression({
 
   const onRowAdded = useCallback(
     (args: { beforeIndex: number; rowsCount: number }) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         const newRules = [...(prev.rule ?? [])];
-        const newItems = [];
+        const newItems: Normalized<DMN15__tDecisionRule>[] = [];
 
         for (let i = 0; i < args.rowsCount; i++) {
           newItems.push({
@@ -673,7 +672,7 @@ export function DecisionTableExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = {
+        const ret: Normalized<BoxedDecisionTable> = {
           ...prev,
           rule: newRules,
         };
@@ -711,12 +710,12 @@ export function DecisionTableExpression({
 
       const localIndexInsideGroup = getLocalIndexInsideGroupType(args.beforeIndex, groupType);
 
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         const nextRows = [...(prev.rule ?? [])];
 
         switch (groupType) {
           case DecisionTableColumnType.InputClause:
-            const inputColumnsToAdd: DMN15__tInputClause[] = [];
+            const inputColumnsToAdd: Normalized<DMN15__tInputClause>[] = [];
 
             const currentInputNames = prev.input?.map((c) => c.inputExpression.text?.__$$text ?? "") ?? [];
             for (let i = 0; i < args.columnsCount; i++) {
@@ -749,7 +748,7 @@ export function DecisionTableExpression({
             }
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retInput: BoxedDecisionTable = {
+            const retInput: Normalized<BoxedDecisionTable> = {
               ...prev,
               input: nextInputColumns,
               rule: nextRows,
@@ -758,7 +757,7 @@ export function DecisionTableExpression({
             return retInput;
 
           case DecisionTableColumnType.OutputClause:
-            const outputColumnsToAdd: DMN15__tOutputClause[] = [];
+            const outputColumnsToAdd: Normalized<DMN15__tOutputClause>[] = [];
 
             const currentOutputColumnNames = prev.output?.map((c) => c["@_name"] ?? "") ?? [];
             for (let i = 0; i < args.columnsCount; i++) {
@@ -788,7 +787,7 @@ export function DecisionTableExpression({
             }
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retOutput: BoxedDecisionTable = {
+            const retOutput: Normalized<BoxedDecisionTable> = {
               ...prev,
               output: nextOutputColumns,
               rule: nextRows,
@@ -797,18 +796,18 @@ export function DecisionTableExpression({
             return retOutput;
 
           case DecisionTableColumnType.Annotation:
-            const annotationColumsnToAdd: DMN15__tRuleAnnotationClause[] = [];
+            const annotationColumnsToAdd: Normalized<DMN15__tRuleAnnotationClause>[] = [];
 
             const currentAnnotationColumnNames = prev.annotation?.map((c) => c["@_name"] ?? "") ?? [];
             for (let i = 0; i < args.columnsCount; i++) {
               const newName = getNextAvailablePrefixedName(currentAnnotationColumnNames, "Annotations");
               currentAnnotationColumnNames.push(newName);
-              annotationColumsnToAdd.push({ "@_name": newName });
+              annotationColumnsToAdd.push({ "@_name": newName });
             }
 
             const nextAnnotationColumns = [...(prev.annotation ?? [])];
-            for (/* Add new columns */ let i = 0; i < annotationColumsnToAdd.length; i++) {
-              nextAnnotationColumns.splice(localIndexInsideGroup + i, 0, annotationColumsnToAdd[i]);
+            for (/* Add new columns */ let i = 0; i < annotationColumnsToAdd.length; i++) {
+              nextAnnotationColumns.splice(localIndexInsideGroup + i, 0, annotationColumnsToAdd[i]);
             }
 
             for (/* Add new cells to each row */ let i = 0; i < nextRows.length; i++) {
@@ -822,7 +821,7 @@ export function DecisionTableExpression({
             }
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retAnnotation: BoxedDecisionTable = {
+            const retAnnotation: Normalized<BoxedDecisionTable> = {
               ...prev,
               annotation: nextAnnotationColumns,
               rule: nextRows,
@@ -859,7 +858,7 @@ export function DecisionTableExpression({
 
   const onColumnDeleted = useCallback(
     (args: { columnIndex: number; groupType: DecisionTableColumnType }) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         const groupType = args.groupType;
         if (!groupType) {
           throw new Error("Column without groupType for Decision table.");
@@ -873,7 +872,7 @@ export function DecisionTableExpression({
             newInputs.splice(localIndexInsideGroup, 1);
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retInput: BoxedDecisionTable = {
+            const retInput: Normalized<BoxedDecisionTable> = {
               ...prev,
               input: newInputs,
               rule: [...(prev.rule ?? [])].map((rule) => {
@@ -891,7 +890,7 @@ export function DecisionTableExpression({
             newOutputs.splice(localIndexInsideGroup, 1);
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retOutput: BoxedDecisionTable = {
+            const retOutput: Normalized<BoxedDecisionTable> = {
               ...prev,
               output: newOutputs,
               rule: [...(prev.rule ?? [])].map((rule) => {
@@ -910,7 +909,7 @@ export function DecisionTableExpression({
             newAnnotations.splice(localIndexInsideGroup, 1);
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const retAnnotation: BoxedDecisionTable = {
+            const retAnnotation: Normalized<BoxedDecisionTable> = {
               ...prev,
               annotation: newAnnotations,
               rule: [...(prev.rule ?? [])].map((rule) => {
@@ -940,12 +939,12 @@ export function DecisionTableExpression({
 
   const onRowDeleted = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         const newRules = [...(prev.rule ?? [])];
         newRules.splice(args.rowIndex, 1);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = {
+        const ret: Normalized<BoxedDecisionTable> = {
           ...prev,
           rule: newRules,
         };
@@ -957,7 +956,7 @@ export function DecisionTableExpression({
 
   const onRowDuplicated = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedDecisionTable) => {
+      setExpression((prev: Normalized<BoxedDecisionTable>) => {
         const duplicatedRule = {
           "@_id": generateUuid(),
           inputEntry: prev.rule![args.rowIndex].inputEntry?.map((input) => ({
@@ -975,7 +974,7 @@ export function DecisionTableExpression({
         newRules.splice(args.rowIndex, 0, duplicatedRule);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedDecisionTable = {
+        const ret: Normalized<BoxedDecisionTable> = {
           ...prev,
           rule: newRules,
         };

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
@@ -20,14 +20,14 @@
 import * as React from "react";
 import { useCallback, useEffect, useRef } from "react";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
-import { BoxedExpression, generateUuid } from "../../api";
+import { BoxedExpression, generateUuid, Normalized } from "../../api";
 import { findAllIdsDeep } from "../../ids/ids";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
 import { useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
 import { ExpressionDefinitionLogicTypeSelector } from "./ExpressionDefinitionLogicTypeSelector";
 
 export interface ExpressionContainerProps {
-  expression?: BoxedExpression;
+  expression?: Normalized<BoxedExpression>;
   isNested: boolean;
   isResetSupported: boolean;
   rowIndex: number;
@@ -67,9 +67,9 @@ export const ExpressionContainer: React.FunctionComponent<ExpressionContainerPro
       const { expression: defaultExpression, widthsById: defaultWidthsById } =
         beeGwtService!.getDefaultExpressionDefinition(logicType, parentElementTypeRef ?? expressionTypeRef, !isNested);
 
-      setExpression((prev: BoxedExpression) => {
+      setExpression((prev: Normalized<BoxedExpression>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedExpression = {
+        const ret: Normalized<BoxedExpression> = {
           ...defaultExpression,
           "@_id": defaultExpression["@_id"] ?? generateUuid(),
           "@_label": defaultExpression["@_label"] ?? parentElementName ?? DEFAULT_EXPRESSION_VARIABLE_NAME,

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector.tsx
@@ -34,7 +34,7 @@ import { ResourcesAlmostEmptyIcon } from "@patternfly/react-icons/dist/js/icons/
 import { ResourcesFullIcon } from "@patternfly/react-icons/dist/js/icons/resources-full-icon";
 import * as React from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { BoxedExpression } from "../../api";
+import { BoxedExpression, Normalized } from "../../api";
 import { useCustomContextMenuHandler } from "../../contextMenu";
 import { MenuItemWithHelp } from "../../contextMenu/MenuWithHelp";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
@@ -62,7 +62,7 @@ import FilterIcon from "@patternfly/react-icons/dist/esm/icons/filter-icon";
 
 export interface ExpressionDefinitionLogicTypeSelectorProps {
   /** Expression properties */
-  expression?: BoxedExpression;
+  expression?: Normalized<BoxedExpression>;
   /** Function to be invoked when logic type changes */
   onLogicTypeSelected: (logicType: BoxedExpression["__$$element"] | undefined) => void;
   /** Function to be invoked when logic type is reset */
@@ -147,9 +147,7 @@ export function ExpressionDefinitionLogicTypeSelector({
       case "context":
         return <ContextExpression expression={expression} isNested={isNested} parentElementId={parentElementId} />;
       case "decisionTable":
-        return (
-          <DecisionTableExpression expression={expression} isNested={isNested} parentElementId={parentElementId} />
-        );
+        return <DecisionTableExpression expression={expression} isNested={isNested} />;
       case "list":
         return <ListExpression expression={expression} isNested={isNested} parentElementId={parentElementId} />;
       case "invocation":
@@ -321,8 +319,8 @@ export function ExpressionDefinitionLogicTypeSelector({
 
       const newIdsByOriginalId = mutateExpressionRandomizingIds(clipboard.expression);
 
-      let oldExpression: BoxedExpression | undefined;
-      setExpression((prev: BoxedExpression) => {
+      let oldExpression: Normalized<BoxedExpression> | undefined;
+      setExpression((prev: Normalized<BoxedExpression>) => {
         oldExpression = prev;
         return clipboard.expression;
       }); // This is mutated to have new IDs by the ID randomizer above.

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from "react";
-import { BoxedExpression } from "../../api";
+import { BoxedExpression, Normalized } from "../../api";
 import { ResizingWidthsContextProvider } from "../../resizing/ResizingWidthsContext";
 import { ExpressionContainer } from "./ExpressionContainer";
 import "./ExpressionDefinitionRoot.css";
@@ -26,7 +26,7 @@ import "./ExpressionDefinitionRoot.css";
 export interface ExpressionDefinitionRootProps {
   expressionHolderId: string;
   expressionHolderTypeRef: string | undefined;
-  expression?: BoxedExpression;
+  expression?: Normalized<BoxedExpression>;
   isResetSupported: boolean | undefined;
   expressionHolderName?: string;
 }

--- a/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionCollectionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionCollectionCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback } from "react";
-import { BeeTableCellProps, BoxedFilter } from "../../api";
+import { BeeTableCellProps, BoxedFilter, Normalized } from "../../api";
 import {
   NestedExpressionDispatchContextProvider,
   useBoxedExpressionEditorDispatch,
@@ -38,7 +38,7 @@ export function FilterExpressionCollectionCell({
 
   const onSetExpression = useCallback(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedFilter) => {
+      setExpression((prev: Normalized<BoxedFilter>) => {
         return {
           ...prev,
           in: {

--- a/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionComponent.tsx
+++ b/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionComponent.tsx
@@ -25,6 +25,7 @@ import {
   BeeTableProps,
   BoxedFilter,
   DmnBuiltInDataType,
+  Normalized,
 } from "../../api";
 import { BeeTable, BeeTableColumnUpdate } from "../../table/BeeTable";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
@@ -45,14 +46,14 @@ import { FilterExpressionCollectionCell } from "./FilterExpressionCollectionCell
 import { FilterExpressionMatchCell } from "./FilterExpressionMatchCell";
 import "./FilterExpression.css";
 
-export type ROWTYPE = DMN15__tChildExpression;
+export type ROWTYPE = Normalized<DMN15__tChildExpression>;
 
 export function FilterExpressionComponent({
   isNested,
   parentElementId,
   expression: filterExpression,
 }: {
-  expression: BoxedFilter;
+  expression: Normalized<BoxedFilter>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -149,9 +150,9 @@ export function FilterExpressionComponent({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedFilter) => {
+      setExpression((prev: Normalized<BoxedFilter>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFilter = {
+        const ret: Normalized<BoxedFilter> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,

--- a/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionMatchCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/FilterExpression/FilterExpressionMatchCell.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BeeTableCellProps, BoxedFilter } from "../../api";
+import { BeeTableCellProps, BoxedFilter, Normalized } from "../../api";
 import {
   NestedExpressionDispatchContextProvider,
   OnSetExpression,
@@ -57,11 +57,11 @@ export function FilterExpressionMatchCell({
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedFilter) => {
+      setExpression((prev: Normalized<BoxedFilter>) => {
         const newExpression = getNewExpression(prev.match.expression);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFilter = {
+        const ret: Normalized<BoxedFilter> = {
           ...prev,
           match: {
             ...prev.match,

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
@@ -31,6 +31,7 @@ import {
   BoxedFunction,
   BoxedFunctionKind,
   DmnBuiltInDataType,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";
@@ -53,7 +54,7 @@ import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionConta
 import { DMN15__tFunctionDefinition } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import { findAllIdsDeep } from "../../ids/ids";
 
-export type FEEL_ROWTYPE = { functionExpression: BoxedFunction };
+export type FEEL_ROWTYPE = { functionExpression: Normalized<BoxedFunction> };
 
 export type BoxedFunctionFeel = DMN15__tFunctionDefinition & {
   "@_kind": "FEEL";
@@ -65,7 +66,7 @@ export function FeelFunctionExpression({
   parentElementId,
   functionExpression,
 }: {
-  functionExpression: BoxedFunctionFeel;
+  functionExpression: Normalized<BoxedFunctionFeel>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -107,9 +108,9 @@ export function FeelFunctionExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<FEEL_ROWTYPE>[]) => {
-      setExpression((prev: BoxedFunctionFeel) => {
+      setExpression((prev: Normalized<BoxedFunctionFeel>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunctionFeel = {
+        const ret: Normalized<BoxedFunctionFeel> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,
@@ -151,8 +152,8 @@ export function FeelFunctionExpression({
   }, []);
 
   const onRowReset = useCallback(() => {
-    let oldExpression: BoxedExpression | undefined;
-    setExpression((prev: BoxedFunctionFeel) => {
+    let oldExpression: Normalized<BoxedExpression> | undefined;
+    setExpression((prev: Normalized<BoxedFunctionFeel>) => {
       oldExpression = prev.expression;
       return undefined!; // SPEC DISCREPANCY
     });
@@ -236,10 +237,14 @@ export function FeelFunctionImplementationCell({
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const onSetExpression = useCallback<OnSetExpression>(
-    ({ getNewExpression }: { getNewExpression: (prev: BoxedExpression) => BoxedExpression }) => {
-      setExpression((prev: BoxedFunctionFeel) => {
+    ({
+      getNewExpression,
+    }: {
+      getNewExpression: (prev: Normalized<BoxedExpression>) => Normalized<BoxedExpression>;
+    }) => {
+      setExpression((prev: Normalized<BoxedFunctionFeel>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunctionFeel = {
+        const ret: Normalized<BoxedFunctionFeel> = {
           ...prev,
           expression: getNewExpression(prev.expression ?? undefined!),
         };

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FunctionExpression.tsx
@@ -20,7 +20,7 @@
 import _ from "lodash";
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { BoxedFunction, BoxedFunctionKind, DmnBuiltInDataType, generateUuid } from "../../api";
+import { BoxedFunction, BoxedFunctionKind, DmnBuiltInDataType, generateUuid, Normalized } from "../../api";
 import { PopoverMenu } from "../../contextMenu/PopoverMenu";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
@@ -40,7 +40,7 @@ export function FunctionExpression({
   parentElementId,
   expression: boxedFunction,
 }: {
-  expression: BoxedFunction;
+  expression: Normalized<BoxedFunction>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -48,24 +48,22 @@ export function FunctionExpression({
     case "Java":
       return (
         <JavaFunctionExpression
-          functionExpression={boxedFunction as BoxedFunctionJava}
+          functionExpression={boxedFunction as Normalized<BoxedFunctionJava>}
           isNested={isNested}
-          parentElementId={parentElementId}
         />
       );
     case "PMML":
       return (
         <PmmlFunctionExpression
-          functionExpression={boxedFunction as BoxedFunctionPmml}
+          functionExpression={boxedFunction as Normalized<BoxedFunctionPmml>}
           isNested={isNested}
-          parentElementId={parentElementId}
         />
       );
     case "FEEL":
     default:
       return (
         <FeelFunctionExpression
-          functionExpression={boxedFunction as BoxedFunctionFeel}
+          functionExpression={boxedFunction as Normalized<BoxedFunctionFeel>}
           isNested={isNested}
           parentElementId={parentElementId}
         />
@@ -73,15 +71,15 @@ export function FunctionExpression({
   }
 }
 
-export function useFunctionExpressionControllerCell(functionKind: DMN15__tFunctionKind) {
+export function useFunctionExpressionControllerCell(functionKind: Normalized<DMN15__tFunctionKind>) {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const onFunctionKindSelect = useCallback(
-    (kind: DMN15__tFunctionKind) => {
-      setExpression((prev: BoxedFunction) => {
+    (kind: Normalized<DMN15__tFunctionKind>) => {
+      setExpression((prev: Normalized<BoxedFunction>) => {
         if (kind === BoxedFunctionKind.Feel) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const retFeel: BoxedFunction = {
+          const retFeel: Normalized<BoxedFunction> = {
             __$$element: "functionDefinition",
             "@_label": prev["@_label"],
             "@_id": generateUuid(),
@@ -99,7 +97,7 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
           const expressionId = generateUuid();
 
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const retJava: BoxedFunction = {
+          const retJava: Normalized<BoxedFunction> = {
             __$$element: "functionDefinition",
             "@_label": prev["@_label"],
             "@_id": expressionId,
@@ -114,7 +112,7 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
           return retJava;
         } else if (kind === BoxedFunctionKind.Pmml) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const retPmml: BoxedFunction = {
+          const retPmml: Normalized<BoxedFunction> = {
             __$$element: "functionDefinition",
             "@_label": prev["@_label"],
             "@_id": generateUuid(),
@@ -142,7 +140,7 @@ export function useFunctionExpressionControllerCell(functionKind: DMN15__tFuncti
 }
 
 export function useFunctionExpressionParametersColumnHeader(
-  formalParameters: DMN15__tFunctionDefinition["formalParameter"]
+  formalParameters: Normalized<DMN15__tFunctionDefinition["formalParameter"]>
 ) {
   const { i18n } = useBoxedExpressionEditorI18n();
 

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -33,6 +33,7 @@ import {
   BoxedFunctionKind,
   DmnBuiltInDataType,
   generateUuid,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
@@ -69,21 +70,19 @@ export type BoxedFunctionJava = DMN15__tFunctionDefinition & {
 export function JavaFunctionExpression({
   functionExpression,
   isNested,
-  parentElementId,
 }: {
-  functionExpression: BoxedFunctionJava;
+  functionExpression: Normalized<BoxedFunctionJava>;
   isNested: boolean;
-  parentElementId: string;
 }) {
   const { i18n } = useBoxedExpressionEditorI18n();
   const { expressionHolderId, widthsById } = useBoxedExpressionEditor();
   const { setExpression, setWidthsById } = useBoxedExpressionEditorDispatch();
 
-  const getClassContextEntry = useCallback((c: DMN15__tContext) => {
+  const getClassContextEntry = useCallback((c: Normalized<DMN15__tContext>) => {
     return c.contextEntry?.find(({ variable }) => variable?.["@_name"] === "class");
   }, []);
 
-  const getVariableContextEntry = useCallback((c: DMN15__tContext) => {
+  const getVariableContextEntry = useCallback((c: Normalized<DMN15__tContext>) => {
     return c.contextEntry?.find(({ variable }) => variable?.["@_name"] === "method signature");
   }, []);
 
@@ -181,9 +180,9 @@ export function JavaFunctionExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<JAVA_ROWTYPE>[]) => {
-      setExpression((prev: BoxedFunctionJava) => {
+      setExpression((prev: Normalized<BoxedFunctionJava>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunctionJava = {
+        const ret: Normalized<BoxedFunctionJava> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,
@@ -195,7 +194,7 @@ export function JavaFunctionExpression({
   );
 
   // It is always a Context
-  const context = functionExpression.expression! as DMN15__tContext;
+  const context = functionExpression.expression! as Normalized<DMN15__tContext>;
   const clazz = getClassContextEntry(context);
   const method = getVariableContextEntry(context);
 
@@ -232,9 +231,9 @@ export function JavaFunctionExpression({
   }, []);
 
   const onRowReset = useCallback(() => {
-    setExpression((prev: BoxedFunctionJava) => {
+    setExpression((prev: Normalized<BoxedFunctionJava>) => {
       // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-      const ret: BoxedFunctionJava = {
+      const ret: Normalized<BoxedFunctionJava> = {
         ...prev,
         expression: undefined!,
       };
@@ -298,32 +297,36 @@ export function JavaFunctionExpression({
   const onCellUpdates = useCallback(
     (cellUpdates: BeeTableCellUpdate<JAVA_ROWTYPE>[]) => {
       for (const u of cellUpdates) {
-        const context: DMN15__tContext = functionExpression.expression!;
+        const context: Normalized<DMN15__tContext> = functionExpression.expression!;
 
         const clazz = getClassContextEntry(context) ?? {
+          "@_id": generateUuid(),
           expression: {
             __$$element: "literalExpression",
             "@_id": generateUuid(),
             text: { __$$text: "" },
           },
           variable: {
+            "@_id": generateUuid(),
             "@_name": "class",
           },
         };
         const method = getVariableContextEntry(context) ?? {
+          "@_id": generateUuid(),
           expression: {
             __$$element: "literalExpression",
             "@_id": generateUuid(),
             text: { __$$text: "" },
           },
           variable: {
+            "@_id": generateUuid(),
             "@_name": "method signature",
           },
         };
 
         // Class
         if (u.rowIndex === 0) {
-          setExpression((prev: BoxedFunctionJava) => {
+          setExpression((prev: Normalized<BoxedFunctionJava>) => {
             clazz.expression = {
               ...clazz.expression,
               __$$element: "literalExpression",
@@ -333,7 +336,7 @@ export function JavaFunctionExpression({
             };
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedFunction = {
+            const ret: Normalized<BoxedFunction> = {
               ...prev,
               expression: {
                 __$$element: "context",
@@ -347,7 +350,7 @@ export function JavaFunctionExpression({
         }
         // Method
         else if (u.rowIndex === 1) {
-          setExpression((prev: BoxedFunctionJava) => {
+          setExpression((prev: Normalized<BoxedFunctionJava>) => {
             method.expression = {
               ...method.expression,
               __$$element: "literalExpression",
@@ -358,7 +361,7 @@ export function JavaFunctionExpression({
             };
 
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedFunction = {
+            const ret: Normalized<BoxedFunction> = {
               ...prev,
               expression: {
                 __$$element: "context",

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/ParametersPopover.tsx
@@ -24,7 +24,7 @@ import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { OutlinedTrashAltIcon } from "@patternfly/react-icons/dist/js/icons/outlined-trash-alt-icon";
 import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
-import { BoxedFunction, DmnBuiltInDataType, generateUuid, getNextAvailablePrefixedName } from "../../api";
+import { BoxedFunction, generateUuid, getNextAvailablePrefixedName, Normalized } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
 import { DMN15__tInformationItem } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
@@ -32,7 +32,7 @@ import { DataTypeSelector } from "../../expressionVariable/DataTypeSelector";
 import "./ParametersPopover.css";
 
 export interface ParametersPopoverProps {
-  parameters: DMN15__tInformationItem[];
+  parameters: Normalized<DMN15__tInformationItem>[];
 }
 
 export const ParametersPopover: React.FunctionComponent<ParametersPopoverProps> = ({ parameters }) => {
@@ -42,7 +42,7 @@ export const ParametersPopover: React.FunctionComponent<ParametersPopoverProps> 
   const addParameter = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      setExpression((prev: BoxedFunction) => {
+      setExpression((prev: Normalized<BoxedFunction>) => {
         const newParameters = [
           ...(prev.formalParameter ?? []),
           {
@@ -56,7 +56,7 @@ export const ParametersPopover: React.FunctionComponent<ParametersPopoverProps> 
         ];
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunction = {
+        const ret: Normalized<BoxedFunction> = {
           ...prev,
           formalParameter: newParameters,
         };
@@ -101,14 +101,14 @@ function ParameterEntry({ parameter, index }: { parameter: DMN15__tInformationIt
   const onNameChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       e.stopPropagation();
-      setExpression((prev: BoxedFunction) => {
+      setExpression((prev: Normalized<BoxedFunction>) => {
         const newParameters = [...(prev.formalParameter ?? [])];
         newParameters[index] = {
           ...newParameters[index],
           "@_name": e.target.value,
         };
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunction = {
+        const ret: Normalized<BoxedFunction> = {
           ...prev,
           formalParameter: newParameters,
         };
@@ -121,14 +121,14 @@ function ParameterEntry({ parameter, index }: { parameter: DMN15__tInformationIt
 
   const onDataTypeChange = useCallback(
     (typeRef: string | undefined) => {
-      setExpression((prev: BoxedFunction) => {
+      setExpression((prev: Normalized<BoxedFunction>) => {
         const newParameters = [...(prev.formalParameter ?? [])];
         newParameters[index] = {
           ...newParameters[index],
           "@_typeRef": typeRef,
         };
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunction = {
+        const ret: Normalized<BoxedFunction> = {
           ...prev,
           formalParameter: newParameters,
         };
@@ -142,11 +142,11 @@ function ParameterEntry({ parameter, index }: { parameter: DMN15__tInformationIt
   const onParameterRemove = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      setExpression((prev: BoxedFunction) => {
+      setExpression((prev: Normalized<BoxedFunction>) => {
         const newParameters = [...(prev.formalParameter ?? [])];
         newParameters.splice(index, 1);
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunction = {
+        const ret: Normalized<BoxedFunction> = {
           ...prev,
           formalParameter: newParameters,
         };

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
@@ -32,6 +32,7 @@ import {
   BoxedFunctionKind,
   DmnBuiltInDataType,
   generateUuid,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
@@ -63,17 +64,15 @@ export type BoxedFunctionPmml = DMN15__tFunctionDefinition & {
 type PMML_ROWTYPE = {
   value: string;
   label: string;
-  pmmlFunctionExpression: BoxedFunctionPmml;
+  pmmlFunctionExpression: Normalized<BoxedFunctionPmml>;
 };
 
 export function PmmlFunctionExpression({
   functionExpression,
   isNested,
-  parentElementId,
 }: {
-  functionExpression: BoxedFunctionPmml;
+  functionExpression: Normalized<BoxedFunctionPmml>;
   isNested: boolean;
-  parentElementId: string;
 }) {
   const { i18n } = useBoxedExpressionEditorI18n();
   const { expressionHolderId } = useBoxedExpressionEditor();
@@ -134,9 +133,9 @@ export function PmmlFunctionExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef: dataType }]: BeeTableColumnUpdate<PMML_ROWTYPE>[]) => {
-      setExpression((prev: BoxedFunctionPmml) => {
+      setExpression((prev: Normalized<BoxedFunctionPmml>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedFunctionPmml = {
+        const ret: Normalized<BoxedFunctionPmml> = {
           ...prev,
           "@_label": name,
           "@_typeRef": dataType,
@@ -199,9 +198,9 @@ export function PmmlFunctionExpression({
   }, []);
 
   const onRowReset = useCallback(() => {
-    setExpression((prev: BoxedFunctionPmml) => {
+    setExpression((prev: Normalized<BoxedFunctionPmml>) => {
       // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-      const ret: BoxedFunctionPmml = {
+      const ret: Normalized<BoxedFunctionPmml> = {
         ...prev,
         expression: undefined!,
       };
@@ -325,9 +324,9 @@ function PmmlFunctionExpressionValueCell(props: React.PropsWithChildren<BeeTable
   );
 }
 
-function getDocumentEntry(pmmlFunction: BoxedFunctionPmml): DMN15__tContextEntry {
+function getDocumentEntry(pmmlFunction: Normalized<BoxedFunctionPmml>): Normalized<DMN15__tContextEntry> {
   return (
-    (pmmlFunction.expression as DMN15__tContext).contextEntry?.find(
+    (pmmlFunction.expression as Normalized<DMN15__tContext>).contextEntry?.find(
       ({ variable }) => variable?.["@_name"] === "document"
     ) ?? {
       "@_id": generateUuid(),
@@ -339,9 +338,9 @@ function getDocumentEntry(pmmlFunction: BoxedFunctionPmml): DMN15__tContextEntry
   );
 }
 
-function getModelEntry(pmmlFunction: BoxedFunctionPmml): DMN15__tContextEntry {
+function getModelEntry(pmmlFunction: Normalized<BoxedFunctionPmml>): Normalized<DMN15__tContextEntry> {
   return (
-    (pmmlFunction.expression as DMN15__tContext).contextEntry?.find(
+    (pmmlFunction.expression as Normalized<DMN15__tContext>).contextEntry?.find(
       ({ variable }) => variable?.["@_name"] === "model"
     ) ?? {
       "@_id": generateUuid(),
@@ -353,23 +352,30 @@ function getModelEntry(pmmlFunction: BoxedFunctionPmml): DMN15__tContextEntry {
   );
 }
 
-function getUpdatedExpression(prev: BoxedFunctionPmml, newDocument: string, newModel: string): BoxedFunction {
+function getUpdatedExpression(
+  prev: Normalized<BoxedFunctionPmml>,
+  newDocument: string,
+  newModel: string
+): Normalized<BoxedFunction> {
   const document = getDocumentEntry(prev);
   const model = getModelEntry(prev);
 
   // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-  const ret: BoxedFunction = {
+  const ret: Normalized<BoxedFunction> = {
     ...prev,
     expression: {
+      "@_id": generateUuid(),
       __$$element: "context",
       ...(prev.expression as DMN15__tContext),
       contextEntry: [
         {
           ...document,
           variable: {
+            "@_id": generateUuid(),
             "@_name": "document",
           },
           expression: {
+            "@_id": generateUuid(),
             __$$element: "literalExpression",
             text: { __$$text: newDocument },
           },
@@ -377,9 +383,11 @@ function getUpdatedExpression(prev: BoxedFunctionPmml, newDocument: string, newM
         {
           ...model,
           variable: {
+            "@_id": generateUuid(),
             "@_name": "model",
           },
           expression: {
+            "@_id": generateUuid(),
             __$$element: "literalExpression",
             text: { __$$text: newModel },
           },
@@ -418,7 +426,7 @@ function PmmlFunctionExpressionDocumentCell(props: React.PropsWithChildren<BeeTa
   const onSelect = useCallback(
     (event, newDocument) => {
       setSelectOpen(false);
-      setExpression((prev: BoxedFunctionPmml) => {
+      setExpression((prev: Normalized<BoxedFunctionPmml>) => {
         return getUpdatedExpression(prev, newDocument, "");
       });
     },
@@ -475,7 +483,7 @@ function PmmlFunctionExpressionModelCell(props: React.PropsWithChildren<BeeTable
     (event, newModel) => {
       setSelectOpen(false);
 
-      setExpression((prev: BoxedFunctionPmml) => {
+      setExpression((prev: Normalized<BoxedFunctionPmml>) => {
         const document = getDocumentEntry(prev);
         const currentDocument =
           document.expression?.__$$element === "literalExpression" ? document.expression.text?.__$$text ?? "" : "";

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/ArgumentEntryExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/ArgumentEntryExpressionCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useEffect } from "react";
-import { BoxedInvocation, BeeTableCellProps } from "../../api";
+import { BeeTableCellProps, BoxedInvocation, Normalized } from "../../api";
 import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionContainer";
 import {
   NestedExpressionDispatchContextProvider,
@@ -47,7 +47,7 @@ export const ArgumentEntryExpressionCell: React.FunctionComponent<
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedInvocation) => {
+      setExpression((prev: Normalized<BoxedInvocation>) => {
         const newBindings = [...(prev.binding ?? [])];
         newBindings[index] = {
           ...newBindings[index],
@@ -55,7 +55,7 @@ export const ArgumentEntryExpressionCell: React.FunctionComponent<
         };
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedInvocation = {
+        const ret: Normalized<BoxedInvocation> = {
           ...prev,
           binding: newBindings,
         };

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -31,6 +31,7 @@ import {
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { NestedExpressionContainerContext } from "../../resizing/NestedExpressionContainerContext";
@@ -63,7 +64,7 @@ export function InvocationExpression({
   parentElementId,
   expression: invocationExpression,
 }: {
-  expression: BoxedInvocation;
+  expression: Normalized<BoxedInvocation>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -228,32 +229,33 @@ export function InvocationExpression({
     (columnUpdates: BeeTableColumnUpdate<ROWTYPE>[]) => {
       for (const u of columnUpdates) {
         if (u.column.originalId === id) {
-          setExpression((prev: BoxedInvocation) => ({
+          setExpression((prev: Normalized<BoxedInvocation>) => ({
             ...prev,
             "@_id": prev["@_id"],
             name: u.name,
           }));
         } else if (u.column.originalId === invocationId) {
-          setExpression((prev: BoxedInvocation) => {
+          setExpression((prev: Normalized<BoxedInvocation>) => {
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedInvocation = {
+            const ret: Normalized<BoxedInvocation> = {
               ...prev,
               expression: {
                 ...prev.expression,
+                "@_id": prev.expression?.["@_id"] ?? generateUuid(),
                 __$$element: "literalExpression",
                 text: {
                   __$$text: u.name,
                 },
               },
             };
-
             return ret;
           });
         } else {
-          setExpression((prev: BoxedInvocation) => {
+          setExpression((prev: Normalized<BoxedInvocation>) => {
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedInvocation = {
+            const ret: Normalized<BoxedInvocation> = {
               ...prev,
+              "@_id": prev["@_id"] ?? generateUuid(),
               "@_typeRef": u.typeRef,
               "@_label": u.name,
             };
@@ -277,14 +279,14 @@ export function InvocationExpression({
 
   const updateParameter = useCallback(
     (index: number, { expression, variable }: ExpressionWithVariable) => {
-      setExpression((prev: BoxedInvocation) => {
+      setExpression((prev: Normalized<BoxedInvocation>) => {
         const newArgumentEntries = [...(prev.binding ?? [])];
         newArgumentEntries[index] = {
           parameter: variable,
           expression: expression,
         };
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedInvocation = {
+        const ret: Normalized<BoxedInvocation> = {
           ...prev,
           binding: newArgumentEntries,
         };
@@ -328,7 +330,7 @@ export function InvocationExpression({
   }, [i18n]);
 
   const getDefaultArgumentEntry = useCallback(
-    (name?: string): DMN15__tBinding => {
+    (name?: string): Normalized<DMN15__tBinding> => {
       return {
         parameter: {
           "@_id": generateUuid(),
@@ -348,14 +350,14 @@ export function InvocationExpression({
 
   const onRowAdded = useCallback(
     (args: { beforeIndex: number; rowsCount: number }) => {
-      const newEntries: DMN15__tBinding[] = [];
+      const newEntries: Normalized<DMN15__tBinding>[] = [];
       const names = (invocationExpression.binding ?? []).map((e) => e.parameter["@_name"]);
       for (let i = 0; i < args.rowsCount; i++) {
         const name = getNextAvailablePrefixedName(names, "p");
         names.push(name);
         newEntries.push(getDefaultArgumentEntry(name));
       }
-      setExpression((prev: BoxedInvocation) => {
+      setExpression((prev: Normalized<BoxedInvocation>) => {
         const newArgumentEntries = [...(prev.binding ?? [])];
 
         for (const newEntry of newEntries) {
@@ -363,7 +365,7 @@ export function InvocationExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedInvocation = {
+        const ret: Normalized<BoxedInvocation> = {
           ...prev,
           binding: newArgumentEntries,
         };
@@ -376,13 +378,13 @@ export function InvocationExpression({
 
   const onRowDeleted = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
-      setExpression((prev: BoxedInvocation) => {
+      let oldExpression: Normalized<BoxedExpression> | undefined;
+      setExpression((prev: Normalized<BoxedInvocation>) => {
         const newArgumentEntries = [...(prev.binding ?? [])];
         oldExpression = newArgumentEntries[args.rowIndex].expression;
         newArgumentEntries.splice(args.rowIndex, 1);
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedInvocation = {
+        const ret: Normalized<BoxedInvocation> = {
           ...prev,
           binding: newArgumentEntries,
         };
@@ -401,14 +403,14 @@ export function InvocationExpression({
 
   const onRowReset = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
-      setExpression((prev: BoxedInvocation) => {
+      let oldExpression: Normalized<BoxedExpression> | undefined;
+      setExpression((prev: Normalized<BoxedInvocation>) => {
         const newArgumentEntries = [...(prev.binding ?? [])];
         oldExpression = newArgumentEntries[args.rowIndex].expression;
         const defaultArgumentEntry = getDefaultArgumentEntry(newArgumentEntries[args.rowIndex].parameter["@_name"]);
         newArgumentEntries.splice(args.rowIndex, 1, defaultArgumentEntry);
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedInvocation = {
+        const ret: Normalized<BoxedInvocation> = {
           ...prev,
           binding: newArgumentEntries,
         };

--- a/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { BoxedIterator } from "../../api";
+import { BoxedIterator, generateUuid, Normalized } from "../../api";
 import {
   NestedExpressionDispatchContextProvider,
   useBoxedExpressionEditorDispatch,
@@ -28,7 +28,7 @@ import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionConta
 import { IteratorClause } from "./IteratorExpressionComponent";
 
 export interface IteratorExpressionCellExpressionCellProps {
-  iteratorClause: IteratorClause;
+  iteratorClause: Normalized<IteratorClause>;
   rowIndex: number;
   columnIndex: number;
   columnId: string;
@@ -44,12 +44,13 @@ export function IteratorExpressionCell({
 
   const onSetExpression = useCallback(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedIterator) => {
+      setExpression((prev: Normalized<BoxedIterator>) => {
         switch (rowIndex) {
           case 1:
             return {
               ...prev,
               in: {
+                "@_id": generateUuid(),
                 expression: getNewExpression(prev.in.expression),
               },
             };
@@ -59,6 +60,7 @@ export function IteratorExpressionCell({
               return {
                 ...prev,
                 return: {
+                  "@_id": generateUuid(),
                   expression: getNewExpression(prev.return.expression),
                 },
               };
@@ -66,6 +68,7 @@ export function IteratorExpressionCell({
               return {
                 ...prev,
                 satisfies: {
+                  "@_id": generateUuid(),
                   expression: getNewExpression(prev.satisfies.expression),
                 },
               };

--- a/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionComponent.tsx
+++ b/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionComponent.tsx
@@ -25,6 +25,8 @@ import {
   BoxedFor,
   BoxedIterator,
   DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
 } from "../../api";
 import { BeeTable, BeeTableColumnUpdate, BeeTableRef } from "../../table/BeeTable";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
@@ -49,7 +51,7 @@ import {
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../../expressionVariable/ExpressionVariableMenu";
 import { IteratorExpressionVariableCell } from "./IteratorExpressionVariableCell";
 
-type ROWTYPE = IteratorClause;
+type ROWTYPE = Normalized<IteratorClause>;
 
 export type IteratorClause = {
   child: DMN15__tTypedChildExpression | DMN15__tChildExpression | string | undefined;
@@ -61,7 +63,7 @@ export function IteratorExpressionComponent({
   parentElementId,
   expression: expression,
 }: {
-  expression: BoxedIterator;
+  expression: Normalized<BoxedIterator>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -239,9 +241,9 @@ export function IteratorExpressionComponent({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedIterator) => {
+      setExpression((prev: Normalized<BoxedIterator>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedIterator = {
+        const ret: Normalized<BoxedIterator> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,
@@ -254,34 +256,43 @@ export function IteratorExpressionComponent({
   );
   const onRowReset = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedIterator) => {
+      setExpression((prev: Normalized<BoxedIterator>) => {
         if (args.rowIndex === 0) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedIterator = {
+          const ret: Normalized<BoxedIterator> = {
             ...prev,
             "@_iteratorVariable": undefined,
           };
           return ret;
         } else if (args.rowIndex === 1) {
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-          const ret: BoxedIterator = {
+          const ret: Normalized<BoxedIterator> = {
             ...prev,
-            in: { expression: undefined! }, // SPEC DISCREPANCY
+            in: {
+              "@_id": generateUuid(),
+              expression: undefined!,
+            }, // SPEC DISCREPANCY
           };
           return ret;
         } else if (args.rowIndex === 2) {
           if (prev.__$$element === "for") {
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedFor = {
+            const ret: Normalized<BoxedFor> = {
               ...prev,
-              return: { expression: undefined! }, // SPEC DISCREPANCY
+              return: {
+                "@_id": generateUuid(),
+                expression: undefined!,
+              }, // SPEC DISCREPANCY
             };
             return ret;
           } else if (prev.__$$element === "some" || prev.__$$element === "every") {
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const iterator: BoxedIterator = {
+            const iterator: Normalized<BoxedIterator> = {
               ...prev,
-              satisfies: { expression: undefined! }, // SPEC DISCREPANCY
+              satisfies: {
+                "@_id": generateUuid(),
+                expression: undefined!,
+              }, // SPEC DISCREPANCY
             };
             return iterator;
           } else {

--- a/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionVariableCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/IteratorExpression/IteratorExpressionVariableCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useEffect } from "react";
-import { BoxedIterator } from "../../api";
+import { BoxedIterator, Normalized } from "../../api";
 import { useBoxedExpressionEditor, useBoxedExpressionEditorDispatch } from "../../BoxedExpressionEditorContext";
 import { IteratorClause } from "./IteratorExpressionComponent";
 import { InlineEditableTextInput } from "../../table/BeeTable/InlineEditableTextInput";
@@ -64,9 +64,9 @@ export function IteratorExpressionVariableCell({
       <InlineEditableTextInput
         value={data[rowIndex].child as string}
         onChange={(updatedValue) => {
-          setExpression((prev: BoxedIterator) => {
+          setExpression((prev: Normalized<BoxedIterator>) => {
             // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-            const ret: BoxedIterator = {
+            const ret: Normalized<BoxedIterator> = {
               ...prev,
               "@_iteratorVariable": updatedValue,
             };

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
@@ -30,6 +30,8 @@ import {
   BoxedExpression,
   BoxedList,
   DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useNestedExpressionContainerWithNestedExpressions } from "../../resizing/Hooks";
@@ -44,14 +46,14 @@ import { DMN15__tContextEntry } from "@kie-tools/dmn-marshaller/dist/schemas/dmn
 import { findAllIdsDeep } from "../../ids/ids";
 import "./ListExpression.css";
 
-export type ROWTYPE = DMN15__tContextEntry;
+export type ROWTYPE = Normalized<DMN15__tContextEntry>;
 
 export function ListExpression({
   isNested,
   parentElementId,
   expression: listExpression,
 }: {
-  expression: BoxedList;
+  expression: Normalized<BoxedList>;
   isNested: boolean;
   parentElementId: string;
 }) {
@@ -111,11 +113,13 @@ export function ListExpression({
 
   const beeTableRows = useMemo(() => {
     const rows = (listExpression.expression ?? []).map((item) => ({
+      "@_id": generateUuid(),
       expression: item,
     }));
 
     if (rows.length === 0) {
       rows.push({
+        "@_id": generateUuid(),
         expression: undefined!,
       });
     }
@@ -152,9 +156,9 @@ export function ListExpression({
 
   const onRowAdded = useCallback(
     (args: { beforeIndex: number; rowsCount: number }) => {
-      setExpression((prev: BoxedList) => {
+      setExpression((prev: Normalized<BoxedList>) => {
         const newItems = [...(prev.expression ?? [])];
-        const newListItems: BoxedExpression[] = [];
+        const newListItems: Normalized<BoxedExpression>[] = [];
 
         for (let i = 0; i < args.rowsCount; i++) {
           newListItems.push(undefined!); // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
@@ -165,7 +169,7 @@ export function ListExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedList = {
+        const ret: Normalized<BoxedList> = {
           ...prev,
           expression: newItems,
         };
@@ -178,14 +182,14 @@ export function ListExpression({
 
   const onRowDeleted = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
-      setExpression((prev: BoxedList) => {
+      let oldExpression: Normalized<BoxedExpression> | undefined;
+      setExpression((prev: Normalized<BoxedList>) => {
         const newItems = [...(prev.expression ?? [])];
         oldExpression = newItems[args.rowIndex];
         newItems.splice(args.rowIndex, 1);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedList = {
+        const ret: Normalized<BoxedList> = {
           ...prev,
           expression: newItems,
         };
@@ -204,14 +208,14 @@ export function ListExpression({
 
   const onRowReset = useCallback(
     (args: { rowIndex: number }) => {
-      let oldExpression: BoxedExpression | undefined;
-      setExpression((prev: BoxedList) => {
+      let oldExpression: Normalized<BoxedExpression> | undefined;
+      setExpression((prev: Normalized<BoxedList>) => {
         const newItems = [...(prev.expression ?? [])];
         oldExpression = newItems[args.rowIndex];
         newItems.splice(args.rowIndex, 1, undefined!); // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedList = {
+        const ret: Normalized<BoxedList> = {
           ...prev,
           expression: newItems,
         };
@@ -234,9 +238,9 @@ export function ListExpression({
 
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedList) => {
+      setExpression((prev: Normalized<BoxedList>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedList = {
+        const ret: Normalized<BoxedList> = {
           ...prev,
           "@_label": name,
           "@_typeRef": typeRef,

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListItemCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListItemCell.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback } from "react";
-import { BeeTableCellProps, BoxedList } from "../../api";
+import { BeeTableCellProps, BoxedList, Normalized } from "../../api";
 import {
   useBoxedExpressionEditorDispatch,
   NestedExpressionDispatchContextProvider,
@@ -35,17 +35,17 @@ export function ListItemCell({
   columnIndex,
   parentElementId,
   listExpression,
-}: BeeTableCellProps<ROWTYPE> & { parentElementId: string; listExpression: DMN15__tList }) {
+}: BeeTableCellProps<ROWTYPE> & { parentElementId: string; listExpression: Normalized<DMN15__tList> }) {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const onSetExpression = useCallback<OnSetExpression>(
     ({ getNewExpression }) => {
-      setExpression((prev: BoxedList) => {
+      setExpression((prev: Normalized<BoxedList>) => {
         const newItems = [...(prev.expression ?? [])];
         newItems[rowIndex] = getNewExpression(newItems[rowIndex])!; // SPEC DISCREPANCY: Allowing undefined expression
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedList = {
+        const ret: Normalized<BoxedList> = {
           ...prev,
           expression: newItems,
         };

--- a/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
@@ -26,6 +26,7 @@ import {
   BeeTableOperation,
   BoxedLiteral,
   DmnBuiltInDataType,
+  Normalized,
 } from "../../api";
 import { useNestedExpressionContainer } from "../../resizing/NestedExpressionContainerContext";
 import {
@@ -48,7 +49,7 @@ export function LiteralExpression({
   isNested,
   expression: literalExpression,
 }: {
-  expression: BoxedLiteral;
+  expression: Normalized<BoxedLiteral>;
   isNested: boolean;
 }) {
   const { setExpression, setWidthsById } = useBoxedExpressionEditorDispatch();
@@ -62,9 +63,9 @@ export function LiteralExpression({
 
   const setValue = useCallback(
     (value: string) => {
-      setExpression((prev: BoxedLiteral) => {
+      setExpression((prev: Normalized<BoxedLiteral>) => {
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedLiteral = { ...literalExpression, text: { __$$text: value } };
+        const ret: Normalized<BoxedLiteral> = { ...literalExpression, text: { __$$text: value } };
         return ret;
       });
     },
@@ -86,7 +87,7 @@ export function LiteralExpression({
   const onColumnUpdates = useCallback(
     ([{ name, typeRef }]: BeeTableColumnUpdate<ROWTYPE>[]) => {
       setExpression(
-        (): BoxedLiteral => ({
+        (): Normalized<BoxedLiteral> => ({
           ...literalExpression,
           "@_label": name,
           "@_typeRef": typeRef,

--- a/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/RelationExpression/RelationExpression.tsx
@@ -30,6 +30,7 @@ import {
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
+  Normalized,
 } from "../../api";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
@@ -52,7 +53,6 @@ export const RELATION_EXPRESSION_DEFAULT_VALUE = "";
 
 export function RelationExpression({
   isNested,
-  parentElementId,
   expression: relationExpression,
 }: {
   expression: BoxedRelation;
@@ -203,8 +203,8 @@ export function RelationExpression({
 
   const onCellUpdates = useCallback(
     (cellUpdates: BeeTableCellUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedRelation) => {
-        let previousExpression: BoxedRelation = { ...prev };
+      setExpression((prev: Normalized<BoxedRelation>) => {
+        let previousExpression: Normalized<BoxedRelation> = { ...prev };
 
         cellUpdates.forEach((cellUpdate) => {
           const newRows = [...(previousExpression.row ?? [])];
@@ -235,7 +235,7 @@ export function RelationExpression({
 
   const onColumnUpdates = useCallback(
     (columnUpdates: BeeTableColumnUpdate<ROWTYPE>[]) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const n = { ...prev };
         const newColumns = [...(prev.column ?? [])];
 
@@ -253,7 +253,7 @@ export function RelationExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...n,
           column: newColumns,
         };
@@ -281,7 +281,7 @@ export function RelationExpression({
 
   const onRowAdded = useCallback(
     (args: { beforeIndex: number; rowsCount: number }) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const newRows = [...(prev.row ?? [])];
         const newItems = [];
 
@@ -299,7 +299,7 @@ export function RelationExpression({
         }
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...prev,
           row: newRows,
         };
@@ -312,7 +312,7 @@ export function RelationExpression({
 
   const onColumnAdded = useCallback(
     (args: { beforeIndex: number; columnsCount: number }) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const newColumns = [...(prev.column ?? [])];
 
         const newItems = [];
@@ -343,7 +343,7 @@ export function RelationExpression({
         });
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...prev,
           column: newColumns,
           row: newRows,
@@ -368,7 +368,7 @@ export function RelationExpression({
 
   const onColumnDeleted = useCallback(
     (args: { columnIndex: number }) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const newColumns = [...(prev.column ?? [])];
         newColumns.splice(args.columnIndex, 1);
 
@@ -382,7 +382,7 @@ export function RelationExpression({
         });
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...prev,
           column: newColumns,
           row: newRows,
@@ -403,12 +403,12 @@ export function RelationExpression({
 
   const onRowDeleted = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const newRows = [...(prev.row ?? [])];
         newRows.splice(args.rowIndex, 1);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...prev,
           row: newRows,
         };
@@ -421,7 +421,7 @@ export function RelationExpression({
 
   const onRowDuplicated = useCallback(
     (args: { rowIndex: number }) => {
-      setExpression((prev: BoxedRelation) => {
+      setExpression((prev: Normalized<BoxedRelation>) => {
         const duplicatedRow = {
           "@_id": generateUuid(),
           expression: prev.row![args.rowIndex].expression?.map((cell) => ({
@@ -434,7 +434,7 @@ export function RelationExpression({
         newRows.splice(args.rowIndex, 0, duplicatedRow);
 
         // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
-        const ret: BoxedRelation = {
+        const ret: Normalized<BoxedRelation> = {
           ...prev,
           row: newRows,
         };

--- a/packages/boxed-expression-component/src/table/BeeTable/StandaloneBeeTable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/StandaloneBeeTable.tsx
@@ -20,11 +20,11 @@
 import { I18nDictionariesProvider } from "@kie-tools-core/i18n/dist/react-components";
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { BeeTableProps, BoxedExpression } from "../../api";
+import { BeeTableProps, BoxedExpression, Normalized } from "../../api";
 import { BoxedExpressionEditorContextProvider } from "../../BoxedExpressionEditorContext";
 import {
-  BoxedExpressionEditorI18nContext,
   boxedExpressionEditorDictionaries,
+  BoxedExpressionEditorI18nContext,
   boxedExpressionEditorI18nDefaults,
 } from "../../i18n";
 import { ResizingWidthsContextProvider } from "../../resizing/ResizingWidthsContext";
@@ -46,7 +46,7 @@ export function StandaloneBeeTable<R extends object>(
     // Empty on purpose.
   }, []);
 
-  const expression = useMemo<BoxedExpression>(() => {
+  const expression = useMemo<Normalized<BoxedExpression>>(() => {
     return undefined!;
   }, []);
 

--- a/packages/boxed-expression-component/stories/boxedExpressionStoriesWrapper.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressionStoriesWrapper.tsx
@@ -21,8 +21,7 @@ import { useArgs } from "@storybook/preview-api";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../src/BoxedExpressionEditor";
-import { BeeGwtService, BoxedExpression, DmnBuiltInDataType, generateUuid } from "../src/api";
-import { getDefaultBoxedExpressionForDevWebapp } from "./dev/getDefaultBoxedExpressionForDevWebapp";
+import { BeeGwtService, BoxedExpression, DmnBuiltInDataType, generateUuid, Normalized } from "../src/api";
 import { DEFAULT_EXPRESSION_VARIABLE_NAME } from "../src/expressionVariable/ExpressionVariableMenu";
 import { getDefaultBoxedExpressionForStories } from "./getDefaultBoxedExpressionForStories";
 
@@ -93,7 +92,7 @@ export type BoxedExpressionEditorStoryArgs = Omit<BoxedExpressionEditorProps, "w
 export function BoxedExpressionEditorStory(props?: Partial<BoxedExpressionEditorStoryArgs>) {
   const emptyRef = useRef<HTMLDivElement>(null);
   const [args, updateArgs] = useArgs<BoxedExpressionEditorStoryArgs>();
-  const [expressionState, setExpressionState] = useState<BoxedExpression | undefined>(
+  const [expressionState, setExpressionState] = useState<Normalized<BoxedExpression> | undefined>(
     args?.expression ?? props?.expression
   );
 

--- a/packages/boxed-expression-component/stories/boxedExpressions/BoxedExpressions.mdx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/BoxedExpressions.mdx
@@ -39,6 +39,9 @@ Currently, the following boxed expressions are supported:
 - [Literal](/docs/boxed-expressions-literal--overview)
 - [Relation](/docs/boxed-expressions-relation--overview)
 - [Filter](/docs/boxed-expressions-filter--overview)
+- [Every](/docs/boxed-expressions-every--overview)
+- [For](/docs/boxed-expressions-for--overview)
+- [Some](/docs/boxed-expressions-some--overview)
 
 ## Reference
 

--- a/packages/boxed-expression-component/stories/boxedExpressions/Context/Context.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Context/Context.stories.tsx
@@ -46,6 +46,7 @@ export const Base: Story = {
       "@_typeRef": undefined,
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",
@@ -72,6 +73,7 @@ export const InstallmentCalculation: Story = {
       "@_typeRef": DmnBuiltInDataType.Number,
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "Fee",
@@ -86,6 +88,7 @@ export const InstallmentCalculation: Story = {
           },
         },
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "Repayments",
@@ -100,6 +103,7 @@ export const InstallmentCalculation: Story = {
           },
         },
         {
+          "@_id": generateUuid(),
           // The result expression is a ContextEntry without variable
           expression: {
             __$$element: "literalExpression",
@@ -127,6 +131,7 @@ export const Customer: Story = {
       "@_typeRef": "tCustomer",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "Name",
@@ -141,6 +146,7 @@ export const Customer: Story = {
           },
         },
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "Age",
@@ -171,6 +177,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",
@@ -181,6 +188,7 @@ export const Nested: Story = {
             "@_label": "Expression Name",
             contextEntry: [
               {
+                "@_id": generateUuid(),
                 variable: {
                   "@_id": generateUuid(),
                   "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/DecisionTable/DecisionTable.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/DecisionTable/DecisionTable.stories.tsx
@@ -186,6 +186,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/Every/Every.mdx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Every/Every.mdx
@@ -1,0 +1,27 @@
+{/* Licensed to the Apache Software Foundation (ASF) under one */}
+{/* or more contributor license agreements. See the NOTICE file */}
+{/* distributed with this work for additional information */}
+{/* regarding copyright ownership. The ASF licenses this file */}
+{/* to you under the Apache License, Version 2.0 (the */}
+{/* "License"); you may not use this file except in compliance */}
+{/* with the License. You may obtain a copy of the License at */}
+{/*  */}
+{/* http://www.apache.org/licenses/LICENSE-2.0 */}
+{/*  */}
+{/* Unless required by applicable law or agreed to in writing, */}
+{/* software distributed under the License is distributed on an */}
+{/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY */}
+{/* KIND, either express or implied. See the License for the */}
+{/* specific language governing permissions and limitations */}
+{/* under the License. */}
+
+import { Meta } from "@storybook/blocks";
+import * as Every from "./Every.stories";
+
+<Meta title="MDX/Every" of={Every} />
+
+# Boxed Every Expression
+
+A boxed iterator offers a visual representation of an iterator statement.
+For the "every" loop, the right part of the "every" displays the iterator variable name. The second row holds an expression representing the collection that will be iterated over. The expression in the "in" row MUST resolve to a collection.
+The last line is an expression that will be evaluated on each item. The expression defined in the "satisfies" MUST resolve to a boolean.

--- a/packages/boxed-expression-component/stories/boxedExpressions/Every/Every.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Every/Every.stories.tsx
@@ -17,18 +17,19 @@
  * under the License.
  */
 
-import type { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
+import { generateUuid } from "../../../src/api";
 import { Base as EmptyExpression } from "../../misc/Empty/EmptyExpression.stories";
-import { DmnBuiltInDataType, generateUuid } from "../../../src/api";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<BoxedExpressionEditorProps> = {
-  title: "Boxed Expressions/Literal",
+  title: "Boxed Expressions/Every",
   component: BoxedExpressionEditor,
   includeStories: /^[A-Z]/,
 };
+
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
@@ -39,58 +40,17 @@ export const Base: Story = {
   args: {
     ...EmptyExpression.args,
     expression: {
-      __$$element: "literalExpression",
+      __$$element: "every",
       "@_id": generateUuid(),
       "@_label": "Expression Name",
+      in: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
+      satisfies: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
     },
-    isResetSupportedOnRootExpression: true,
-  },
-};
-
-export const CanDrive: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "literalExpression",
-      "@_id": "_D98FB35A-C6A5-4BA7-AD38-176D56A31872",
-      "@_label": "Can Drive?",
-      "@_typeRef": DmnBuiltInDataType.Boolean,
-      text: { __$$text: "Age >= 18 then true else false" },
-    },
-    widthsById: {
-      "_D98FB35A-C6A5-4BA7-AD38-176D56A31872": [500],
-    },
-    isResetSupportedOnRootExpression: false,
-  },
-};
-
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Nested: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "context",
-      "@_id": generateUuid(),
-      "@_label": "Expression Name",
-      contextEntry: [
-        {
-          "@_id": generateUuid(),
-          variable: {
-            "@_id": generateUuid(),
-            "@_name": "ContextEntry-1",
-          },
-          expression: {
-            __$$element: "literalExpression",
-            "@_id": generateUuid(),
-            "@_label": "Expression Name",
-          },
-        },
-      ],
-    },
-    isResetSupportedOnRootExpression: false,
   },
 };

--- a/packages/boxed-expression-component/stories/boxedExpressions/Filter/Filter.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Filter/Filter.stories.tsx
@@ -96,6 +96,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/For/For.mdx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/For/For.mdx
@@ -1,0 +1,27 @@
+{/* Licensed to the Apache Software Foundation (ASF) under one */}
+{/* or more contributor license agreements. See the NOTICE file */}
+{/* distributed with this work for additional information */}
+{/* regarding copyright ownership. The ASF licenses this file */}
+{/* to you under the Apache License, Version 2.0 (the */}
+{/* "License"); you may not use this file except in compliance */}
+{/* with the License. You may obtain a copy of the License at */}
+{/*  */}
+{/* http://www.apache.org/licenses/LICENSE-2.0 */}
+{/*  */}
+{/* Unless required by applicable law or agreed to in writing, */}
+{/* software distributed under the License is distributed on an */}
+{/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY */}
+{/* KIND, either express or implied. See the License for the */}
+{/* specific language governing permissions and limitations */}
+{/* under the License. */}
+
+import { Meta } from "@storybook/blocks";
+import * as For from "./For.stories";
+
+<Meta title="MDX/Every" of={For} />
+
+# Boxed For Expression
+
+A boxed iterator offers a visual representation of an iterator statement.
+For the "for" loop, the right part of the "for" displays the iterator variable name. The second row holds an expression representing the collection that will be iterated over. The expression in the "in" row MUST resolve to a collection.
+The last row contains the expression that will process each element of the collection.

--- a/packages/boxed-expression-component/stories/boxedExpressions/For/For.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/For/For.stories.tsx
@@ -17,18 +17,19 @@
  * under the License.
  */
 
-import type { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
+import { generateUuid } from "../../../src/api";
 import { Base as EmptyExpression } from "../../misc/Empty/EmptyExpression.stories";
-import { DmnBuiltInDataType, generateUuid } from "../../../src/api";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<BoxedExpressionEditorProps> = {
-  title: "Boxed Expressions/Literal",
+  title: "Boxed Expressions/For",
   component: BoxedExpressionEditor,
   includeStories: /^[A-Z]/,
 };
+
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
@@ -39,58 +40,17 @@ export const Base: Story = {
   args: {
     ...EmptyExpression.args,
     expression: {
-      __$$element: "literalExpression",
+      __$$element: "for",
       "@_id": generateUuid(),
       "@_label": "Expression Name",
+      in: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
+      return: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
     },
-    isResetSupportedOnRootExpression: true,
-  },
-};
-
-export const CanDrive: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "literalExpression",
-      "@_id": "_D98FB35A-C6A5-4BA7-AD38-176D56A31872",
-      "@_label": "Can Drive?",
-      "@_typeRef": DmnBuiltInDataType.Boolean,
-      text: { __$$text: "Age >= 18 then true else false" },
-    },
-    widthsById: {
-      "_D98FB35A-C6A5-4BA7-AD38-176D56A31872": [500],
-    },
-    isResetSupportedOnRootExpression: false,
-  },
-};
-
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Nested: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "context",
-      "@_id": generateUuid(),
-      "@_label": "Expression Name",
-      contextEntry: [
-        {
-          "@_id": generateUuid(),
-          variable: {
-            "@_id": generateUuid(),
-            "@_name": "ContextEntry-1",
-          },
-          expression: {
-            __$$element: "literalExpression",
-            "@_id": generateUuid(),
-            "@_label": "Expression Name",
-          },
-        },
-      ],
-    },
-    isResetSupportedOnRootExpression: false,
   },
 };

--- a/packages/boxed-expression-component/stories/boxedExpressions/Function/Function.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Function/Function.stories.tsx
@@ -21,8 +21,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
 import { Base as EmptyExpression } from "../../misc/Empty/EmptyExpression.stories";
-import { DmnBuiltInDataType, BoxedFunctionKind, generateUuid } from "../../../src/api";
-import { BEE_TABLE_ROW_INDEX_COLUMN_WIDTH } from "../../../src/resizing/WidthConstants";
+import { BoxedFunctionKind, DmnBuiltInDataType, generateUuid } from "../../../src/api";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<BoxedExpressionEditorProps> = {
@@ -100,6 +99,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/Invocation/Invocation.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Invocation/Invocation.stories.tsx
@@ -138,6 +138,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/Relation/Relation.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Relation/Relation.stories.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
@@ -260,6 +259,7 @@ export const Nested: Story = {
       "@_label": "Expression Name",
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",

--- a/packages/boxed-expression-component/stories/boxedExpressions/Some/Some.mdx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Some/Some.mdx
@@ -1,0 +1,27 @@
+{/* Licensed to the Apache Software Foundation (ASF) under one */}
+{/* or more contributor license agreements. See the NOTICE file */}
+{/* distributed with this work for additional information */}
+{/* regarding copyright ownership. The ASF licenses this file */}
+{/* to you under the Apache License, Version 2.0 (the */}
+{/* "License"); you may not use this file except in compliance */}
+{/* with the License. You may obtain a copy of the License at */}
+{/*  */}
+{/* http://www.apache.org/licenses/LICENSE-2.0 */}
+{/*  */}
+{/* Unless required by applicable law or agreed to in writing, */}
+{/* software distributed under the License is distributed on an */}
+{/* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY */}
+{/* KIND, either express or implied. See the License for the */}
+{/* specific language governing permissions and limitations */}
+{/* under the License. */}
+
+import { Meta } from "@storybook/blocks";
+import * as Some from "./Some.stories";
+
+<Meta title="MDX/Every" of={Some} />
+
+# Boxed Some Expression
+
+A boxed iterator offers a visual representation of an iterator statement.
+For the "some" loop, the right part of the "some" displays the iterator variable name. The second row holds an expression representing the collection that will be iterated over. The expression in the "in" row MUST resolve to a collection.
+The last line is an expression that will be evaluated on each item. The expression defined in the "satisfies" MUST resolve to a boolean.

--- a/packages/boxed-expression-component/stories/boxedExpressions/Some/Some.stories.tsx
+++ b/packages/boxed-expression-component/stories/boxedExpressions/Some/Some.stories.tsx
@@ -17,18 +17,19 @@
  * under the License.
  */
 
-import type { Meta, StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
+import { generateUuid } from "../../../src/api";
 import { Base as EmptyExpression } from "../../misc/Empty/EmptyExpression.stories";
-import { DmnBuiltInDataType, generateUuid } from "../../../src/api";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<BoxedExpressionEditorProps> = {
-  title: "Boxed Expressions/Literal",
+  title: "Boxed Expressions/Some",
   component: BoxedExpressionEditor,
   includeStories: /^[A-Z]/,
 };
+
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
@@ -39,58 +40,17 @@ export const Base: Story = {
   args: {
     ...EmptyExpression.args,
     expression: {
-      __$$element: "literalExpression",
+      __$$element: "some",
       "@_id": generateUuid(),
       "@_label": "Expression Name",
+      in: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
+      satisfies: {
+        "@_id": generateUuid(),
+        expression: undefined!, // SPEC DISCREPANCY: Starting without an expression gives users the ability to select the expression type.
+      },
     },
-    isResetSupportedOnRootExpression: true,
-  },
-};
-
-export const CanDrive: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "literalExpression",
-      "@_id": "_D98FB35A-C6A5-4BA7-AD38-176D56A31872",
-      "@_label": "Can Drive?",
-      "@_typeRef": DmnBuiltInDataType.Boolean,
-      text: { __$$text: "Age >= 18 then true else false" },
-    },
-    widthsById: {
-      "_D98FB35A-C6A5-4BA7-AD38-176D56A31872": [500],
-    },
-    isResetSupportedOnRootExpression: false,
-  },
-};
-
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Nested: Story = {
-  render: (args) => BoxedExpressionEditorStory(),
-  parameters: { exclude: ["dataTypes", "beeGwtService", "pmmlDocuments"] },
-  args: {
-    ...EmptyExpression.args,
-    expression: {
-      __$$element: "context",
-      "@_id": generateUuid(),
-      "@_label": "Expression Name",
-      contextEntry: [
-        {
-          "@_id": generateUuid(),
-          variable: {
-            "@_id": generateUuid(),
-            "@_name": "ContextEntry-1",
-          },
-          expression: {
-            __$$element: "literalExpression",
-            "@_id": generateUuid(),
-            "@_label": "Expression Name",
-          },
-        },
-      ],
-    },
-    isResetSupportedOnRootExpression: false,
   },
 };

--- a/packages/boxed-expression-component/stories/dev/WebApp.stories.tsx
+++ b/packages/boxed-expression-component/stories/dev/WebApp.stories.tsx
@@ -18,8 +18,8 @@
  */
 
 import * as React from "react";
-import { useEffect, useState, useCallback } from "react";
-import { BeeGwtService, DmnBuiltInDataType, BoxedExpression } from "../../src/api";
+import { useCallback, useEffect, useState } from "react";
+import { BeeGwtService, BoxedExpression, DmnBuiltInDataType, Normalized } from "../../src/api";
 import { getDefaultBoxedExpressionForDevWebapp } from "./getDefaultBoxedExpressionForDevWebapp";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditorStory, BoxedExpressionEditorStoryArgs } from "../boxedExpressionStoriesWrapper";
@@ -90,12 +90,12 @@ const pmmlDocuments = [
   },
 ];
 
-const INITIAL_EXPRESSION: BoxedExpression | undefined = undefined;
+const INITIAL_EXPRESSION: Normalized<BoxedExpression> | undefined = undefined;
 const INITIAL_WIDTHS_BY_ID: Record<string, number[]> = {};
 
 function App() {
   const [version, setVersion] = useState(-1);
-  const [boxedExpression, setBoxedExpression] = useState<BoxedExpression | undefined>(INITIAL_EXPRESSION);
+  const [boxedExpression, setBoxedExpression] = useState<Normalized<BoxedExpression> | undefined>(INITIAL_EXPRESSION);
   const [widthsById, setWidthsById] = useState<Record<string, number[]>>(INITIAL_WIDTHS_BY_ID);
   const [selectedObjectId, setSelectedObjectId] = useState<string>();
 
@@ -103,10 +103,13 @@ function App() {
     setVersion((prev) => prev + 1);
   }, [boxedExpression]);
 
-  const setSample = useCallback((sample: BoxedExpression | undefined, widthsById: Record<string, number[]>) => {
-    setBoxedExpression(sample);
-    setWidthsById(widthsById);
-  }, []);
+  const setSample = useCallback(
+    (sample: Normalized<BoxedExpression> | undefined, widthsById: Record<string, number[]>) => {
+      setBoxedExpression(sample);
+      setWidthsById(widthsById);
+    },
+    []
+  );
 
   const beeGwtService: BeeGwtService = {
     getDefaultExpressionDefinition(logicType, typeRef) {

--- a/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
+++ b/packages/boxed-expression-component/stories/dev/getDefaultBoxedExpressionForDevWebapp.ts
@@ -18,21 +18,22 @@
  */
 
 import {
+  BoxedConditional,
   BoxedContext,
   BoxedDecisionTable,
+  BoxedEvery,
   BoxedExpression,
+  BoxedFilter,
+  BoxedFor,
   BoxedFunction,
   BoxedFunctionKind,
-  generateUuid,
   BoxedInvocation,
   BoxedList,
   BoxedLiteral,
   BoxedRelation,
-  BoxedConditional,
-  BoxedFor,
   BoxedSome,
-  BoxedEvery,
-  BoxedFilter,
+  generateUuid,
+  Normalized,
 } from "../../src/api";
 import { INVOCATION_EXPRESSION_DEFAULT_PARAMETER_NAME } from "../../src/expressions/InvocationExpression/InvocationExpression";
 import {
@@ -43,16 +44,16 @@ import {
 export function getDefaultBoxedExpressionForDevWebapp(
   logicType: BoxedExpression["__$$element"] | undefined,
   typeRef: string | undefined
-): BoxedExpression {
+): Normalized<BoxedExpression> {
   if (logicType === "literalExpression") {
-    const literalExpression: BoxedLiteral = {
+    const literalExpression: Normalized<BoxedLiteral> = {
       __$$element: "literalExpression",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
     };
     return literalExpression;
   } else if (logicType === "functionDefinition") {
-    const functionExpression: BoxedFunction = {
+    const functionExpression: Normalized<BoxedFunction> = {
       __$$element: "functionDefinition",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -61,7 +62,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return functionExpression;
   } else if (logicType === "context") {
-    const contextExpression: BoxedContext = {
+    const contextExpression: Normalized<BoxedContext> = {
       __$$element: "context",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -90,7 +91,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return contextExpression;
   } else if (logicType === "list") {
-    const listExpression: BoxedList = {
+    const listExpression: Normalized<BoxedList> = {
       __$$element: "list",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -98,7 +99,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return listExpression;
   } else if (logicType === "invocation") {
-    const invocationExpression: BoxedInvocation = {
+    const invocationExpression: Normalized<BoxedInvocation> = {
       __$$element: "invocation",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -119,7 +120,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return invocationExpression;
   } else if (logicType === "relation") {
-    const relationExpression: BoxedRelation = {
+    const relationExpression: Normalized<BoxedRelation> = {
       __$$element: "relation",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -162,7 +163,7 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return relationExpression;
   } else if (logicType === "decisionTable") {
-    const decisionTableExpression: BoxedDecisionTable = {
+    const decisionTableExpression: Normalized<BoxedDecisionTable> = {
       __$$element: "decisionTable",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -220,7 +221,8 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return decisionTableExpression;
   } else if (logicType === "conditional") {
-    const conditionalExpression: BoxedConditional = {
+    const conditionalExpression: Normalized<BoxedConditional> = {
+      "@_id": generateUuid(),
       __$$element: "conditional",
       if: {
         "@_id": generateUuid(),
@@ -238,7 +240,8 @@ export function getDefaultBoxedExpressionForDevWebapp(
 
     return conditionalExpression;
   } else if (logicType === "for") {
-    const forExpression: BoxedFor = {
+    const forExpression: Normalized<BoxedFor> = {
+      "@_id": generateUuid(),
       __$$element: "for",
       return: {
         "@_id": generateUuid(),
@@ -251,7 +254,8 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return forExpression;
   } else if (logicType == "some") {
-    const someExpression: BoxedSome = {
+    const someExpression: Normalized<BoxedSome> = {
+      "@_id": generateUuid(),
       __$$element: "some",
       satisfies: {
         "@_id": generateUuid(),
@@ -264,7 +268,8 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return someExpression;
   } else if (logicType === "every") {
-    const everyExpression: BoxedEvery = {
+    const everyExpression: Normalized<BoxedEvery> = {
+      "@_id": generateUuid(),
       __$$element: "every",
       satisfies: {
         "@_id": generateUuid(),
@@ -277,7 +282,8 @@ export function getDefaultBoxedExpressionForDevWebapp(
     };
     return everyExpression;
   } else if (logicType === "filter") {
-    const filterExpression: BoxedFilter = {
+    const filterExpression: Normalized<BoxedFilter> = {
+      "@_id": generateUuid(),
       __$$element: "filter",
       match: {
         "@_id": generateUuid(),

--- a/packages/boxed-expression-component/stories/features/Resizing/Resizing.stories.tsx
+++ b/packages/boxed-expression-component/stories/features/Resizing/Resizing.stories.tsx
@@ -17,12 +17,18 @@
  * under the License.
  */
 
-import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import * as Literal from "../../boxedExpressions/Literal/Literal.stories";
 import * as Context from "../../boxedExpressions/Context/Context.stories";
-import { DmnBuiltInDataType, BoxedExpression, BoxedFunctionKind, BoxedLiteral } from "../../../src/api";
+import {
+  BoxedExpression,
+  BoxedFunctionKind,
+  BoxedLiteral,
+  DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
+} from "../../../src/api";
 import { BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -39,17 +45,18 @@ export const CanDrive: Story = {
   args: {
     ...Literal.CanDrive.args,
     expression: {
-      ...(Literal.CanDrive.args!.expression! as BoxedLiteral),
+      ...(Literal.CanDrive.args!.expression! as Normalized<BoxedLiteral>),
     },
   },
 };
 
-const expression: BoxedExpression = {
+const expression: Normalized<BoxedExpression> = {
   "@_id": "_577B0672-0DCE-48E2-A387-A06D89770346",
   "@_typeRef": DmnBuiltInDataType.Boolean,
   __$$element: "context",
   contextEntry: [
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_04EAD539-9830-42CF-BECC-F718D2929F16",
         "@_name": "Affordability Calculation",
@@ -93,6 +100,7 @@ const expression: BoxedExpression = {
           __$$element: "context",
           contextEntry: [
             {
+              "@_id": generateUuid(),
               variable: {
                 "@_id": "_D1B671D5-DA59-4292-B407-A200CC5716B1",
                 "@_name": "Disposable Income",
@@ -106,6 +114,7 @@ const expression: BoxedExpression = {
               },
             },
             {
+              "@_id": generateUuid(),
               variable: {
                 "@_id": "_9FDEECB8-92EB-41B1-B44A-A93105BF6181",
                 "@_name": "Credit Contigency Factor",
@@ -117,6 +126,7 @@ const expression: BoxedExpression = {
                 __$$element: "context",
                 contextEntry: [
                   {
+                    "@_id": generateUuid(),
                     variable: {
                       "@_id": "_893A101E-970A-406F-81B3-64CDF93E143F",
                       "@_name": "Risk Category",
@@ -130,6 +140,7 @@ const expression: BoxedExpression = {
                     },
                   },
                   {
+                    "@_id": generateUuid(),
                     expression: {
                       "@_id": "_B7FA5008-05B1-4A5D-AAF5-EA3447C6307B",
                       __$$element: "decisionTable",
@@ -213,6 +224,7 @@ const expression: BoxedExpression = {
               },
             },
             {
+              "@_id": generateUuid(),
               variable: {
                 "@_id": "_F7311902-5700-4EB3-AA36-ADAFBB33752D",
                 "@_name": "Affordability",
@@ -229,6 +241,7 @@ const expression: BoxedExpression = {
               },
             },
             {
+              "@_id": generateUuid(),
               expression: {
                 "@_id": "_002EF0D0-D8AE-4086-82FC-526E9B5028CA",
                 __$$element: "literalExpression",
@@ -240,6 +253,7 @@ const expression: BoxedExpression = {
       },
     },
     {
+      "@_id": generateUuid(),
       expression: {
         __$$element: "invocation",
         "@_id": "_DC4F55F0-5650-427A-B0F6-6ED93E73E66F",

--- a/packages/boxed-expression-component/stories/features/Selection/Selection.stories.tsx
+++ b/packages/boxed-expression-component/stories/features/Selection/Selection.stories.tsx
@@ -23,7 +23,7 @@ import * as Empty from "../../misc/Empty/EmptyExpression.stories";
 import * as Literal from "../../boxedExpressions/Literal/Literal.stories";
 import * as Relation from "../../boxedExpressions/Relation/Relation.stories";
 import * as DecisionTable from "../../boxedExpressions/DecisionTable/DecisionTable.stories";
-import { BoxedDecisionTable, generateUuid } from "../../../src/api";
+import { BoxedDecisionTable, generateUuid, Normalized } from "../../../src/api";
 import { BoxedExpressionEditorStoryArgs } from "../../boxedExpressionStoriesWrapper";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -64,7 +64,7 @@ export const Discount: Story = {
   args: {
     ...DecisionTable.Discount.args!,
     expression: {
-      ...(DecisionTable.Discount.args!.expression! as BoxedDecisionTable),
+      ...(DecisionTable.Discount.args!.expression! as Normalized<BoxedDecisionTable>),
       rule: [
         {
           "@_id": generateUuid(),

--- a/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
+++ b/packages/boxed-expression-component/stories/getDefaultBoxedExpressionForStories.ts
@@ -36,6 +36,7 @@ import {
   BoxedRelation,
   BoxedSome,
   generateUuid,
+  Normalized,
 } from "../src/api";
 import {
   DECISION_TABLE_INPUT_DEFAULT_VALUE,
@@ -66,9 +67,9 @@ export function getDefaultBoxedExpressionForStories({
   logicType: BoxedExpression["__$$element"] | undefined;
   typeRef: string | undefined;
   widthsById: Map<string, number[]>;
-}): BoxedExpression {
+}): Normalized<BoxedExpression> {
   if (logicType === "literalExpression") {
-    const literalExpression: BoxedLiteral = {
+    const literalExpression: Normalized<BoxedLiteral> = {
       __$$element: "literalExpression",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -79,7 +80,7 @@ export function getDefaultBoxedExpressionForStories({
   }
   //
   else if (logicType === "functionDefinition") {
-    const functionExpression: BoxedFunction = {
+    const functionExpression: Normalized<BoxedFunction> = {
       __$$element: "functionDefinition",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -90,12 +91,13 @@ export function getDefaultBoxedExpressionForStories({
   }
   //
   else if (logicType === "context") {
-    const contextExpression: BoxedContext = {
+    const contextExpression: Normalized<BoxedContext> = {
       __$$element: "context",
       "@_typeRef": typeRef,
       "@_id": generateUuid(),
       contextEntry: [
         {
+          "@_id": generateUuid(),
           variable: {
             "@_id": generateUuid(),
             "@_name": "ContextEntry-1",
@@ -113,7 +115,7 @@ export function getDefaultBoxedExpressionForStories({
     widthsById.set(contextExpression["@_id"]!, [CONTEXT_ENTRY_VARIABLE_MIN_WIDTH]);
     return contextExpression;
   } else if (logicType === "list") {
-    const listExpression: BoxedList = {
+    const listExpression: Normalized<BoxedList> = {
       __$$element: "list",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -123,7 +125,7 @@ export function getDefaultBoxedExpressionForStories({
     };
     return listExpression;
   } else if (logicType === "invocation") {
-    const invocationExpression: BoxedInvocation = {
+    const invocationExpression: Normalized<BoxedInvocation> = {
       __$$element: "invocation",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -146,7 +148,7 @@ export function getDefaultBoxedExpressionForStories({
     widthsById.set(invocationExpression["@_id"]!, [CONTEXT_ENTRY_VARIABLE_MIN_WIDTH]);
     return invocationExpression;
   } else if (logicType === "relation") {
-    const relationExpression: BoxedRelation = {
+    const relationExpression: Normalized<BoxedRelation> = {
       __$$element: "relation",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -197,7 +199,7 @@ export function getDefaultBoxedExpressionForStories({
       },
     ];
 
-    const output: DMN15__tOutputClause[] = [
+    const output: Normalized<DMN15__tOutputClause>[] = [
       {
         "@_id": generateUuid(),
         "@_name": singleOutputColumn.name,
@@ -205,7 +207,7 @@ export function getDefaultBoxedExpressionForStories({
       },
     ];
 
-    const decisionTableExpression: BoxedDecisionTable = {
+    const decisionTableExpression: Normalized<BoxedDecisionTable> = {
       __$$element: "decisionTable",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -242,7 +244,7 @@ export function getDefaultBoxedExpressionForStories({
 
     return decisionTableExpression;
   } else if (logicType === "filter") {
-    const filterExpression: BoxedFilter = {
+    const filterExpression: Normalized<BoxedFilter> = {
       __$$element: "filter",
       "@_id": generateUuid(),
       "@_typeRef": typeRef,
@@ -258,7 +260,7 @@ export function getDefaultBoxedExpressionForStories({
     widthsById.set(filterExpression["@_id"]!, [FILTER_EXPRESSION_MIN_WIDTH]);
     return filterExpression;
   } else if (logicType === "conditional") {
-    const conditionalExpression: BoxedConditional = {
+    const conditionalExpression: Normalized<BoxedConditional> = {
       __$$element: "conditional",
       "@_id": generateUuid(),
       if: {
@@ -276,7 +278,7 @@ export function getDefaultBoxedExpressionForStories({
     };
     return conditionalExpression;
   } else if (logicType === "for") {
-    const forExpression: BoxedFor = {
+    const forExpression: Normalized<BoxedFor> = {
       __$$element: "for",
       "@_id": generateUuid(),
       return: {
@@ -290,7 +292,7 @@ export function getDefaultBoxedExpressionForStories({
     };
     return forExpression;
   } else if (logicType == "some") {
-    const someExpression: BoxedSome = {
+    const someExpression: Normalized<BoxedSome> = {
       __$$element: "some",
       "@_id": generateUuid(),
       satisfies: {
@@ -304,7 +306,7 @@ export function getDefaultBoxedExpressionForStories({
     };
     return someExpression;
   } else if (logicType === "every") {
-    const everyExpression: BoxedEvery = {
+    const everyExpression: Normalized<BoxedEvery> = {
       __$$element: "every",
       "@_id": generateUuid(),
       satisfies: {

--- a/packages/boxed-expression-component/stories/useCases/CanDrive/CanDrive.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/CanDrive/CanDrive.stories.tsx
@@ -18,7 +18,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react";
-import { BoxedDecisionTable, DmnBuiltInDataType } from "../../../src/api";
+import { BoxedDecisionTable, DmnBuiltInDataType, Normalized } from "../../../src/api";
 import { BoxedExpressionEditor, BoxedExpressionEditorProps } from "../../../src/BoxedExpressionEditor";
 import {
   beeGwtService,
@@ -40,7 +40,7 @@ type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
 export const findEmployeesDataTypes = [...dataTypes, { name: "tPerson", isCustom: true }];
 
-export const canDriveExpressionDefinition: BoxedDecisionTable = {
+export const canDriveExpressionDefinition: Normalized<BoxedDecisionTable> = {
   __$$element: "decisionTable",
   "@_id": "_21608B6A-1D9E-426D-86CF-B0CA7AB20D31",
   "@_label": "Can drive?",

--- a/packages/boxed-expression-component/stories/useCases/FindEmployees/FindEmployees.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/FindEmployees/FindEmployees.stories.tsx
@@ -17,7 +17,15 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind, BoxedInvocation, BoxedRelation } from "../../../src/api";
+import {
+  BoxedFunction,
+  BoxedFunctionKind,
+  BoxedInvocation,
+  BoxedRelation,
+  DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
+} from "../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -47,7 +55,7 @@ export const findEmployeesDataTypes = [
   { name: "tKnowledges", isCustom: true },
 ];
 
-export const employeesExpression: BoxedRelation = {
+export const employeesExpression: Normalized<BoxedRelation> = {
   __$$element: "relation",
   "@_id": "_03E4FDF0-AF4A-4C82-A589-2F9BED02921B",
   "@_label": "Employees",
@@ -170,7 +178,7 @@ export const employeesWidthsById = {
   "_03E4FDF0-AF4A-4C82-A589-2F9BED02921B": [BEE_TABLE_ROW_INDEX_COLUMN_WIDTH, 100, 156, 150, 252, 100],
 };
 
-export const findEmployeesByKnowledgeExpression: BoxedFunction = {
+export const findEmployeesByKnowledgeExpression: Normalized<BoxedFunction> = {
   __$$element: "functionDefinition",
   "@_id": "_243056C9-28EA-4EF2-8510-6F3BC6A5E5DC",
   "@_label": "Find employee by knowledge",
@@ -187,6 +195,7 @@ export const findEmployeesByKnowledgeExpression: BoxedFunction = {
     "@_label": "Feel Expression",
     contextEntry: [
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_A762CB8E-56C3-45AE-B59F-731E4A0CA73F",
           "@_name": "Employees by Dept",
@@ -201,6 +210,7 @@ export const findEmployeesByKnowledgeExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_C772ADED-2499-4AF1-9C99-63AA17901EBB",
           "@_name": "Employees with Knowledge",
@@ -218,6 +228,7 @@ export const findEmployeesByKnowledgeExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         expression: {
           __$$element: "literalExpression",
           "@_id": "_049ECA86-1971-48B7-86FF-7E89B399074A",
@@ -239,7 +250,7 @@ export const findEmployeesByKnowledgeWidthsById = {
   "_049ECA86-1971-48B7-86FF-7E89B399074A": [400],
 };
 
-export const findEmployeesExpression: BoxedInvocation = {
+export const findEmployeesExpression: Normalized<BoxedInvocation> = {
   __$$element: "invocation",
   "@_id": "_8001CBC8-8DE4-4DBF-8B02-7FBFC582B136",
   "@_label": "Find employees",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/ApplicationRiskScore/ApplicationRiskScore.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/ApplicationRiskScore/ApplicationRiskScore.stories.tsx
@@ -18,7 +18,7 @@
  */
 
 import { loanOriginationsDataTypes } from "../boxedExpressionEditorBase";
-import { BoxedContext, DmnBuiltInDataType } from "../../../../src/api";
+import { BoxedContext, DmnBuiltInDataType, generateUuid, Normalized } from "../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,13 +38,14 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const applicationRiskScoreExpression: BoxedContext = {
+export const applicationRiskScoreExpression: Normalized<BoxedContext> = {
   __$$element: "context",
   "@_id": "_36398C55-5ED1-41C6-B643-98DBDD52D143",
   "@_label": "Application risk score",
   "@_typeRef": DmnBuiltInDataType.Number,
   contextEntry: [
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_BB4F357E-80D8-4E5A-955F-387B5DBB2EC5",
         "@_name": "Age",
@@ -59,6 +60,7 @@ export const applicationRiskScoreExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_A3E35C5D-A643-40AA-A490-772105D00738",
         "@_name": "Marital Status",
@@ -74,6 +76,7 @@ export const applicationRiskScoreExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_4509453F-BB4B-46F2-915C-FA90D90A4DFB",
         "@_name": "Employment Status",
@@ -89,6 +92,7 @@ export const applicationRiskScoreExpression: BoxedContext = {
     },
 
     {
+      "@_id": generateUuid(),
       expression: {
         __$$element: "decisionTable",
         "@_id": "_40CCF542-F80F-4C14-AAE5-AAAFA3304648",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/BureauCallType/BureauCallType.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/BureauCallType/BureauCallType.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedDecisionTable } from "../../../../../src/api";
+import { BoxedDecisionTable, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,7 +38,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const bureauCallTypeExpression: BoxedDecisionTable = {
+export const bureauCallTypeExpression: Normalized<BoxedDecisionTable> = {
   __$$element: "decisionTable",
   "@_id": "_7FB4A019-EC04-4153-86C1-C90A8BA8E6C3",
   "@_label": "Bureau call type",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/Eligibility/Eligibility.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/Eligibility/Eligibility.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedDecisionTable, DmnBuiltInDataType } from "../../../../../src/api";
+import { BoxedDecisionTable, DmnBuiltInDataType, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,7 +38,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const eligibilityExpression: BoxedDecisionTable = {
+export const eligibilityExpression: Normalized<BoxedDecisionTable> = {
   __$$element: "decisionTable",
   "@_id": "_830C9FEF-FA57-4245-8FFF-1E7F305F4536",
   "@_label": "Eligibility",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/PreBureauAffordability/PreBureauAffordability.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/PreBureauAffordability/PreBureauAffordability.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedInvocation } from "../../../../../src/api";
+import { BoxedInvocation, DmnBuiltInDataType, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -37,7 +37,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const preBureauAffordabilityExpression: BoxedInvocation = {
+export const preBureauAffordabilityExpression: Normalized<BoxedInvocation> = {
   __$$element: "invocation",
   "@_id": "_1E880009-77B2-4309-AE2A-8964E05636B1",
   "@_label": "Pre-bureau affordability",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/PreBureauRiskCategory/PreBureauRiskCategory.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/PreBureauRiskCategory/PreBureauRiskCategory.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedContext, DmnBuiltInDataType } from "../../../../../src/api";
+import { BoxedContext, DmnBuiltInDataType, generateUuid, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,13 +38,14 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const preBureauRiskCategoryExpression: BoxedContext = {
+export const preBureauRiskCategoryExpression: Normalized<BoxedContext> = {
   __$$element: "context",
   "@_id": "_21BA0CB9-F15E-482F-BCBB-F6694EF9B1FC",
   "@_label": "Pre-bureau risk category",
   "@_typeRef": "t.BureauRiskCategory",
   contextEntry: [
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_E0D6DEC1-A390-4AA7-86A0-42CFCE32C41E",
         "@_name": "Existing Customer",
@@ -59,6 +60,7 @@ export const preBureauRiskCategoryExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       expression: {
         __$$element: "decisionTable",
         "@_id": "_DD3AABF1-9E83-4F71-A769-D9CC01231580",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/Strategy/Strategy.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/BureauStrategyDecisionService/Strategy/Strategy.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedDecisionTable } from "../../../../../src/api";
+import { BoxedDecisionTable, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,7 +38,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const strategyExpression: BoxedDecisionTable = {
+export const strategyExpression: Normalized<BoxedDecisionTable> = {
   __$$element: "decisionTable",
   "@_id": "_1AAE9CB0-2B4B-4159-A994-A93D5F91EE23",
   "@_label": "Strategy",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/Functions/AffordabilityCalculation/AffordabilityCalculation.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/Functions/AffordabilityCalculation/AffordabilityCalculation.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind } from "../../../../../src/api";
+import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind, Normalized, generateUuid } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,7 +38,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const affordabilityCalculationExpression: BoxedFunction = {
+export const affordabilityCalculationExpression: Normalized<BoxedFunction> = {
   __$$element: "functionDefinition",
   "@_id": "_72FC1D95-7AB8-4459-9815-D2EC186DD40A",
   "@_label": "Affordability calculation",
@@ -77,6 +77,7 @@ export const affordabilityCalculationExpression: BoxedFunction = {
     "@_label": "Feel Expression",
     contextEntry: [
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_AC69745A-2636-4D69-9402-5B5DBBEB789F",
           "@_name": "Disposable Income",
@@ -91,6 +92,7 @@ export const affordabilityCalculationExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_D7DDD7CE-91AD-451D-8F23-1F38C336B4F4",
           "@_name": "Credit Contigency Factor",
@@ -171,6 +173,7 @@ export const affordabilityCalculationExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         expression: {
           __$$element: "literalExpression",
           "@_id": "_B325C569-762E-408B-AAB5-D55AF7FF01C4",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/Functions/InstallmentCalculation/InstallmentCalculation.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/Functions/InstallmentCalculation/InstallmentCalculation.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind } from "../../../../../src/api";
+import { DmnBuiltInDataType, BoxedFunction, BoxedFunctionKind, Normalized, generateUuid } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -37,7 +37,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const installmentCalculationExpression: BoxedFunction = {
+export const installmentCalculationExpression: Normalized<BoxedFunction> = {
   __$$element: "functionDefinition",
   "@_id": "_1E31E836-0609-4B4C-8FAF-389F774B1FE3",
   "@_label": "Installment calculation",
@@ -59,6 +59,7 @@ export const installmentCalculationExpression: BoxedFunction = {
     "@_label": "Feel Expression",
     contextEntry: [
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_4AAFD507-11D2-4C6A-82E0-CBEEFA26FCE9",
           "@_name": "Monthly Fee",
@@ -76,6 +77,7 @@ export const installmentCalculationExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         variable: {
           "@_id": "_1852E1E0-A49C-49D8-BB83-18D395672ECB",
           "@_name": "Monthly Repayments",
@@ -90,6 +92,7 @@ export const installmentCalculationExpression: BoxedFunction = {
         },
       },
       {
+        "@_id": generateUuid(),
         expression: {
           __$$element: "literalExpression",
           "@_id": "_94444797-708D-418A-A22A-5CE6CAB35F6F",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/RequiredMonthlyInstallment/RequiredMonthlyInstallment.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/RequiredMonthlyInstallment/RequiredMonthlyInstallment.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedInvocation } from "../../../../src/api";
+import { DmnBuiltInDataType, BoxedInvocation, Normalized } from "../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -37,7 +37,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const requiredMonthlyInstallmentExpression: BoxedInvocation = {
+export const requiredMonthlyInstallmentExpression: Normalized<BoxedInvocation> = {
   __$$element: "invocation",
   "@_id": "_EF51A747-D5E1-414E-9DD5-964362FB2AEC",
   "@_label": "Required monthly installment",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/PostBureauAffordability/PostBureauAffordability.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/PostBureauAffordability/PostBureauAffordability.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnBuiltInDataType, BoxedInvocation } from "../../../../../src/api";
+import { BoxedInvocation, DmnBuiltInDataType, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -37,7 +37,7 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const postBureauAffordabilityExpression: BoxedInvocation = {
+export const postBureauAffordabilityExpression: Normalized<BoxedInvocation> = {
   __$$element: "invocation",
   "@_id": "_1E880009-77B2-4309-AE2A-8964E05636B1",
   "@_label": "Post-bureau affordability",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/PostBureauRiskCategory/PostBureauRiskCategory.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/PostBureauRiskCategory/PostBureauRiskCategory.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedContext, DmnBuiltInDataType } from "../../../../../src/api";
+import { BoxedContext, DmnBuiltInDataType, generateUuid, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,13 +38,14 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-export const postBureauRiskCategoryExpression: BoxedContext = {
+export const postBureauRiskCategoryExpression: Normalized<BoxedContext> = {
   __$$element: "context",
   "@_id": "_55A050DB-250D-473E-A7DF-43C49CE87694",
   "@_label": "Post-bureau risk category",
   "@_typeRef": "t.BureauRiskCategory",
   contextEntry: [
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_79173F55-FFE4-4FE7-9620-A4CAC4CCD084",
         "@_name": "Existing Customer",
@@ -59,6 +60,7 @@ export const postBureauRiskCategoryExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_538E6427-680B-4307-A234-D1C6C60D5D75",
         "@_name": "Credit Score",
@@ -73,6 +75,7 @@ export const postBureauRiskCategoryExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       expression: {
         __$$element: "decisionTable",
         "@_id": "_E26346D5-7A7C-44A2-8EF2-D79CECB257FF",

--- a/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/Routing/Routing.stories.tsx
+++ b/packages/boxed-expression-component/stories/useCases/LoanOriginations/RoutingDecisionService/Routing/Routing.stories.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedContext, DmnBuiltInDataType } from "../../../../../src/api";
+import { BoxedContext, DmnBuiltInDataType, generateUuid, Normalized } from "../../../../../src/api";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   beeGwtService,
@@ -38,13 +38,14 @@ const meta: Meta<BoxedExpressionEditorProps> = {
 export default meta;
 type Story = StoryObj<BoxedExpressionEditorStoryArgs>;
 
-const routingExpression: BoxedContext = {
+const routingExpression: Normalized<BoxedContext> = {
   __$$element: "context",
   "@_id": "_336E0FC5-5548-4720-A6B2-A8FA4834DB7B",
   "@_label": "Routing",
   "@_typeRef": "t.Routing",
   contextEntry: [
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_6626CBDF-A422-42A1-89B3-4491EB069A3E",
         "@_name": "Bankrupt",
@@ -59,6 +60,7 @@ const routingExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       variable: {
         "@_id": "_66A38FAC-3D28-4590-AAE8-A0EB17191B5A",
         "@_name": "Credit Score",
@@ -73,6 +75,7 @@ const routingExpression: BoxedContext = {
       },
     },
     {
+      "@_id": generateUuid(),
       expression: {
         __$$element: "decisionTable",
         "@_id": "_1FB1191F-F05C-4609-8BA4-77BE0D25570D",

--- a/packages/boxed-expression-component/tests-e2e/__fixtures__/jsonModel.ts
+++ b/packages/boxed-expression-component/tests-e2e/__fixtures__/jsonModel.ts
@@ -18,6 +18,7 @@
  */
 
 import { Page } from "@playwright/test";
+import { BoxedContext, BoxedEvery, BoxedFilter, BoxedFor, BoxedSome, Normalized } from "../../src/api";
 
 interface BoxedExpressionComponent {
   expression: string;
@@ -53,6 +54,31 @@ export class JsonModel {
     }
     const widthsById = jsonObject.widthsById || {};
     return widthsById[decisionTableId] || [];
+  }
+
+  public async getContextExpression(): Promise<Normalized<BoxedContext>> {
+    const content = await this.getBoxedExpressionContent();
+    return (content?.expression || {}) as Normalized<BoxedContext>;
+  }
+
+  public async getFilterExpression(): Promise<Normalized<BoxedFilter>> {
+    const content = await this.getBoxedExpressionContent();
+    return (content?.expression || {}) as Normalized<BoxedFilter>;
+  }
+
+  public async getEveryExpression(): Promise<Normalized<BoxedEvery>> {
+    const content = await this.getBoxedExpressionContent();
+    return (content?.expression || {}) as Normalized<BoxedEvery>;
+  }
+
+  public async getForExpression(): Promise<Normalized<BoxedFor>> {
+    const content = await this.getBoxedExpressionContent();
+    return (content?.expression || {}) as Normalized<BoxedFor>;
+  }
+
+  public async getSomeExpression(): Promise<Normalized<BoxedSome>> {
+    const content = await this.getBoxedExpressionContent();
+    return (content?.expression || {}) as Normalized<BoxedSome>;
   }
 
   private async getBoxedExpressionContent(): Promise<BoxedExpressionComponent | undefined> {

--- a/packages/boxed-expression-component/tests-e2e/__fixtures__/jsonModel.ts
+++ b/packages/boxed-expression-component/tests-e2e/__fixtures__/jsonModel.ts
@@ -18,7 +18,7 @@
  */
 
 import { Page } from "@playwright/test";
-import { BoxedContext, BoxedEvery, BoxedFilter, BoxedFor, BoxedSome, Normalized } from "../../src/api";
+import { BoxedContext, BoxedEvery, BoxedFilter, BoxedFor, BoxedSome, Normalized } from "../api/types";
 
 interface BoxedExpressionComponent {
   expression: string;

--- a/packages/boxed-expression-component/tests-e2e/__fixtures__/stories.ts
+++ b/packages/boxed-expression-component/tests-e2e/__fixtures__/stories.ts
@@ -66,15 +66,15 @@ export class Stories {
     await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-filter--${type}`)}` ?? "");
   }
 
-  public async openBoxedEvery(type: BoxedExpressionTypes) {
+  public async openBoxedEvery(type: BoxedExpressionTypes = "base") {
     await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-every--${type}`)}` ?? "");
   }
 
-  public async openBoxedSome(type: BoxedExpressionTypes) {
+  public async openBoxedSome(type: BoxedExpressionTypes = "base") {
     await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-some--${type}`)}` ?? "");
   }
 
-  public async openBoxedFor(type: BoxedExpressionTypes) {
+  public async openBoxedFor(type: BoxedExpressionTypes = "base") {
     await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-for--${type}`)}` ?? "");
   }
 }

--- a/packages/boxed-expression-component/tests-e2e/__fixtures__/stories.ts
+++ b/packages/boxed-expression-component/tests-e2e/__fixtures__/stories.ts
@@ -65,4 +65,16 @@ export class Stories {
   public async openBoxedFilter(type: BoxedExpressionTypes | "rebooked-flights" = "base") {
     await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-filter--${type}`)}` ?? "");
   }
+
+  public async openBoxedEvery(type: BoxedExpressionTypes) {
+    await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-every--${type}`)}` ?? "");
+  }
+
+  public async openBoxedSome(type: BoxedExpressionTypes) {
+    await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-some--${type}`)}` ?? "");
+  }
+
+  public async openBoxedFor(type: BoxedExpressionTypes) {
+    await this.page.goto(`${this.baseURL}/${this.getIframeURL(`boxed-expressions-for--${type}`)}` ?? "");
+  }
 }

--- a/packages/boxed-expression-component/tests-e2e/api/expressionContainer.ts
+++ b/packages/boxed-expression-component/tests-e2e/api/expressionContainer.ts
@@ -173,6 +173,10 @@ export class ChildExpression {
   get selectExpressionMenu() {
     return new SelectExpressionMenu(this.locator.getByTestId("kie-tools--bee--expression-container").nth(0));
   }
+
+  get contextMenu() {
+    return new ContextMenu(this.locator.getByRole("cell").nth(0));
+  }
 }
 
 export class IteratorVariable {

--- a/packages/boxed-expression-component/tests-e2e/api/types.ts
+++ b/packages/boxed-expression-component/tests-e2e/api/types.ts
@@ -1,0 +1,36 @@
+import {
+  DMN15__tConditional,
+  DMN15__tContext,
+  DMN15__tDecisionTable,
+  DMN15__tFilter,
+  DMN15__tFor,
+  DMN15__tFunctionDefinition,
+  DMN15__tInvocation,
+  DMN15__tList,
+  DMN15__tLiteralExpression,
+  DMN15__tQuantified,
+  DMN15__tRelation,
+} from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
+
+export type BoxedLiteral = { __$$element: "literalExpression" } & DMN15__tLiteralExpression;
+export type BoxedRelation = { __$$element: "relation" } & DMN15__tRelation;
+export type BoxedContext = { __$$element: "context" } & DMN15__tContext;
+export type BoxedDecisionTable = { __$$element: "decisionTable" } & DMN15__tDecisionTable;
+export type BoxedList = { __$$element: "list" } & DMN15__tList;
+export type BoxedInvocation = { __$$element: "invocation" } & DMN15__tInvocation;
+export type BoxedFunction = { __$$element: "functionDefinition" } & DMN15__tFunctionDefinition;
+export type BoxedFor = { __$$element: "for" } & DMN15__tFor;
+export type BoxedEvery = { __$$element: "every" } & DMN15__tQuantified;
+export type BoxedSome = { __$$element: "some" } & DMN15__tQuantified;
+export type BoxedConditional = { __$$element: "conditional" } & DMN15__tConditional;
+export type BoxedFilter = { __$$element: "filter" } & DMN15__tFilter;
+
+export type Normalized<T> = WithRequiredDeep<T, "@_id">;
+
+type WithRequiredDeep<T, K extends keyof any> = T extends undefined
+  ? T
+  : T extends Array<infer U>
+    ? Array<WithRequiredDeep<U, K>>
+    : { [P in keyof T]: WithRequiredDeep<T[P], K> } & (K extends keyof T
+        ? { [P in K]-?: NonNullable<WithRequiredDeep<T[P], K>> }
+        : T);

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/contextExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/contextExpression.spec.ts
@@ -18,10 +18,14 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
+import { TestAnnotations } from "../../../../playwright-base/annotations";
 
 test.describe("Create Boxed Context", () => {
-  test("should render expression correctly", async ({ bee, stories, page }) => {
+  test.beforeEach(async ({ stories }) => {
     await stories.openBoxedContext();
+  });
+
+  test("should render expression correctly", async ({ bee, stories, page }) => {
     await expect(page.getByRole("columnheader", { name: "Expression Name (<Undefined>)" })).toBeAttached();
     await expect(page.getByRole("cell", { name: "ContextEntry-1 (<Undefined>)" })).toBeAttached();
     await expect(page.getByRole("cell", { name: "<result>" })).toBeAttached();
@@ -29,5 +33,31 @@ test.describe("Create Boxed Context", () => {
     await expect(page.getByRole("columnheader")).toHaveCount(1);
     await expect(page.getByRole("cell")).toHaveCount(4);
     await expect(bee.getContainer()).toHaveScreenshot("boxed-context.png");
+  });
+
+  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1182",
+    });
+
+    const contextExpression = bee.expression.asContext();
+    await contextExpression.result.selectExpressionMenu.selectLiteral();
+    await contextExpression.result.expression.asLiteral().fill("test");
+    await contextExpression.result.contextMenu.open();
+    await contextExpression.result.contextMenu.option("Reset").nth(0).click();
+    await contextExpression.result.selectExpressionMenu.selectLiteral();
+    await contextExpression.result.expression.asLiteral().fill("test2");
+
+    await contextExpression.entry(0).selectExpressionMenu.selectLiteral();
+    await contextExpression.entry(0).expression.asLiteral().fill("test");
+    await contextExpression.entry(0).variable.contextMenu.open();
+    await contextExpression.entry(0).variable.contextMenu.option("Reset").nth(0).click();
+    await contextExpression.entry(0).selectExpressionMenu.selectLiteral();
+    await contextExpression.entry(0).expression.asLiteral().fill("test2");
+
+    expect((await jsonModel.getContextExpression()).contextEntry).not.toBeUndefined();
+    expect((await jsonModel.getContextExpression()).contextEntry?.[0]["@_id"]).not.toBeUndefined();
+    expect((await jsonModel.getContextExpression()).contextEntry?.[1]["@_id"]).not.toBeUndefined();
   });
 });

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/contextExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/contextExpression.spec.ts
@@ -18,14 +18,14 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
-import { TestAnnotations } from "../../../../playwright-base/annotations";
+import { TestAnnotations } from "@kie-tools/playwright-base/annotations";
 
 test.describe("Create Boxed Context", () => {
   test.beforeEach(async ({ stories }) => {
     await stories.openBoxedContext();
   });
 
-  test("should render expression correctly", async ({ bee, stories, page }) => {
+  test("should render expression correctly", async ({ bee, page }) => {
     await expect(page.getByRole("columnheader", { name: "Expression Name (<Undefined>)" })).toBeAttached();
     await expect(page.getByRole("cell", { name: "ContextEntry-1 (<Undefined>)" })).toBeAttached();
     await expect(page.getByRole("cell", { name: "<result>" })).toBeAttached();
@@ -35,7 +35,7 @@ test.describe("Create Boxed Context", () => {
     await expect(bee.getContainer()).toHaveScreenshot("boxed-context.png");
   });
 
-  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+  test("should have IDs after resetting entries and setting it again", async ({ bee, jsonModel }) => {
     test.info().annotations.push({
       type: TestAnnotations.REGRESSION,
       description: "https://github.com/apache/incubator-kie-issues/issues/1182",

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/every/everyExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/every/everyExpression.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from "../../__fixtures__/base";
+import { TestAnnotations } from "../../../../playwright-base/annotations";
+
+test.describe("Create Boxed Every", () => {
+  test.beforeEach(async ({ stories }) => {
+    await stories.openBoxedEvery("base");
+  });
+  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1182",
+    });
+
+    const everyExpression = bee.expression.asEvery();
+    await everyExpression.in.selectExpressionMenu.selectLiteral();
+    await everyExpression.satisfies.selectExpressionMenu.selectLiteral();
+    await everyExpression.in.expression.asLiteral().fill("test");
+    await everyExpression.satisfies.expression.asLiteral().fill("test");
+    await everyExpression.in.contextMenu.open();
+    await everyExpression.in.contextMenu.option("Reset").nth(0).click();
+    await everyExpression.satisfies.contextMenu.open();
+    await everyExpression.satisfies.contextMenu.option("Reset").nth(0).click();
+
+    expect((await jsonModel.getEveryExpression()).in).not.toBeUndefined();
+    expect((await jsonModel.getEveryExpression()).satisfies).not.toBeUndefined();
+    expect((await jsonModel.getEveryExpression()).in["@_id"]).not.toBeUndefined();
+    expect((await jsonModel.getEveryExpression()).satisfies["@_id"]).not.toBeUndefined();
+  });
+});

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/every/everyExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/every/everyExpression.spec.ts
@@ -18,13 +18,13 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
-import { TestAnnotations } from "../../../../playwright-base/annotations";
+import { TestAnnotations } from "@kie-tools/playwright-base/annotations";
 
 test.describe("Create Boxed Every", () => {
   test.beforeEach(async ({ stories }) => {
-    await stories.openBoxedEvery("base");
+    await stories.openBoxedEvery();
   });
-  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+  test("should have IDs after resetting 'in' and 'satisfies' and setting it again", async ({ bee, jsonModel }) => {
     test.info().annotations.push({
       type: TestAnnotations.REGRESSION,
       description: "https://github.com/apache/incubator-kie-issues/issues/1182",

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/filter/filterExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/filter/filterExpression.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
+import { TestAnnotations } from "../../../../playwright-base/annotations";
 
 test.describe("Create Boxed Filter", () => {
   test("should rename a filter", async ({ page, stories }) => {
@@ -82,5 +83,29 @@ test.describe("Create Boxed Filter", () => {
     await filterExpression.match.expression.asLiteral().fill("item.Flight Number = Flight.Flight Number");
 
     await expect(bee.getContainer()).toHaveScreenshot("boxed-filter-nested-boxed-list.png");
+  });
+
+  test("should keep IDs after resetting entries", async ({ bee, jsonModel, stories }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1182",
+    });
+
+    await stories.openBoxedFilter("base");
+
+    const filterExpression = bee.expression.asFilter();
+    await filterExpression.in.selectExpressionMenu.selectLiteral();
+    await filterExpression.match.selectExpressionMenu.selectLiteral();
+    await filterExpression.in.expression.asLiteral().fill("test");
+    await filterExpression.match.expression.asLiteral().fill("test");
+    await filterExpression.in.contextMenu.open();
+    await filterExpression.in.contextMenu.option("Reset").nth(0).click();
+    await filterExpression.match.contextMenu.open();
+    await filterExpression.match.contextMenu.option("Reset").nth(0).click();
+
+    expect((await jsonModel.getFilterExpression()).in).not.toBeUndefined();
+    expect((await jsonModel.getFilterExpression()).match).not.toBeUndefined();
+    expect((await jsonModel.getFilterExpression()).in["@_id"]).not.toBeUndefined();
+    expect((await jsonModel.getFilterExpression()).match["@_id"]).not.toBeUndefined();
   });
 });

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/filter/filterExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/filter/filterExpression.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
-import { TestAnnotations } from "../../../../playwright-base/annotations";
+import { TestAnnotations } from "@kie-tools/playwright-base/annotations";
 
 test.describe("Create Boxed Filter", () => {
   test("should rename a filter", async ({ page, stories }) => {
@@ -50,7 +50,7 @@ test.describe("Create Boxed Filter", () => {
     await expect(bee.getContainer()).toHaveScreenshot("boxed-filter-nested-reset.png");
   });
 
-  test("should correctly create a nested filter", async ({ bee, stories }) => {
+  test("should correctly create a nested filter", async ({ bee }) => {
     await bee.goto();
 
     await bee.selectExpressionMenu.selectContext();
@@ -85,7 +85,7 @@ test.describe("Create Boxed Filter", () => {
     await expect(bee.getContainer()).toHaveScreenshot("boxed-filter-nested-boxed-list.png");
   });
 
-  test("should keep IDs after resetting entries", async ({ bee, jsonModel, stories }) => {
+  test("should have IDs after resetting 'in' and 'match' and setting it again", async ({ bee, jsonModel, stories }) => {
     test.info().annotations.push({
       type: TestAnnotations.REGRESSION,
       description: "https://github.com/apache/incubator-kie-issues/issues/1182",

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/for/forExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/for/forExpression.spec.ts
@@ -18,13 +18,13 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
-import { TestAnnotations } from "../../../../playwright-base/annotations";
+import { TestAnnotations } from "@kie-tools/playwright-base/annotations";
 
 test.describe("Create Boxed For", () => {
   test.beforeEach(async ({ stories }) => {
-    await stories.openBoxedFor("base");
+    await stories.openBoxedFor();
   });
-  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+  test("should have IDs after resetting 'in' and 'return' and setting it again", async ({ bee, jsonModel }) => {
     test.info().annotations.push({
       type: TestAnnotations.REGRESSION,
       description: "https://github.com/apache/incubator-kie-issues/issues/1182",

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/for/forExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/for/forExpression.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from "../../__fixtures__/base";
+import { TestAnnotations } from "../../../../playwright-base/annotations";
+
+test.describe("Create Boxed For", () => {
+  test.beforeEach(async ({ stories }) => {
+    await stories.openBoxedFor("base");
+  });
+  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1182",
+    });
+
+    const forExpression = bee.expression.asFor();
+    await forExpression.in.selectExpressionMenu.selectLiteral();
+    await forExpression.return.selectExpressionMenu.selectLiteral();
+    await forExpression.in.expression.asLiteral().fill("test");
+    await forExpression.return.expression.asLiteral().fill("test");
+    await forExpression.in.contextMenu.open();
+    await forExpression.in.contextMenu.option("Reset").nth(0).click();
+    await forExpression.return.contextMenu.open();
+    await forExpression.return.contextMenu.option("Reset").nth(0).click();
+
+    expect((await jsonModel.getForExpression()).in).not.toBeUndefined();
+    expect((await jsonModel.getForExpression()).return).not.toBeUndefined();
+    expect((await jsonModel.getForExpression()).in["@_id"]).not.toBeUndefined();
+    expect((await jsonModel.getForExpression()).return["@_id"]).not.toBeUndefined();
+  });
+});

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/some/someExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/some/someExpression.spec.ts
@@ -18,13 +18,13 @@
  */
 
 import { expect, test } from "../../__fixtures__/base";
-import { TestAnnotations } from "../../../../playwright-base/annotations";
+import { TestAnnotations } from "@kie-tools/playwright-base/annotations";
 
 test.describe("Create Boxed Some", () => {
   test.beforeEach(async ({ stories }) => {
-    await stories.openBoxedSome("base");
+    await stories.openBoxedSome();
   });
-  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+  test("should have IDs after resetting 'in' and 'satisfies' and setting it again", async ({ bee, jsonModel }) => {
     test.info().annotations.push({
       type: TestAnnotations.REGRESSION,
       description: "https://github.com/apache/incubator-kie-issues/issues/1182",

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/some/someExpression.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/some/someExpression.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from "../../__fixtures__/base";
+import { TestAnnotations } from "../../../../playwright-base/annotations";
+
+test.describe("Create Boxed Some", () => {
+  test.beforeEach(async ({ stories }) => {
+    await stories.openBoxedSome("base");
+  });
+  test("should keep IDs after resetting entries", async ({ bee, jsonModel, page }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1182",
+    });
+
+    const someExpression = bee.expression.asSome();
+    await someExpression.in.selectExpressionMenu.selectLiteral();
+    await someExpression.satisfies.selectExpressionMenu.selectLiteral();
+    await someExpression.in.expression.asLiteral().fill("test");
+    await someExpression.satisfies.expression.asLiteral().fill("test");
+    await someExpression.in.contextMenu.open();
+    await someExpression.in.contextMenu.option("Reset").nth(0).click();
+    await someExpression.satisfies.contextMenu.open();
+    await someExpression.satisfies.contextMenu.option("Reset").nth(0).click();
+
+    expect((await jsonModel.getSomeExpression()).in).not.toBeUndefined();
+    expect((await jsonModel.getSomeExpression()).satisfies).not.toBeUndefined();
+    expect((await jsonModel.getSomeExpression()).in["@_id"]).not.toBeUndefined();
+    expect((await jsonModel.getSomeExpression()).satisfies["@_id"]).not.toBeUndefined();
+  });
+});

--- a/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
@@ -81,6 +81,7 @@ import { useDmnEditorStore, useDmnEditorStoreApi } from "../store/StoreContext";
 import { getDefaultColumnWidth } from "./getDefaultColumnWidth";
 import { getDefaultBoxedExpression } from "./getDefaultBoxedExpression";
 import { Normalized } from "../normalization/normalize";
+import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
 
 export function BoxedExpressionScreen({ container }: { container: React.RefObject<HTMLElement> }) {
   const { externalModelsByNamespace } = useExternalModels();

--- a/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/BoxedExpressionScreen.tsx
@@ -20,7 +20,6 @@
 import {
   BeeGwtService,
   BoxedExpression,
-  DmnBuiltInDataType,
   DmnDataType,
   generateUuid,
   PmmlDocument,
@@ -81,7 +80,6 @@ import { useDmnEditorStore, useDmnEditorStoreApi } from "../store/StoreContext";
 import { getDefaultColumnWidth } from "./getDefaultColumnWidth";
 import { getDefaultBoxedExpression } from "./getDefaultBoxedExpression";
 import { Normalized } from "../normalization/normalize";
-import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
 
 export function BoxedExpressionScreen({ container }: { container: React.RefObject<HTMLElement> }) {
   const { externalModelsByNamespace } = useExternalModels();

--- a/packages/dmn-editor/src/mutations/updateExpression.ts
+++ b/packages/dmn-editor/src/mutations/updateExpression.ts
@@ -24,6 +24,7 @@ import {
 } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import { renameDrgElement } from "./renameNode";
 import { Normalized } from "../normalization/normalize";
+import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
 
 export function updateExpression({
   definitions,
@@ -64,4 +65,12 @@ export function updateExpression({
   } else {
     throw new Error("DMN MUTATION: Can't update expression for drgElement that is not a Decision or a BKM.");
   }
+
+  getNewDmnIdRandomizer()
+    .ack({
+      json: definitions.drgElement,
+      type: "DMN15__tDefinitions",
+      attr: "drgElement",
+    })
+    .randomize();
 }

--- a/packages/dmn-editor/src/mutations/updateExpression.ts
+++ b/packages/dmn-editor/src/mutations/updateExpression.ts
@@ -24,7 +24,6 @@ import {
 } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import { renameDrgElement } from "./renameNode";
 import { Normalized } from "../normalization/normalize";
-import { getNewDmnIdRandomizer } from "../idRandomizer/dmnIdRandomizer";
 
 export function updateExpression({
   definitions,

--- a/packages/dmn-editor/src/mutations/updateExpression.ts
+++ b/packages/dmn-editor/src/mutations/updateExpression.ts
@@ -65,12 +65,4 @@ export function updateExpression({
   } else {
     throw new Error("DMN MUTATION: Can't update expression for drgElement that is not a Decision or a BKM.");
   }
-
-  getNewDmnIdRandomizer()
-    .ack({
-      json: definitions.drgElement,
-      type: "DMN15__tDefinitions",
-      attr: "drgElement",
-    })
-    .randomize();
 }

--- a/packages/stunner-editors-dmn-loader/src/gwtToBee.ts
+++ b/packages/stunner-editors-dmn-loader/src/gwtToBee.ts
@@ -31,12 +31,20 @@ import {
   GwtExpressionDefinitionLogicType,
 } from "./types";
 import { DMN15_SPEC } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/Dmn15Spec";
-import { BoxedExpression, DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
+import {
+  BoxedExpression,
+  DmnBuiltInDataType,
+  generateUuid,
+  Normalized,
+} from "@kie-tools/boxed-expression-component/dist/api";
 
 /** Converts a GwtExpressionDefinition to a BoxedExpression. This convertion is
  *  necessary for historical reasons, as the Boxed Expression Editor was
  *  created prior to the DMN Editor, needing to declare its own model. */
-export function gwtToBee(expression: GwtExpressionDefinition, __widths: Map<string, number[]>): BoxedExpression {
+export function gwtToBee(
+  expression: GwtExpressionDefinition,
+  __widths: Map<string, number[]>
+): Normalized<BoxedExpression> {
   if (!expression) {
     return undefined!; // SPEC DISCREPANCY
   }
@@ -56,6 +64,7 @@ export function gwtToBee(expression: GwtExpressionDefinition, __widths: Map<stri
               "@_id": e.entryInfo.id,
               expression: gwtToBee(e.entryExpression, __widths)!,
               variable: {
+                "@_id": generateUuid(),
                 "@_name": e.entryInfo.name,
                 "@_typeRef": normalizeTypeRef(e.entryInfo.dataType),
               },
@@ -158,23 +167,32 @@ export function gwtToBee(expression: GwtExpressionDefinition, __widths: Map<stri
                     expression.classAndMethodNamesWidth ?? JAVA_FUNCTION_EXPRESSION_VALUES_MIN_WIDTH,
                   ]);
                   return {
+                    "@_id": generateUuid(),
                     __$$element: "context",
                     contextEntry: [
                       {
-                        "@_id": expression.classFieldId,
+                        "@_id": expression.classFieldId ?? generateUuid(),
                         expression: {
+                          "@_id": generateUuid(),
                           __$$element: "literalExpression",
                           text: { __$$text: expression.className ?? "" },
                         },
-                        variable: { "@_name": DMN15_SPEC.BOXED.FUNCTION.JAVA.classFieldName },
+                        variable: {
+                          "@_id": generateUuid(),
+                          "@_name": DMN15_SPEC.BOXED.FUNCTION.JAVA.classFieldName,
+                        },
                       },
                       {
-                        "@_id": expression.methodFieldId,
+                        "@_id": expression.methodFieldId ?? generateUuid(),
                         expression: {
+                          "@_id": generateUuid(),
                           __$$element: "literalExpression",
                           text: { __$$text: expression.methodName ?? "" },
                         },
-                        variable: { "@_name": DMN15_SPEC.BOXED.FUNCTION.JAVA.methodSignatureFieldName },
+                        variable: {
+                          "@_id": generateUuid(),
+                          "@_name": DMN15_SPEC.BOXED.FUNCTION.JAVA.methodSignatureFieldName,
+                        },
                       },
                     ],
                   };
@@ -182,23 +200,32 @@ export function gwtToBee(expression: GwtExpressionDefinition, __widths: Map<stri
               : expression.functionKind === FunctionExpressionDefinitionKind.Pmml
                 ? (() => {
                     return {
+                      "@_id": generateUuid(),
                       __$$element: "context",
                       contextEntry: [
                         {
-                          "@_id": expression.documentFieldId,
+                          "@_id": expression.documentFieldId ?? generateUuid(),
                           expression: {
+                            "@_id": generateUuid(),
                             __$$element: "literalExpression",
                             text: { __$$text: expression.document ?? "" },
                           },
-                          variable: { "@_name": DMN15_SPEC.BOXED.FUNCTION.PMML.documentFieldName },
+                          variable: {
+                            "@_id": generateUuid(),
+                            "@_name": DMN15_SPEC.BOXED.FUNCTION.PMML.documentFieldName,
+                          },
                         },
                         {
-                          "@_id": expression.modelFieldId,
+                          "@_id": expression.modelFieldId ?? generateUuid(),
                           expression: {
+                            "@_id": generateUuid(),
                             __$$element: "literalExpression",
                             text: { __$$text: expression.model ?? "" },
                           },
-                          variable: { "@_name": DMN15_SPEC.BOXED.FUNCTION.PMML.modelFieldName },
+                          variable: {
+                            "@_id": generateUuid(),
+                            "@_name": DMN15_SPEC.BOXED.FUNCTION.PMML.modelFieldName,
+                          },
                         },
                       ],
                     };

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -19,8 +19,8 @@
 
 import { BoxedExpressionEditor } from "@kie-tools/boxed-expression-component/dist/BoxedExpressionEditor";
 import {
-  ImportJavaClasses,
   GWTLayerService,
+  ImportJavaClasses,
   JavaClass,
   JavaCodeCompletionService,
 } from "@kie-tools/import-java-classes-component";
@@ -29,15 +29,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as ReactDOM from "react-dom";
 import {
   BeeGwtService,
-  DmnDataType,
   BoxedExpression,
-  PmmlDocument,
   DmnBuiltInDataType,
+  DmnDataType,
+  Normalized,
+  PmmlDocument,
 } from "@kie-tools/boxed-expression-component/dist/api";
 import { FeelVariables } from "@kie-tools/dmn-feel-antlr4-parser";
 import { GwtExpressionDefinition } from "./types";
-import { dmnExpressionToGwtExpression, gwtLogicType } from "./mapping";
-import { gwtExpressionToDmnExpression } from "./mapping";
+import { dmnExpressionToGwtExpression, gwtExpressionToDmnExpression, gwtLogicType } from "./mapping";
 import { DmnLatestModel, getMarshaller } from "@kie-tools/dmn-marshaller";
 import { updateExpression } from "./tmpDuplicateCode__updateExpression";
 
@@ -75,7 +75,7 @@ const BoxedExpressionEditorWrapper: React.FunctionComponent<BoxedExpressionEdito
 }) => {
   const [expressionWrapper, setExpressionWrapper] = useState<{
     source: "gwt" | "react";
-    expression: BoxedExpression | undefined;
+    expression: Normalized<BoxedExpression> | undefined;
     widthsById: Map<string, number[]>;
   }>({ source: "gwt", ...gwtExpressionToDmnExpression(gwtExpression) });
 
@@ -113,18 +113,21 @@ const BoxedExpressionEditorWrapper: React.FunctionComponent<BoxedExpressionEdito
     },
   };
 
-  const setExpressionNotifyingUserAction = useCallback((newExpressionAction: React.SetStateAction<BoxedExpression>) => {
-    setExpressionWrapper((prevState) => {
-      return {
-        source: "react",
-        expression:
-          typeof newExpressionAction === "function"
-            ? newExpressionAction(prevState.expression as any)
-            : newExpressionAction,
-        widthsById: prevState.widthsById,
-      };
-    });
-  }, []);
+  const setExpressionNotifyingUserAction = useCallback(
+    (newExpressionAction: React.SetStateAction<Normalized<BoxedExpression>>) => {
+      setExpressionWrapper((prevState) => {
+        return {
+          source: "react",
+          expression:
+            typeof newExpressionAction === "function"
+              ? newExpressionAction(prevState.expression as any)
+              : newExpressionAction,
+          widthsById: prevState.widthsById,
+        };
+      });
+    },
+    []
+  );
 
   const setWidthsByIdNotifyingUserAction = useCallback(
     (newWidthsByIdAction: React.SetStateAction<Map<string, number[]>>) => {

--- a/packages/stunner-editors-dmn-loader/src/mapping.ts
+++ b/packages/stunner-editors-dmn-loader/src/mapping.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { BoxedExpression } from "@kie-tools/boxed-expression-component/dist/api";
+import { BoxedExpression, Normalized } from "@kie-tools/boxed-expression-component/dist/api";
 import { GwtExpressionDefinition, GwtExpressionDefinitionLogicType } from "./types";
 import { gwtToBee } from "./gwtToBee";
 import { beeToGwt } from "./beeToGwt";
 
 export function gwtExpressionToDmnExpression(gwtExpression: GwtExpressionDefinition): {
-  expression: BoxedExpression;
+  expression: Normalized<BoxedExpression>;
   widthsById: Map<string, number[]>;
 } {
   const widthsById = new Map<string, number[]>();


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1182

The issue was that BEE was providing expressions without IDs, which was not expected by the DMN Editor.

This change guarantees that every expression and its nested components (like variables, context entries, and so on) that have IDs will have its ID defined (no more undefined IDs if they are optional in the XML definitions).
