### PR TITLE
[10.0.x] NO-ISSUE: Fix Dashbuilder javadocs

### DIFF
--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/debug/Debug.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/debug/Debug.java
@@ -87,8 +87,7 @@ public class Debug {
      * <li>the first letter of each component of the package name
      * <li>a dot
      * <li>the class name. If the class is an inner class, the name is of the form Outer$Inner
-     * <ol>
-     * <p>
+     * </ol>
      * For classes in the default package, items 1 and 2 are omitted.
      * @param c the class whose name to abbreviate. Can be null, but will result in a null return value.
      * @return the abbreviated FQCN as described, or null if the input is null.

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
@@ -65,7 +65,7 @@ public interface PlaceRequest {
     void setUpdateLocationBar(boolean updateLocationBar);
 
     /**
-     * Invokes {@link #toString()} but exported to JavaScript so it can be invoked from different scripts.
+     * Invokes toString() but exported to JavaScript so it can be invoked from different scripts.
      */
     default String asString() {
         return this.toString();

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/CustomPanelDefinition.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/CustomPanelDefinition.java
@@ -25,12 +25,11 @@ import com.google.gwt.user.client.ui.HasWidgets;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsType;
 import org.jboss.errai.common.client.dom.HTMLElement;
-import org.uberfire.mvp.PlaceRequest;
 
 /**
  * A custom {@link PanelDefinition} that is associated with a HasWidgets
- * or HTMLElement container. See {@link PlaceManager#goTo(PlaceRequest, HasWidgets)}
- * and {@link PlaceManager#goTo(PlaceRequest, HTMLElement)}
+ * or HTMLElement container. See PlaceManager#goTo(PlaceRequest, HasWidgets)
+ * and PlaceManager#goTo(PlaceRequest, HTMLElement)
  */
 @JsType
 public interface CustomPanelDefinition extends PanelDefinition {

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/PanelDefinition.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/PanelDefinition.java
@@ -61,7 +61,6 @@ public interface PanelDefinition {
      * Specifies content that should be put in this panel's main display area when it is materialized. The content to
      * add is specified by a PartDefinition, at the core of which is a {@link PlaceRequest} that identifies a
      * WorkbenchActivity (either a screen or an editor).
-     * <p>
      * If the given part already belongs to an existing panel, it will be removed from that panel by a call to
      * removePart(part).
      * @param part The Part to add. Must not be null. The part's place must specify a WorkbenchActivity bean.
@@ -70,9 +69,8 @@ public interface PanelDefinition {
 
     /**
      * Specifies content that should be put in this panel's main display area when it is materialized.
-     * <p>
      * This is a convenience method equivalent to
-     * <tt>addPart(new&nbsp;PartDefinitionImpl(DefaultPlaceRequest.parse(partSpec)))</tt>.
+     * <code>addPart(new&nbsp;PartDefinitionImpl(DefaultPlaceRequest.parse(partSpec)))</code>.
      * @param partSpec An PlaceRequest ID with optional parameters, encoded as specified in
      * {@link DefaultPlaceRequest#parse(CharSequence)}. Must not be null. The place ID must specify a
      * WorkbenchActivity bean (either a screen or an editor).
@@ -183,7 +181,7 @@ public interface PanelDefinition {
 
     /**
      * Set the height of this panel in pixels using a primitive int to make this method exportable to JS.
-     * @param width The width to set.
+     * @param height The height to set.
      */
     default void setHeight(int height) {
         setHeight(Integer.valueOf(height));
@@ -315,7 +313,7 @@ public interface PanelDefinition {
     void setContextDisplayMode(final ContextDisplayMode contextDisplayMode);
 
     /**
-     * Invokes {@link #toString()} but exported to JavaScript so it can be invoked from different scripts.
+     * Invokes toString() but exported to JavaScript so it can be invoked from different scripts.
      */
     default String asString() {
         return this.toString();

--- a/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/PartDefinition.java
+++ b/packages/dashbuilder/appformer/uberfire-api/src/main/java/org/uberfire/workbench/model/PartDefinition.java
@@ -49,7 +49,7 @@ public interface PartDefinition {
     void setContextDisplayMode(final ContextDisplayMode contextDisplayMode);
 
     /**
-     * Invokes {@link #toString()} but exported to JavaScript so it can be invoked from different scripts.
+     * Invokes toString() but exported to JavaScript so it can be invoked from different scripts.
      */
     default String asString() {
         return this.toString();

--- a/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPanel.java
+++ b/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPanel.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * Specifies an UberFire workbench panel within a templated perspective.
  * <p>
- * <h3>Prerequisites</h3>
+ * <strong>Prerequisites</strong>
  * This annotation can only be used within a class annotated with {@link WorkbenchPerspective}, and it must target a
  * field that implements the GWT HasWidgets interface. Further, the class this annotation is used in must not have a
  * method annotated with {@link Perspective}. See {@link WorkbenchPerspective} for details.

--- a/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPerspective.java
+++ b/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPerspective.java
@@ -35,16 +35,16 @@ import org.uberfire.workbench.model.PerspectiveDefinition;
  * programmatically build a {@link PerspectiveDefinition} object, or declare panel structure and content using Errai UI
  * templates. Note that you cannot mix the two approaches.
  * <p>
- * <h3>Programmatic Perspective Definition</h3>
+ * <strong>Programmatic Perspective Definition</strong>
  * To define the perspective layout programmatically, create a zero-argument method annotated with {@code @Perspective}
  * that returns a {@link PerspectiveDefinition}.
  * <p>
- * <h3>Templated Perspective Definition</h3>
+ * <strong>Templated Perspective Definition</strong>
  * To declare perspective layout using templates, make the class an Errai UI templated component, and then add the
  * {@link WorkbenchPanel} annotation to one or more of its {@code @DataField} widgets. This designates them as panel
  * containers and allows you to specify which parts should be added to them when the perspective launches.
  * <p>
- * <h3>Perspective Lifecycle</h3>
+ * <strong>Perspective Lifecycle</strong>
  * WorkbenchPerspectives receive the standard set of lifecycle calls for a Workbench component:
  * <ul>
  * <li>{@code @OnStartup}</li>

--- a/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPopup.java
+++ b/packages/dashbuilder/appformer/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchPopup.java
@@ -42,11 +42,10 @@ import java.lang.annotation.Target;
  * In this latter case the {@code @WorkbenchPopup} need not extend
  * {@code com.google.gwt.user.client.ui.PopupPanel}.
  * </p>
- * <p>
  * WorkbechPopups can receive the following life-cycle calls:
  * <ul>
  * <li>{@code @OnOpen}</li>
- * </p>
+ * </ul>
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/BaseModal.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/BaseModal.java
@@ -44,7 +44,7 @@ import org.gwtbootstrap3.client.ui.constants.ModalBackdrop;
 /**
  * Base class for modal popup implementations. Setting the following properties by default:
  * <ul>
- * <li>setBackdrop( {@link BackdropType#STATIC} );</li>
+ * <li>setBackdrop( BackdropType#STATIC );</li>
  * <li>setKeyboard( true );</li>
  * <li>setAnimation( true );</li>
  * <li>setDynamicSafe( true );</li>

--- a/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/TitledTextCell.java
+++ b/packages/dashbuilder/appformer/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/TitledTextCell.java
@@ -47,7 +47,7 @@ public class TitledTextCell extends AbstractSafeHtmlCell<TitledTextCell.TitledTe
     /**
      * Constructs a TextCell that uses the provided {@link SafeHtmlRenderer} to
      * render its text.
-     * @param renderer a {@link SafeHtmlRenderer SafeHtmlRenderer<String>} instance
+     * @param renderer a {@link SafeHtmlRenderer} instance
      */
     public TitledTextCell(final SafeHtmlRenderer<TitledText> renderer) {
         super(renderer);

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/TabPanelWithDropdowns.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/TabPanelWithDropdowns.java
@@ -273,7 +273,7 @@ public class TabPanelWithDropdowns extends Composite {
      * Adds a new tab to this panel that doesn't have any contents itself, but can contain multiple items that appear in
      * a dropdown menu when the tab is clicked. This dropdown menu is initially empty. Items can be added and removed
      * using the {@link DropDownTab#addItem(String, Widget)} and
-     * {@link DropDownTab#removeItem(String, Widget)} methods.
+     * DropDownTab#removeItem(String, Widget) methods.
      * @param label The text that should appear on the dropdown tab.
      * @return the container for the items that appear when the tab is clicked.
      */
@@ -298,7 +298,7 @@ public class TabPanelWithDropdowns extends Composite {
     /**
      * Adds a pre-made dropdown tab to this tab panel. This can be used for re-attaching a dropdown tab that was
      * previously added with {@link #addDropdownTab(String)} and then removed.
-     * @param tab the tab to add back
+     * @param contents contents
      */
     public void addDropdownTab(DropDownTab contents) {
         AnchorListItem tab = contents.owningTab;

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractActivity.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractActivity.java
@@ -41,7 +41,7 @@ public abstract class AbstractActivity implements Activity {
     }
 
     /**
-     * Tracks start/shutdown lifecycle. Subclasses should always call <tt>super.onStartup()</tt> in methods that
+     * Tracks start/shutdown lifecycle. Subclasses should always call <code>super.onStartup()</code> in methods that
      * override this one.
      */
     @Override
@@ -51,7 +51,7 @@ public abstract class AbstractActivity implements Activity {
     }
 
     /**
-     * Tracks open/closed lifecycle. Subclasses should always call <tt>super.onOpen()</tt> in methods that override this
+     * Tracks open/closed lifecycle. Subclasses should always call <code>super.onOpen()</code> in methods that override this
      * one.
      */
     @Override
@@ -67,7 +67,7 @@ public abstract class AbstractActivity implements Activity {
     }
 
     /**
-     * Tracks open/closed lifecycle. Subclasses should always call <tt>super.onClose()</tt> in methods that override
+     * Tracks open/closed lifecycle. Subclasses should always call <code>super.onClose()</code> in methods that override
      * this one.
      */
     @Override
@@ -83,7 +83,7 @@ public abstract class AbstractActivity implements Activity {
     }
 
     /**
-     * Tracks start/shutdown lifecycle. Subclasses should always call <tt>super.onShutdown()</tt> in methods that
+     * Tracks start/shutdown lifecycle. Subclasses should always call <code>super.onShutdown()</code> in methods that
      * override this one.
      */
     @Override

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/Activity.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/Activity.java
@@ -31,15 +31,15 @@ import org.uberfire.workbench.model.ActivityResourceType;
  * see the subinterfaces for specific activity types that do get implemented.
  * <p>
  * Also, implementations of this interface and its subinterfaces are typically not written by hand; instead, they are
- * generated from classes annotated with {@link WorkbenchScreen}, {@link WorkbenchEditor}, {@link WorkbenchPopup}, and
+ * generated from classes annotated with {@link WorkbenchScreen}, {@link WorkbenchPopup}, and
  * others by an UberFire annotation processor.
- * <p>
+ * </p>
  * Developers of UberFire applications will not typically come into direct contact with things that implement Activity
  * or its subinterfaces; instead, they will work with a {@link PlaceManager} to manipulate activities at arm's length.
  * <p>
  * If you do need to get your hands on a particular {@code Activity} instance, do so using an {@link ActivityManager}.
- * <p>
- * <h3>Activity Lifecycle</h3>
+ * </p>
+ * <strong>Activity Lifecycle</strong>
  * Activities have the following lifecycle, which is normally driven by an {@link ActivityManager}:
  * <ol>
  * <li>The activity starts off in the <i>uninitialized</i> state.
@@ -56,7 +56,7 @@ import org.uberfire.workbench.model.ActivityResourceType;
  * <p>
  * An activity will never receive a call to {@link #onStartup(PlaceRequest)} when it is started or open, but it may be
  * restarted (perhaps with a different PlaceRequest) after a call to {@link #onShutdown()}.
- * <p>
+ * </p>
  * An activity will never receive a call to {@link #onOpen()} when it is uninitialized or open, but it may be reopened after a call
  * to {@link #onClose()}.
  * @see PlaceManager

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManager.java
@@ -53,7 +53,7 @@ public interface ActivityManager {
      * certain path, the returned set can contain any number of activities.
      * @param placeRequest the PlaceRequest to resolve activities for. Although null is permitted for convenience, it always
      * resolves to the empty set.
-     * @param secure flag indicating if calls to the {@link AuthorizationManager} service are required in order to
+     * @param secure flag indicating if calls to the AuthorizationManager service are required in order to
      * determine which activities are available.
      * @return an unmodifiable set of activities that can handle the given PlaceRequest. Never null, but can be empty.
      * To prevent memory leaks, pass Activity in the returned set to {@link #destroyActivity(Activity)} when you
@@ -81,7 +81,7 @@ public interface ActivityManager {
     /**
      * Finds an activity that can handle the given PlaceRequest, creating and starting a new one if necessary.
      * @param placeRequest the place the resolved activity should handle
-     * @param secure flag indicating if calls to the {@link AuthorizationManager} service are required in order to
+     * @param secure flag indicating if calls to the AuthorizationManager service are required in order to
      * determine if the resulting activity is available.
      * @return an activity that can handle the request, or null if no known activity can handle it. If the return value
      * is non-null, it will be an activity in the <i>started</i> or <i>open</i> state.
@@ -102,7 +102,7 @@ public interface ActivityManager {
      * to use {@link #getActivities(PlaceRequest, boolean)} and cast its return value explicitly.
      * @param clazz the type of activity that you expect to find.
      * @param placeRequest the place the resolved activity should handle
-     * @param secure flag indicating if calls to the {@link AuthorizationManager} service are required in order to
+     * @param secure flag indicating if calls to the AuthorizationManager service are required in order to
      * determine if the resulting activity is available.
      * @return an activity that can handle the request, or null if no known activity can handle it. If the return value
      * is non-null, it will be an activity in the <i>started</i> or <i>open</i> state.

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveManager.java
@@ -36,7 +36,6 @@ import org.uberfire.workbench.model.PerspectiveDefinition;
  * perspective, and switching between perspectives. This includes a sequence of asynchronous operations such as fetching
  * any stored definition the current user has for the new perspective, and saving the definition when the user has
  * modified it (for example, by dragging and dropping components, launching new activities, and so on).
- * <p/>
  * Structurally, the PerspectiveManager performs actions at the request of the {@link PlaceManager}, and it accomplishes
  * these actions by delegating to the {@link PanelManager} and {@link WorkbenchServicesProxy}.
  */
@@ -67,7 +66,6 @@ public interface PerspectiveManager {
     /**
      * This method should only be invoked by PlaceManager. To launch a perspective within an UberFire app, pass a
      * PlaceRequest for that perspective to {@link PlaceManager#goTo(org.uberfire.mvp.PlaceRequest)}.
-     * <p/>
      * Closes all current panels in the PanelManager (they must have already had their parts removed), then builds up
      * the new panel arrangement based on the {@link PerspectiveDefinition} associated with the given perspective
      * activity. If the given perspective is transient, its default perspective definition will always be used.
@@ -76,7 +74,6 @@ public interface PerspectiveManager {
      * @param placeRequest the placeRequest that originated the perspective to switch to. Must not be null.
      * @param perspective the perspective to switch to. Must not be null.
      * @param doWhenFinished The command to execute once the new perspective's panels have been created. Must not be null.
-     * <p/>
      * When the callback is invoked, the panels will be set up in their correct positions, but no parts will
      * have been added.
      */

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -37,8 +37,8 @@ import org.uberfire.workbench.model.PartDefinition;
 /**
  * A Workbench-centric abstraction over the browser's history mechanism. Allows the application to initiate navigation
  * to any displayable thing: a {@link WorkbenchPerspective}, a {@link WorkbenchScreen}, a {@link WorkbenchPopup}, a
- * a {@link WorkbenchPart} within a screen or editor, or the editor associated with a VFS file
- * located at a particular {@link Path}.
+ * a WorkbenchPart within a screen or editor, or the editor associated with a VFS file
+ * located at a particular Path.
  */
 @JsType
 public interface PlaceManager {
@@ -61,7 +61,7 @@ public interface PlaceManager {
 
     /**
      * Finds the <i>currently open</i> activity that handles the given PlaceRequest by ID. No attempt is made to match
-     * by path, but see {@link ActivityManagerImpl#resolveExistingParts(PlaceRequest)} for a variant that does.
+     * by path, but see ActivityManagerImpl#resolveExistingParts(PlaceRequest) for a variant that does.
      *
      * @param place the PlaceRequest whose activity to search for
      * @return the activity that currently exists in service of the given PlaceRequest's ID. Null if no current activity

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -283,7 +283,7 @@ public class PlaceManagerImpl implements PlaceManager {
     /**
      * Resolves the given place request into an Activity instance, if one can be found. If not, this method substitutes
      * special "not found" or "too many" place requests when the resolution doesn't work.
-     * <p/>
+     * </p>
      * The behaviour of this method is affected by the boolean-valued
      * {@code org.uberfire.client.mvp.PlaceManagerImpl.ignoreUnkownPlaces} property in {@link UberfirePreferences}.
      * @param place A non-null place request that could have originated from within application code, from within the

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/AlternativeLayout.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/AlternativeLayout.java
@@ -32,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Part of the worbench layout SPI. Used to declare {@link org.uberfire.client.workbench.WorkbenchLayout}
- * implementations, that should be used as an alternative to the default {@link org.uberfire.client.workbench.WorkbenchLayoutImpl}.<p/>
+ * implementations, that should be used as an alternative to the default {@link org.uberfire.client.workbench.WorkbenchLayoutImpl}.
  * The actual discovery mechenism resides with {@link org.uberfire.client.workbench.LayoutSelection}
  */
 @Qualifier

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/BeanFactory.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/BeanFactory.java
@@ -35,11 +35,9 @@ public interface BeanFactory {
 
     /**
      * Creates a new part presenter/view pair with the given properties.
-     * @param menus The menus to associate with the new part. Null means no menus.
      * @param title The title to associate with the new part that the containing panel may display
      * @param titleDecoration The title decoration that a panel may choose to display beside the part's title. Null is permitted,
      * and means no title decoration.
-     * <p>
      * NOTE: presently, none of the built-in panel types display a part's title decoration.
      * @param definition Defines all other aspects of the part to create. Must not be null.
      * @param partType The new part type.
@@ -72,10 +70,10 @@ public interface BeanFactory {
     public CompassDropController newDropController(final WorkbenchPanelView<?> view);
 
     /**
-     * Destroys the entire graph of beans that were created and returned via a call to any of the <tt>newXXX()</tt>
+     * Destroys the entire graph of beans that were created and returned via a call to any of the <code>newXXX()</code>
      * methods in this class. For example, passing a {@link WorkbenchPartPresenter} instance in will result in the
      * destruction of that presenter, its view, and all other dependent beans injected into that graph of objects.
-     * @param o a bean which was returned from one of the <tt>newXXX()</tt> methods in this class and which has not
+     * @param o a bean which was returned from one of the <code>newXXX()</code> methods in this class and which has not
      * been destroyed yet.
      */
     public void destroy(final Object o);

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
@@ -58,7 +58,6 @@ public interface PanelManager {
      * @param part The description of the part to add. Not null.
      * @param panel definition of the panel to add the part to (must describe a panel that is already present in the
      * layout). Not null.
-     * @param menus The menus to display for the given part. Null means no menus.
      * @param uiPart The part's title and physical view. Not null.
      * @param contextId part of a removed framework feature (TODO: remove this?)
      * @param minInitialWidth minimum pixel width of the part's activity, or null if there is no known minimum width. The target
@@ -108,7 +107,7 @@ public interface PanelManager {
     /**
      * Creates an UberFire panel and installs its view in the given widget container.
      * <p>
-     * <h3>Custom Panel Lifecycle</h3>
+     * <strong>Custom Panel Lifecycle</strong>
      * <p>
      * Custom panels can be disposed like any other panel: by calling {@link #removeWorkbenchPanel(PanelDefinition)}.
      * Additionally, custom panels are monitored for DOM detachment. When a custom panel's view is removed from the DOM
@@ -124,7 +123,7 @@ public interface PanelManager {
     /**
      * Creates an UberFire panel and installs its view in the given html element container.
      * <p>
-     * <h3>Custom Panel Lifecycle</h3>
+     * <strong>Custom Panel Lifecycle</strong>
      * <p>
      * Custom panels can be disposed like any other panel: by calling {@link #removeWorkbenchPanel(PanelDefinition)}.
      * Additionally, custom panels are monitored for DOM detachment. When a custom panel's view is removed from the DOM
@@ -140,7 +139,7 @@ public interface PanelManager {
     /**
      * Creates an UberFire panel and installs its view in the given html element container.
      * <p>
-     * <h3>Custom Panel Lifecycle</h3>
+     * <strong>Custom Panel Lifecycle</strong>
      * <p>
      * Custom panels can be disposed like any other panel: by calling {@link #removeWorkbenchPanel(PanelDefinition)}.
      * Additionally, custom panels are monitored for DOM detachment. When a custom panel's view is removed from the DOM
@@ -184,7 +183,7 @@ public interface PanelManager {
     void onPanelFocus(final PanelDefinition panel);
 
     /**
-     * Closes the given part. This is a convenience method for <tt>placeManager.closePlace(part.getPlace())</tt>.
+     * Closes the given part. This is a convenience method for <code>placeManager.closePlace(part.getPlace())</code>.
      * @param part the part to close (remove from the GUI). Must not be null.
      */
     void closePart(final PartDefinition part);

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayout.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayout.java
@@ -49,7 +49,6 @@ public interface WorkbenchLayout {
     /**
      * Will be invoked by the {@link org.uberfire.client.workbench.Workbench}
      * when the discovery of header and footer elements is completed.
-     * @see {@link #setFooterContents(java.util.List)}
      */
     public void onBootstrap();
 
@@ -71,7 +70,6 @@ public interface WorkbenchLayout {
     /**
      * Makes the given widget fill the entire space normally dedicated to the perspective container. Has no effect if
      * the given widget is already maximized.
-     * <p/>
      * <b>Important:</b> this feature is used by panels to maximize themselves. You should not pass a WorkbenchPanelView
      * to this method yourself; instead, you should use the panel's own API to maximize it. You are free to use this method
      * to maximize your own widgets that are not workbench panels.
@@ -82,7 +80,6 @@ public interface WorkbenchLayout {
     /**
      * Makes the given widget fill the entire space normally dedicated to the perspective container. Has no effect if
      * the given widget is already maximized.
-     * <p/>
      * <b>Important:</b> this feature is used by panels to maximize themselves. You should not pass a WorkbenchPanelView
      * to this method yourself; instead, you should use the panel's own API to maximize it. You are free to use this method
      * to maximize your own widgets that are not workbench panels.
@@ -95,7 +92,6 @@ public interface WorkbenchLayout {
     /**
      * Restores a previously maximized widget to its original size and position. Has no effect if the given widget is
      * not currently in a maximized state set up by {@link #maximize(Widget)}.
-     * <p/>
      * <b>Important:</b> this feature is used by panels to unmaximize themselves. You should not pass a WorkbenchPanelView
      * to this method yourself; instead, you should use the panel's own API to unmaximize it. You are free to use this method
      * to unmaximize your own widgets that have previously been passed to {@link #maximize(Widget)}.
@@ -106,7 +102,6 @@ public interface WorkbenchLayout {
     /**
      * Restores a previously maximized widget to its original size and position. Has no effect if the given widget is
      * not currently in a maximized state set up by {@link #maximize(Widget)}.
-     * <p/>
      * <b>Important:</b> this feature is used by panels to unmaximize themselves. You should not pass a WorkbenchPanelView
      * to this method yourself; instead, you should use the panel's own API to unmaximize it. You are free to use this method
      * to unmaximize your own widgets that have previously been passed to {@link #maximize(Widget)}.
@@ -118,7 +113,6 @@ public interface WorkbenchLayout {
 
     /**
      * Will insert the implementations of Header and Footer in the Workbench
-     * @see {@link #setFooterContents(java.util.List)}
      */
     void setMarginWidgets(boolean isStandaloneMode,
                           Set<String> headersToKeep);

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/listbar/ResizeFlowPanel.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/listbar/ResizeFlowPanel.java
@@ -28,7 +28,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 /**
  * A FlowPanel that can exist in a hierarchy of {@link LayoutPanel}s. Behaves exactly like FlowPanel, but also
- * propagates <tt>onResize</tt> events to the child widgets.
+ * propagates <code>onResize</code> events to the child widgets.
  */
 public class ResizeFlowPanel extends FlowPanel implements RequiresResize,
                                                           ProvidesResize {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/listbar/ResizeFocusPanel.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/listbar/ResizeFocusPanel.java
@@ -29,7 +29,7 @@ import org.uberfire.client.util.Layouts;
 
 /**
  * A FocusPanel that can exist in a hierarchy of {@link LayoutPanel}s. Behaves exactly like FocusPanel, but also
- * propagates <tt>onResize</tt> events to the child widget.
+ * propagates <code>>onResize</code> events to the child widget.
  */
 public class ResizeFocusPanel extends FocusPanel implements RequiresResize,
                                                             ProvidesResize {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/split/WorkbenchSplitLayoutPanel.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/split/WorkbenchSplitLayoutPanel.java
@@ -42,12 +42,10 @@ import org.uberfire.workbench.model.CompassPosition;
 /**
  * A panel that adds user-positioned splitters between each of its child
  * widgets.
- * <p>
  * This is a fork of the standard SplitLayoutPanel with the following changes:-
  * <ol>
  * <li>http://code.google.com/p/google-web-toolkit/issues/detail?id=7135</li>
  * </ol>
- * </p>
  * <p>
  * This panel is used in the same way as {@link DockLayoutPanel}, except that
  * its children's sizes are always specified in {@link Unit#PX} units, and each
@@ -58,7 +56,7 @@ import org.uberfire.workbench.model.CompassPosition;
  * the HTML page in which it is run have an explicit &lt;!DOCTYPE&gt;
  * declaration.
  * </p>
- * <h3>CSS Style Rules</h3>
+ * <strong>CSS Style Rules</strong>
  * <ul class='css'>
  * <li>.gwt-SplitLayoutPanel { the panel itself }</li>
  * <li>.gwt-SplitLayoutPanel .gwt-SplitLayoutPanel-HDragger { horizontal dragger
@@ -67,7 +65,7 @@ import org.uberfire.workbench.model.CompassPosition;
  * </li>
  * </ul>
  * <p>
- * <h3>Example</h3> {@example com.google.gwt.examples.SplitLayoutPanelExample}
+ * <strong>Example</strong> com.google.gwt.examples.SplitLayoutPanelExample
  * </p>
  */
 public class WorkbenchSplitLayoutPanel extends DockLayoutPanel {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/PanelManagerTest.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/PanelManagerTest.java
@@ -112,7 +112,7 @@ public class PanelManagerTest {
     private PerspectiveDefinition testPerspectiveDef;
 
     /**
-     * This is the Panel Presenter returned by the mock BeanFactory when asked for <tt>newWorkbenchPanel( testPerspectiveDef.getRoot() ) )</tt>.
+     * This is the Panel Presenter returned by the mock BeanFactory when asked for <code>newWorkbenchPanel( testPerspectiveDef.getRoot() ) )</code>.
      */
     private WorkbenchPanelPresenter testPerspectiveRootPanelPresenter;
 

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -994,7 +994,7 @@ public class PlaceManagerTest {
     /**
      * Verifies that all the expected side effects of a screen or editor activity launch have happened.
      * @param placeRequest The place request that was passed to some variant of PlaceManager.goTo().
-     * @param activity <b>A Mockito mock<b> of the activity that was resolved for <tt>placeRequest</tt>.
+     * @param activity <b>A Mockito mock<b> of the activity that was resolved for <code>placeRequest</code>.
      */
     private void verifyActivityLaunchSideEffects(PlaceRequest placeRequest,
                                                  WorkbenchActivity activity,
@@ -1065,7 +1065,7 @@ public class PlaceManagerTest {
     /**
      * Verifies that the "place change" side effects have not happened, and that the given activity is still current.
      * @param expectedCurrentPlace The place request that placeManager should still consider "current."
-     * @param activity <b>A Mockito mock<b> of the activity tied to <tt>expectedCurrentPlace</tt>.
+     * @param activity <b>A Mockito mock<b> of the activity tied to <code>expectedCurrentPlace</code>.
      */
     private void verifyNoActivityLaunchSideEffects(PlaceRequest expectedCurrentPlace,
                                                    WorkbenchScreenActivity activity) {

--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -76,7 +76,6 @@ public class GeneratorUtils {
      * Finds the {@code @OnStartup} method suitable for workbench classes that are not {@code @WorkbenchEditor}.
      * The method must be public, non-static, have a return-type of void and either take zero parameters or one
      * parameter of type {@code PlaceRequest}.
-     * <p/>
      * If no such method is found, returns null. If methods annotated with {@code @OnStartup} are found but they do not
      * satisfy all the requirements, they are marked with errors explaining the problem.
      */
@@ -171,7 +170,6 @@ public class GeneratorUtils {
      * Finds the {@code @OnStartup} method suitable for {@code @WorkbenchEditor} classes.
      * The method must be public, non-static, have a return-type of void and either take one parameter
      * of type {@code Path} or two parameters of type {@code (Path, PlaceRequest)}.
-     * <p/>
      * If no such method is found, returns null. If methods annotated with {@code @OnStartup} are found but they do not
      * satisfy all the requirements, they are marked with errors explaining the problem.
      */

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServices.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServices.java
@@ -79,7 +79,6 @@ public interface DataSetClientServices {
      * Creates a brand new data set definition for the provider type specified
      *
      * @param type The provider type
-     * @return A data set definition instance
      */
     void newDataSet(DataSetProviderType type,
                            RemoteCallback<DataSetDef> callback) throws Exception;

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServicesImpl.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServicesImpl.java
@@ -212,7 +212,6 @@ public class DataSetClientServicesImpl implements DataSetClientServices {
      * Creates a brand new data set definition for the provider type specified
      *
      * @param type The provider type
-     * @return A data set definition instance
      */
     public void newDataSet(DataSetProviderType type,
                            RemoteCallback<DataSetDef> callback) throws Exception {

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/AbstractDisplayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/AbstractDisplayer.java
@@ -58,7 +58,7 @@ import org.dashbuilder.displayer.client.formatter.ValueFormatter;
  * Base class for implementing custom displayers.
  * <p>Any derived class must implement:
  * <ul>
- *     <li>The draw(), redraw() & close() methods.</li>
+ *     <li>The draw(), redraw() and close() methods.</li>
  *     <li>The capture of events coming from the DisplayerListener interface.</li>
  * </ul>
  */

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/Displayer.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/Displayer.java
@@ -70,7 +70,7 @@ public interface Displayer extends DisplayerListener, IsWidget {
 
     /**
      * Same as draw but does not necessary implies to repaint everything again.
-     * It's just a matter of update & display the latest data set changes.
+     * It's just a matter of update and display the latest data set changes.
      */
     void redraw();
 

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/RendererLibrary.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/RendererLibrary.java
@@ -31,7 +31,7 @@ import org.dashbuilder.displayer.DisplayerType;
  * <p>A renderer library must:</p>
  * <ul>
  *     <li>Perform all the required initializations before any displayer can be drawn</li>
- *     <li>Declare the displayer types & subtypes supported</li>
+ *     <li>Declare the displayer types and subtypes supported</li>
  *     <li>Take care of the initialization of displayer instances</li>
  * </ul>
  */

--- a/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/src/main/java/org/dashbuilder/renderer/client/table/TableDisplayerView.java
+++ b/packages/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/src/main/java/org/dashbuilder/renderer/client/table/TableDisplayerView.java
@@ -300,7 +300,7 @@ public class TableDisplayerView extends AbstractGwtDisplayerView<TableDisplayer>
         }
 
         /**
-         * Both filter & sort invoke this method from redraw()
+         * Both filter and sort invoke this method from redraw()
          */
         public void gotoFirstPage() {
             // Avoid fetching the data set again

--- a/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerSettingsBuilder.java
+++ b/packages/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/DisplayerSettingsBuilder.java
@@ -50,7 +50,7 @@ public interface DisplayerSettingsBuilder<T> extends DataSetLookupBuilder<T> {
 
     /**
      * Set a direct reference to the source data set that will be used by the Displayer that is being assembled.
-     * <p>When using this <i>dataset provided mode</i> the data set lookup operations set (if any): filter, group & sort  will not be taking into account).
+     * <p>When using this <i>dataset provided mode</i> the data set lookup operations set (if any): filter, group and sort  will not be taking into account).
      *
      * @return The DisplayerSettingsBuilder instance that is being used to configure a DisplayerSettings.
      * @see org.dashbuilder.dataset.DataSet
@@ -127,7 +127,7 @@ public interface DisplayerSettingsBuilder<T> extends DataSetLookupBuilder<T> {
     /**
      * Force the displayer to redraw every time interval.
      *
-     * @param seconds The refresh time frame in seconds. If < 0 then periodic refresh is disabled.
+     * @param seconds The refresh time frame in seconds. <code>if &lt; 0</code> then periodic refresh is disabled.
      * @param onStale Refresh when the data becomes stale.
      *
      * @return The DisplayerSettingsBuilder instance that is being used to configure a DisplayerSettings.

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataprovider/DataSetProvider.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataprovider/DataSetProvider.java
@@ -26,7 +26,7 @@ import org.dashbuilder.dataset.def.DataSetDef;
 
 /**
  * This service provider interface is designed to provide access to different data set storage implementations with
- * the main goal of providing a unified interface for the data set fetch & lookup operations.
+ * the main goal of providing a unified interface for the data set fetch and lookup operations.
  */
 public interface DataSetProvider {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataColumn.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataColumn.java
@@ -100,7 +100,7 @@ public interface DataColumn {
     DataColumn cloneEmpty();
 
     /**
-     * Clone the column entirely (definition & values).
+     * Clone the column entirely (definition and values).
      */
     DataColumn cloneInstance();
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetGenerator.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetGenerator.java
@@ -29,7 +29,7 @@ public interface DataSetGenerator {
     /**
      * Build and get a DataSet instance.
      *
-     * @params A map of parameters to be passed through the generator.
+     * @param params A map of parameters to be passed through the generator.
      */
     DataSet buildDataSet(Map<String,String> params);
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeAmount.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeAmount.java
@@ -30,7 +30,6 @@ import org.dashbuilder.dataset.group.DateIntervalType;
  * <li><i>-1year</i></li>
  * <li><i>+2quarter</i></li>
  * </ul>
- * </p>
  */
 public class TimeAmount {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeFrame.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeFrame.java
@@ -21,7 +21,7 @@ package org.dashbuilder.dataset.date;
 
 /**
  * A time frame defines a time period between two time instants where these two instants depends on the current time.
- * <p>Some examples of time frame expressions are:
+ * <p>Some examples of time frame expressions are:</p>
  * <ul>
  * <li>&quot;<i>now till 10second</i>&quot; => next 10 seconds</li>
  * <li>&quot;<i>begin[minute] till 10second</i>&quot; => first 10 seconds of current minute</li>
@@ -34,7 +34,6 @@ package org.dashbuilder.dataset.date;
  * <li>&quot;<i>end[year March] +2quarter till 1quarter</i>&quot; => 3rd quarter of next year</li>
  * <li>&quot;<i>begin[year March] -7day till begin[year March]</i>&quot; => Last week of last year</li>
  * </ul>
- * </p>
  */
 public class TimeFrame {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeInstant.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeInstant.java
@@ -25,7 +25,7 @@ import org.dashbuilder.dataset.group.DateIntervalType;
 
 /**
  * This class is used to represent a given time instant relative to the current time.
- * <p>Some examples of time instants are:
+ * <p>Some examples of time instants are:</p>
  * <ul>
  * <li><i>now</i></li>
  * <li><i>now -10second</i> or just <i>-10second</i></li>
@@ -34,7 +34,6 @@ import org.dashbuilder.dataset.group.DateIntervalType;
  * <li><i>end[year March] +1year</i> => end of next year (year starting on March)</li>
  * <li><i>begin[year March] -7day</i> => last year's last week start</li>
  * </ul>
- * </p>
  */
 public class TimeInstant {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/main/java/org/dashbuilder/dataprovider/StaticDataSetProvider.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-core/src/main/java/org/dashbuilder/dataprovider/StaticDataSetProvider.java
@@ -30,13 +30,12 @@ import org.dashbuilder.dataset.filter.DataSetFilter;
 
 /**
  * DataSetProvider implementation for static (in-memory) data sets.
- * <p>It's been designed with several goals in mind:
+ * <p>It's been designed with several goals in mind:</p>
  * <ul>
  *     <li>To provide a highly reusable data set cache.</li>
  *     <li>To index almost every operation performed over a data set.</li>
  *     <li>Multiple clients requesting the same data set operations will benefit from the indexing/caching services provided.</li>
  * </ul>
- * </p>
  */
 public class StaticDataSetProvider implements DataSetProvider {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/Chronometer.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/Chronometer.java
@@ -43,7 +43,7 @@ public interface Chronometer {
     /**
      * Return the time specified in human readable format.
      * @param millis The time to format in milliseconds.
-     * @return Examples: <i>2d 3h 44m 2s<i>  or  <i>20 weeks 3h 3s</i>
+     * @return Examples: <i>2d 3h 44m 2s</i>  or  <i>20 weeks 3h 3s</i>
      */
     String formatElapsedTime(long millis);
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/group/IntervalBuilderFixedDate.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/group/IntervalBuilderFixedDate.java
@@ -36,7 +36,7 @@ import static org.dashbuilder.dataset.group.DateIntervalType.SECOND;
 
 /**
  * Interval builder for date columns which generates a fixed number of intervals for a given interval size.
- * <p>The only intervals sizes supported are: QUARTER, MONTH, DAY_OF_WEEK, HOUR, MINUTE & SECOND.</p>
+ * <p>The only intervals sizes supported are: QUARTER, MONTH, DAY_OF_WEEK, HOUR, MINUTE and SECOND.</p>
  */
 public class IntervalBuilderFixedDate implements IntervalBuilder {
 

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/index/spi/DataSetIndexRegistry.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/index/spi/DataSetIndexRegistry.java
@@ -41,7 +41,7 @@ public interface DataSetIndexRegistry {
     /**
      * Removes the index for the specified data set.
      * @param uuid The data set unique identifier.
-     * @return The removed index or <tt>null</tt> if there was no mapping for <tt>uuid</tt>.
+     * @return The removed index or <code>null</code> if there was no mapping for <code>uuid</code>.
      */
     DataSetIndex remove(String uuid);
 }

--- a/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/sort/CollectionsDataSetSort.java
+++ b/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/sort/CollectionsDataSetSort.java
@@ -28,7 +28,7 @@ import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.sort.ColumnSort;
 
 /**
- * A basic sort algorithm takes relies on the default <tt>Collections.sort()</tt> implementation.
+ * A basic sort algorithm takes relies on the default <code>Collections.sort()</code> implementation.
  */
 public class CollectionsDataSetSort implements DataSetSortAlgorithm {
 

--- a/packages/stunner-editors/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
+++ b/packages/stunner-editors/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
@@ -70,7 +70,7 @@ public interface PlaceRequest {
     }
 
     /**
-     * Invokes {@link #toString()} but exported to JavaScript so it can be invoked from different scripts.
+     * Invokes toString() but exported to JavaScript so it can be invoked from different scripts.
      */
     default String asString() {
         return this.toString();


### PR DESCRIPTION
This PR fixes the errors we are facing when running `sonataflow-quarkus-devui` release job.

```
packages/dashbuilder build:prod: [ERROR] /home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/sonataflow-quarkus-devui/kie-tools/packages/dashbuilder/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataColumn.java:103: error: bad HTML entity
packages/dashbuilder build:prod: [ERROR]      * Clone the column entirely (definition & values).
packages/dashbuilder build:prod: [ERROR]                                              ^
```