### PR TITLE
NO-ISSUE: Upgrade webpack to 5.92.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The Apache KIE Tools project contains several applications. To develop each one 
 
 1. After you've successfully built the project following the instructions above, open the `packages/kie-editors-dev-vscode-extension` folder on VS Code. Use a new VS Code window so that the `packages/kie-editors-dev-vscode-extension` folder shows up as root in the VS Code explorer.
 2. From there, you can Run the extension or the end-to-end tests by using the `Debug` menu/section. You can also use the respective shortcuts (F5 to start debugging, for instance).
-3. **NOTE:** To run the VS Code extension in development mode, you need `webpack` and `webpack-cli` to be globally installed on NPM. Normally you can do that with `npm install -g webpack@^5.88.2 webpack-cli@^4.10.0`, but `sudo` may be required depending on your installation.
+3. **NOTE:** To run the VS Code extension in development mode, you need `webpack` and `webpack-cli` to be globally installed on NPM. Normally you can do that with `npm install -g webpack@^5.92.1 webpack-cli@^4.10.0`, but `sudo` may be required depending on your installation.
 4. **Remember!** If you make changes to any package other than `packages/kie-editors-dev-vscode-extension`, you have to manually rebuild them before relaunching the extension on VS Code.
 
 #### VS Code Extension (Serverless Workflow Editor)

--- a/examples/base64png-editor-chrome-extension/package.json
+++ b/examples/base64png-editor-chrome-extension/package.json
@@ -33,7 +33,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/examples/base64png-editor-vscode-extension/package.json
+++ b/examples/base64png-editor-vscode-extension/package.json
@@ -38,7 +38,7 @@
     "@vscode/vsce": "^2.22.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/examples/ping-pong-view-angular/package.json
+++ b/examples/ping-pong-view-angular/package.json
@@ -46,6 +46,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "rimraf": "^3.0.2",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "webpack": "^5.92.1"
   }
 }

--- a/examples/todo-list-view-vscode-extension/package.json
+++ b/examples/todo-list-view-vscode-extension/package.json
@@ -36,7 +36,7 @@
     "@vscode/vsce": "^2.22.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/examples/uniforms-patternfly/package.json
+++ b/examples/uniforms-patternfly/package.json
@@ -36,7 +36,7 @@
     "react-router-dom": "^5.3.4",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/examples/webapp/package.json
+++ b/examples/webapp/package.json
@@ -46,7 +46,7 @@
     "react-router-dom": "^5.3.4",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/boxed-expression-component/package.json
+++ b/packages/boxed-expression-component/package.json
@@ -80,7 +80,7 @@
     "storybook": "^7.3.2",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -45,7 +45,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/chrome-extension-pack-kogito-kie-editors/package.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/package.json
@@ -57,7 +57,7 @@
     "start-server-and-test": "^2.0.3",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/chrome-extension-serverless-workflow-editor/package.json
+++ b/packages/chrome-extension-serverless-workflow-editor/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.5.3",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -50,7 +50,7 @@
     "run-script-os": "^1.1.6",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-merge": "^5.9.0"
   }

--- a/packages/dashbuilder-component-assembler/package.json
+++ b/packages/dashbuilder-component-assembler/package.json
@@ -36,7 +36,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-echarts/package.json
+++ b/packages/dashbuilder-component-echarts/package.json
@@ -42,7 +42,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-map/package.json
+++ b/packages/dashbuilder-component-map/package.json
@@ -46,7 +46,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-svg-heatmap/package.json
+++ b/packages/dashbuilder-component-svg-heatmap/package.json
@@ -43,7 +43,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-table/package.json
+++ b/packages/dashbuilder-component-table/package.json
@@ -45,7 +45,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-timeseries/package.json
+++ b/packages/dashbuilder-component-timeseries/package.json
@@ -42,7 +42,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-uniforms/package.json
+++ b/packages/dashbuilder-component-uniforms/package.json
@@ -48,7 +48,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-component-victory-charts/package.json
+++ b/packages/dashbuilder-component-victory-charts/package.json
@@ -49,7 +49,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-editor/package.json
+++ b/packages/dashbuilder-editor/package.json
@@ -65,7 +65,7 @@
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.5.3",
     "vscode-json-languageservice": "^4.2.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-viewer-deployment-webapp/package.json
+++ b/packages/dashbuilder-viewer-deployment-webapp/package.json
@@ -54,7 +54,7 @@
     "html-webpack-plugin": "^5.3.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dashbuilder-viewer/package.json
+++ b/packages/dashbuilder-viewer/package.json
@@ -55,7 +55,7 @@
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.5.3",
     "vscode-json-languageservice": "^4.2.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dev-deployment-dmn-form-webapp/package.json
+++ b/packages/dev-deployment-dmn-form-webapp/package.json
@@ -72,7 +72,7 @@
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dmn-editor-standalone/package.json
+++ b/packages/dmn-editor-standalone/package.json
@@ -84,7 +84,7 @@
     "run-script-os": "^1.1.6",
     "storybook": "^7.3.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",

--- a/packages/dmn-editor/package.json
+++ b/packages/dmn-editor/package.json
@@ -97,7 +97,7 @@
     "start-server-and-test": "^2.0.3",
     "storybook": "^7.3.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -48,7 +48,7 @@
     "process": "^0.11.10",
     "rimraf": "^3.0.2",
     "stream-browserify": "3.0.0",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/extended-services-vscode-extension/package.json
+++ b/packages/extended-services-vscode-extension/package.json
@@ -45,7 +45,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "node-fetch": "^3.3.1",
     "rimraf": "^3.0.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/feel-input-component/package.json
+++ b/packages/feel-input-component/package.json
@@ -49,7 +49,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/form-generation-tool/package.json
+++ b/packages/form-generation-tool/package.json
@@ -62,7 +62,7 @@
     "run-script-os": "^1.1.6",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/image-env-to-json/package.json
+++ b/packages/image-env-to-json/package.json
@@ -36,7 +36,7 @@
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/import-java-classes-component/package.json
+++ b/packages/import-java-classes-component/package.json
@@ -55,7 +55,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -76,7 +76,7 @@
     "sanitize-filename-ts": "^1.0.2",
     "typescript": "^5.5.3",
     "vscode-extension-tester": "^8.3.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/kie-editors-standalone/package.json
+++ b/packages/kie-editors-standalone/package.json
@@ -87,7 +87,7 @@
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
     "underscore": "^1.13.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -32,7 +32,7 @@
     "ts-loader": "^9.4.2",
     "typescript": "^5.5.3",
     "url-loader": "^4.1.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -119,7 +119,7 @@
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/patternfly-base/package.json
+++ b/packages/patternfly-base/package.json
@@ -27,6 +27,6 @@
     "style-loader": "^2.0.0",
     "svg-url-loader": "^8.0.0",
     "url-loader": "^4.1.1",
-    "webpack": "^5.88.2"
+    "webpack": "^5.92.1"
   }
 }

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -105,7 +105,7 @@
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/pmml-vscode-extension/package.json
+++ b/packages/pmml-vscode-extension/package.json
@@ -45,7 +45,7 @@
     "file-loader": "^6.2.0",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -64,7 +64,6 @@
     "@types/react-dom": "^17.0.5",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
-    "@types/webpack": "^4.41.33",
     "apollo-server-express": "^3.13.0",
     "body-parser": "^1.20.2",
     "concurrently": "^8.2.2",
@@ -95,7 +94,7 @@
     "url-loader": "^4.1.1",
     "uuid": "^8.3.2",
     "waait": "^1.0.5",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -78,7 +78,6 @@
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "@types/uuid": "^8.3.0",
-    "@types/webpack": "^4.41.33",
     "apollo-server-express": "^3.13.0",
     "body-parser": "^1.20.2",
     "concurrently": "^8.2.2",
@@ -113,7 +112,7 @@
     "url": "^0.11.3",
     "url-loader": "^4.1.1",
     "waait": "^1.0.5",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/runtime-tools-task-console-webapp/package.json
+++ b/packages/runtime-tools-task-console-webapp/package.json
@@ -68,7 +68,6 @@
     "@types/react-dom": "^17.0.5",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
-    "@types/webpack": "^4.41.33",
     "apollo-server-express": "^3.13.0",
     "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^11.0.0",
@@ -93,7 +92,7 @@
     "url-loader": "^4.1.1",
     "uuid": "^8.3.2",
     "waait": "^1.0.5",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/scesim-editor/package.json
+++ b/packages/scesim-editor/package.json
@@ -62,7 +62,7 @@
     "run-script-os": "^1.1.6",
     "storybook": "^7.3.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/serverless-logic-web-tools/package.json
+++ b/packages/serverless-logic-web-tools/package.json
@@ -143,7 +143,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "vscode-languageserver-textdocument": "^1.0.4",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/serverless-workflow-combined-editor/package.json
+++ b/packages/serverless-workflow-combined-editor/package.json
@@ -67,7 +67,7 @@
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.5.3",
     "vscode-json-languageservice": "^4.2.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/serverless-workflow-dev-ui-webapp/package.json
+++ b/packages/serverless-workflow-dev-ui-webapp/package.json
@@ -105,7 +105,7 @@
     "typescript": "^5.5.3",
     "url": "^0.11.3",
     "url-loader": "^4.1.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/serverless-workflow-standalone-editor/package.json
+++ b/packages/serverless-workflow-standalone-editor/package.json
@@ -80,7 +80,7 @@
     "vscode-json-languageservice": "^4.2.1",
     "vscode-languageserver-textdocument": "^1.0.4",
     "vscode-languageserver-types": "^3.16.0",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/serverless-workflow-text-editor/package.json
+++ b/packages/serverless-workflow-text-editor/package.json
@@ -59,7 +59,7 @@
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.5.3",
     "vscode-json-languageservice": "^4.2.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -81,7 +81,7 @@
     "selenium-webdriver": "^4.15.0",
     "typescript": "^5.5.3",
     "vscode-extension-tester": "^8.3.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/sonataflow-deployment-webapp/package.json
+++ b/packages/sonataflow-deployment-webapp/package.json
@@ -78,7 +78,7 @@
     "terser-webpack-plugin": "^5.3.9",
     "ts-jest": "^29.1.5",
     "url": "^0.11.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/storybook-base/package.json
+++ b/packages/storybook-base/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^3.0.2",
     "storybook": "^7.3.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-merge": "^5.9.0"
   }
 }

--- a/packages/stunner-editors-dmn-loader/package.json
+++ b/packages/stunner-editors-dmn-loader/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "^17.0.5",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/uniforms-bootstrap4-codegen/package.json
+++ b/packages/uniforms-bootstrap4-codegen/package.json
@@ -59,7 +59,7 @@
     "simpl-schema": "^1.12.0",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",
     "webpack-node-externals": "^3.0.0"

--- a/packages/uniforms-patternfly-codegen/package.json
+++ b/packages/uniforms-patternfly-codegen/package.json
@@ -57,7 +57,7 @@
     "simpl-schema": "^1.12.0",
     "ts-jest": "^29.1.5",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0",

--- a/packages/uniforms-patternfly/package.json
+++ b/packages/uniforms-patternfly/package.json
@@ -61,7 +61,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "uniforms-bridge-simple-schema-2": "^3.10.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/vscode-extension-dashbuilder-editor/package.json
+++ b/packages/vscode-extension-dashbuilder-editor/package.json
@@ -70,7 +70,7 @@
     "selenium-webdriver": "^4.15.0",
     "typescript": "^5.5.3",
     "vscode-extension-tester": "^8.3.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/vscode-extension-kie-ba-bundle/package.json
+++ b/packages/vscode-extension-kie-ba-bundle/package.json
@@ -30,7 +30,7 @@
     "@types/vscode": "1.67.0",
     "@vscode/vsce": "^2.22.0",
     "rimraf": "^3.0.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/vscode-extension-kogito-bundle/package.json
+++ b/packages/vscode-extension-kogito-bundle/package.json
@@ -30,7 +30,7 @@
     "@types/vscode": "1.67.0",
     "@vscode/vsce": "^2.22.0",
     "rimraf": "^3.0.2",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/webpack-base/package.json
+++ b/packages/webpack-base/package.json
@@ -25,6 +25,6 @@
     "querystring-es3": "^0.2.1",
     "source-map-loader": "^2.0.2",
     "ts-loader": "^9.4.2",
-    "webpack": "^5.88.2"
+    "webpack": "^5.92.1"
   }
 }

--- a/packages/yard-editor/package.json
+++ b/packages/yard-editor/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^3.0.2",
     "start-server-and-test": "^2.0.3",
     "typescript": "^5.5.3",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/packages/yard-model/package.json
+++ b/packages/yard-model/package.json
@@ -36,7 +36,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6",
-    "webpack": "^5.88.2"
+    "webpack": "^5.92.1"
   },
   "kieTools": {
     "requiredPreinstalledCliCommands": [

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -73,7 +73,7 @@
     "selenium-webdriver": "^4.15.0",
     "typescript": "^5.5.3",
     "vscode-extension-tester": "^8.3.1",
-    "webpack": "^5.88.2",
+    "webpack": "^5.92.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.15.1",
     "webpack-merge": "^5.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         version: 0.0.193
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -166,20 +166,20 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
       zip-webpack-plugin:
         specifier: ^4.0.1
-        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.92.1(webpack-cli@4.10.0))
 
   examples/base64png-editor-vscode-extension:
     dependencies:
@@ -224,14 +224,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -395,6 +395,9 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
+      webpack:
+        specifier: ^5.92.1
+        version: 5.92.1
 
   examples/ping-pong-view-react:
     dependencies:
@@ -532,14 +535,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -609,7 +612,7 @@ importers:
         version: 1.12.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       react-router-dom:
         specifier: ^5.3.4
         version: 5.3.4(react@17.0.2)
@@ -620,14 +623,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -724,7 +727,7 @@ importers:
         version: 5.3.3
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -738,14 +741,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -948,7 +951,7 @@ importers:
         version: 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/react-dom@17.0.8)(@types/react@17.0.21)(@types/webpack@4.41.38)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+        version: 7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -972,7 +975,7 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -981,7 +984,7 @@ importers:
         version: 7.0.3
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -1010,14 +1013,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -1130,7 +1133,7 @@ importers:
         version: 2.22.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -1138,14 +1141,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -1312,7 +1315,7 @@ importers:
         version: 4.3.10
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -1344,20 +1347,20 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
       zip-webpack-plugin:
         specifier: ^4.0.1
-        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.92.1(webpack-cli@4.10.0))
 
   packages/chrome-extension-serverless-workflow-editor:
     devDependencies:
@@ -1429,7 +1432,7 @@ importers:
         version: 3.5.5
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -1447,7 +1450,7 @@ importers:
         version: 0.39.0
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       monaco-yaml:
         specifier: ^4.0.4
         version: 4.0.4(monaco-editor@0.39.0)
@@ -1473,20 +1476,20 @@ importers:
         specifier: ^3.16.0
         version: 3.17.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
       zip-webpack-plugin:
         specifier: ^4.0.1
-        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.1(webpack-sources@3.2.3)(webpack@5.92.1(webpack-cli@4.10.0))
 
   packages/chrome-extension-test-helper:
     devDependencies:
@@ -1582,11 +1585,11 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack@5.88.2)
+        version: 4.10.0(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -1781,7 +1784,7 @@ importers:
         version: link:../tsconfig
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1789,14 +1792,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -1897,10 +1900,10 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1908,14 +1911,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2028,10 +2031,10 @@ importers:
         version: 1.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2039,14 +2042,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2104,10 +2107,10 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2115,14 +2118,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2180,13 +2183,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2194,14 +2197,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2256,10 +2259,10 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2267,14 +2270,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2347,10 +2350,10 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2358,14 +2361,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2435,13 +2438,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2449,14 +2452,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2547,7 +2550,7 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -2556,7 +2559,7 @@ importers:
         version: 3.0.1
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2570,14 +2573,14 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2732,7 +2735,7 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -2752,14 +2755,14 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -2847,13 +2850,13 @@ importers:
         version: 5.3.3
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-replace-webpack-plugin:
         specifier: ^2.6.0
         version: 2.6.0
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2861,14 +2864,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -3032,13 +3035,13 @@ importers:
         version: 5.3.3
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -3053,7 +3056,7 @@ importers:
         version: 3.6.0(jest@29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3)))
       node-polyfill-webpack-plugin:
         specifier: ^2.0.1
