### PR TITLE
NO-ISSUE: Add option to disable the extended services wizard

### DIFF
--- a/packages/online-editor/build/defaultEnvJson.ts
+++ b/packages/online-editor/build/defaultEnvJson.ts
@@ -44,6 +44,7 @@ export const defaultEnvJson: EnvJson = {
   KIE_SANDBOX_CORS_PROXY_URL: buildEnv.onlineEditor.corsProxyUrl,
   KIE_SANDBOX_FEEDBACK_URL: buildEnv.onlineEditor.feedbackUrl,
   KIE_SANDBOX_EXTENDED_SERVICES_URL: buildEnv.onlineEditor.extendedServicesUrl,
+  KIE_SANDBOX_DISABLE_EXTENDED_SERVICES_WIZARD: buildEnv.onlineEditor.disableExtendedServicesWizard,
   KIE_SANDBOX_DEV_DEPLOYMENT_BASE_IMAGE_URL: getDevDeploymentImageUrl(buildEnv.devDeployments.baseImage),
   KIE_SANDBOX_DEV_DEPLOYMENT_KOGITO_QUARKUS_BLANK_APP_IMAGE_URL: getDevDeploymentImageUrl(
     buildEnv.devDeployments.kogitoQuarkusBlankAppImage

--- a/packages/online-editor/env/index.js
+++ b/packages/online-editor/env/index.js
@@ -58,6 +58,10 @@ module.exports = composeEnv([rootEnv, extendedServicesEnv, corsProxyEnv], {
       default: `http://${extendedServicesEnv.env.extendedServices.ip}:${extendedServicesEnv.env.extendedServices.port}`,
       description: "Extended Services URL.",
     },
+    ONLINE_EDITOR__disableExtendedServicesWizard: {
+      default: `${false}`,
+      description: "Disables the Extended Services Wizard.",
+    },
     ONLINE_EDITOR__feedbackUrl: {
       default: "https://github.com/apache/incubator-kie-issues/issues/439#issuecomment-1821845917",
       description: "URL where users can give feedback, currently present in the New DMN Editor dropdown.",
@@ -154,6 +158,7 @@ module.exports = composeEnv([rootEnv, extendedServicesEnv, corsProxyEnv], {
         },
         appName: getOrDefault(this.vars.ONLINE_EDITOR__appName),
         extendedServicesUrl: getOrDefault(this.vars.ONLINE_EDITOR__extendedServicesUrl),
+        disableExtendedServicesWizard: str2bool(getOrDefault(this.vars.ONLINE_EDITOR__disableExtendedServicesWizard)),
         corsProxyUrl: getOrDefault(this.vars.ONLINE_EDITOR__corsProxyUrl),
         feedbackUrl: getOrDefault(this.vars.ONLINE_EDITOR__feedbackUrl),
         requireCustomCommitMessage: str2bool(getOrDefault(this.vars.ONLINE_EDITOR__requireCustomCommitMessage)),

--- a/packages/online-editor/src/env/EnvJson.ts
+++ b/packages/online-editor/src/env/EnvJson.ts
@@ -24,6 +24,7 @@ import { EditorConfig } from "../envelopeLocator/EditorEnvelopeLocatorApi";
 export interface EnvJson {
   KIE_SANDBOX_VERSION: string;
   KIE_SANDBOX_EXTENDED_SERVICES_URL: string;
+  KIE_SANDBOX_DISABLE_EXTENDED_SERVICES_WIZARD: boolean;
   KIE_SANDBOX_CORS_PROXY_URL: string;
   KIE_SANDBOX_FEEDBACK_URL: string;
   KIE_SANDBOX_DEV_DEPLOYMENT_BASE_IMAGE_URL: string;

--- a/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
@@ -785,9 +785,7 @@ export function ExtendedServicesModal() {
           <br />
           <List>
             <ListItem>
-              <TextContent>
-                <Text>{i18n.dmnRunner.modal.wizard.disabled.message}</Text>
-              </TextContent>
+              <Text>{i18n.dmnRunner.modal.wizard.disabled.message}</Text>
             </ListItem>
             <ListItem>
               <Text>{i18n.dmnRunner.modal.wizard.disabled.helper}</Text>

--- a/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
@@ -638,7 +638,7 @@ export function ExtendedServicesModal() {
       case ModalPage.WIZARD:
         return i18n.dmnRunner.modal.wizard.title;
       case ModalPage.DISABLED:
-        return i18n.dmnRunner.modal.wizard.packaged.title;
+        return i18n.dmnRunner.modal.wizard.disabled.title;
     }
   }, [modalPage, i18n]);
 
@@ -781,16 +781,16 @@ export function ExtendedServicesModal() {
       )}
       {modalPage === ModalPage.DISABLED && (
         <div>
-          <Alert variant="danger" title={i18n.dmnRunner.modal.wizard.packaged.alert} aria-live="polite" isInline />
+          <Alert variant="danger" title={i18n.dmnRunner.modal.wizard.disabled.alert} aria-live="polite" isInline />
           <br />
           <List>
             <ListItem>
               <TextContent>
-                <Text>{i18n.dmnRunner.modal.wizard.packaged.message}</Text>
+                <Text>{i18n.dmnRunner.modal.wizard.disabled.message}</Text>
               </TextContent>
             </ListItem>
             <ListItem>
-              <Text>{i18n.dmnRunner.modal.wizard.packaged.helper}</Text>
+              <Text>{i18n.dmnRunner.modal.wizard.disabled.helper}</Text>
             </ListItem>
           </List>
         </div>

--- a/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
@@ -45,10 +45,12 @@ import { DependentFeature, useExtendedServices } from "./ExtendedServicesContext
 import { ExtendedServicesStatus } from "./ExtendedServicesStatus";
 import { useRoutes } from "../navigation/Hooks";
 import { useSettingsDispatch } from "../settings/SettingsContext";
+import { useEnv } from "../env/hooks/EnvContext";
 
 enum ModalPage {
   INITIAL,
   WIZARD,
+  DISABLED,
 }
 
 const UBUNTU_APP_INDICATOR_LIB = "apt install libayatana-appindicator3-1";
@@ -60,6 +62,7 @@ export function ExtendedServicesModal() {
   const [operatingSystem, setOperatingSystem] = useState(getOperatingSystem() ?? OperatingSystem.LINUX);
   const [modalPage, setModalPage] = useState<ModalPage>(ModalPage.INITIAL);
   const extendedServices = useExtendedServices();
+  const { env } = useEnv();
 
   const KIE_SANDBOX_EXTENDED_SERVICES_MACOS_DMG = useMemo(
     () => `kie_sandbox_extended_services_macos_${extendedServices.version}.dmg`,
@@ -634,6 +637,8 @@ export function ExtendedServicesModal() {
         return "";
       case ModalPage.WIZARD:
         return i18n.dmnRunner.modal.wizard.title;
+      case ModalPage.DISABLED:
+        return i18n.dmnRunner.modal.wizard.packaged.title;
     }
   }, [modalPage, i18n]);
 
@@ -643,6 +648,8 @@ export function ExtendedServicesModal() {
         return ModalVariant.medium;
       case ModalPage.WIZARD:
         return ModalVariant.large;
+      case ModalPage.DISABLED:
+        return ModalVariant.medium;
     }
   }, [modalPage]);
 
@@ -660,7 +667,11 @@ export function ExtendedServicesModal() {
           {modalPage === ModalPage.INITIAL && (
             <Button
               className="pf-u-mt-xl kogito--editor__extended-services-modal-initial-center"
-              onClick={() => setModalPage(ModalPage.WIZARD)}
+              onClick={() =>
+                env.KIE_SANDBOX_DISABLE_EXTENDED_SERVICES_WIZARD === false
+                  ? setModalPage(ModalPage.WIZARD)
+                  : setModalPage(ModalPage.DISABLED)
+              }
             >
               {i18n.terms.setup}
             </Button>
@@ -766,6 +777,22 @@ export function ExtendedServicesModal() {
             height={400}
             footer={<ExtendedServicesWizardFooter onClose={onClose} steps={wizardSteps} setModalPage={setModalPage} />}
           />
+        </div>
+      )}
+      {modalPage === ModalPage.DISABLED && (
+        <div>
+          <Alert variant="danger" title={i18n.dmnRunner.modal.wizard.packaged.alert} aria-live="polite" isInline />
+          <br />
+          <List>
+            <ListItem>
+              <TextContent>
+                <Text>{i18n.dmnRunner.modal.wizard.packaged.message}</Text>
+              </TextContent>
+            </ListItem>
+            <ListItem>
+              <Text>{i18n.dmnRunner.modal.wizard.packaged.helper}</Text>
+            </ListItem>
+          </List>
         </div>
       )}
     </Modal>

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -399,7 +399,7 @@ interface OnlineDictionary extends ReferenceDictionary {
           title: string;
           message: string;
         };
-        packaged: {
+        disabled: {
           title: string;
           alert: string;
           message: string;

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -399,6 +399,12 @@ interface OnlineDictionary extends ReferenceDictionary {
           title: string;
           message: string;
         };
+        packaged: {
+          title: string;
+          alert: string;
+          message: string;
+          helper: string;
+        };
         macos: {
           install: {
             download: string;

--- a/packages/online-editor/src/i18n/locales/de.ts
+++ b/packages/online-editor/src/i18n/locales/de.ts
@@ -469,6 +469,12 @@ export const de: OnlineI18n = {
           title: `${de_common.names.extendedServices} wurde angehalten!`,
           message: `Es sieht so aus, als ob ${de_common.names.extendedServices} plötzlich beendet wurde, bitte folgen Sie diesen Anweisungen, um es wieder zu starten.`,
         },
+        packaged: {
+          title: `${de_common.names.dmnRunner}`,
+          alert: `Sie sind nicht mit ${de_common.names.extendedServices} verbunden.`,
+          message: `Beachten Sie, dass einige Funktionen wie der ${de_common.names.dmnRunner}, ohne ${de_common.names.extendedServices} nicht verfügbar sind.`,
+          helper: `Eine Anleitung zur Bereitstellung von ${de_common.names.extendedServices} als Image finden Sie in der Dokumentation.`,
+        },
         macos: {
           install: {
             download: ` ${de_common.names.extendedServices}.`,

--- a/packages/online-editor/src/i18n/locales/de.ts
+++ b/packages/online-editor/src/i18n/locales/de.ts
@@ -473,7 +473,7 @@ export const de: OnlineI18n = {
           title: `${de_common.names.dmnRunner}`,
           alert: `Sie sind nicht mit ${de_common.names.extendedServices} verbunden.`,
           message: `Beachten Sie, dass einige Funktionen wie der ${de_common.names.dmnRunner}, ohne ${de_common.names.extendedServices} nicht verfügbar sind.`,
-          helper: `Stellen Sie sicher, dass Extended Services ausgeführt wird, und überprüfen Sie dann die Host- und Porteinstellungen.`,
+          helper: `Stellen Sie sicher, dass ${de_common.names.extendedServices} ausgeführt wird, und überprüfen Sie dann die Host- und Porteinstellungen.`,
         },
         macos: {
           install: {

--- a/packages/online-editor/src/i18n/locales/de.ts
+++ b/packages/online-editor/src/i18n/locales/de.ts
@@ -469,11 +469,11 @@ export const de: OnlineI18n = {
           title: `${de_common.names.extendedServices} wurde angehalten!`,
           message: `Es sieht so aus, als ob ${de_common.names.extendedServices} plötzlich beendet wurde, bitte folgen Sie diesen Anweisungen, um es wieder zu starten.`,
         },
-        packaged: {
+        disabled: {
           title: `${de_common.names.dmnRunner}`,
           alert: `Sie sind nicht mit ${de_common.names.extendedServices} verbunden.`,
           message: `Beachten Sie, dass einige Funktionen wie der ${de_common.names.dmnRunner}, ohne ${de_common.names.extendedServices} nicht verfügbar sind.`,
-          helper: `Eine Anleitung zur Bereitstellung von ${de_common.names.extendedServices} als Image finden Sie in der Dokumentation.`,
+          helper: `Stellen Sie sicher, dass Extended Services ausgeführt wird, und überprüfen Sie dann die Host- und Porteinstellungen.`,
         },
         macos: {
           install: {

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -457,6 +457,12 @@ export const en: OnlineI18n = {
           title: `${en_common.names.extendedServices} has stopped!`,
           message: `It looks like the ${en_common.names.extendedServices} has suddenly stopped, please follow these instructions to start it again.`,
         },
+        packaged: {
+          title: `${en_common.names.dmnRunner}`,
+          alert: `You are not connected to ${en_common.names.extendedServices}.`,
+          message: `Note that some features, such as the ${en_common.names.dmnRunner}, are unavailable without ${en_common.names.extendedServices}.`,
+          helper: `Refer to the documentation for guidance on deploying ${en_common.names.extendedServices} as an image.`,
+        },
         macos: {
           install: {
             download: ` ${en_common.names.extendedServices}.`,

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -457,11 +457,11 @@ export const en: OnlineI18n = {
           title: `${en_common.names.extendedServices} has stopped!`,
           message: `It looks like the ${en_common.names.extendedServices} has suddenly stopped, please follow these instructions to start it again.`,
         },
-        packaged: {
+        disabled: {
           title: `${en_common.names.dmnRunner}`,
           alert: `You are not connected to ${en_common.names.extendedServices}.`,
           message: `Note that some features, such as the ${en_common.names.dmnRunner}, are unavailable without ${en_common.names.extendedServices}.`,
-          helper: `Refer to the documentation for guidance on deploying ${en_common.names.extendedServices} as an image.`,
+          helper: `Ensure ${en_common.names.extendedServices} is running, then review the host and port settings.`,
         },
         macos: {
           install: {


### PR DESCRIPTION
This environmental variable is being added for users who don't use a local extended services. In this case it doesn't make sense for them to see the wizard, so instead they'll be shown a modal alerting them that extended services is not running.

Normal behaviour:

https://github.com/user-attachments/assets/a67406aa-06d9-4022-8eab-9a817e06644b

Disabled behaviour:

https://github.com/user-attachments/assets/5f584ea7-f093-4033-af7f-aa369cdf63e0




