### PR TITLE
NO-ISSUE: temporary disable devservice to sonataflow-greeting-quarkus-example

### DIFF
--- a/examples/sonataflow-greeting-quarkus-example/pom.xml
+++ b/examples/sonataflow-greeting-quarkus-example/pom.xml
@@ -89,6 +89,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-data-index-inmemory</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>

--- a/examples/sonataflow-greeting-quarkus-example/src/main/resources/application.properties
+++ b/examples/sonataflow-greeting-quarkus-example/src/main/resources/application.properties
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -20,6 +19,10 @@
 # Packaging
 # quarkus.package.type=fast-jar
 quarkus.native.native-image-xmx=8g
+quarkus.kogito.devservices.enabled=false
+quarkus.devservices.enabled=false
+kogito.service.url=http://localhost:${quarkus.http.port}
+quarkus.oidc.enabled=false
 
 # profile to pack this example into a container, to use it execute activate the maven container profile, -Dcontainer
 %container.quarkus.container-image.build=true


### PR DESCRIPTION
This PR is related to: https://github.com/apache/incubator-kie-tools/pull/2510

During the work on https://github.com/apache/incubator-kie-issues/issues/1406 we found the error below in `sonataflow-greeting-quarkus-example`:
`com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"manifest for apache/incubator-kie-kogito-data-index-ephemeral:main not found: manifest unknown: manifest unknown"}`
This PR temporary disables the devservice in `sonataflow-greeting-quarkus-example` only to fix the error until the dev service issue is solved.

![image](https://github.com/user-attachments/assets/62f1df45-bd54-48a1-a98d-654afc686be8)