-        version: 2.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -3070,14 +3073,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -3308,7 +3311,7 @@ importers:
         version: 7.6.13(react@17.0.2)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+        version: 3.0.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       '@storybook/blocks':
         specifier: ^7.3.2
         version: 7.6.13(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -3323,7 +3326,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@types/d3-drag':
         specifier: ^3.0.3
         version: 3.0.7
@@ -3347,7 +3350,7 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -3359,7 +3362,7 @@ importers:
         version: 1.1.9
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -3379,14 +3382,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -3549,7 +3552,7 @@ importers:
         version: 7.6.13(react@17.0.2)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 3.0.3(webpack@5.92.1(webpack-cli@4.10.0))
       '@storybook/blocks':
         specifier: ^7.3.2
         version: 7.6.13(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -3564,7 +3567,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.23.9)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@types/jest-when':
         specifier: ^3.5.5
         version: 3.5.5
@@ -3597,7 +3600,7 @@ importers:
         version: 9.5.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(webpack-cli@4.10.0))
       junit-report-merger:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3618,7 +3621,7 @@ importers:
         version: 0.11.10
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(webpack-cli@4.10.0))
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -3638,17 +3641,17 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -3988,7 +3991,7 @@ importers:
         version: 6.0.3
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -3999,14 +4002,14 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -4369,7 +4372,7 @@ importers:
         version: 2.22.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.1
@@ -4377,14 +4380,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -4457,13 +4460,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -4483,14 +4486,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -4816,14 +4819,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -4988,14 +4991,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -5080,13 +5083,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       identity-obj-proxy:
         specifier: ^3.0.0
         version: 3.0.0
@@ -5115,14 +5118,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -5548,13 +5551,13 @@ importers:
         version: 4.3.10
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cpr:
         specifier: ^3.0.1
         version: 3.0.1
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       mocha:
         specifier: ^10.6.0
         version: 10.6.0
@@ -5583,14 +5586,14 @@ importers:
         specifier: ^8.3.1
         version: 8.3.1(mocha@10.6.0)(typescript@5.5.3)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -5671,7 +5674,7 @@ importers:
         version: 1.11.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cypress:
         specifier: ^13.13.0
         version: 13.13.0
@@ -5689,7 +5692,7 @@ importers:
         version: 9.5.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -5713,7 +5716,7 @@ importers:
         version: 0.11.10
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(webpack-cli@4.10.0))
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -5742,14 +5745,14 @@ importers:
         specifier: ^1.13.1
         version: 1.13.1
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -6106,31 +6109,31 @@ importers:
         version: link:../tsconfig
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 2.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@5.5.3)(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 9.4.2(typescript@5.5.3)(webpack@5.92.1(webpack-cli@4.10.0))
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2(webpack-cli@4.10.0)))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(webpack-cli@4.10.0)))(webpack@5.92.1(webpack-cli@4.10.0))
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -6411,13 +6414,13 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       html-replace-webpack-plugin:
         specifier: ^2.6.0
         version: 2.6.0
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -6446,14 +6449,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -6492,31 +6495,31 @@ importers:
         version: link:../root-env
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2)
+        version: 5.2.7(webpack@5.92.1)
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2)
+        version: 6.2.0(webpack@5.92.1)
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2)
+        version: 4.0.2(webpack@5.92.1)
       sass:
         specifier: ^1.43.4
         version: 1.49.9
       sass-loader:
         specifier: ^12.3.0
-        version: 12.4.0(sass@1.49.9)(webpack@5.88.2)
+        version: 12.4.0(sass@1.49.9)(webpack@5.92.1)
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2)
+        version: 2.0.0(webpack@5.92.1)
       svg-url-loader:
         specifier: ^8.0.0
-        version: 8.0.0(webpack@5.88.2)
+        version: 8.0.0(webpack@5.92.1)
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2))(webpack@5.88.2)
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1))(webpack@5.92.1)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2
+        specifier: ^5.92.1
+        version: 5.92.1
 
   packages/playwright-base:
     devDependencies:
@@ -6685,7 +6688,7 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -6706,7 +6709,7 @@ importers:
         version: 1.1.2
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -6738,14 +6741,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -6855,7 +6858,7 @@ importers:
         version: 2.22.0
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -6863,14 +6866,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -7112,16 +7115,16 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
-        version: 7.23.9
+        version: 7.24.9
       '@babel/preset-env':
         specifier: ^7.16.0
-        version: 7.23.9(@babel/core@7.23.9)
+        version: 7.24.7(@babel/core@7.24.9)
       '@graphql-codegen/add':
         specifier: ^3.2.3
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.23.9)(@swc/core@1.3.92)(@types/node@22.0.2)(encoding@0.1.13)(enquirer@2.3.6)(graphql@14.3.1)(typescript@5.5.3)
+        version: 2.16.5(@babel/core@7.24.9)(@swc/core@1.3.92)(@types/node@22.0.2)(encoding@0.1.13)(enquirer@2.3.6)(graphql@14.3.1)(typescript@5.5.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -7158,9 +7161,6 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
-      '@types/webpack':
-        specifier: ^4.41.33
-        version: 4.41.38
       apollo-server-express:
         specifier: ^3.13.0
         version: 3.13.0(encoding@0.1.13)(express@4.19.2)(graphql@14.3.1)
@@ -7172,7 +7172,7 @@ importers:
         version: 8.2.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       core-js:
         specifier: 3.6.5
         version: 3.6.5
@@ -7181,19 +7181,19 @@ importers:
         version: 2.8.5
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       css-minimizer-webpack-plugin:
         specifier: ^5.0.1
-        version: 5.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       express:
         specifier: ^4.19.2
         version: 4.19.2
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       https-browserify:
         specifier: ^1.0.0
         version: 1.0.0
@@ -7205,7 +7205,7 @@ importers:
         version: 4.17.21
       mini-css-extract-plugin:
         specifier: ^2.7.6
-        version: 2.8.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.9.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       nodemon:
         specifier: ^3.1.4
         version: 3.1.4
@@ -7214,7 +7214,7 @@ importers:
         version: 3.0.2
       sass-loader:
         specifier: ^12.3.0
-        version: 12.4.0(sass@1.77.6)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 12.4.0(sass@1.77.6)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       serve:
         specifier: ^12.0.1
         version: 12.0.1
@@ -7226,13 +7226,13 @@ importers:
         version: 3.2.0
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       svg-url-loader:
         specifier: ^8.0.0
-        version: 8.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 8.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 9.4.2(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       tsconfig-paths-webpack-plugin:
         specifier: ^3.5.2
         version: 3.5.2
@@ -7244,7 +7244,7 @@ importers:
         version: 0.11.3
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -7252,17 +7252,17 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
-        version: 5.9.0
+        version: 5.10.0
 
   packages/runtime-tools-process-dev-ui-webapp:
     dependencies:
@@ -7310,7 +7310,7 @@ importers:
         version: 4.224.2
       '@patternfly/react-code-editor':
         specifier: 4.82.113
-        version: 4.82.113(react-dom@17.0.2(react@17.0.2))(react-monaco-editor@0.51.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2))(react@17.0.2)
+        version: 4.82.113(react-dom@17.0.2(react@17.0.2))(react-monaco-editor@0.49.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2))(react@17.0.2)
       '@patternfly/react-core':
         specifier: ^4.276.6
         version: 4.276.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -7371,19 +7371,19 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
-        version: 7.23.9
+        version: 7.24.9
       '@babel/preset-env':
         specifier: ^7.16.0
-        version: 7.23.9(@babel/core@7.23.9)
+        version: 7.24.7(@babel/core@7.24.9)
       '@babel/preset-react':
         specifier: ^7.16.0
-        version: 7.22.15(@babel/core@7.23.9)
+        version: 7.22.15(@babel/core@7.24.9)
       '@graphql-codegen/add':
         specifier: ^3.2.3
         version: 3.2.3(graphql@14.3.1)
       '@graphql-codegen/cli':
         specifier: ^2.16.5
-        version: 2.16.5(@babel/core@7.23.9)(@swc/core@1.3.92)(@types/node@22.0.2)(encoding@0.1.13)(enquirer@2.3.6)(graphql@14.3.1)(typescript@5.5.3)
+        version: 2.16.5(@babel/core@7.24.9)(@swc/core@1.3.92)(@types/node@22.0.2)(encoding@0.1.13)(enquirer@2.3.6)(graphql@14.3.1)(typescript@5.5.3)
       '@graphql-codegen/introspection':
         specifier: ^2.2.3
         version: 2.2.3(encoding@0.1.13)(graphql@14.3.1)
@@ -7410,7 +7410,7 @@ importers:
         version: link:../tsconfig
       '@types/history':
         specifier: ^4.7.3
-        version: 4.7.5
+        version: 4.7.11
       '@types/react':
         specifier: ^17.0.6
         version: 17.0.21
@@ -7426,9 +7426,6 @@ importers:
       '@types/uuid':
         specifier: ^8.3.0
         version: 8.3.0
-      '@types/webpack':
-        specifier: ^4.41.33
-        version: 4.41.38
       apollo-server-express:
         specifier: ^3.13.0
         version: 3.13.0(encoding@0.1.13)(express@4.19.2)(graphql@14.3.1)
@@ -7440,7 +7437,7 @@ importers:
         version: 8.2.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       core-js:
         specifier: 3.6.5
         version: 3.6.5
@@ -7449,25 +7446,25 @@ importers:
         version: 2.8.5
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       css-minimizer-webpack-plugin:
         specifier: ^5.0.1
-        version: 5.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       express:
         specifier: ^4.19.2
         version: 4.19.2
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       filemanager-webpack-plugin:
         specifier: ^7.0.0
-        version: 7.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 7.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       graphql:
         specifier: 14.3.1
         version: 14.3.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       https-browserify:
         specifier: ^1.0.0
         version: 1.0.0
@@ -7476,13 +7473,13 @@ importers:
         version: 3.0.0
       mini-css-extract-plugin:
         specifier: ^2.7.6
-        version: 2.8.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.9.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       node-polyfill-webpack-plugin:
         specifier: ^2.0.1
-        version: 2.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       nodemon:
         specifier: ^3.1.4
         version: 3.1.4
@@ -7491,28 +7488,28 @@ importers:
         version: 7.2.3
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       sass-loader:
         specifier: ^12.3.0
-        version: 12.4.0(sass@1.77.6)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 12.4.0(sass@1.77.6)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       stream-http:
         specifier: ^3.2.0
         version: 3.2.0
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       svg-url-loader:
         specifier: ^8.0.0
-        version: 8.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 8.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       swagger-ui-express:
         specifier: ^5.0.0
         version: 5.0.0(express@4.19.2)
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 9.4.2(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       tsconfig-paths-webpack-plugin:
         specifier: ^3.5.2
         version: 3.5.2
@@ -7524,22 +7521,22 @@ importers:
         version: 0.11.3
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       waait:
         specifier: ^1.0.5
         version: 1.0.5
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
-        version: 5.9.0
+        version: 5.10.0
 
   packages/runtime-tools-process-enveloped-components:
     dependencies:
@@ -8599,9 +8596,6 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
-      '@types/webpack':
-        specifier: ^4.41.33
-        version: 4.41.38
       apollo-server-express:
         specifier: ^3.13.0
         version: 3.13.0(encoding@0.1.13)(express@4.19.2)(graphql@14.3.1)
@@ -8610,22 +8604,22 @@ importers:
         version: 8.2.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       css-minimizer-webpack-plugin:
         specifier: ^5.0.1
-        version: 5.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       express:
         specifier: ^4.19.2
         version: 4.19.2
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       https-browserify:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8634,7 +8628,7 @@ importers:
         version: 3.0.0
       mini-css-extract-plugin:
         specifier: ^2.7.6
-        version: 2.8.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.8.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       nodemon:
         specifier: ^3.1.4
         version: 3.1.4
@@ -8643,19 +8637,19 @@ importers:
         version: 3.0.2
       sass-loader:
         specifier: ^12.3.0
-        version: 12.4.0(sass@1.77.6)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 12.4.0(sass@1.77.6)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       stream-http:
         specifier: ^3.2.0
         version: 3.2.0
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       svg-url-loader:
         specifier: ^8.0.0
-        version: 8.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 8.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 9.4.2(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       tsconfig-paths-webpack-plugin:
         specifier: ^3.5.2
         version: 3.5.2
@@ -8667,7 +8661,7 @@ importers:
         version: 0.11.3
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -8675,14 +8669,14 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -8776,7 +8770,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.18.10)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.18.10)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@types/lodash':
         specifier: ^4.14.168
         version: 4.14.169
@@ -8797,13 +8791,13 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -8817,14 +8811,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -9165,7 +9159,7 @@ importers:
         version: 8.3.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       cypress:
         specifier: ^13.13.0
         version: 13.13.0
@@ -9186,7 +9180,7 @@ importers:
         version: 2.6.0
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -9210,10 +9204,10 @@ importers:
         version: 3.0.5
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       node-polyfill-webpack-plugin:
         specifier: ^2.0.1
-        version: 2.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 2.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -9236,14 +9230,14 @@ importers:
         specifier: ^1.0.4
         version: 1.0.7
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -9446,13 +9440,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -9466,14 +9460,14 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -9640,28 +9634,28 @@ importers:
         version: 8.2.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cors:
         specifier: ^2.8.5
         version: 2.8.5
       css-loader:
         specifier: ^5.2.6
-        version: 5.2.7(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.92.1(webpack-cli@4.10.0))
       express:
         specifier: ^4.19.2
         version: 4.19.2
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
       filemanager-webpack-plugin:
         specifier: ^7.0.0
-        version: 7.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       graphql:
         specifier: 14.3.1
         version: 14.3.1
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.5.3(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.5.3(webpack@5.92.1(webpack-cli@4.10.0))
       https-browserify:
         specifier: ^1.0.0
         version: 1.0.0
@@ -9682,28 +9676,28 @@ importers:
         version: 4.17.21
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       node-polyfill-webpack-plugin:
         specifier: ^2.0.1
-        version: 2.0.1(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 2.0.1(webpack@5.92.1(webpack-cli@4.10.0))
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
       sass-loader:
         specifier: ^12.3.0
-        version: 12.4.0(sass@1.77.6)(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 12.4.0(sass@1.77.6)(webpack@5.92.1(webpack-cli@4.10.0))
       stream-http:
         specifier: ^3.2.0
         version: 3.2.0
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 2.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       svg-url-loader:
         specifier: ^8.0.0
-        version: 8.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 8.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       swagger-ui-express:
         specifier: ^5.0.0
         version: 5.0.0(express@4.19.2)
@@ -9718,16 +9712,16 @@ importers:
         version: 0.11.3
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.88.2(webpack-cli@4.10.0)))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(webpack-cli@4.10.0)))(webpack@5.92.1(webpack-cli@4.10.0))
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10148,13 +10142,13 @@ importers:
         version: 1.11.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       filemanager-webpack-plugin:
         specifier: ^7.0.0
-        version: 7.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.3.2
-        version: 5.3.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.2(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -10175,13 +10169,13 @@ importers:
         version: 0.39.0
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       monaco-yaml:
         specifier: ^4.0.4
         version: 4.0.4(monaco-editor@0.39.0)
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(webpack-cli@4.10.0))
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -10219,14 +10213,14 @@ importers:
         specifier: ^3.16.0
         version: 3.17.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10320,10 +10314,10 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -10337,14 +10331,14 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10462,7 +10456,7 @@ importers:
         version: 4.3.10
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cpr:
         specifier: ^3.0.1
         version: 3.0.1
