### PR TITLE
[10.0.x] NO-ISSUE: Add Drools staging repository to the DmnMarshallerBackendCompatibility jbang test script

### DIFF
--- a/packages/dmn-marshaller-backend-compatibility-tester/src/DmnMarshallerBackendCompatibilityTesterScript.java
+++ b/packages/dmn-marshaller-backend-compatibility-tester/src/DmnMarshallerBackendCompatibilityTesterScript.java
@@ -19,7 +19,7 @@
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 17
-//REPOS mavencentral,apache=https://repository.apache.org/content/groups/public/
+//REPOS mavencentral,apache=https://repository.apache.org/content/groups/public/,drools=https://repository.apache.org/content/repositories/orgapachekie-1005/
 //DEPS ch.qos.logback:logback-classic:1.2.13
 //DEPS info.picocli:picocli:4.7.5
 //DEPS org.slf4j:slf4j-simple:2.0.12


### PR DESCRIPTION
This PR adds the Drools staging repository to fix the following issue during the release build:
```
Error: The command failed: 'jbang -Dkogito-runtime.version=10.0.0 /home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/npm-packages/kie-tools/packages/dmn-marshaller-backend-compatibility-tester/src/DmnMarshallerBackendCompatibilityTesterScript.java'. Code: 1
    at jbang.exec (/home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/npm-packages/kie-tools/node_modules/.pnpm/@jbangdev+jbang@0.2.0/node_modules/@jbangdev/jbang/jbang.js:24:15)
    at executeScript (/home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/npm-packages/kie-tools/packages/dmn-marshaller-backend-compatibility-tester/dist/index.js:57:11)
    at executeParentScript (/home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/npm-packages/kie-tools/packages/dmn-marshaller-backend-compatibility-tester/dist/index.js:11:5)
    at Object.<anonymous> (/home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/npm-packages/kie-tools/packages/dmn-marshaller-backend-compatibility-tester/dist/dependenciesFetch.js:4:28)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  code: 1,
  cause: '[jbang] Resolving dependencies...\n' +
    '[jbang]    ch.qos.logback:logback-classic:1.2.13\n' +
    '[jbang]    info.picocli:picocli:4.7.5\n' +
    '[jbang]    org.slf4j:slf4j-simple:2.0.12\n' +
    '[jbang]    org.kie:kie-api:10.0.0\n' +
    '[jbang]    org.kie:kie-internal:10.0.0\n' +
    '[jbang]    org.kie:kie-dmn-api:10.0.0\n' +
    '[jbang]    org.kie:kie-dmn-core:10.0.0\n' +
    '[jbang]    org.kie:kie-dmn-model:10.0.0\n' +
    '[jbang]    org.kie:kie-dmn-validation:10.0.0\n' +
    '[jbang] [ERROR] Could not resolve dependencies: The following artifacts could not be resolved: org.kie:kie-api:jar:10.0.0 (absent), org.kie:kie-internal:jar:10.0.0 (absent), org.kie:kie-dmn-api:jar:10.0.0 (absent), org.kie:kie-dmn-core:jar:10.0.0 (absent), org.kie:kie-dmn-model:jar:10.0.0 (absent), org.kie:kie-dmn-validation:jar:10.0.0 (absent): Could not find artifact org.kie:kie-api:jar:10.0.0 in mavencentral (https://repo1.maven.org/maven2/)\n' +
    '[jbang] Run with --verbose for more details\n'
}
```