### PR TITLE
NO-ISSUE: Use correct properties on jbpm-compact-architecture-example

### DIFF
--- a/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
+++ b/examples/jbpm-compact-architecture-example/src/main/resources/application.properties
@@ -3,6 +3,8 @@
 
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.cors=true
+quarkus.http.cors.origins=*
+quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json
 quarkus.swagger-ui.always-include=true
 quarkus.kogito.data-index.graphql.ui.always-include=true
@@ -13,7 +15,7 @@ kogito.service.url=http://0.0.0.0:8080
 
 #Job-service
 kogito.jobs-service.url=http://0.0.0.0:8080
-kogito.dataindex.http.url=http://0.0.0.0:8080
+kogito.data-index.url=http://0.0.0.0:8080
 
 # run create tables scripts
 quarkus.flyway.migrate-at-start=true


### PR DESCRIPTION
- Replace `kogito.dataindex.http.url` with `kogito.data-index.url`;
- Add CORS properties (to support any host)