@@ -10480,7 +10474,7 @@ importers:
         version: 1.5.1(mocha@10.6.0)
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -10500,14 +10494,14 @@ importers:
         specifier: ^8.3.1
         version: 8.3.1(mocha@10.6.0)(typescript@5.5.3)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10670,7 +10664,7 @@ importers:
         version: 5.3.3
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -10682,10 +10676,10 @@ importers:
         version: 16.0.0
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       node-polyfill-webpack-plugin:
         specifier: ^2.0.1
-        version: 2.0.1(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 2.0.1(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -10694,7 +10688,7 @@ importers:
         version: 3.2.0
       terser-webpack-plugin:
         specifier: ^5.3.9
-        version: 5.3.9(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 5.3.9(webpack@5.92.1(webpack-cli@4.10.0))
       ts-jest:
         specifier: ^29.1.5
         version: 29.1.5(@babel/core@7.18.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.10))(jest@29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3)))(typescript@5.5.3)
@@ -10702,14 +10696,14 @@ importers:
         specifier: ^0.11.3
         version: 0.11.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10842,10 +10836,10 @@ importers:
         version: 7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.88.2(esbuild@0.18.20))
+        version: 3.0.3(webpack@5.92.1(esbuild@0.18.20))
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.4.6(@babel/core@7.23.9)(@types/react-dom@17.0.8)(@types/react@17.0.21)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)
+        version: 7.4.6(@babel/core@7.23.9)(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: ^7.3.2
         version: 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -10862,8 +10856,8 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(esbuild@0.18.20)
+        specifier: ^5.92.1
+        version: 5.92.1(esbuild@0.18.20)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -10959,14 +10953,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11168,7 +11162,7 @@ importers:
         version: 1.11.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2)
+        version: 11.0.0(webpack@5.92.1)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -11183,7 +11177,7 @@ importers:
         version: 3.6.0(jest@29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3)))
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2)
+        version: 4.0.2(webpack@5.92.1)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11197,11 +11191,11 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2
+        specifier: ^5.92.1
+        version: 5.92.1
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack@5.88.2)
+        version: 4.15.1(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11277,7 +11271,7 @@ importers:
         version: 1.12.2
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))
@@ -11306,14 +11300,14 @@ importers:
         specifier: ^3.10.2
         version: 3.10.2(react@17.0.2)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11392,7 +11386,7 @@ importers:
         version: 1.12.0
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3))
@@ -11407,7 +11401,7 @@ importers:
         version: 3.6.0(jest@29.7.0(@types/node@22.0.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3)))
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 4.0.2(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11421,14 +11415,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11853,7 +11847,7 @@ importers:
         version: 4.3.10
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       cpr:
         specifier: ^3.0.1
         version: 3.0.1
@@ -11888,14 +11882,14 @@ importers:
         specifier: ^8.3.1
         version: 8.3.1(mocha@10.6.0)(typescript@5.5.3)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11924,14 +11918,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -11960,14 +11954,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -12040,13 +12034,13 @@ importers:
         version: 0.2.1
       source-map-loader:
         specifier: ^2.0.2
-        version: 2.0.2(webpack@5.88.2)
+        version: 2.0.2(webpack@5.92.1)
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@5.5.3)(webpack@5.88.2)
+        version: 9.4.2(typescript@5.5.3)(webpack@5.92.1)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2
+        specifier: ^5.92.1
+        version: 5.92.1
 
   packages/workspace:
     dependencies:
@@ -12465,13 +12459,13 @@ importers:
         version: 17.0.8
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 11.0.0(webpack@5.92.1(webpack-cli@4.10.0))
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -12482,14 +12476,14 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -12560,7 +12554,7 @@ importers:
         version: link:../root-env
       copy-webpack-plugin:
         specifier: ^11.0.0
-        version: 11.0.0(webpack@5.88.2)
+        version: 11.0.0(webpack@5.92.1)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -12568,8 +12562,8 @@ importers:
         specifier: ^1.1.6
         version: 1.1.6
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2
+        specifier: ^5.92.1
+        version: 5.92.1
 
   packages/yard-validator:
     dependencies:
@@ -12737,7 +12731,7 @@ importers:
         version: 1.5.1(mocha@10.6.0)
       monaco-editor-webpack-plugin:
         specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0))
+        version: 7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -12757,14 +12751,14 @@ importers:
         specifier: ^8.3.1
         version: 8.3.1(mocha@10.6.0)(typescript@5.5.3)
       webpack:
-        specifier: ^5.88.2
-        version: 5.88.2(webpack-cli@4.10.0)
+        specifier: ^5.92.1
+        version: 5.92.1(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.9.0
@@ -18586,9 +18580,6 @@ packages:
   '@types/estree@0.0.51':
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
-  '@types/estree@1.0.1':
-    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
-
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
@@ -18910,17 +18901,11 @@ packages:
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
-  '@types/source-list-map@0.1.6':
-    resolution: {integrity: sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==}
-
   '@types/ssri@7.1.1':
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==}
 
   '@types/stack-utils@2.0.0':
     resolution: {integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==}
-
-  '@types/tapable@1.0.12':
-    resolution: {integrity: sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==}
 
   '@types/through@0.0.30':
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
@@ -18930,9 +18915,6 @@ packages:
 
   '@types/treeify@1.0.0':
     resolution: {integrity: sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==}
-
-  '@types/uglify-js@3.17.5':
-    resolution: {integrity: sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==}
 
   '@types/underscore@1.11.2':
     resolution: {integrity: sha512-Ls2ylbo7++ITrWk2Yc3G/jijwSq5V3GT0tlgVXEl2kKYXY3ImrtmTCoE2uyTWFRI5owMBriloZFWbE1SXOsE7w==}
@@ -18945,12 +18927,6 @@ packages:
 
   '@types/vscode@1.67.0':
     resolution: {integrity: sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==}
-
-  '@types/webpack-sources@3.2.3':
-    resolution: {integrity: sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==}
-
-  '@types/webpack@4.41.38':
-    resolution: {integrity: sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==}
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -19115,9 +19091,6 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
-  '@webassemblyjs/ast@1.11.6':
-    resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
-
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
 
@@ -19127,9 +19100,6 @@ packages:
   '@webassemblyjs/helper-api-error@1.11.6':
     resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
 
-  '@webassemblyjs/helper-buffer@1.11.6':
-    resolution: {integrity: sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==}
-
   '@webassemblyjs/helper-buffer@1.12.1':
     resolution: {integrity: sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==}
 
@@ -19138,9 +19108,6 @@ packages:
 
   '@webassemblyjs/helper-wasm-bytecode@1.11.6':
     resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
-
-  '@webassemblyjs/helper-wasm-section@1.11.6':
-    resolution: {integrity: sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==}
 
   '@webassemblyjs/helper-wasm-section@1.12.1':
     resolution: {integrity: sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==}
@@ -19154,32 +19121,17 @@ packages:
   '@webassemblyjs/utf8@1.11.6':
     resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
 
-  '@webassemblyjs/wasm-edit@1.11.6':
-    resolution: {integrity: sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==}
-
   '@webassemblyjs/wasm-edit@1.12.1':
     resolution: {integrity: sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==}
-
-  '@webassemblyjs/wasm-gen@1.11.6':
-    resolution: {integrity: sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==}
 
   '@webassemblyjs/wasm-gen@1.12.1':
     resolution: {integrity: sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==}
 
-  '@webassemblyjs/wasm-opt@1.11.6':
-    resolution: {integrity: sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==}
-
   '@webassemblyjs/wasm-opt@1.12.1':
     resolution: {integrity: sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==}
 
-  '@webassemblyjs/wasm-parser@1.11.6':
-    resolution: {integrity: sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==}
-
   '@webassemblyjs/wasm-parser@1.12.1':
     resolution: {integrity: sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==}
-
-  '@webassemblyjs/wast-printer@1.11.6':
-    resolution: {integrity: sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==}
 
   '@webassemblyjs/wast-printer@1.12.1':
     resolution: {integrity: sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==}
@@ -19378,11 +19330,6 @@ packages:
 
   acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
-
-  acorn-import-assertions@1.9.0:
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    peerDependencies:
-      acorn: ^8
 
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
@@ -20144,11 +20091,6 @@ packages:
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
-  browserslist@4.22.1:
-    resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -20307,9 +20249,6 @@ packages:
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
-
-  caniuse-lite@1.0.30001547:
-    resolution: {integrity: sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==}
 
   caniuse-lite@1.0.30001600:
     resolution: {integrity: sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==}
@@ -21624,9 +21563,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.4.549:
-    resolution: {integrity: sha512-gpXfJslSi4hYDkA0mTLEpYKRv9siAgSUgZ+UWyk+J5Cttpd1ThCVwdclzIwQSclz3hYn049+M2fgrP1WpvF8xg==}
-
   electron-to-chromium@1.4.719:
     resolution: {integrity: sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==}
 
@@ -21773,9 +21709,6 @@ packages:
 
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
-
-  es-module-lexer@1.3.0:
-    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
 
   es-module-lexer@1.4.1:
     resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
@@ -24941,9 +24874,6 @@ packages:
     peerDependencies:
       webpack: '>=5'
 
-  node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
-
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
 
@@ -25711,32 +25641,14 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss-modules-extract-imports@3.0.0:
-    resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
-    engines: {node: ^10 || ^12 || >= 14}
-    peerDependencies:
-      postcss: ^8.1.0
-
   postcss-modules-extract-imports@3.1.0:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
 
-  postcss-modules-local-by-default@4.0.0:
-    resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
-    engines: {node: ^10 || ^12 || >= 14}
-    peerDependencies:
-      postcss: ^8.1.0
-
   postcss-modules-local-by-default@4.0.5:
     resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
-    engines: {node: ^10 || ^12 || >= 14}
-    peerDependencies:
-      postcss: ^8.1.0
-
-  postcss-modules-scope@3.0.0:
-    resolution: {integrity: sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
@@ -25843,10 +25755,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.12:
-    resolution: {integrity: sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
@@ -26308,13 +26216,6 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.6
       monaco-editor: ^0.33.0
-      react: '>=17 <= 18'
-
-  react-monaco-editor@0.51.0:
-    resolution: {integrity: sha512-6jx1V8p6gHVKJHFaTvicOtmlhFjOJhekobeNd92ZAo7F5UvAin1cF7bxWLCKgtxClYZ7CB3Ar284Kpbhj22FpQ==}
-    peerDependencies:
-      '@types/react': ^17.0.6
-      monaco-editor: ^0.34.1
       react: '>=17 <= 18'
 
   react-pure-loaders@3.0.1:
@@ -28598,10 +28499,6 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
-  watchpack@2.4.0:
-    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
-    engines: {node: '>=10.13.0'}
-
   watchpack@2.4.1:
     resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
     engines: {node: '>=10.13.0'}
@@ -28738,16 +28635,6 @@ packages:
 
   webpack-virtual-modules@0.5.0:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
-
-  webpack@5.88.2:
-    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
 
   webpack@5.92.1:
     resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
@@ -29148,7 +29035,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1801.3(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1801.3(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1))(webpack@5.92.1)
+      '@angular-devkit/build-webpack': 0.1801.3(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1))(webpack@5.92.1(esbuild@0.21.5))
       '@angular-devkit/core': 18.1.3(chokidar@3.6.0)
       '@angular/build': 18.1.3(@angular/compiler-cli@18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3))(@types/node@22.0.2)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(terser@5.29.2)(typescript@5.5.3)
       '@angular/compiler-cli': 18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3)
@@ -29162,15 +29049,15 @@ snapshots:
       '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
       '@babel/runtime': 7.24.7
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 18.1.3(@angular/compiler-cli@18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1)
+      '@ngtools/webpack': 18.1.3(@angular/compiler-cli@18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(esbuild@0.21.5))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@22.0.2)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5))
       browserslist: 4.23.0
-      copy-webpack-plugin: 12.0.2(webpack@5.92.1)
+      copy-webpack-plugin: 12.0.2(webpack@5.92.1(esbuild@0.21.5))
       critters: 0.0.24
-      css-loader: 7.1.2(webpack@5.92.1)
+      css-loader: 7.1.2(webpack@5.92.1(esbuild@0.21.5))
       esbuild-wasm: 0.21.5
       fast-glob: 3.3.2
       http-proxy-middleware: 3.0.0
@@ -29179,11 +29066,11 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 12.2.0(less@4.2.0)(webpack@5.92.1)
-      license-webpack-plugin: 4.0.2(webpack@5.92.1)
+      less-loader: 12.2.0(less@4.2.0)(webpack@5.92.1(esbuild@0.21.5))
+      license-webpack-plugin: 4.0.2(webpack@5.92.1(esbuild@0.21.5))
       loader-utils: 3.3.1
       magic-string: 0.30.10
-      mini-css-extract-plugin: 2.9.0(webpack@5.92.1)
+      mini-css-extract-plugin: 2.9.0(webpack@5.92.1(esbuild@0.21.5))
       mrmime: 2.0.0
       open: 10.1.0
       ora: 5.4.1
@@ -29191,13 +29078,13 @@ snapshots:
       picomatch: 4.0.2
       piscina: 4.6.1
       postcss: 8.4.38
-      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1)
+      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1(esbuild@0.21.5))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.77.6
-      sass-loader: 14.2.1(sass@1.77.6)(webpack@5.92.1)
+      sass-loader: 14.2.1(sass@1.77.6)(webpack@5.92.1(esbuild@0.21.5))
       semver: 7.6.2
-      source-map-loader: 5.0.0(webpack@5.92.1)
+      source-map-loader: 5.0.0(webpack@5.92.1(esbuild@0.21.5))
       source-map-support: 0.5.21
       terser: 5.29.2
       tree-kill: 1.2.2
@@ -29207,10 +29094,10 @@ snapshots:
       vite: 5.3.2(@types/node@22.0.2)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.29.2)
       watchpack: 2.4.1
       webpack: 5.92.1(esbuild@0.21.5)
-      webpack-dev-middleware: 7.2.1(webpack@5.92.1)
-      webpack-dev-server: 5.0.4(webpack@5.92.1)
+      webpack-dev-middleware: 7.2.1(webpack@5.92.1(esbuild@0.21.5))
+      webpack-dev-server: 5.0.4(webpack@5.92.1(esbuild@0.21.5))
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.92.1))(webpack@5.92.1)
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.92.1))(webpack@5.92.1(esbuild@0.21.5))
     optionalDependencies:
       esbuild: 0.21.5
       jest: 29.7.0(@types/node@22.0.2)
@@ -29234,12 +29121,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1801.3(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1))(webpack@5.92.1)':
+  '@angular-devkit/build-webpack@0.1801.3(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1))(webpack@5.92.1(esbuild@0.21.5))':
     dependencies:
       '@angular-devkit/architect': 0.1801.3(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.92.1(esbuild@0.21.5)
-      webpack-dev-server: 5.0.4(webpack@5.92.1)
+      webpack-dev-server: 5.0.4(webpack@5.92.1(esbuild@0.21.5))
     transitivePeerDependencies:
       - chokidar
 
@@ -29276,7 +29163,7 @@ snapshots:
       '@inquirer/confirm': 3.1.11
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@22.0.2)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.29.2))
       ansi-colors: 4.1.3
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       critters: 0.0.24
       esbuild: 0.21.5
       fast-glob: 3.3.2
@@ -29627,13 +29514,13 @@ snapshots:
 
   '@ardatan/relay-compiler@12.0.0(encoding@0.1.13)(graphql@14.3.1)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/generator': 7.23.6
-      '@babel/parser': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/generator': 7.25.0
+      '@babel/parser': 7.25.3
       '@babel/runtime': 7.23.6
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
-      babel-preset-fbjs: 3.4.0(@babel/core@7.23.9)
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
+      babel-preset-fbjs: 3.4.0(@babel/core@7.24.9)
       chalk: 4.1.2
       fb-watchman: 2.0.1
       fbjs: 3.0.2(encoding@0.1.13)
