### PR TITLE
NO-ISSUE: Extended services wizard refer to non existing binaries

### DIFF
--- a/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
+++ b/packages/online-editor/src/extendedServices/ExtendedServicesModal.tsx
@@ -612,6 +612,11 @@ export function ExtendedServicesModal() {
   useEffect(() => {
     if (extendedServices.status === ExtendedServicesStatus.NOT_RUNNING) {
       setModalPage(ModalPage.INITIAL);
+    } else if (
+      extendedServices.status === ExtendedServicesStatus.STOPPED &&
+      env.KIE_SANDBOX_DISABLE_EXTENDED_SERVICES_WIZARD === true
+    ) {
+      setModalPage(ModalPage.DISABLED);
     } else if (extendedServices.status === ExtendedServicesStatus.STOPPED) {
       setModalPage(ModalPage.WIZARD);
     } else if (extendedServices.status === ExtendedServicesStatus.RUNNING) {
@@ -621,7 +626,12 @@ export function ExtendedServicesModal() {
     if (extendedServices.outdated) {
       setModalPage(ModalPage.WIZARD);
     }
-  }, [extendedServices.status, extendedServices.outdated, extendedServices]);
+  }, [
+    extendedServices.status,
+    extendedServices.outdated,
+    extendedServices,
+    env.KIE_SANDBOX_DISABLE_EXTENDED_SERVICES_WIZARD,
+  ]);
 
   const onClose = useCallback(() => {
     setModalPage(ModalPage.INITIAL);

--- a/packages/online-editor/src/i18n/locales/de.ts
+++ b/packages/online-editor/src/i18n/locales/de.ts
@@ -470,7 +470,7 @@ export const de: OnlineI18n = {
           message: `Es sieht so aus, als ob ${de_common.names.extendedServices} plötzlich beendet wurde, bitte folgen Sie diesen Anweisungen, um es wieder zu starten.`,
         },
         disabled: {
-          title: `${de_common.names.dmnRunner}`,
+          title: `${de_common.names.extendedServices}`,
           alert: `Sie sind nicht mit ${de_common.names.extendedServices} verbunden.`,
           message: `Beachten Sie, dass einige Funktionen wie der ${de_common.names.dmnRunner}, ohne ${de_common.names.extendedServices} nicht verfügbar sind.`,
           helper: `Stellen Sie sicher, dass ${de_common.names.extendedServices} ausgeführt wird, und überprüfen Sie dann die Host- und Porteinstellungen.`,

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -458,7 +458,7 @@ export const en: OnlineI18n = {
           message: `It looks like the ${en_common.names.extendedServices} has suddenly stopped, please follow these instructions to start it again.`,
         },
         disabled: {
-          title: `${en_common.names.dmnRunner}`,
+          title: `${en_common.names.extendedServices}`,
           alert: `You are not connected to ${en_common.names.extendedServices}.`,
           message: `Note that some features, such as the ${en_common.names.dmnRunner}, are unavailable without ${en_common.names.extendedServices}.`,
           helper: `Ensure ${en_common.names.extendedServices} is running, then review the host and port settings.`,


### PR DESCRIPTION
Relates to https://github.com/apache/incubator-kie-tools/pull/2533. This PR deals with the scenario when Extended Services stops running and the extended services wizard modal is displayed. This PR makes it so that, when the disableExtendedServicesWizard environmental variable is set to true, the disabled modal is displayed instead .