### PR TITLE
NO-ISSUE: Fix JBPM DevUI Quarkus HTTP Host and Port

### DIFF
--- a/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
+++ b/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
@@ -9,11 +9,11 @@ quarkus.kogito.data-index.graphql.ui.always-include=true
 quarkus.http.test-port=0
 
 # Kogito-service
-kogito.service.url=http://localhost:8080
+kogito.service.url=http://0.0.0.0:8080
 
 #Job-service
-kogito.jobs-service.url=http://localhost:8080
-kogito.dataindex.http.url=http://localhost:8080
+kogito.jobs-service.url=http://0.0.0.0:8080
+kogito.dataindex.http.url=http://0.0.0.0:8080
 
 # run create tables scripts
 quarkus.flyway.migrate-at-start=true
@@ -26,8 +26,8 @@ kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=postgresql
 %prod.quarkus.datasource.username=kogito-user
 %prod.quarkus.datasource.password=kogito-pass
-%prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/kogito}
-%prod.quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://localhost:5432/kogito}
+%prod.quarkus.datasource.jdbc.url=${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://0.0.0.0:5432/kogito}
+%prod.quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://0.0.0.0:5432/kogito}
 
 quarkus.native.native-image-xmx=8g
 

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -39,7 +39,7 @@ kogito.service.url=http://0.0.0.0:8080/kie
 
 #Job-service
 kogito.jobs-service.url=http://0.0.0.0:8080/kie
-kogito.dataindex.http.url=http://0.0.0.0:8080/kie
+kogito.data-index.url=http://0.0.0.0:8080/kie
 
 quarkus.kogito.data-index.graphql.ui.always-include=true
 

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -116,9 +116,8 @@ public class DevConsoleProcessor {
 
         String devUIUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dev-ui.url");
         String dataIndexUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dataindex.http.url");
-        String trustyServiceUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.trusty.http.url");
-        String quarkusHttpHost = ConfigProvider.getConfig().getValue("quarkus.http.host", String.class);
-        String quarkusHttpPort = ConfigProvider.getConfig().getValue("quarkus.http.port", String.class);
+        String quarkusHttpHost = getProperty(configurationBuildItem, systemPropertyBuildItems, "quarkus.http.host");
+        String quarkusHttpPort = getProperty(configurationBuildItem, systemPropertyBuildItems, "quarkus.http.port");
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -116,8 +116,8 @@ public class DevConsoleProcessor {
 
         String devUIUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dev-ui.url");
         String dataIndexUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dataindex.http.url");
-        String quarkusHttpHost = getProperty(configurationBuildItem, systemPropertyBuildItems, "quarkus.http.host");
-        String quarkusHttpPort = getProperty(configurationBuildItem, systemPropertyBuildItems, "quarkus.http.port");
+        String quarkusHttpHost = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class).orElse("0.0.0.0");
+        String quarkusHttpPort = ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", String.class).orElse("8080");
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -115,7 +115,7 @@ public class DevConsoleProcessor {
                 managementInterfaceBuildTimeConfig, launchModeBuildItem, true);
 
         String devUIUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dev-ui.url");
-        String dataIndexUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dataindex.http.url");
+        String dataIndexUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.data-index.url");
         String quarkusHttpHost = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class).orElse("0.0.0.0");
         String quarkusHttpPort = ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", String.class).orElse("8080");
 

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
@@ -67,7 +67,7 @@ export class QwcJbpmQuarkusDevui extends LitElement {
       container: container,
       isDataIndexAvailable: true,
       isTracingEnabled: isTracingEnabled,
-      quarkusAppOrigin: `http://${quarkusHttpHost}:${quarkusHttpPort}`,
+      quarkusAppOrigin: `http://${quarkusHttpHost ?? "0.0.0.0"}:${quarkusHttpPort ?? "8080"}`,
       quarkusAppRootPath: quarkusAppRootPath,
       shouldReplaceQuarkusAppOriginWithWebappOrigin: true,
       dataIndexUrl: `${dataIndexUrl}/graphql`,

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
@@ -63,11 +63,13 @@ export class QwcJbpmQuarkusDevui extends LitElement {
     const metadata = this._routerController.getCurrentMetaData();
     const container = this.renderRoot.querySelector("#envelope-app");
 
+    console.log({ quarkusHttpHost, quarkusHttpPort });
+
     RuntimeToolsDevUI.open({
       container: container,
       isDataIndexAvailable: true,
       isTracingEnabled: isTracingEnabled,
-      quarkusAppOrigin: `http://${quarkusHttpHost ?? "0.0.0.0"}:${quarkusHttpPort ?? "8080"}`,
+      quarkusAppOrigin: `http://${quarkusHttpHost}:${quarkusHttpPort}`,
       quarkusAppRootPath: quarkusAppRootPath,
       shouldReplaceQuarkusAppOriginWithWebappOrigin: true,
       dataIndexUrl: `${dataIndexUrl}/graphql`,

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/resources/dev-ui/qwc-jbpm-quarkus-devui.js
@@ -63,8 +63,6 @@ export class QwcJbpmQuarkusDevui extends LitElement {
     const metadata = this._routerController.getCurrentMetaData();
     const container = this.renderRoot.querySelector("#envelope-app");
 
-    console.log({ quarkusHttpHost, quarkusHttpPort });
-
     RuntimeToolsDevUI.open({
       container: container,
       isDataIndexAvailable: true,

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/rpc/JBPMDevuiJsonRPCService.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/rpc/JBPMDevuiJsonRPCService.java
@@ -37,8 +37,6 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.lang.Integer.parseInt;
-
 @ApplicationScoped
 public class JBPMDevuiJsonRPCService {
     private static final String DATA_INDEX_URL = "kogito.data-index.url";


### PR DESCRIPTION
- Use `0.0.0.0` instead of `localhost` for Quarkus Apps to support running dev mode on containers;
- Set default values for `quarkus.http.host` and `quarkus.http.port`.