@@ -29763,7 +29650,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/compat-data@7.17.7': {}
 
@@ -29877,7 +29764,7 @@ snapshots:
 
   '@babel/core@7.24.9':
     dependencies:
-      '@ampproject/remapping': 2.2.0
+      '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.25.0
       '@babel/helper-compilation-targets': 7.25.2
@@ -29944,11 +29831,11 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.18.6':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
@@ -29956,11 +29843,11 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.21.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.22.15':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
@@ -29990,7 +29877,7 @@ snapshots:
       '@babel/compat-data': 7.23.5
       '@babel/core': 7.18.10
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -29998,7 +29885,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -30006,7 +29893,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -30096,6 +29983,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.8
+      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.24.9)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/traverse': 7.25.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-regexp-features-plugin@7.21.8(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -30159,10 +30059,17 @@ snapshots:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
+  '@babel/helper-create-regexp-features-plugin@7.25.2(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.24.7
+      regexpu-core: 5.3.2
+      semver: 6.3.1
+
   '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.5
       lodash.debounce: 4.0.8
@@ -30174,7 +30081,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.5
       lodash.debounce: 4.0.8
@@ -30186,7 +30093,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.24.9)':
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.5
       lodash.debounce: 4.0.8
@@ -30198,8 +30105,8 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -30209,8 +30116,8 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -30220,8 +30127,8 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -30231,6 +30138,17 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      debug: 4.3.5
+      lodash.debounce: 4.0.8
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.5
@@ -30258,8 +30176,8 @@ snapshots:
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
-      '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/template': 7.25.0
+      '@babel/types': 7.25.2
 
   '@babel/helper-hoist-variables@7.16.7':
     dependencies:
@@ -30267,11 +30185,11 @@ snapshots:
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-member-expression-to-functions@7.23.0':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
@@ -30282,7 +30200,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
@@ -30393,7 +30311,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-optimise-call-expression@7.24.7':
     dependencies:
@@ -30413,7 +30331,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.24.9)':
     dependencies:
@@ -30421,7 +30339,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.18.10)':
     dependencies:
@@ -30447,6 +30365,15 @@ snapshots:
   '@babel/helper-remap-async-to-generator@7.25.0(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-wrap-function': 7.25.0
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-remap-async-to-generator@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-wrap-function': 7.25.0
       '@babel/traverse': 7.25.3
@@ -30497,9 +30424,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-member-expression-to-functions': 7.24.8
+      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-simple-access@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
@@ -30510,7 +30446,7 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
@@ -30525,11 +30461,11 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.18.6':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
@@ -30556,8 +30492,8 @@ snapshots:
   '@babel/helper-wrap-function@7.22.20':
     dependencies:
       '@babel/helper-function-name': 7.23.0
-      '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/template': 7.25.0
+      '@babel/types': 7.25.2
 
   '@babel/helper-wrap-function@7.25.0':
     dependencies:
@@ -30621,7 +30557,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/parser@7.17.9':
     dependencies:
@@ -30650,6 +30586,14 @@ snapshots:
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/traverse': 7.25.3
     transitivePeerDependencies:
@@ -30688,6 +30632,11 @@ snapshots:
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.16.7(@babel/core@7.16.12)':
@@ -30741,6 +30690,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.9)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -30756,6 +30714,14 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/traverse': 7.25.3
     transitivePeerDependencies:
@@ -30801,10 +30767,10 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.18.10)
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.9)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-proposal-class-static-block@7.17.6(@babel/core@7.16.12)':
@@ -30918,11 +30884,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.18.10)
 
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.9)':
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -30969,14 +30935,14 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.18.10)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.18.10)
 
-  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.9)':
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.9)':
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.9)
 
   '@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -31023,13 +30989,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.18.10)
-
-  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.9)':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.9)':
     dependencies:
@@ -31091,6 +31050,10 @@ snapshots:
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
 
   '@babel/plugin-proposal-unicode-property-regex@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -31155,31 +31118,30 @@ snapshots:
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
     optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
     optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
     optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.9)':
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.22.5
-    optional: true
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.16.12)':
     dependencies:
@@ -31304,22 +31266,27 @@ snapshots:
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.18.10)':
     dependencies:
@@ -31341,9 +31308,19 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.23.0)':
@@ -31366,38 +31343,42 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
     optional: true
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
     optional: true
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.9)':
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.22.5
-    optional: true
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.16.12)':
     dependencies:
@@ -31714,6 +31695,11 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -31730,6 +31716,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-arrow-functions@7.16.7(@babel/core@7.16.12)':
@@ -31767,6 +31759,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-async-generator-functions@7.22.15(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -31798,6 +31795,16 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.24.7)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-generator-functions@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -31852,6 +31859,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.24.9)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-block-scoped-functions@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -31885,6 +31901,11 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-block-scoping@7.16.7(@babel/core@7.16.12)':
@@ -31922,6 +31943,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -31944,6 +31970,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -31975,6 +32009,15 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -32064,6 +32107,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-classes@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.24.9)
+      '@babel/traverse': 7.25.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-computed-properties@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -32104,6 +32159,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
+  '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/template': 7.25.0
+
   '@babel/plugin-transform-destructuring@7.17.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -32137,6 +32198,11 @@ snapshots:
   '@babel/plugin-transform-destructuring@7.24.8(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-destructuring@7.24.8(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.16.12)':
@@ -32199,6 +32265,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -32234,6 +32306,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-dynamic-import@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32257,6 +32334,12 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-transform-exponentiation-operator@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -32302,6 +32385,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-export-namespace-from@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32326,29 +32417,41 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
 
+  '@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.9)
+
   '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.16.12)
 
   '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.18.10)
 
   '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.23.0)
 
   '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.23.9)
+
+  '@babel/plugin-transform-flow-strip-types@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.24.9)
 
   '@babel/plugin-transform-for-of@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -32385,6 +32488,14 @@ snapshots:
   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -32441,6 +32552,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.25.1(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-json-strings@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32464,6 +32584,12 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-transform-literals@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -32500,6 +32626,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-literals@7.25.2(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-logical-assignment-operators@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32523,6 +32654,12 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.9)
 
   '@babel/plugin-transform-member-expression-literals@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -32557,6 +32694,11 @@ snapshots:
   '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.16.12)':
@@ -32601,6 +32743,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -32663,10 +32813,26 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
+  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+
   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-simple-access': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.24.7
     transitivePeerDependencies:
@@ -32732,6 +32898,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.25.0(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/traverse': 7.25.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-umd@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -32776,6 +32952,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.16.8(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -32808,6 +32992,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-new-target@7.16.7(@babel/core@7.16.12)':
@@ -32845,6 +33035,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-nullish-coalescing-operator@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32869,6 +33064,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
+
   '@babel/plugin-transform-numeric-separator@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32892,6 +33093,12 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.9)
 
   '@babel/plugin-transform-object-rest-spread@7.22.15(@babel/core@7.23.0)':
     dependencies:
@@ -32927,6 +33134,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.9)
 
   '@babel/plugin-transform-object-super@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -32972,6 +33187,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.24.9)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-optional-catch-binding@7.22.11(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -32995,6 +33218,12 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+
+  '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-transform-optional-chaining@7.23.0(@babel/core@7.23.0)':
     dependencies:
@@ -33023,6 +33252,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-optional-chaining@7.24.8(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -33076,6 +33314,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -33098,6 +33341,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -33136,6 +33387,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.9)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-property-literals@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33171,10 +33432,15 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-react-constant-elements@7.17.12(@babel/core@7.23.9)':
+  '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-react-constant-elements@7.17.12(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-display-name@7.16.0(@babel/core@7.16.12)':
     dependencies:
@@ -33211,6 +33477,11 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-react-jsx-development@7.16.0(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33245,6 +33516,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.9)
+
+  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.9)
 
   '@babel/plugin-transform-react-jsx@7.16.0(@babel/core@7.16.12)':
     dependencies:
@@ -33360,6 +33636,12 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-regenerator@7.17.9(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33400,6 +33682,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
+  '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      regenerator-transform: 0.15.2
+
   '@babel/plugin-transform-reserved-words@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33433,6 +33721,11 @@ snapshots:
   '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.24.7)':
@@ -33482,6 +33775,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-spread@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33526,6 +33824,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-sticky-regex@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33559,6 +33865,11 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-template-literals@7.16.7(@babel/core@7.16.12)':
@@ -33596,6 +33907,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-typeof-symbol@7.16.7(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33631,6 +33947,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-typescript@7.22.15(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -33662,6 +33983,14 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.9)
+
+  '@babel/plugin-transform-typescript@7.22.15(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.9)
 
   '@babel/plugin-transform-unicode-escapes@7.16.7(@babel/core@7.16.12)':
     dependencies:
@@ -33698,6 +34027,11 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -33720,6 +34054,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.16.12)':
@@ -33764,6 +34104,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.9)
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
@@ -33786,6 +34132,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/preset-env@7.16.11(@babel/core@7.16.12)':
@@ -34369,7 +34721,94 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
       babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
       babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
-      core-js-compat: 3.35.1
+      core-js-compat: 3.37.1
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-env@7.24.7(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/compat-data': 7.25.2
+      '@babel/core': 7.24.9
+      '@babel/helper-compilation-targets': 7.25.2
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.3(@babel/core@7.24.9)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.9)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.9)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.9)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-classes': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-function-name': 7.25.1(@babel/core@7.24.9)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-literals': 7.25.2(@babel/core@7.24.9)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-systemjs': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-typeof-symbol': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.9)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.9)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.9)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.9)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.9)
+      core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -34377,30 +34816,37 @@ snapshots:
   '@babel/preset-flow@7.22.15(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.16.12)
 
   '@babel/preset-flow@7.22.15(@babel/core@7.18.10)':
     dependencies:
       '@babel/core': 7.18.10
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.18.10)
 
   '@babel/preset-flow@7.22.15(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.23.0)
 
   '@babel/preset-flow@7.22.15(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.23.5
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.23.9)
+
+  '@babel/preset-flow@7.22.15(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.24.9)
 
   '@babel/preset-modules@0.1.5(@babel/core@7.16.12)':
     dependencies:
@@ -34432,22 +34878,29 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.0)':
     dependencies:
       '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/types': 7.23.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/types': 7.25.2
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/types': 7.23.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/types': 7.25.2
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/types': 7.23.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/types': 7.25.2
+      esutils: 2.0.3
+
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/types': 7.25.2
       esutils: 2.0.3
 
   '@babel/preset-react@7.16.0(@babel/core@7.16.12)':
@@ -34520,6 +34973,16 @@ snapshots:
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.23.9)
       '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.23.9)
 
+  '@babel/preset-react@7.22.15(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.24.9)
+
   '@babel/preset-typescript@7.23.0(@babel/core@7.16.12)':
     dependencies:
       '@babel/core': 7.16.12
@@ -34556,9 +35019,18 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.9)
 
-  '@babel/register@7.22.15(@babel/core@7.23.9)':
+  '@babel/preset-typescript@7.23.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.24.9)
+      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.24.9)
+
+  '@babel/register@7.22.15(@babel/core@7.24.9)':
+    dependencies:
+      '@babel/core': 7.24.9
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -35062,6 +35534,57 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@graphql-codegen/cli@2.16.5(@babel/core@7.24.9)(@swc/core@1.3.92)(@types/node@22.0.2)(encoding@0.1.13)(enquirer@2.3.6)(graphql@14.3.1)(typescript@5.5.3)':
+    dependencies:
+      '@babel/generator': 7.23.6
+      '@babel/template': 7.23.9
+      '@babel/types': 7.23.9
+      '@graphql-codegen/core': 2.6.8(graphql@14.3.1)
+      '@graphql-codegen/plugin-helpers': 3.1.2(graphql@14.3.1)
+      '@graphql-tools/apollo-engine-loader': 7.3.26(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.24.9)(graphql@14.3.1)
+      '@graphql-tools/git-loader': 7.3.0(@babel/core@7.24.9)(graphql@14.3.1)
+      '@graphql-tools/github-loader': 7.3.28(@babel/core@7.24.9)(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/graphql-file-loader': 7.5.17(graphql@14.3.1)
+      '@graphql-tools/json-file-loader': 7.4.18(graphql@14.3.1)
+      '@graphql-tools/load': 7.8.14(graphql@14.3.1)
+      '@graphql-tools/prisma-loader': 7.2.72(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)
+      '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
+      '@whatwg-node/fetch': 0.6.9(@types/node@22.0.2)
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 7.0.1
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@22.0.2)(cosmiconfig@7.0.1)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3))(typescript@5.5.3)
+      debounce: 1.2.1
+      detect-indent: 6.1.0
+      graphql: 14.3.1
+      graphql-config: 4.5.0(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)
+      inquirer: 8.2.4
+      is-glob: 4.0.3
+      json-to-pretty-yaml: 1.2.2
+      listr2: 4.0.5(enquirer@2.3.6)
+      log-symbols: 4.1.0
+      shell-quote: 1.8.1
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.5
+      ts-node: 10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3)
+      tslib: 2.6.2
+      yaml: 1.10.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - cosmiconfig-toml-loader
+      - encoding
+      - enquirer
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   '@graphql-codegen/core@2.6.8(graphql@14.3.1)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2(graphql@14.3.1)
@@ -35221,6 +35744,18 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  '@graphql-tools/code-file-loader@7.3.23(@babel/core@7.24.9)(graphql@14.3.1)':
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.24.9)(graphql@14.3.1)
+      '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
+      globby: 11.1.0
+      graphql: 14.3.1
+      tslib: 2.6.2
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@graphql-tools/delegate@9.0.35(graphql@14.3.1)':
     dependencies:
       '@graphql-tools/batch-execute': 8.5.22(graphql@14.3.1)
@@ -35294,11 +35829,40 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  '@graphql-tools/git-loader@7.3.0(@babel/core@7.24.9)(graphql@14.3.1)':
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.24.9)(graphql@14.3.1)
+      '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
+      graphql: 14.3.1
+      is-glob: 4.0.3
+      micromatch: 4.0.5
+      tslib: 2.6.2
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   '@graphql-tools/github-loader@7.3.28(@babel/core@7.23.9)(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
       '@graphql-tools/executor-http': 0.1.10(@types/node@22.0.2)(graphql@14.3.1)
       '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.23.9)(graphql@14.3.1)
+      '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
+      '@whatwg-node/fetch': 0.8.8
+      graphql: 14.3.1
+      tslib: 2.6.2
+      value-or-promise: 1.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - encoding
+      - supports-color
+
+  '@graphql-tools/github-loader@7.3.28(@babel/core@7.24.9)(@types/node@22.0.2)(encoding@0.1.13)(graphql@14.3.1)':
+    dependencies:
+      '@ardatan/sync-fetch': 0.0.1(encoding@0.1.13)
+      '@graphql-tools/executor-http': 0.1.10(@types/node@22.0.2)(graphql@14.3.1)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.24.9)(graphql@14.3.1)
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       '@whatwg-node/fetch': 0.8.8
       graphql: 14.3.1
@@ -35321,10 +35885,23 @@ snapshots:
 
   '@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.23.9)(graphql@14.3.1)':
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.23.9)
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.25.3
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.23.9)
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
+      '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
+      graphql: 14.3.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  '@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.24.9)(graphql@14.3.1)':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.9)
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       graphql: 14.3.1
       tslib: 2.6.2
@@ -35359,7 +35936,7 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 8.9.0(graphql@14.3.1)
       graphql: 14.3.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@graphql-tools/merge@8.4.2(graphql@14.3.1)':
     dependencies:
@@ -35373,7 +35950,7 @@ snapshots:
       '@graphql-tools/utils': 9.2.1(graphql@14.3.1)
       fast-json-stable-stringify: 2.1.0
       graphql: 14.3.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@graphql-tools/optimize@1.4.0(graphql@14.3.1)':
     dependencies:
