### PR TITLE
NO-ISSUE: Removing duplicated items on all READMEs

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -11,10 +11,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-* Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-* Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
-* 
-
 * Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 * Some files, particularly test files, and those not supporting comments, may

--- a/examples/base64png-editor-chrome-extension/README.md
+++ b/examples/base64png-editor-chrome-extension/README.md
@@ -56,10 +56,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/base64png-editor-vscode-extension/README.md
+++ b/examples/base64png-editor-vscode-extension/README.md
@@ -61,10 +61,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/base64png-editor/README.md
+++ b/examples/base64png-editor/README.md
@@ -38,10 +38,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/commit-message-validation-service/README.md
+++ b/examples/commit-message-validation-service/README.md
@@ -62,10 +62,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/drools-process-usertasks-quarkus-example/README.md
+++ b/examples/drools-process-usertasks-quarkus-example/README.md
@@ -246,10 +246,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/ping-pong-view-angular/README.md
+++ b/examples/ping-pong-view-angular/README.md
@@ -42,10 +42,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/ping-pong-view-react/README.md
+++ b/examples/ping-pong-view-react/README.md
@@ -38,10 +38,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/ping-pong-view/README.md
+++ b/examples/ping-pong-view/README.md
@@ -96,10 +96,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/sonataflow-greeting-quarkus-example/README.md
+++ b/examples/sonataflow-greeting-quarkus-example/README.md
@@ -183,10 +183,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/todo-list-view-vscode-extension/README.md
+++ b/examples/todo-list-view-vscode-extension/README.md
@@ -53,10 +53,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/todo-list-view/README.md
+++ b/examples/todo-list-view/README.md
@@ -47,10 +47,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/uniforms-patternfly/README.md
+++ b/examples/uniforms-patternfly/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/examples/webapp/README.md
+++ b/examples/webapp/README.md
@@ -76,10 +76,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/boxed-expression-component/README.md
+++ b/packages/boxed-expression-component/README.md
@@ -91,10 +91,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/bpmn-marshaller/README.md
+++ b/packages/bpmn-marshaller/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/bpmn-vscode-extension/README.md
+++ b/packages/bpmn-vscode-extension/README.md
@@ -65,10 +65,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/chrome-extension-pack-kogito-kie-editors/README.md
+++ b/packages/chrome-extension-pack-kogito-kie-editors/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/chrome-extension-serverless-workflow-editor/README.md
+++ b/packages/chrome-extension-serverless-workflow-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/chrome-extension-test-helper/README.md
+++ b/packages/chrome-extension-test-helper/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/cors-proxy-api/README.md
+++ b/packages/cors-proxy-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/cors-proxy-image/README.md
+++ b/packages/cors-proxy-image/README.md
@@ -82,10 +82,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/cors-proxy/README.md
+++ b/packages/cors-proxy/README.md
@@ -80,10 +80,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-client/README.md
+++ b/packages/dashbuilder-client/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-api/README.md
+++ b/packages/dashbuilder-component-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-assembler/README.md
+++ b/packages/dashbuilder-component-assembler/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-dev/README.md
+++ b/packages/dashbuilder-component-dev/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-echarts-base/README.md
+++ b/packages/dashbuilder-component-echarts-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-echarts/README.md
+++ b/packages/dashbuilder-component-echarts/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-map/README.md
+++ b/packages/dashbuilder-component-map/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-svg-heatmap/README.md
+++ b/packages/dashbuilder-component-svg-heatmap/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-table/README.md
+++ b/packages/dashbuilder-component-table/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-timeseries/README.md
+++ b/packages/dashbuilder-component-timeseries/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-uniforms/README.md
+++ b/packages/dashbuilder-component-uniforms/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-component-victory-charts/README.md
+++ b/packages/dashbuilder-component-victory-charts/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-editor/README.md
+++ b/packages/dashbuilder-editor/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-language-service/README.md
+++ b/packages/dashbuilder-language-service/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-swf-monitoring-dashboard/README.md
+++ b/packages/dashbuilder-swf-monitoring-dashboard/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-viewer-deployment-webapp/README.md
+++ b/packages/dashbuilder-viewer-deployment-webapp/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-viewer-image-env/README.md
+++ b/packages/dashbuilder-viewer-image-env/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-viewer-image/README.md
+++ b/packages/dashbuilder-viewer-image/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder-viewer/README.md
+++ b/packages/dashbuilder-viewer/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dashbuilder/README.md
+++ b/packages/dashbuilder/README.md
@@ -55,10 +55,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-base-image/README.md
+++ b/packages/dev-deployment-base-image/README.md
@@ -66,10 +66,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-dmn-form-webapp-image/README.md
+++ b/packages/dev-deployment-dmn-form-webapp-image/README.md
@@ -64,10 +64,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-dmn-form-webapp/README.md
+++ b/packages/dev-deployment-dmn-form-webapp/README.md
@@ -47,10 +47,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/README.md
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/README.md
@@ -66,10 +66,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-kogito-quarkus-blank-app/README.md
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dev-deployment-upload-service/README.md
+++ b/packages/dev-deployment-upload-service/README.md
@@ -123,10 +123,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-editor-envelope/README.md
+++ b/packages/dmn-editor-envelope/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-editor-standalone/README.md
+++ b/packages/dmn-editor-standalone/README.md
@@ -100,10 +100,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-editor/README.md
+++ b/packages/dmn-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-feel-antlr4-parser/README.md
+++ b/packages/dmn-feel-antlr4-parser/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-language-service/README.md
+++ b/packages/dmn-language-service/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-marshaller-backend-compatibility-tester/README.md
+++ b/packages/dmn-marshaller-backend-compatibility-tester/README.md
@@ -67,10 +67,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-marshaller/README.md
+++ b/packages/dmn-marshaller/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-runner/README.md
+++ b/packages/dmn-runner/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-testing-models/README.md
+++ b/packages/dmn-testing-models/README.md
@@ -51,10 +51,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/dmn-vscode-extension/README.md
+++ b/packages/dmn-vscode-extension/README.md
@@ -74,10 +74,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/envelope-bus/README.md
+++ b/packages/envelope-bus/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/envelope/README.md
+++ b/packages/envelope/README.md
@@ -15,10 +15,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/extended-services-api/README.md
+++ b/packages/extended-services-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/extended-services-java/README.md
+++ b/packages/extended-services-java/README.md
@@ -63,10 +63,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/extended-services/README.md
+++ b/packages/extended-services/README.md
@@ -86,10 +86,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/feel-input-component/README.md
+++ b/packages/feel-input-component/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/form-dmn/README.md
+++ b/packages/form-dmn/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/form-generation-tool/README.md
+++ b/packages/form-generation-tool/README.md
@@ -127,10 +127,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/i18n-common-dictionary/README.md
+++ b/packages/i18n-common-dictionary/README.md
@@ -13,10 +13,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -136,10 +136,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/image-env-to-json/README.md
+++ b/packages/image-env-to-json/README.md
@@ -84,10 +84,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/import-java-classes-component/README.md
+++ b/packages/import-java-classes-component/README.md
@@ -76,10 +76,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/jbpm-quarkus-devui/README.md
+++ b/packages/jbpm-quarkus-devui/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/jest-base/README.md
+++ b/packages/jest-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/json-yaml-language-service/README.md
+++ b/packages/json-yaml-language-service/README.md
@@ -48,10 +48,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/k8s-yaml-to-apiserver-requests/README.md
+++ b/packages/k8s-yaml-to-apiserver-requests/README.md
@@ -61,10 +61,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/keyboard-shortcuts/README.md
+++ b/packages/keyboard-shortcuts/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-bc-editors/README.md
+++ b/packages/kie-bc-editors/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-editors-dev-vscode-extension/README.md
+++ b/packages/kie-editors-dev-vscode-extension/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-editors-standalone/README.md
+++ b/packages/kie-editors-standalone/README.md
@@ -110,10 +110,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-sandbox-distribution/README.md
+++ b/packages/kie-sandbox-distribution/README.md
@@ -94,10 +94,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-sandbox-extended-services-image/README.md
+++ b/packages/kie-sandbox-extended-services-image/README.md
@@ -80,10 +80,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-sandbox-fs/README.md
+++ b/packages/kie-sandbox-fs/README.md
@@ -321,10 +321,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kie-sandbox-webapp-image/README.md
+++ b/packages/kie-sandbox-webapp-image/README.md
@@ -377,10 +377,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kn-plugin-workflow/README.md
+++ b/packages/kn-plugin-workflow/README.md
@@ -80,10 +80,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kogito-management-console/README.md
+++ b/packages/kogito-management-console/README.md
@@ -124,10 +124,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kogito-task-console/README.md
+++ b/packages/kogito-task-console/README.md
@@ -126,10 +126,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/kubernetes-bridge/README.md
+++ b/packages/kubernetes-bridge/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/maven-base/README.md
+++ b/packages/maven-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/maven-config-setup-helper/README.md
+++ b/packages/maven-config-setup-helper/README.md
@@ -36,10 +36,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/monaco-editor/README.md
+++ b/packages/monaco-editor/README.md
@@ -39,10 +39,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -79,10 +79,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/online-editor/README.md
+++ b/packages/online-editor/README.md
@@ -107,10 +107,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/operating-system/README.md
+++ b/packages/operating-system/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/patternfly-base/README.md
+++ b/packages/patternfly-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/playwright-base/README.md
+++ b/packages/playwright-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/pmml-editor-marshaller/README.md
+++ b/packages/pmml-editor-marshaller/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/pmml-editor/README.md
+++ b/packages/pmml-editor/README.md
@@ -44,10 +44,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/pmml-vscode-extension/README.md
+++ b/packages/pmml-vscode-extension/README.md
@@ -49,10 +49,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/python-venv/README.md
+++ b/packages/python-venv/README.md
@@ -36,10 +36,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/root-env/README.md
+++ b/packages/root-env/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-components/README.md
+++ b/packages/runtime-tools-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-management-console-webapp/README.md
+++ b/packages/runtime-tools-management-console-webapp/README.md
@@ -230,10 +230,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-process-dev-ui-webapp/README.md
+++ b/packages/runtime-tools-process-dev-ui-webapp/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-process-enveloped-components/README.md
+++ b/packages/runtime-tools-process-enveloped-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-process-gateway-api/README.md
+++ b/packages/runtime-tools-process-gateway-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-process-webapp-components/README.md
+++ b/packages/runtime-tools-process-webapp-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-shared-enveloped-components/README.md
+++ b/packages/runtime-tools-shared-enveloped-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-shared-gateway-api/README.md
+++ b/packages/runtime-tools-shared-gateway-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-shared-webapp-components/README.md
+++ b/packages/runtime-tools-shared-webapp-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-swf-enveloped-components/README.md
+++ b/packages/runtime-tools-swf-enveloped-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-swf-gateway-api/README.md
+++ b/packages/runtime-tools-swf-gateway-api/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-swf-webapp-components/README.md
+++ b/packages/runtime-tools-swf-webapp-components/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/runtime-tools-task-console-webapp/README.md
+++ b/packages/runtime-tools-task-console-webapp/README.md
@@ -97,10 +97,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/scesim-editor/README.md
+++ b/packages/scesim-editor/README.md
@@ -70,10 +70,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/scesim-marshaller/README.md
+++ b/packages/scesim-marshaller/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-base-builder-image-env/README.md
+++ b/packages/serverless-logic-web-tools-base-builder-image-env/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-base-builder-image/README.md
+++ b/packages/serverless-logic-web-tools-base-builder-image/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-swf-builder-image-env/README.md
+++ b/packages/serverless-logic-web-tools-swf-builder-image-env/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-swf-builder-image/README.md
+++ b/packages/serverless-logic-web-tools-swf-builder-image/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/README.md
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image-env/README.md
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image-env/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/README.md
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-logic-web-tools/README.md
+++ b/packages/serverless-logic-web-tools/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-combined-editor/README.md
+++ b/packages/serverless-workflow-combined-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-dev-ui-monitoring-webapp/README.md
+++ b/packages/serverless-workflow-dev-ui-monitoring-webapp/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-dev-ui-webapp/README.md
+++ b/packages/serverless-workflow-dev-ui-webapp/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-diagram-editor-assets/README.md
+++ b/packages/serverless-workflow-diagram-editor-assets/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-diagram-editor-envelope/README.md
+++ b/packages/serverless-workflow-diagram-editor-envelope/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-diagram-editor/README.md
+++ b/packages/serverless-workflow-diagram-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-jq-expressions/README.md
+++ b/packages/serverless-workflow-jq-expressions/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-language-service/README.md
+++ b/packages/serverless-workflow-language-service/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-service-catalog/README.md
+++ b/packages/serverless-workflow-service-catalog/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-standalone-editor/README.md
+++ b/packages/serverless-workflow-standalone-editor/README.md
@@ -82,10 +82,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-text-editor/README.md
+++ b/packages/serverless-workflow-text-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/serverless-workflow-vscode-extension/README.md
+++ b/packages/serverless-workflow-vscode-extension/README.md
@@ -114,10 +114,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-builder-image/README.md
+++ b/packages/sonataflow-builder-image/README.md
@@ -92,10 +92,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-deployment-webapp/README.md
+++ b/packages/sonataflow-deployment-webapp/README.md
@@ -203,10 +203,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-devmode-image/README.md
+++ b/packages/sonataflow-devmode-image/README.md
@@ -92,10 +92,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-image-common/README.md
+++ b/packages/sonataflow-image-common/README.md
@@ -68,10 +68,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-operator/README.md
+++ b/packages/sonataflow-operator/README.md
@@ -85,10 +85,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/sonataflow-quarkus-devui/README.md
+++ b/packages/sonataflow-quarkus-devui/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/storybook-base/README.md
+++ b/packages/storybook-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/stunner-editors-dmn-loader/README.md
+++ b/packages/stunner-editors-dmn-loader/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/stunner-editors/README.md
+++ b/packages/stunner-editors/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/switch-expression-ts/README.md
+++ b/packages/switch-expression-ts/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/text-editor/README.md
+++ b/packages/text-editor/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/uniforms-bootstrap4-codegen/README.md
+++ b/packages/uniforms-bootstrap4-codegen/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/uniforms-patternfly-codegen/README.md
+++ b/packages/uniforms-patternfly-codegen/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/uniforms-patternfly/README.md
+++ b/packages/uniforms-patternfly/README.md
@@ -128,10 +128,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/unitables-dmn/README.md
+++ b/packages/unitables-dmn/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/unitables/README.md
+++ b/packages/unitables/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-extension-common-test-helpers/README.md
+++ b/packages/vscode-extension-common-test-helpers/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-extension-dashbuilder-editor/README.md
+++ b/packages/vscode-extension-dashbuilder-editor/README.md
@@ -58,10 +58,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-extension-kie-ba-bundle/README.md
+++ b/packages/vscode-extension-kie-ba-bundle/README.md
@@ -53,10 +53,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-extension-kogito-bundle/README.md
+++ b/packages/vscode-extension-kogito-bundle/README.md
@@ -63,10 +63,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-java-code-completion-extension-plugin/README.md
+++ b/packages/vscode-java-code-completion-extension-plugin/README.md
@@ -67,10 +67,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/vscode-java-code-completion/README.md
+++ b/packages/vscode-java-code-completion/README.md
@@ -70,10 +70,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/webpack-base/README.md
+++ b/packages/webpack-base/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/workspaces-git-fs/README.md
+++ b/packages/workspaces-git-fs/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/xml-parser-ts-codegen/README.md
+++ b/packages/xml-parser-ts-codegen/README.md
@@ -74,10 +74,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/xml-parser-ts/README.md
+++ b/packages/xml-parser-ts/README.md
@@ -44,10 +44,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yaml-language-server/README.md
+++ b/packages/yaml-language-server/README.md
@@ -34,10 +34,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-editor/README.md
+++ b/packages/yard-editor/README.md
@@ -57,10 +57,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-language-service/README.md
+++ b/packages/yard-language-service/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-model/README.md
+++ b/packages/yard-model/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-validator-worker/README.md
+++ b/packages/yard-validator-worker/README.md
@@ -53,10 +53,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-validator/README.md
+++ b/packages/yard-validator/README.md
@@ -39,10 +39,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/packages/yard-vscode-extension/README.md
+++ b/packages/yard-vscode-extension/README.md
@@ -48,10 +48,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/scripts/build-env/README.md
+++ b/scripts/build-env/README.md
@@ -135,10 +135,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/scripts/check-junit-report-results/README.md
+++ b/scripts/check-junit-report-results/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/scripts/sparse-checkout/README.md
+++ b/scripts/sparse-checkout/README.md
@@ -79,10 +79,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may

--- a/scripts/update-version/README.md
+++ b/scripts/update-version/README.md
@@ -32,10 +32,6 @@ policy. For example, releases may have incomplete or un-reviewed licensing
 conditions. What follows is a list of known issues the project is currently
 aware of (note that this list, by definition, is likely to be incomplete):
 
-- Hibernate, an LGPL project, is being used. Hibernate is in the process of relicensing to ASL v2
-- Some files, particularly test files, and those not supporting comments, may be missing the ASF Licensing Header
--
-
 - Hibernate, an LGPL project, is being used. Hibernate is in the process of
   relicensing to ASL v2
 - Some files, particularly test files, and those not supporting comments, may


### PR DESCRIPTION
Not sure why those were duplicated but here I am fixing it.