@@ -35423,7 +36000,7 @@ snapshots:
       '@graphql-tools/merge': 8.3.1(graphql@14.3.1)
       '@graphql-tools/utils': 8.9.0(graphql@14.3.1)
       graphql: 14.3.1
-      tslib: 2.6.2
+      tslib: 2.6.3
       value-or-promise: 1.0.11
 
   '@graphql-tools/schema@9.0.19(graphql@14.3.1)':
@@ -35464,7 +36041,7 @@ snapshots:
   '@graphql-tools/utils@8.9.0(graphql@14.3.1)':
     dependencies:
       graphql: 14.3.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@graphql-tools/utils@9.2.1(graphql@14.3.1)':
     dependencies:
@@ -35941,7 +36518,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 20.14.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -35970,7 +36547,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 20.14.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -36000,7 +36577,7 @@ snapshots:
 
   '@jest/source-map@29.6.3':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       callsites: 3.1.0
       graceful-fs: 4.2.11
 
@@ -36020,7 +36597,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.18
       babel-plugin-istanbul: 6.1.1
@@ -36075,7 +36652,7 @@ snapshots:
   '@jridgewell/source-map@0.3.3':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.4.14': {}
 
@@ -36247,7 +36824,7 @@ snapshots:
       pump: 3.0.0
       tar-fs: 2.1.1
 
-  '@ngtools/webpack@18.1.3(@angular/compiler-cli@18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1)':
+  '@ngtools/webpack@18.1.3(@angular/compiler-cli@18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(esbuild@0.21.5))':
     dependencies:
       '@angular/compiler-cli': 18.1.3(@angular/compiler@18.1.3(@angular/core@18.1.3(rxjs@7.5.2)(zone.js@0.14.8)))(typescript@5.5.3)
       typescript: 5.5.3
@@ -36494,7 +37071,7 @@ snapshots:
       victory-voronoi-container: 36.6.8(react@17.0.2)
       victory-zoom-container: 36.6.8(react@17.0.2)
 
-  '@patternfly/react-code-editor@4.82.113(react-dom@17.0.2(react@17.0.2))(react-monaco-editor@0.51.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2))(react@17.0.2)':
+  '@patternfly/react-code-editor@4.82.113(react-dom@17.0.2(react@17.0.2))(react-monaco-editor@0.49.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@patternfly/react-core': 4.276.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@patternfly/react-icons': 4.93.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -36502,8 +37079,8 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-dropzone: 11.7.1(react@17.0.2)
-      react-monaco-editor: 0.51.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2)
-      tslib: 2.6.2
+      react-monaco-editor: 0.49.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2)
+      tslib: 2.6.3
 
   '@patternfly/react-core@4.276.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -36562,7 +37139,7 @@ snapshots:
     dependencies:
       playwright: 1.45.2
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -36574,14 +37151,13 @@ snapshots:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
     optionalDependencies:
-      '@types/webpack': 4.41.38
       type-fest: 4.21.0
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-hot-middleware@2.25.4)(webpack@5.88.2(esbuild@0.18.20))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-hot-middleware@2.25.4)(webpack@5.92.1(esbuild@0.18.20))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -36593,13 +37169,12 @@ snapshots:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(esbuild@0.18.20)
+      webpack: 5.92.1(esbuild@0.18.20)
     optionalDependencies:
-      '@types/webpack': 4.41.38
       type-fest: 4.21.0
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -36611,14 +37186,13 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
     optionalDependencies:
-      '@types/webpack': 4.41.38
       type-fest: 4.21.0
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -36630,11 +37204,10 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     optionalDependencies:
-      '@types/webpack': 4.41.38
       type-fest: 4.21.0
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
       webpack-hot-middleware: 2.25.4
 
   '@pnpm/build-modules@9.3.5(@pnpm/logger@4.0.0)(typanion@3.9.0)':
@@ -38191,26 +38764,26 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
     dependencies:
       '@babel/core': 7.23.9
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.88.2(esbuild@0.18.20))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.92.1(esbuild@0.18.20))':
     dependencies:
       '@babel/core': 7.23.9
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(esbuild@0.18.20))
+      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.92.1(esbuild@0.18.20))
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
       '@babel/core': 7.23.9
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(webpack-cli@4.10.0))
+      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.92.1(webpack-cli@4.10.0))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -38390,7 +38963,7 @@ snapshots:
 
   '@storybook/builder-webpack5@7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@storybook/addons': 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/channels': 7.4.6
       '@storybook/client-api': 7.4.6
@@ -38410,30 +38983,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 16.18.58
       '@types/semver': 7.5.2
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      css-loader: 6.7.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      html-webpack-plugin: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       path-browserify: 1.0.1
       process: 0.11.10
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       semver: 7.5.4
-      style-loader: 3.3.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      style-loader: 3.3.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack-dev-middleware: 6.1.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -38448,9 +39021,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@storybook/builder-webpack5@7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@storybook/addons': 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/channels': 7.4.6
       '@storybook/client-api': 7.4.6
@@ -38470,30 +39043,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 16.18.58
       '@types/semver': 7.5.2
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      css-loader: 6.7.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      html-webpack-plugin: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       path-browserify: 1.0.1
       process: 0.11.10
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       semver: 7.5.4
-      style-loader: 3.3.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      style-loader: 3.3.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
-      webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack-dev-middleware: 6.1.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -38508,9 +39081,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@storybook/channels': 7.6.13
       '@storybook/client-logger': 7.6.13
       '@storybook/core-common': 7.6.13(encoding@0.1.13)
@@ -38522,30 +39095,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      css-loader: 6.7.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       es-module-lexer: 1.4.1
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      html-webpack-plugin: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       magic-string: 0.30.7
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.4
-      style-loader: 3.3.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      style-loader: 3.3.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
-      webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack-dev-middleware: 6.1.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -38558,9 +39131,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@storybook/channels': 7.6.13
       '@storybook/client-logger': 7.6.13
       '@storybook/core-common': 7.6.13(encoding@0.1.13)
@@ -38572,30 +39145,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      css-loader: 6.7.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       es-module-lexer: 1.4.1
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      html-webpack-plugin: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       magic-string: 0.30.7
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.4
-      style-loader: 3.3.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      style-loader: 3.3.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      webpack-dev-middleware: 6.1.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -38608,9 +39181,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@storybook/channels': 7.6.13
       '@storybook/client-logger': 7.6.13
       '@storybook/core-common': 7.6.13(encoding@0.1.13)
@@ -38622,30 +39195,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
-      babel-loader: 9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      css-loader: 6.7.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       es-module-lexer: 1.4.1
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       fs-extra: 11.1.1
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      html-webpack-plugin: 5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       magic-string: 0.30.7
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.4
-      style-loader: 3.3.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      style-loader: 3.3.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      webpack-dev-middleware: 6.1.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -38678,8 +39251,8 @@ snapshots:
 
   '@storybook/cli@7.4.6':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
       '@babel/types': 7.23.9
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.4.6
@@ -38706,7 +39279,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.3
       globby: 11.1.0
-      jscodeshift: 0.14.0(@babel/preset-env@7.23.9(@babel/core@7.23.9))
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.7(@babel/core@7.24.9))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -38727,8 +39300,8 @@ snapshots:
 
   '@storybook/cli@7.4.6(encoding@0.1.13)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
       '@babel/types': 7.23.9
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.4.6
@@ -38755,7 +39328,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.3
       globby: 11.1.0
-      jscodeshift: 0.14.0(@babel/preset-env@7.23.9(@babel/core@7.23.9))
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.7(@babel/core@7.24.9))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -38776,8 +39349,8 @@ snapshots:
 
   '@storybook/cli@7.6.13(encoding@0.1.13)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
       '@babel/types': 7.23.9
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.6.13
@@ -38804,7 +39377,7 @@ snapshots:
       get-port: 5.1.1
       giget: 1.1.3
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.9(@babel/core@7.23.9))
+      jscodeshift: 0.15.1(@babel/preset-env@7.24.7(@babel/core@7.24.9))
       leven: 3.1.0
       ora: 5.4.1
       prettier: 2.8.8
@@ -38837,9 +39410,9 @@ snapshots:
 
   '@storybook/codemod@7.4.6':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
-      '@babel/types': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
+      '@babel/types': 7.25.2
       '@storybook/csf': 0.1.2
       '@storybook/csf-tools': 7.4.6
       '@storybook/node-logger': 7.4.6
@@ -38847,7 +39420,7 @@ snapshots:
       '@types/cross-spawn': 6.0.3
       cross-spawn: 7.0.3
       globby: 11.1.0
-      jscodeshift: 0.14.0(@babel/preset-env@7.23.9(@babel/core@7.23.9))
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.7(@babel/core@7.24.9))
       lodash: 4.17.21
       prettier: 2.8.8
       recast: 0.23.4
@@ -38856,9 +39429,9 @@ snapshots:
 
   '@storybook/codemod@7.6.13':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
-      '@babel/types': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
+      '@babel/types': 7.25.2
       '@storybook/csf': 0.1.2
       '@storybook/csf-tools': 7.6.13
       '@storybook/node-logger': 7.6.13
@@ -38866,7 +39439,7 @@ snapshots:
       '@types/cross-spawn': 6.0.3
       cross-spawn: 7.0.3
       globby: 11.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@7.23.9(@babel/core@7.23.9))
+      jscodeshift: 0.15.1(@babel/preset-env@7.24.7(@babel/core@7.24.9))
       lodash: 4.17.21
       prettier: 2.8.8
       recast: 0.23.4
@@ -39049,13 +39622,13 @@ snapshots:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.2
       telejson: 7.2.0
       tiny-invariant: 1.3.1
       ts-dedent: 2.2.0
       util: 0.12.5
       util-deprecate: 1.0.2
-      watchpack: 2.4.0
+      watchpack: 2.4.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -39098,13 +39671,13 @@ snapshots:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.2
       telejson: 7.2.0
       tiny-invariant: 1.3.1
       ts-dedent: 2.2.0
       util: 0.12.5
       util-deprecate: 1.0.2
-      watchpack: 2.4.0
+      watchpack: 2.4.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -39147,13 +39720,13 @@ snapshots:
       pretty-hrtime: 1.0.3
       prompts: 2.4.2
       read-pkg-up: 7.0.1
-      semver: 7.5.4
+      semver: 7.6.2
       telejson: 7.2.0
       tiny-invariant: 1.3.1
       ts-dedent: 2.2.0
       util: 0.12.5
       util-deprecate: 1.0.2
-      watchpack: 2.4.0
+      watchpack: 2.4.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -39217,10 +39790,10 @@ snapshots:
 
   '@storybook/csf-tools@7.6.13':
     dependencies:
-      '@babel/generator': 7.23.6
-      '@babel/parser': 7.23.9
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/generator': 7.25.0
+      '@babel/parser': 7.25.3
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
       '@storybook/csf': 0.1.2
       '@storybook/types': 7.6.13
       fs-extra: 11.2.0
@@ -39330,16 +39903,16 @@ snapshots:
 
   '@storybook/postinstall@7.4.6': {}
 
-  '@storybook/preset-react-webpack@7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/webpack@4.41.38)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.16.12)
       '@babel/preset-react': 7.22.15(@babel/core@7.16.12)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       '@storybook/core-webpack': 7.4.6
       '@storybook/docs-tools': 7.4.6
       '@storybook/node-logger': 7.4.6
       '@storybook/react': 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       '@types/node': 16.18.58
       '@types/semver': 7.5.2
       babel-plugin-add-react-displayname: 0.0.5
@@ -39349,7 +39922,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.11.0
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
     optionalDependencies:
       '@babel/core': 7.16.12
       typescript: 5.5.3
@@ -39367,16 +39940,16 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@7.4.6(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.4.6(@babel/core@7.23.9)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.23.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.23.9)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-hot-middleware@2.25.4)(webpack@5.88.2(esbuild@0.18.20))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.11.0)(type-fest@4.21.0)(webpack-hot-middleware@2.25.4)(webpack@5.92.1(esbuild@0.18.20))
       '@storybook/core-webpack': 7.4.6(encoding@0.1.13)
       '@storybook/docs-tools': 7.4.6(encoding@0.1.13)
       '@storybook/node-logger': 7.4.6
       '@storybook/react': 7.4.6(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(esbuild@0.18.20))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(esbuild@0.18.20))
       '@types/node': 16.18.58
       '@types/semver': 7.5.2
       babel-plugin-add-react-displayname: 0.0.5
@@ -39386,7 +39959,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.11.0
       semver: 7.5.4
-      webpack: 5.88.2(esbuild@0.18.20)
+      webpack: 5.92.1(esbuild@0.18.20)
     optionalDependencies:
       '@babel/core': 7.23.9
       typescript: 5.5.3
@@ -39404,16 +39977,16 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.18.10)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.18.10)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.18.10)
       '@babel/preset-react': 7.22.15(@babel/core@7.18.10)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(webpack-cli@4.10.0))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(webpack-cli@4.10.0))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(webpack-cli@4.10.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(webpack-cli@4.10.0))
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
       babel-plugin-add-react-displayname: 0.0.5
@@ -39424,7 +39997,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.14.0
       semver: 7.5.4
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     optionalDependencies:
       '@babel/core': 7.18.10
       typescript: 5.5.3
@@ -39442,16 +40015,16 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.23.0)
       '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
       babel-plugin-add-react-displayname: 0.0.5
@@ -39462,7 +40035,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.14.0
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
     optionalDependencies:
       '@babel/core': 7.23.0
       typescript: 5.5.3
@@ -39480,16 +40053,16 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.23.9)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.23.9)
       '@babel/preset-react': 7.22.15(@babel/core@7.23.9)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.38)(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)(webpack@5.88.2(webpack-cli@4.10.0))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@4.21.0)(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)(webpack@5.92.1(webpack-cli@4.10.0))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(webpack-cli@4.10.0))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(webpack-cli@4.10.0))
       '@types/node': 18.17.18
       '@types/semver': 7.5.2
       babel-plugin-add-react-displayname: 0.0.5
@@ -39500,7 +40073,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.14.0
       semver: 7.5.4
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     optionalDependencies:
       '@babel/core': 7.23.9
       typescript: 5.5.3
@@ -39556,7 +40129,7 @@ snapshots:
 
   '@storybook/preview@7.6.13': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))':
     dependencies:
       debug: 4.3.5
       endent: 2.1.0
@@ -39566,11 +40139,11 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(esbuild@0.18.20))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(esbuild@0.18.20))':
     dependencies:
       debug: 4.3.5
       endent: 2.1.0
@@ -39580,11 +40153,11 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.88.2(esbuild@0.18.20)
+      webpack: 5.92.1(esbuild@0.18.20)
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.3)(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
       debug: 4.3.5
       endent: 2.1.0
@@ -39594,7 +40167,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.5.3)
       tslib: 2.6.2
       typescript: 5.5.3
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -39608,10 +40181,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@storybook/react-webpack5@7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/react-dom@17.0.8)(@types/react@17.0.21)(@types/webpack@4.41.38)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@storybook/preset-react-webpack': 7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(@types/webpack@4.41.38)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@storybook/preset-react-webpack': 7.4.6(@babel/core@7.16.12)(@swc/core@1.3.92)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.4.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@types/node': 16.18.58
       react: 17.0.2
@@ -39636,10 +40209,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react-webpack5@7.4.6(@babel/core@7.23.9)(@types/react-dom@17.0.8)(@types/react@17.0.21)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.4.6(@babel/core@7.23.9)(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@storybook/builder-webpack5': 7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
-      '@storybook/preset-react-webpack': 7.4.6(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)
+      '@storybook/preset-react-webpack': 7.4.6(@babel/core@7.23.9)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.4.6(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@types/node': 16.18.58
       react: 17.0.2
@@ -39664,10 +40237,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.18.10)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.18.10)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.18.10)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.18.10)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@types/node': 18.17.18
       react: 17.0.2
@@ -39690,10 +40263,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(@types/webpack@4.41.38)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.23.0)(@swc/core@1.3.92)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@types/node': 18.17.18
       react: 17.0.2
@@ -39716,10 +40289,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.23.9)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.23.9)(@types/webpack@4.41.38)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.23.9)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.21.0)(typescript@5.5.3)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)
       '@types/node': 18.17.18
       react: 17.0.2
@@ -39928,49 +40501,49 @@ snapshots:
       '@types/express': 4.17.17
       file-system-cache: 2.3.0
 
-  '@svgr/babel-plugin-add-jsx-attribute@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-add-jsx-attribute@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-remove-jsx-attribute@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-remove-jsx-attribute@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-svg-dynamic-title@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-svg-dynamic-title@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-svg-em-dimensions@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-svg-em-dimensions@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-transform-react-native-svg@6.0.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-transform-react-native-svg@6.0.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-plugin-transform-svg-component@6.2.0(@babel/core@7.23.9)':
+  '@svgr/babel-plugin-transform-svg-component@6.2.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
-  '@svgr/babel-preset@6.2.0(@babel/core@7.23.9)':
+  '@svgr/babel-preset@6.2.0(@babel/core@7.24.9)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@svgr/babel-plugin-add-jsx-attribute': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-remove-jsx-attribute': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-svg-dynamic-title': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-svg-em-dimensions': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-transform-react-native-svg': 6.0.0(@babel/core@7.23.9)
-      '@svgr/babel-plugin-transform-svg-component': 6.2.0(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@svgr/babel-plugin-add-jsx-attribute': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-remove-jsx-attribute': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-svg-dynamic-title': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-svg-em-dimensions': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-transform-react-native-svg': 6.0.0(@babel/core@7.24.9)
+      '@svgr/babel-plugin-transform-svg-component': 6.2.0(@babel/core@7.24.9)
 
   '@svgr/core@6.2.1':
     dependencies:
@@ -39982,13 +40555,13 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@6.2.1':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
       entities: 3.0.1
 
   '@svgr/plugin-jsx@6.2.1(@svgr/core@6.2.1)':
     dependencies:
-      '@babel/core': 7.23.9
-      '@svgr/babel-preset': 6.2.0(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@svgr/babel-preset': 6.2.0(@babel/core@7.24.9)
       '@svgr/core': 6.2.1
       '@svgr/hast-util-to-babel-ast': 6.2.1
       svg-parser: 2.0.4
@@ -40004,11 +40577,11 @@ snapshots:
 
   '@svgr/webpack@6.2.1':
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-transform-react-constant-elements': 7.17.12(@babel/core@7.23.9)
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
-      '@babel/preset-react': 7.22.15(@babel/core@7.23.9)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/plugin-transform-react-constant-elements': 7.17.12(@babel/core@7.24.9)
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
+      '@babel/preset-react': 7.22.15(@babel/core@7.24.9)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.24.9)
       '@svgr/core': 6.2.1
       '@svgr/plugin-jsx': 6.2.1(@svgr/core@6.2.1)
       '@svgr/plugin-svgo': 6.2.0(@svgr/core@6.2.1)
@@ -40170,7 +40743,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
 
   '@types/archiver@5.3.1':
     dependencies:
@@ -40188,7 +40761,7 @@ snapshots:
 
   '@types/babel__generator@7.6.1':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@types/babel__standalone@7.1.7':
     dependencies:
@@ -40196,12 +40769,12 @@ snapshots:
 
   '@types/babel__template@7.0.2':
     dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.25.3
+      '@babel/types': 7.25.2
 
   '@types/babel__traverse@7.20.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.25.2
 
   '@types/body-parser@1.19.2':
     dependencies:
@@ -40260,7 +40833,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.3':
     dependencies:
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
 
   '@types/cypress@1.1.3':
     dependencies:
@@ -40419,22 +40992,20 @@ snapshots:
   '@types/eslint-scope@3.7.3':
     dependencies:
       '@types/eslint': 7.2.10
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.5
 
   '@types/eslint@7.2.10':
     dependencies:
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
 
   '@types/estree@0.0.51': {}
-
-  '@types/estree@1.0.1': {}
 
   '@types/estree@1.0.5': {}
 
   '@types/express-serve-static-core@4.17.31':
     dependencies:
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -40450,7 +41021,7 @@ snapshots:
       '@types/body-parser': 1.19.2
       '@types/express-serve-static-core': 4.17.35
       '@types/qs': 6.9.7
-      '@types/serve-static': 1.13.10
+      '@types/serve-static': 1.15.7
 
   '@types/express@4.17.17':
     dependencies:
@@ -40488,7 +41059,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.3':
     dependencies:
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
 
   '@types/har-format@1.2.5': {}
 
@@ -40806,15 +41377,11 @@ snapshots:
     dependencies:
       '@types/node': 20.14.2
 
-  '@types/source-list-map@0.1.6': {}
-
   '@types/ssri@7.1.1':
     dependencies:
       '@types/node': 20.14.2
 
   '@types/stack-utils@2.0.0': {}
-
-  '@types/tapable@1.0.12': {}
 
   '@types/through@0.0.30':
     dependencies:
@@ -40824,10 +41391,6 @@ snapshots:
 
   '@types/treeify@1.0.0': {}
 
-  '@types/uglify-js@3.17.5':
-    dependencies:
-      source-map: 0.6.1
-
   '@types/underscore@1.11.2': {}
 
   '@types/unist@2.0.8': {}
@@ -40835,21 +41398,6 @@ snapshots:
   '@types/uuid@8.3.0': {}
 
   '@types/vscode@1.67.0': {}
-
-  '@types/webpack-sources@3.2.3':
-    dependencies:
-      '@types/node': 20.14.2
-      '@types/source-list-map': 0.1.6
-      source-map: 0.7.4
-
-  '@types/webpack@4.41.38':
-    dependencies:
-      '@types/node': 20.14.2
-      '@types/tapable': 1.0.12
-      '@types/uglify-js': 3.17.5
-      '@types/webpack-sources': 3.2.3
-      anymatch: 3.1.2
-      source-map: 0.6.1
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -41099,11 +41647,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@webassemblyjs/ast@1.11.6':
-    dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-
   '@webassemblyjs/ast@1.12.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.6
@@ -41112,8 +41655,6 @@ snapshots:
   '@webassemblyjs/floating-point-hex-parser@1.11.6': {}
 
   '@webassemblyjs/helper-api-error@1.11.6': {}
-
-  '@webassemblyjs/helper-buffer@1.11.6': {}
 
   '@webassemblyjs/helper-buffer@1.12.1': {}
 
@@ -41124,13 +41665,6 @@ snapshots:
       '@xtuc/long': 4.2.2
 
   '@webassemblyjs/helper-wasm-bytecode@1.11.6': {}
-
-  '@webassemblyjs/helper-wasm-section@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/helper-buffer': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/wasm-gen': 1.11.6
 
   '@webassemblyjs/helper-wasm-section@1.12.1':
     dependencies:
@@ -41149,17 +41683,6 @@ snapshots:
 
   '@webassemblyjs/utf8@1.11.6': {}
 
-  '@webassemblyjs/wasm-edit@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/helper-buffer': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/helper-wasm-section': 1.11.6
-      '@webassemblyjs/wasm-gen': 1.11.6
-      '@webassemblyjs/wasm-opt': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      '@webassemblyjs/wast-printer': 1.11.6
-
   '@webassemblyjs/wasm-edit@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
@@ -41171,14 +41694,6 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.12.1
       '@webassemblyjs/wast-printer': 1.12.1
 
-  '@webassemblyjs/wasm-gen@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/ieee754': 1.11.6
-      '@webassemblyjs/leb128': 1.11.6
-      '@webassemblyjs/utf8': 1.11.6
-
   '@webassemblyjs/wasm-gen@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
@@ -41187,28 +41702,12 @@ snapshots:
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
 
-  '@webassemblyjs/wasm-opt@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/helper-buffer': 1.11.6
-      '@webassemblyjs/wasm-gen': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-
   '@webassemblyjs/wasm-opt@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/helper-buffer': 1.12.1
       '@webassemblyjs/wasm-gen': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-
-  '@webassemblyjs/wasm-parser@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/helper-api-error': 1.11.6
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
-      '@webassemblyjs/ieee754': 1.11.6
-      '@webassemblyjs/leb128': 1.11.6
-      '@webassemblyjs/utf8': 1.11.6
 
   '@webassemblyjs/wasm-parser@1.12.1':
     dependencies:
@@ -41219,61 +41718,56 @@ snapshots:
       '@webassemblyjs/leb128': 1.11.6
       '@webassemblyjs/utf8': 1.11.6
 
-  '@webassemblyjs/wast-printer@1.11.6':
-    dependencies:
-      '@webassemblyjs/ast': 1.11.6
-      '@xtuc/long': 4.2.2
-
   '@webassemblyjs/wast-printer@1.12.1':
     dependencies:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
-      webpack: 5.88.2(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack: 5.92.1(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
-      webpack: 5.88.2(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack: 5.92.1(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))':
     dependencies:
-      webpack: 5.88.2(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack: 5.92.1(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack@5.92.1)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))':
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack@5.88.2))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack@5.92.1))':
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack@5.92.1)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))':
     dependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)
     optionalDependencies:
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))':
     dependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
     optionalDependencies:
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack@5.88.2))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack@5.92.1))':
     dependencies:
-      webpack-cli: 4.10.0(webpack@5.88.2)
+      webpack-cli: 4.10.0(webpack@5.92.1)
 
   '@whatwg-node/events@0.0.2': {}
 
@@ -41421,17 +41915,17 @@ snapshots:
       cross-spawn: 7.0.3
       diff: 5.2.0
       dotenv: 16.3.1
-      fast-glob: 3.2.11
+      fast-glob: 3.3.2
       got: 11.8.2
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.5.4
+      semver: 7.6.2
       strip-ansi: 6.0.1
-      tar: 6.2.0
+      tar: 6.2.1
       tinylogic: 2.0.0
       treeify: 1.1.0
-      tslib: 2.6.2
+      tslib: 2.6.3
       tunnel: 0.0.6
     transitivePeerDependencies:
       - typanion
@@ -41452,7 +41946,7 @@ snapshots:
 
   '@yarnpkg/fslib@3.0.0-rc.50':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@yarnpkg/json-proxy@2.1.1':
     dependencies:
@@ -41468,7 +41962,7 @@ snapshots:
     dependencies:
       '@types/emscripten': 1.39.6
       '@yarnpkg/fslib': 3.0.0-rc.50
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -41487,7 +41981,7 @@ snapshots:
   '@yarnpkg/parsers@3.0.0-rc.50':
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@yarnpkg/pnp@2.3.2':
     dependencies:
@@ -41535,9 +42029,9 @@ snapshots:
       chalk: 3.0.0
       clipanion: 4.0.0-rc.2(typanion@3.9.0)
       cross-spawn: 7.0.3
-      fast-glob: 3.2.11
+      fast-glob: 3.3.2
       micromatch: 4.0.5
-      tslib: 2.6.2
+      tslib: 2.6.3
     transitivePeerDependencies:
       - typanion
 
@@ -41585,10 +42079,6 @@ snapshots:
     dependencies:
       acorn: 8.10.0
       acorn-walk: 8.2.0
-
-  acorn-import-assertions@1.9.0(acorn@8.10.0):
-    dependencies:
-      acorn: 8.10.0
 
   acorn-import-attributes@1.9.5(acorn@8.10.0):
     dependencies:
@@ -42129,7 +42619,7 @@ snapshots:
 
   autoprefixer@10.4.19(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       caniuse-lite: 1.0.30001600
       fraction.js: 4.3.7
       normalize-range: 0.1.2
@@ -42178,9 +42668,9 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.4
 
-  babel-core@7.0.0-bridge.0(@babel/core@7.23.9):
+  babel-core@7.0.0-bridge.0(@babel/core@7.24.9):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
 
   babel-jest@29.7.0(@babel/core@7.16.12):
     dependencies:
@@ -42249,56 +42739,62 @@ snapshots:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       '@babel/core': 7.23.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.92.1(esbuild@0.18.20)):
     dependencies:
       '@babel/core': 7.23.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(esbuild@0.18.20)
 
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       '@babel/core': 7.23.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
-    dependencies:
-      '@babel/core': 7.23.9
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(esbuild@0.18.20)):
-    dependencies:
-      '@babel/core': 7.23.9
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.88.2(esbuild@0.18.20)
-
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.88.2(webpack-cli@4.10.0)):
-    dependencies:
-      '@babel/core': 7.23.9
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
-
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.92.1(esbuild@0.21.5)
+
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+    dependencies:
+      '@babel/core': 7.24.9
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
+    dependencies:
+      '@babel/core': 7.24.9
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
+
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
+    dependencies:
+      '@babel/core': 7.24.9
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
+
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
+    dependencies:
+      '@babel/core': 7.24.9
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -42321,7 +42817,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.8
       '@istanbuljs/load-nyc-config': 1.0.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.1.0
@@ -42331,14 +42827,14 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/template': 7.25.0
+      '@babel/types': 7.25.2
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
 
   babel-plugin-macros@2.8.0:
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
       cosmiconfig: 6.0.0
       resolve: 1.22.8
 
@@ -42380,6 +42876,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.24.9):
+    dependencies:
+      '@babel/compat-data': 7.25.2
+      '@babel/core': 7.24.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.9)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.23.0):
     dependencies:
       '@babel/compat-data': 7.23.5
@@ -42411,6 +42916,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.7)
+      core-js-compat: 3.37.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.9):
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.9)
       core-js-compat: 3.37.1
     transitivePeerDependencies:
       - supports-color
@@ -42512,6 +43025,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.24.9):
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.9)
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-react-docgen@4.2.1:
     dependencies:
       ast-types: 0.14.2
@@ -42606,38 +43126,39 @@ snapshots:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.9)
-    optional: true
 
-  babel-preset-fbjs@3.4.0(@babel/core@7.23.9):
+  babel-preset-fbjs@3.4.0(@babel/core@7.24.9):
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.9)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.9)
-      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-block-scoped-functions': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.23.9)
-      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.23.9)
-      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-transform-for-of': 7.23.6(@babel/core@7.23.9)
-      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-member-expression-literals': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-object-super': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-property-literals': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.9)
-      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.9)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.9)
+      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-classes': 7.25.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-function-name': 7.25.1(@babel/core@7.24.9)
+      '@babel/plugin-transform-literals': 7.25.2(@babel/core@7.24.9)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.24.9)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.9)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
+    transitivePeerDependencies:
+      - supports-color
 
   babel-preset-jest@29.6.3(@babel/core@7.16.12):
     dependencies:
@@ -42671,7 +43192,6 @@ snapshots:
       '@babel/core': 7.24.9
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
-    optional: true
 
   balanced-match@0.4.2: {}
 
@@ -42884,13 +43404,6 @@ snapshots:
   browserify-zlib@0.2.0:
     dependencies:
       pako: 1.0.11
-
-  browserslist@4.22.1:
-    dependencies:
-      caniuse-lite: 1.0.30001547
-      electron-to-chromium: 1.4.549
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.13(browserslist@4.22.1)
 
   browserslist@4.23.0:
     dependencies:
@@ -43111,12 +43624,10 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.23.0
-      caniuse-lite: 1.0.30001600
+      browserslist: 4.23.2
+      caniuse-lite: 1.0.30001646
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-
-  caniuse-lite@1.0.30001547: {}
 
   caniuse-lite@1.0.30001600: {}
 
@@ -43601,7 +44112,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@11.0.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  copy-webpack-plugin@11.0.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       fast-glob: 3.2.11
       glob-parent: 6.0.2
@@ -43609,9 +44120,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  copy-webpack-plugin@11.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  copy-webpack-plugin@11.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       fast-glob: 3.2.11
       glob-parent: 6.0.2
@@ -43619,9 +44130,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  copy-webpack-plugin@11.0.0(webpack@5.88.2(webpack-cli@4.10.0)):
+  copy-webpack-plugin@11.0.0(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       fast-glob: 3.2.11
       glob-parent: 6.0.2
@@ -43629,9 +44140,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  copy-webpack-plugin@11.0.0(webpack@5.88.2):
+  copy-webpack-plugin@11.0.0(webpack@5.92.1):
     dependencies:
       fast-glob: 3.2.11
       glob-parent: 6.0.2
@@ -43639,9 +44150,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.88.2
+      webpack: 5.92.1
 
-  copy-webpack-plugin@12.0.2(webpack@5.92.1):
+  copy-webpack-plugin@12.0.2(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -43663,24 +44174,24 @@ snapshots:
 
   core-js-compat@3.21.1:
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       semver: 7.0.0
 
   core-js-compat@3.30.2:
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
 
   core-js-compat@3.33.0:
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
 
   core-js-compat@3.35.1:
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
 
   core-js-compat@3.37.1:
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
 
   core-js-pure@3.33.0: {}
 
@@ -43932,97 +44443,97 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@5.2.7(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  css-loader@5.2.7(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.12)
-      loader-utils: 2.0.2
-      postcss: 8.4.12
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.12)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.12)
-      postcss-modules-scope: 3.0.0(postcss@8.4.12)
-      postcss-modules-values: 4.0.0(postcss@8.4.12)
+      icss-utils: 5.1.0(postcss@8.4.38)
+      loader-utils: 2.0.4
+      postcss: 8.4.38
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
+      postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
-      semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      schema-utils: 3.3.0
+      semver: 7.6.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  css-loader@5.2.7(webpack@5.88.2(webpack-cli@4.10.0)):
+  css-loader@5.2.7(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.12)
-      loader-utils: 2.0.2
-      postcss: 8.4.12
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.12)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.12)
-      postcss-modules-scope: 3.0.0(postcss@8.4.12)
-      postcss-modules-values: 4.0.0(postcss@8.4.12)
+      icss-utils: 5.1.0(postcss@8.4.38)
+      loader-utils: 2.0.4
+      postcss: 8.4.38
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
+      postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
-      semver: 7.5.4
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      schema-utils: 3.3.0
+      semver: 7.6.2
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  css-loader@5.2.7(webpack@5.88.2):
+  css-loader@5.2.7(webpack@5.92.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.12)
-      loader-utils: 2.0.2
-      postcss: 8.4.12
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.12)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.12)
-      postcss-modules-scope: 3.0.0(postcss@8.4.12)
-      postcss-modules-values: 4.0.0(postcss@8.4.12)
+      icss-utils: 5.1.0(postcss@8.4.38)
+      loader-utils: 2.0.4
+      postcss: 8.4.38
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
+      postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
-      semver: 7.5.4
-      webpack: 5.88.2
+      schema-utils: 3.3.0
+      semver: 7.6.2
+      webpack: 5.92.1
 
-  css-loader@6.7.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  css-loader@6.7.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.38)
-      postcss-modules-scope: 3.0.0(postcss@8.4.38)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      semver: 7.6.2
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  css-loader@6.7.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  css-loader@6.7.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.38)
-      postcss-modules-scope: 3.0.0(postcss@8.4.38)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      semver: 7.6.2
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  css-loader@6.7.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  css-loader@6.7.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.38)
-      postcss-modules-scope: 3.0.0(postcss@8.4.38)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      semver: 7.6.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  css-loader@6.7.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  css-loader@6.7.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.38)
-      postcss-modules-scope: 3.0.0(postcss@8.4.38)
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
+      postcss-modules-scope: 3.2.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      semver: 7.6.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  css-loader@7.1.2(webpack@5.92.1):
+  css-loader@7.1.2(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -44035,15 +44546,15 @@ snapshots:
     optionalDependencies:
       webpack: 5.92.1(esbuild@0.21.5)
 
-  css-minimizer-webpack-plugin@5.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  css-minimizer-webpack-plugin@5.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.1.2(postcss@8.4.38)
       jest-worker: 29.7.0
       postcss: 8.4.38
       schema-utils: 4.2.0
-      serialize-javascript: 6.0.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      serialize-javascript: 6.0.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   css-select@4.3.0:
     dependencies:
@@ -44088,7 +44599,7 @@ snapshots:
 
   cssnano-preset-default@6.1.2(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       css-declaration-sorter: 7.2.0(postcss@8.4.38)
       cssnano-utils: 4.0.2(postcss@8.4.38)
       postcss: 8.4.38
@@ -44393,7 +44904,7 @@ snapshots:
 
   date-fns@2.30.0:
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
 
   date-format@4.0.3: {}
 
@@ -44819,8 +45330,6 @@ snapshots:
     dependencies:
       jake: 10.8.7
 
-  electron-to-chromium@1.4.549: {}
-
   electron-to-chromium@1.4.719: {}
 
   electron-to-chromium@1.5.4: {}
@@ -45064,8 +45573,6 @@ snapshots:
       internal-slot: 1.0.7
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
-
-  es-module-lexer@1.3.0: {}
 
   es-module-lexer@1.4.1: {}
 
@@ -45410,8 +45917,8 @@ snapshots:
 
   estree-to-babel@3.2.1:
     dependencies:
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
       c8: 7.14.0
     transitivePeerDependencies:
       - supports-color
@@ -45715,29 +46222,29 @@ snapshots:
     dependencies:
       flat-cache: 3.0.4
 
-  file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  file-loader@6.2.0(webpack@5.88.2(webpack-cli@4.10.0)):
+  file-loader@6.2.0(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  file-loader@6.2.0(webpack@5.88.2):
+  file-loader@6.2.0(webpack@5.92.1):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2
+      webpack: 5.92.1
 
   file-selector@0.2.4:
     dependencies:
@@ -45762,7 +46269,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.6
 
-  filemanager-webpack-plugin@7.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  filemanager-webpack-plugin@7.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       '@types/archiver': 5.3.1
       archiver: 5.3.1
@@ -45772,9 +46279,9 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.0.0
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  filemanager-webpack-plugin@7.0.0(webpack@5.88.2(webpack-cli@4.10.0)):
+  filemanager-webpack-plugin@7.0.0(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       '@types/archiver': 5.3.1
       archiver: 5.3.1
@@ -45784,7 +46291,7 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.0.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
   filename-reserved-regex@2.0.0: {}
 
@@ -45928,9 +46435,9 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.0.1
@@ -45940,14 +46447,14 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.0.1
@@ -45957,14 +46464,14 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.0.1
@@ -45974,14 +46481,14 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.0.1
@@ -45991,10 +46498,10 @@ snapshots:
       minimatch: 3.1.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
   form-data-encoder@2.1.4: {}
 
@@ -46575,77 +47082,77 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.3.2(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.3.2(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 5.1.1
       html-minifier-terser: 5.1.1
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.0
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  html-webpack-plugin@5.3.2(webpack@5.88.2(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.3.2(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 5.1.1
       html-minifier-terser: 5.1.1
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.5.3(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
   html-webpack-plugin@5.5.3(webpack@5.92.1):
     dependencies:
@@ -46654,7 +47161,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1
     optional: true
 
   htmlparser2@6.1.0:
@@ -46874,10 +47381,6 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-
-  icss-utils@5.1.0(postcss@8.4.12):
-    dependencies:
-      postcss: 8.4.12
 
   icss-utils@5.1.0(postcss@8.4.38):
     dependencies:
@@ -47296,8 +47799,8 @@ snapshots:
 
   istanbul-lib-instrument@5.1.0:
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/parser': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/parser': 7.25.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -47306,7 +47809,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.2:
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.24.9
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -47376,7 +47879,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -47542,10 +48045,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.2):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47573,10 +48076,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47604,10 +48107,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.5.3)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47666,10 +48169,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47697,10 +48200,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@22.0.2)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47728,10 +48231,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.0.2):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47759,10 +48262,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@22.0.2)(typescript@5.5.3)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47790,10 +48293,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.0.2)(ts-node@10.9.2(@types/node@22.0.2)(typescript@5.5.3)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47821,10 +48324,10 @@ snapshots:
 
   jest-config@29.7.0(@types/node@22.0.2)(ts-node@10.9.2(@types/node@22.0.2)):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.24.9
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.23.9)
+      babel-jest: 29.7.0(@babel/core@7.24.9)
       chalk: 4.1.2
       ci-info: 3.3.2
       deepmerge: 4.2.2
@@ -47889,7 +48392,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -47939,7 +48442,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.0
       chalk: 4.1.2
@@ -48035,15 +48538,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/generator': 7.23.6
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.9)
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.9)
-      '@babel/types': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/generator': 7.25.0
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.9)
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.9)
+      '@babel/types': 7.25.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.9)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.9)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -48054,7 +48557,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -48113,7 +48616,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.14.2
+      '@types/node': 20.14.13
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -48249,19 +48752,19 @@ snapshots:
 
   jsbn@1.1.0: {}
 
-  jscodeshift@0.14.0(@babel/preset-env@7.23.9(@babel/core@7.23.9)):
+  jscodeshift@0.14.0(@babel/preset-env@7.24.7(@babel/core@7.24.9)):
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/parser': 7.23.9
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.9)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
-      '@babel/preset-flow': 7.22.15(@babel/core@7.23.9)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.9)
-      '@babel/register': 7.22.15(@babel/core@7.23.9)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/parser': 7.25.3
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.9)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.9)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.9)
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
+      '@babel/preset-flow': 7.22.15(@babel/core@7.24.9)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.24.9)
+      '@babel/register': 7.22.15(@babel/core@7.24.9)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.24.9)
       chalk: 4.1.2
       flow-parser: 0.218.0
       graceful-fs: 4.2.11
@@ -48274,19 +48777,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jscodeshift@0.15.1(@babel/preset-env@7.23.9(@babel/core@7.23.9)):
+  jscodeshift@0.15.1(@babel/preset-env@7.24.7(@babel/core@7.24.9)):
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/parser': 7.23.9
-      '@babel/plugin-transform-class-properties': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.23.4(@babel/core@7.23.9)
-      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.9)
-      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.9)
-      '@babel/preset-flow': 7.22.15(@babel/core@7.23.9)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.9)
-      '@babel/register': 7.22.15(@babel/core@7.23.9)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.23.9)
+      '@babel/core': 7.24.9
+      '@babel/parser': 7.25.3
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.9)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.9)
+      '@babel/preset-flow': 7.22.15(@babel/core@7.24.9)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.24.9)
+      '@babel/register': 7.22.15(@babel/core@7.24.9)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.24.9)
       chalk: 4.1.2
       flow-parser: 0.218.0
       graceful-fs: 4.2.11
@@ -48297,7 +48800,7 @@ snapshots:
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
-      '@babel/preset-env': 7.23.9(@babel/core@7.23.9)
+      '@babel/preset-env': 7.24.7(@babel/core@7.24.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -48464,7 +48967,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.5.4
+      semver: 7.6.2
 
   jsprim@2.0.2:
     dependencies:
@@ -48750,7 +49253,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.7
 
-  less-loader@12.2.0(less@4.2.0)(webpack@5.92.1):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       less: 4.2.0
     optionalDependencies:
@@ -48779,7 +49282,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.92.1):
+  license-webpack-plugin@4.0.2(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -49036,7 +49539,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   make-error@1.3.6: {}
 
@@ -49232,13 +49735,19 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.8.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  mini-css-extract-plugin@2.8.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       schema-utils: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  mini-css-extract-plugin@2.9.0(webpack@5.92.1):
+  mini-css-extract-plugin@2.9.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+    dependencies:
+      schema-utils: 4.2.0
+      tapable: 2.2.1
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+
+  mini-css-extract-plugin@2.9.0(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -49396,19 +49905,19 @@ snapshots:
 
   moment@2.29.4: {}
 
-  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.88.2(webpack-cli@4.10.0)):
+  monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.39.0)(monaco-yaml@4.0.4(monaco-editor@0.39.0))(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
   monaco-editor@0.39.0: {}
 
@@ -49542,7 +50051,7 @@ snapshots:
 
   node-abi@3.43.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   node-abort-controller@3.1.1: {}
 
@@ -49647,7 +50156,7 @@ snapshots:
       which: 2.0.2
     optional: true
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -49674,9 +50183,9 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.88.2(webpack-cli@4.10.0)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -49703,9 +50212,7 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.88.2(webpack-cli@4.10.0)
-
-  node-releases@2.0.13: {}
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
   node-releases@2.0.14: {}
 
@@ -50172,7 +50679,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.23.5
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
@@ -50452,7 +50959,7 @@ snapshots:
 
   postcss-colormin@6.1.0(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.38
@@ -50460,7 +50967,7 @@ snapshots:
 
   postcss-convert-values@6.1.0(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       postcss: 8.4.38
       postcss-value-parser: 4.2.0
 
@@ -50480,7 +50987,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1):
+  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.3)
       jiti: 1.21.6
@@ -50501,7 +51008,7 @@ snapshots:
 
   postcss-merge-rules@6.1.1(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.4.38)
       postcss: 8.4.38
@@ -50521,7 +51028,7 @@ snapshots:
 
   postcss-minify-params@6.1.0(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       cssnano-utils: 4.0.2(postcss@8.4.38)
       postcss: 8.4.38
       postcss-value-parser: 4.2.0
@@ -50531,31 +51038,9 @@ snapshots:
       postcss: 8.4.38
       postcss-selector-parser: 6.0.16
 
-  postcss-modules-extract-imports@3.0.0(postcss@8.4.12):
-    dependencies:
-      postcss: 8.4.12
-
-  postcss-modules-extract-imports@3.0.0(postcss@8.4.38):
-    dependencies:
-      postcss: 8.4.38
-
   postcss-modules-extract-imports@3.1.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
-
-  postcss-modules-local-by-default@4.0.0(postcss@8.4.12):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.12)
-      postcss: 8.4.12
-      postcss-selector-parser: 6.0.16
-      postcss-value-parser: 4.2.0
-
-  postcss-modules-local-by-default@4.0.0(postcss@8.4.38):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.38)
-      postcss: 8.4.38
-      postcss-selector-parser: 6.0.16
-      postcss-value-parser: 4.2.0
 
   postcss-modules-local-by-default@4.0.5(postcss@8.4.38):
     dependencies:
@@ -50564,25 +51049,10 @@ snapshots:
       postcss-selector-parser: 6.0.16
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.0.0(postcss@8.4.12):
-    dependencies:
-      postcss: 8.4.12
-      postcss-selector-parser: 6.0.16
-
-  postcss-modules-scope@3.0.0(postcss@8.4.38):
-    dependencies:
-      postcss: 8.4.38
-      postcss-selector-parser: 6.0.16
-
   postcss-modules-scope@3.2.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
       postcss-selector-parser: 6.0.16
-
-  postcss-modules-values@4.0.0(postcss@8.4.12):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.12)
-      postcss: 8.4.12
 
   postcss-modules-values@4.0.0(postcss@8.4.38):
     dependencies:
@@ -50620,7 +51090,7 @@ snapshots:
 
   postcss-normalize-unicode@6.1.0(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       postcss: 8.4.38
       postcss-value-parser: 4.2.0
 
@@ -50642,7 +51112,7 @@ snapshots:
 
   postcss-reduce-initial@6.1.0(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
       postcss: 8.4.38
 
@@ -50668,12 +51138,6 @@ snapshots:
       postcss-selector-parser: 6.0.16
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.12:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.0
-      source-map-js: 1.2.0
 
   postcss@8.4.38:
     dependencies:
@@ -50959,23 +51423,23 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-loader@4.0.2(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  raw-loader@4.0.2(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  raw-loader@4.0.2(webpack@5.88.2(webpack-cli@4.10.0)):
+  raw-loader@4.0.2(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  raw-loader@4.0.2(webpack@5.88.2):
+  raw-loader@4.0.2(webpack@5.92.1):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2
+      webpack: 5.92.1
 
   rc@1.2.8:
     dependencies:
@@ -51119,9 +51583,9 @@ snapshots:
 
   react-docgen@5.4.3:
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/generator': 7.23.6
-      '@babel/runtime': 7.23.6
+      '@babel/core': 7.24.9
+      '@babel/generator': 7.25.0
+      '@babel/runtime': 7.24.7
       ast-types: 0.14.2
       commander: 2.20.3
       doctrine: 3.0.0
@@ -51134,9 +51598,9 @@ snapshots:
 
   react-docgen@7.0.3:
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/core': 7.24.9
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
       '@types/doctrine': 0.0.9
@@ -51267,13 +51731,6 @@ snapshots:
       react: 17.0.2
 
   react-monaco-editor@0.49.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2):
-    dependencies:
-      '@types/react': 17.0.21
-      monaco-editor: 0.39.0
-      prop-types: 15.8.1
-      react: 17.0.2
-
-  react-monaco-editor@0.51.0(@types/react@17.0.21)(monaco-editor@0.39.0)(react@17.0.2):
     dependencies:
       '@types/react': 17.0.21
       monaco-editor: 0.39.0
@@ -51694,7 +52151,7 @@ snapshots:
 
   relay-runtime@12.0.0(encoding@0.1.13):
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.24.7
       fbjs: 3.0.2(encoding@0.1.13)
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -51983,31 +52440,31 @@ snapshots:
     dependencies:
       truncate-utf8-bytes: 1.0.2
 
-  sass-loader@12.4.0(sass@1.49.9)(webpack@5.88.2):
+  sass-loader@12.4.0(sass@1.49.9)(webpack@5.92.1):
     dependencies:
       klona: 2.0.5
       neo-async: 2.6.2
-      webpack: 5.88.2
+      webpack: 5.92.1
     optionalDependencies:
       sass: 1.49.9
 
-  sass-loader@12.4.0(sass@1.77.6)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  sass-loader@12.4.0(sass@1.77.6)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       klona: 2.0.5
       neo-async: 2.6.2
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
     optionalDependencies:
       sass: 1.77.6
 
-  sass-loader@12.4.0(sass@1.77.6)(webpack@5.88.2(webpack-cli@4.10.0)):
+  sass-loader@12.4.0(sass@1.77.6)(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       klona: 2.0.5
       neo-async: 2.6.2
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     optionalDependencies:
       sass: 1.77.6
 
-  sass-loader@14.2.1(sass@1.77.6)(webpack@5.92.1):
+  sass-loader@14.2.1(sass@1.77.6)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -52422,14 +52879,14 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-loader@2.0.2(webpack@5.88.2):
+  source-map-loader@2.0.2(webpack@5.92.1):
     dependencies:
       abab: 2.0.5
       iconv-lite: 0.6.3
       source-map-js: 0.6.2
-      webpack: 5.88.2
+      webpack: 5.92.1
 
-  source-map-loader@5.0.0(webpack@5.92.1):
+  source-map-loader@5.0.0(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
@@ -52779,43 +53236,43 @@ snapshots:
 
   strnum@1.0.5: {}
 
-  style-loader@2.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  style-loader@2.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  style-loader@2.0.0(webpack@5.88.2(webpack-cli@4.10.0)):
+  style-loader@2.0.0(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  style-loader@2.0.0(webpack@5.88.2):
+  style-loader@2.0.0(webpack@5.92.1):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.88.2
+      webpack: 5.92.1
 
-  style-loader@3.3.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  style-loader@3.3.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  style-loader@3.3.3(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  style-loader@3.3.3(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  style-loader@3.3.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  style-loader@3.3.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  style-loader@3.3.3(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  style-loader@3.3.3(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
   stylehacks@6.1.1(postcss@8.4.38):
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       postcss: 8.4.38
       postcss-selector-parser: 6.0.16
 
@@ -52842,7 +53299,7 @@ snapshots:
       mime: 2.6.0
       qs: 6.11.2
       readable-stream: 3.6.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -52862,20 +53319,20 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svg-url-loader@8.0.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  svg-url-loader@8.0.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      file-loader: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  svg-url-loader@8.0.0(webpack@5.88.2(webpack-cli@4.10.0)):
+  svg-url-loader@8.0.0(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      file-loader: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  svg-url-loader@8.0.0(webpack@5.88.2):
+  svg-url-loader@8.0.0(webpack@5.92.1):
     dependencies:
-      file-loader: 6.2.0(webpack@5.88.2)
-      webpack: 5.88.2
+      file-loader: 6.2.0(webpack@5.92.1)
+      webpack: 5.92.1
 
   svgo@2.8.0:
     dependencies:
@@ -52884,7 +53341,7 @@ snapshots:
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       stable: 0.1.8
 
   svgo@3.2.0:
@@ -52895,7 +53352,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   swagger-ui-dist@5.11.2: {}
 
@@ -52908,25 +53365,25 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
   symbol-observable@1.2.0: {}
 
@@ -53049,7 +53506,75 @@ snapshots:
     dependencies:
       execa: 0.7.0
 
-  terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.92.1):
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+    optionalDependencies:
+      '@swc/core': 1.3.92
+      esbuild: 0.18.20
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
+    optionalDependencies:
+      '@swc/core': 1.3.92
+      esbuild: 0.18.20
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
+    optionalDependencies:
+      '@swc/core': 1.3.92
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+    optionalDependencies:
+      '@swc/core': 1.3.92
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+    optionalDependencies:
+      '@swc/core': 1.3.92
+
+  terser-webpack-plugin@5.3.10(esbuild@0.18.20)(webpack@5.92.1(esbuild@0.18.20)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(esbuild@0.18.20)
+    optionalDependencies:
+      esbuild: 0.18.20
+
+  terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.4.6
@@ -53060,6 +53585,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.21.5
 
+  terser-webpack-plugin@5.3.10(webpack@5.92.1(webpack-cli@4.10.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.4.6
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(webpack-cli@4.10.0)
+
   terser-webpack-plugin@5.3.10(webpack@5.92.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -53069,91 +53603,14 @@ snapshots:
       terser: 5.29.2
       webpack: 5.92.1
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
+  terser-webpack-plugin@5.3.9(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       jest-worker: 27.4.6
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.3
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-      esbuild: 0.18.20
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-      esbuild: 0.18.20
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
-    optionalDependencies:
-      '@swc/core': 1.3.92
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-    optionalDependencies:
-      '@swc/core': 1.3.92
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-
-  terser-webpack-plugin@5.3.9(esbuild@0.18.20)(webpack@5.88.2(esbuild@0.18.20)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(esbuild@0.18.20)
-    optionalDependencies:
-      esbuild: 0.18.20
-
-  terser-webpack-plugin@5.3.9(webpack@5.88.2(webpack-cli@4.10.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2(webpack-cli@4.10.0)
-
-  terser-webpack-plugin@5.3.9(webpack@5.88.2):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.4.6
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.3
-      webpack: 5.88.2
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
   terser@4.8.0:
     dependencies:
@@ -53575,32 +54032,32 @@ snapshots:
       safe-stable-stringify: 2.4.1
       typescript: 4.8.4
 
-  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.9.3
       micromatch: 4.0.5
       semver: 7.5.4
       typescript: 5.5.3
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
-  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.88.2(webpack-cli@4.10.0)):
+  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.9.3
       micromatch: 4.0.5
       semver: 7.5.4
       typescript: 5.5.3
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.88.2):
+  ts-loader@9.4.2(typescript@5.5.3)(webpack@5.92.1):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.9.3
       micromatch: 4.0.5
       semver: 7.5.4
       typescript: 5.5.3
-      webpack: 5.88.2
+      webpack: 5.92.1
 
   ts-log@2.2.5: {}
 
@@ -53971,12 +54428,6 @@ snapshots:
 
   untildify@4.0.0: {}
 
-  update-browserslist-db@1.0.13(browserslist@4.22.1):
-    dependencies:
-      browserslist: 4.22.1
-      escalade: 3.1.1
-      picocolors: 1.0.0
-
   update-browserslist-db@1.0.13(browserslist@4.23.0):
     dependencies:
       browserslist: 4.23.0
@@ -54010,32 +54461,32 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)))(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.34
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
+      file-loader: 6.2.0(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.88.2(webpack-cli@4.10.0)))(webpack@5.88.2(webpack-cli@4.10.0)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.92.1(webpack-cli@4.10.0)))(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.34
       schema-utils: 3.3.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.88.2(webpack-cli@4.10.0))
+      file-loader: 6.2.0(webpack@5.92.1(webpack-cli@4.10.0))
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.88.2))(webpack@5.88.2):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.92.1))(webpack@5.92.1):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.34
       schema-utils: 3.3.0
-      webpack: 5.88.2
+      webpack: 5.92.1
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.88.2)
+      file-loader: 6.2.0(webpack@5.92.1)
 
   url-parse@1.5.10:
     dependencies:
@@ -54119,7 +54570,7 @@ snapshots:
 
   v8-to-istanbul@9.1.3:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.1
       convert-source-map: 2.0.0
 
@@ -54465,11 +54916,6 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
-  watchpack@2.4.0:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-
   watchpack@2.4.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -54517,12 +54963,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2):
+  webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))
       colorette: 2.0.16
       commander: 7.2.0
       cross-spawn: 7.0.3
@@ -54530,18 +54976,18 @@ snapshots:
       import-local: 3.0.2
       interpret: 2.2.0
       rechoir: 0.7.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
 
-  webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2):
+  webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))(webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1))
       colorette: 2.0.16
       commander: 7.2.0
       cross-spawn: 7.0.3
@@ -54549,17 +54995,17 @@ snapshots:
       import-local: 3.0.2
       interpret: 2.2.0
       rechoir: 0.7.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
     optionalDependencies:
-      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@4.10.0)(webpack@5.92.1)
 
-  webpack-cli@4.10.0(webpack@5.88.2):
+  webpack-cli@4.10.0(webpack@5.92.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack@5.88.2))(webpack@5.88.2(webpack-cli@4.10.0))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack@5.88.2))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack@5.88.2))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack@5.92.1))(webpack@5.92.1(webpack-cli@4.10.0))
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack@5.92.1))
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack@5.92.1))
       colorette: 2.0.16
       commander: 7.2.0
       cross-spawn: 7.0.3
@@ -54567,38 +55013,28 @@ snapshots:
       import-local: 3.0.2
       interpret: 2.2.0
       rechoir: 0.7.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.88.2(webpack-cli@4.10.0)):
+  webpack-dev-middleware@5.3.3(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
       mime-types: 2.1.34
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
 
-  webpack-dev-middleware@5.3.3(webpack@5.88.2):
+  webpack-dev-middleware@5.3.3(webpack@5.92.1):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
       mime-types: 2.1.34
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2
+      webpack: 5.92.1
 
-  webpack-dev-middleware@6.1.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.1
-      mime-types: 2.1.34
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-    optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
-
-  webpack-dev-middleware@6.1.1(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)):
+  webpack-dev-middleware@6.1.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -54606,9 +55042,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
 
-  webpack-dev-middleware@6.1.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  webpack-dev-middleware@6.1.1(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -54616,9 +55052,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
-  webpack-dev-middleware@6.1.1(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))):
+  webpack-dev-middleware@6.1.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -54626,9 +55062,19 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2))
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1))
 
-  webpack-dev-middleware@7.2.1(webpack@5.92.1):
+  webpack-dev-middleware@6.1.1(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.1
+      mime-types: 2.1.34
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1))
+
+  webpack-dev-middleware@7.2.1(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.11.1
@@ -54639,7 +55085,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.92.1(esbuild@0.21.5)
 
-  webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.88.2):
+  webpack-dev-server@4.15.1(webpack-cli@4.10.0)(webpack@5.92.1):
     dependencies:
       '@types/bonjour': 3.5.10
       '@types/connect-history-api-fallback': 1.3.5
@@ -54669,18 +55115,18 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.88.2(webpack-cli@4.10.0))
+      webpack-dev-middleware: 5.3.3(webpack@5.92.1(webpack-cli@4.10.0))
       ws: 8.13.0
     optionalDependencies:
-      webpack: 5.88.2(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack: 5.92.1(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.1(webpack@5.88.2):
+  webpack-dev-server@4.15.1(webpack@5.92.1):
     dependencies:
       '@types/bonjour': 3.5.10
       '@types/connect-history-api-fallback': 1.3.5
@@ -54710,17 +55156,17 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.88.2)
+      webpack-dev-middleware: 5.3.3(webpack@5.92.1)
       ws: 8.13.0
     optionalDependencies:
-      webpack: 5.88.2
+      webpack: 5.92.1
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.0.4(webpack@5.92.1):
+  webpack-dev-server@5.0.4(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -54750,7 +55196,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.2.1(webpack@5.92.1)
+      webpack-dev-middleware: 7.2.1(webpack@5.92.1(esbuild@0.21.5))
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.92.1(esbuild@0.21.5)
@@ -54785,7 +55231,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.92.1))(webpack@5.92.1):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.92.1))(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       typed-assert: 1.0.8
       webpack: 5.92.1(esbuild@0.21.5)
@@ -54793,264 +55239,6 @@ snapshots:
       html-webpack-plugin: 5.5.3(webpack@5.92.1)
 
   webpack-virtual-modules@0.5.0: {}
-
-  webpack@5.88.2:
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.88.2(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.88.2)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.92)(webpack@5.88.2(@swc/core@1.3.92)(webpack-cli@4.10.0))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(esbuild@0.18.20):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.18.20)(webpack@5.88.2(esbuild@0.18.20))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.88.2(webpack-cli@4.10.0):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.2.0
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.88.2(webpack-cli@4.10.0))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.88.2)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.92.1:
     dependencies:
@@ -55061,7 +55249,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.10.0
       acorn-import-attributes: 1.9.5(acorn@8.10.0)
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       chrome-trace-event: 1.0.2
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.4.1
@@ -55083,7 +55271,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.92.1(esbuild@0.21.5):
+  webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20):
     dependencies:
       '@types/eslint-scope': 3.7.3
       '@types/estree': 1.0.5
@@ -55092,7 +55280,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.10.0
       acorn-import-attributes: 1.9.5(acorn@8.10.0)
-      browserslist: 4.23.0
+      browserslist: 4.23.2
       chrome-trace-event: 1.0.2
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.4.1
@@ -55106,9 +55294,236 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.92.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.92)(webpack@5.92.1(@swc/core@1.3.92)(webpack-cli@4.10.0))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(esbuild@0.18.20):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(esbuild@0.18.20)(webpack@5.92.1(esbuild@0.18.20))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(esbuild@0.21.5):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.92.1(esbuild@0.21.5))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.92.1(webpack-cli@4.10.0):
+    dependencies:
+      '@types/eslint-scope': 3.7.3
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.10.0
+      acorn-import-attributes: 1.9.5(acorn@8.10.0)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 5.17.1
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.2.0
+      mime-types: 2.1.34
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(webpack@5.92.1(webpack-cli@4.10.0))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -55448,9 +55863,9 @@ snapshots:
       compress-commons: 4.1.0
       readable-stream: 3.6.0
 
-  zip-webpack-plugin@4.0.1(webpack-sources@3.2.3)(webpack@5.88.2(webpack-cli@4.10.0)):
+  zip-webpack-plugin@4.0.1(webpack-sources@3.2.3)(webpack@5.92.1(webpack-cli@4.10.0)):
     dependencies:
-      webpack: 5.88.2(webpack-cli@4.10.0)
+      webpack: 5.92.1(webpack-cli@4.10.0)
       webpack-sources: 3.2.3
       yazl: 2.5.1
 


### PR DESCRIPTION
Angular CLI uses webpack 5.92.1 as a transitive dependency while the rest of the repo is still on 5.88.2.

This PR makes every package use the same webpack version.