### PR TITLE
kie-issues#1475: Classic Standalone Editors TypeScript errors for `resources` property

### DIFF
--- a/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
+++ b/packages/chrome-extension/src/app/components/common/ChromeResourceContentService.ts
@@ -44,7 +44,7 @@ class ChromeResourceContentService implements ResourceContentService {
     normalizedPosixPathRelativeToTheWorkspaceRoot: string,
     opts?: ResourceContentOptions
   ): Promise<ResourceContent | undefined> {
-    opts = opts ?? { type: ContentType.TEXT };
+    opts = opts ?? { type: "text" };
     return fetchFile(
       this.octokit,
       this.repoInfo.owner,

--- a/packages/chrome-extension/src/app/github/api.ts
+++ b/packages/chrome-extension/src/app/github/api.ts
@@ -35,7 +35,7 @@ export function fetchFile(
       ref: ref,
       path: path,
     })
-    .then((res) => (contentType === ContentType.BINARY ? (res.data as any).content : atob((res.data as any).content)))
+    .then((res) => (contentType === "binary" ? (res.data as any).content : atob((res.data as any).content)))
     .catch((e) => {
       console.debug(`Error fetching ${path} with Octokit. Fallback is 'raw.githubusercontent.com'.`);
       return fetch(`https://raw.githubusercontent.com/${org}/${repo}/${ref}/${path}`).then((res) =>

--- a/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
@@ -267,7 +267,7 @@ export class DmnEditorRoot extends React.Component<DmnEditorRootProps, DmnEditor
     );
     const resource = await this.props.onRequestWorkspaceFileContent({
       normalizedPosixPathRelativeToTheWorkspaceRoot,
-      opts: { type: ContentType.TEXT },
+      opts: { type: "text" },
     });
 
     const ext = __path.extname(normalizedPosixPathRelativeToTheOpenFile);
@@ -584,7 +584,7 @@ function ExternalModelsManager({
           resources.push(
             onRequestWorkspaceFileContent({
               normalizedPosixPathRelativeToTheWorkspaceRoot,
-              opts: { type: ContentType.TEXT },
+              opts: { type: "text" },
             })
           );
         }

--- a/packages/dmn-editor-standalone/src/DmnEditorStandaloneChannelApiImpl.ts
+++ b/packages/dmn-editor-standalone/src/DmnEditorStandaloneChannelApiImpl.ts
@@ -102,9 +102,7 @@ export class DmnEditorStandaloneChannelApiImpl implements KogitoEditorChannelApi
     return new ResourceContent(
       request.normalizedPosixPathRelativeToTheWorkspaceRoot,
       await resource.content,
-      // We need to typecast because ContentType is not exported
-      // and TS complains when trying to match strings with enums
-      resource.contentType as ContentType
+      resource.contentType
     );
   }
 

--- a/packages/dmn-editor-standalone/stories/DevWebApp.stories.tsx
+++ b/packages/dmn-editor-standalone/stories/DevWebApp.stories.tsx
@@ -24,11 +24,10 @@ import { useRef, useState, useEffect, useCallback, useMemo } from "react";
 import "@patternfly/react-core/dist/styles/base.css";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import * as DmnEditor from "../dist/index";
-import { DmnEditorStandaloneApi } from "../dist/index";
+import { DmnEditorStandaloneApi, DmnEditorStandaloneResource } from "../dist/index";
 import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex/Flex";
 import { FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex/FlexItem";
 import { Text, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
 
 const droppingFileStyle = {
   position: "absolute",
@@ -53,7 +52,7 @@ export type DevWebAppProps = {
   initialFileNormalizedPosixPathRelativeToTheWorkspaceRoot: string;
   initialContent: string;
   readOnly: boolean;
-  resources: Array<[string, { contentType: ContentType; content: string }]>;
+  resources: Array<[string, DmnEditorStandaloneResource]>;
   origin: string;
 };
 

--- a/packages/dmn-editor-standalone/tests-e2e/__fixtures__/editor.ts
+++ b/packages/dmn-editor-standalone/tests-e2e/__fixtures__/editor.ts
@@ -18,7 +18,6 @@
  */
 
 import { Page, expect } from "@playwright/test";
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
 import type { open, DmnEditorStandaloneApi } from "@kie-tools/dmn-editor-standalone/dist";
 import * as prettier from "prettier";
 
@@ -40,7 +39,7 @@ export class Editor {
   constructor(public page: Page) {}
 
   public async open(args?: {
-    resources?: Array<[string, { contentType: ContentType; content: string }]>;
+    resources?: Array<[string, { contentType: "text" | "binary"; content: string }]>;
     initialFileNormalizedPosixPathRelativeToTheWorkspaceRoot?: string;
   }) {
     await this.page.goto("");

--- a/packages/dmn-editor-standalone/tests-e2e/includedModels/includedModels.spec.ts
+++ b/packages/dmn-editor-standalone/tests-e2e/includedModels/includedModels.spec.ts
@@ -18,27 +18,20 @@
  */
 
 import { test, expect } from "../__fixtures__/base";
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
 import { ExternalFile } from "../__fixtures__/files";
 
 test.describe("DMN Editor - Standalone - Resources", () => {
   test.describe("includedModels/resources", () => {
     test("should list all resources", async ({ editor, files }) => {
-      const resources: Array<[string, { contentType: ContentType; content: string }]> = [
+      const resources: Array<[string, { contentType: "text" | "binary"; content: string }]> = [
         [
           "loan-pre-qualification.dmn",
-          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: "text" },
         ],
-        ["can-drive.dmn", { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: ContentType.TEXT }],
-        [
-          "find-employees.dmn",
-          { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: ContentType.TEXT },
-        ],
-        ["types.dmn", { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: ContentType.TEXT }],
-        [
-          "scorecard.pmml",
-          { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: ContentType.TEXT },
-        ],
+        ["can-drive.dmn", { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: "text" }],
+        ["find-employees.dmn", { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: "text" }],
+        ["types.dmn", { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: "text" }],
+        ["scorecard.pmml", { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: "text" }],
       ];
 
       // Open the editor
@@ -61,23 +54,20 @@ test.describe("DMN Editor - Standalone - Resources", () => {
     });
 
     test("should not list any models to be included", async ({ editor, files }) => {
-      const resources: Array<[string, { contentType: ContentType; content: string }]> = [
+      const resources: Array<[string, { contentType: "text" | "binary"; content: string }]> = [
         [
           "loan-pre-qualification.dmn",
-          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: "text" },
         ],
-        [
-          "path1/can-drive.dmn",
-          { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: ContentType.TEXT },
-        ],
+        ["path1/can-drive.dmn", { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: "text" }],
         [
           "path2/find-employees.dmn",
-          { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: "text" },
         ],
-        ["path3/types.dmn", { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: ContentType.TEXT }],
+        ["path3/types.dmn", { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: "text" }],
         [
           "path1/pmml/scorecard.pmml",
-          { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: "text" },
         ],
       ];
 
@@ -94,26 +84,20 @@ test.describe("DMN Editor - Standalone - Resources", () => {
     });
 
     test("should list all resources on same parent path", async ({ editor, files }) => {
-      const resources: Array<[string, { contentType: ContentType; content: string }]> = [
+      const resources: Array<[string, { contentType: "text" | "binary"; content: string }]> = [
         [
           "loan-pre-qualification.dmn",
-          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.LOAN_PRE_QUALIFICATION_DMN), contentType: "text" },
         ],
-        [
-          "path1/can-drive.dmn",
-          { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: ContentType.TEXT },
-        ],
+        ["path1/can-drive.dmn", { content: await files.getFile(ExternalFile.CAN_DRIVE_DMN), contentType: "text" }],
         [
           "path2/find-employees.dmn",
-          { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.FIND_EMPLOYEES_DMN), contentType: "text" },
         ],
-        [
-          "path3/types/types.dmn",
-          { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: ContentType.TEXT },
-        ],
+        ["path3/types/types.dmn", { content: await files.getFile(ExternalFile.TYPES_DMN), contentType: "text" }],
         [
           "path1/pmml/scorecard.pmml",
-          { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: ContentType.TEXT },
+          { content: await files.getFile(ExternalFile.SCORECARD_PMML), contentType: "text" },
         ],
       ];
 

--- a/packages/kie-editors-standalone/e2e-tests/src/App.tsx
+++ b/packages/kie-editors-standalone/e2e-tests/src/App.tsx
@@ -105,7 +105,7 @@ export function App() {
                     [
                       "custom-workitem.wid",
                       {
-                        contentType: ContentType.TEXT,
+                        contentType: "text",
                         content: Promise.resolve(customWorkItemWid),
                       },
                     ],

--- a/packages/kie-editors-standalone/e2e-tests/src/components/EditorComponent.tsx
+++ b/packages/kie-editors-standalone/e2e-tests/src/components/EditorComponent.tsx
@@ -93,7 +93,7 @@ export const EditorComponent = ({
         name: modelName,
         value: {
           normalizedPosixPathRelativeToTheWorkspaceRoot: modelName,
-          type: ContentType.TEXT,
+          type: "text",
           content,
         },
       },

--- a/packages/kie-editors-standalone/e2e-tests/src/components/FileLoader.tsx
+++ b/packages/kie-editors-standalone/e2e-tests/src/components/FileLoader.tsx
@@ -50,7 +50,7 @@ export const FileLoader: React.FC<Props> = (props: Props) => {
               name: file.name,
               value: {
                 normalizedPosixPathRelativeToTheWorkspaceRoot: file.name,
-                type: ContentType.TEXT,
+                type: "text",
                 content: fileContent,
               },
             },

--- a/packages/kie-editors-standalone/src/bpmn/index.ts
+++ b/packages/kie-editors-standalone/src/bpmn/index.ts
@@ -29,8 +29,7 @@ import {
 } from "@kie-tools-core/editor/dist/api";
 import { StandaloneEditorsEditorChannelApiImpl } from "../envelope/StandaloneEditorsEditorChannelApiImpl";
 import { StateControl } from "@kie-tools-core/editor/dist/channel";
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
-import { createEditor, Editor, StandaloneEditorApi } from "../common/Editor";
+import { createEditor, Editor, EditorStandaloneResource, StandaloneEditorApi } from "../common/Editor";
 import { BpmnEditorDiagramApi } from "../jsdiagram/BpmnEditorDiagramApi";
 import { BpmnEditorEnvelopeApi } from "@kie-tools/kie-bc-editors/dist/bpmn/api";
 
@@ -71,7 +70,7 @@ export function open(args: {
   readOnly?: boolean;
   origin?: string;
   onError?: () => any;
-  resources?: Map<string, { contentType: ContentType; content: Promise<string> }>;
+  resources?: Map<string, EditorStandaloneResource>;
 }): StandaloneEditorApi & BpmnEditorDiagramApi {
   const iframe = document.createElement("iframe");
   iframe.srcdoc = bpmnEnvelopeIndex;

--- a/packages/kie-editors-standalone/src/common/Editor.ts
+++ b/packages/kie-editors-standalone/src/common/Editor.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
 import { EditorApi, KogitoEditorEnvelopeApi } from "@kie-tools-core/editor/dist/api";
 import { StateControl } from "@kie-tools-core/editor/dist/channel";
 import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
@@ -30,13 +29,15 @@ export interface StandaloneEditorApi extends EditorApi {
   close: () => void;
 }
 
+export type EditorStandaloneResource = { contentType: "text" | "binary"; content: Promise<string> };
+
 export interface Editor {
   open: (args: {
     container: Element;
     initialContent: Promise<string>;
     readOnly: boolean;
     origin?: string;
-    resources?: Map<string, { contentType: ContentType; content: Promise<string> }>;
+    resources?: Map<string, EditorStandaloneResource>;
   }) => StandaloneEditorApi;
 }
 

--- a/packages/kie-editors-standalone/src/dmn/index.ts
+++ b/packages/kie-editors-standalone/src/dmn/index.ts
@@ -29,8 +29,7 @@ import {
 } from "@kie-tools-core/editor/dist/api";
 import { StandaloneEditorsEditorChannelApiImpl } from "../envelope/StandaloneEditorsEditorChannelApiImpl";
 import { StateControl } from "@kie-tools-core/editor/dist/channel";
-import { ContentType } from "@kie-tools-core/workspace/dist/api";
-import { createEditor, Editor, StandaloneEditorApi } from "../common/Editor";
+import { createEditor, Editor, EditorStandaloneResource, StandaloneEditorApi } from "../common/Editor";
 import { DmnEditorDiagramApi } from "../jsdiagram/DmnEditorDiagramApi";
 import { DmnEditorEnvelopeApi } from "@kie-tools/kie-bc-editors/dist/dmn/api";
 
@@ -71,7 +70,7 @@ export function open(args: {
   readOnly?: boolean;
   origin?: string;
   onError?: () => any;
-  resources?: Map<string, { contentType: ContentType; content: Promise<string> }>;
+  resources?: Map<string, EditorStandaloneResource>;
 }): StandaloneEditorApi & DmnEditorDiagramApi {
   const iframe = document.createElement("iframe");
   iframe.srcdoc = dmnEnvelopeIndex;

--- a/packages/kie-editors-standalone/src/envelope/StandaloneEditorsEditorChannelApiImpl.ts
+++ b/packages/kie-editors-standalone/src/envelope/StandaloneEditorsEditorChannelApiImpl.ts
@@ -18,12 +18,12 @@
  */
 
 import {
-  ContentType,
   WorkspaceEdit,
   ResourceContent,
   ResourceContentRequest,
   ResourceListRequest,
   ResourcesList,
+  ContentType,
 } from "@kie-tools-core/workspace/dist/api";
 import {
   EditorContent,
@@ -34,6 +34,7 @@ import {
 import { EmbeddedEditorFile, StateControl } from "@kie-tools-core/editor/dist/channel";
 import { Minimatch } from "minimatch";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
+import { EditorStandaloneResource } from "../common/Editor";
 
 export class StandaloneEditorsEditorChannelApiImpl implements KogitoEditorChannelApi {
   constructor(
@@ -43,7 +44,7 @@ export class StandaloneEditorsEditorChannelApiImpl implements KogitoEditorChanne
     private readonly overrides: Partial<KogitoEditorChannelApi>,
     private readonly resources?: Map<
       string /** normalized posix path relative to the "workspace" root */,
-      { contentType: ContentType; content: Promise<string> }
+      EditorStandaloneResource
     >
   ) {}
 

--- a/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceForDanglingFiles.ts
+++ b/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceForDanglingFiles.ts
@@ -85,17 +85,17 @@ export class VsCodeResourceContentServiceForDanglingFiles implements ResourceCon
     try {
       const content = await vscode.workspace.fs.readFile(vscode.Uri.file(absoluteFsPath));
 
-      if (opts?.type === ContentType.BINARY) {
+      if (opts?.type === "binary") {
         return new ResourceContent(
           normalizedPosixPathRelativeToTheWorkspaceRoot, // Always return the relative path.
           Buffer.from(content).toString("base64"),
-          ContentType.BINARY
+          "binary"
         );
       } else {
         return new ResourceContent(
           normalizedPosixPathRelativeToTheWorkspaceRoot, // Always return the relative path.
           Buffer.from(content).toString(),
-          ContentType.TEXT
+          "text"
         );
       }
     } catch (e) {

--- a/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceForWorkspaces.ts
+++ b/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceForWorkspaces.ts
@@ -149,17 +149,17 @@ Resolved path: ${__path.resolve(workspaceRootAbsoluteFsPath, normalizedFsPathRel
     try {
       const content = await vscode.workspace.fs.readFile(vscode.Uri.file(absoluteFsPath));
 
-      if (opts?.type === ContentType.BINARY) {
+      if (opts?.type === "binary") {
         return new ResourceContent(
           normalizedPosixPathRelativeToTheWorkspaceRoot, // Always return the relative path.
           Buffer.from(content).toString("base64"),
-          ContentType.BINARY
+          "binary"
         );
       } else {
         return new ResourceContent(
           normalizedPosixPathRelativeToTheWorkspaceRoot, // Always return the relative path.
           Buffer.from(content).toString(),
-          ContentType.TEXT
+          "text"
         );
       }
     } catch (e) {

--- a/packages/vscode-extension/tests/VsCodeResourceContentServiceForDanglingFiles.test.ts
+++ b/packages/vscode-extension/tests/VsCodeResourceContentServiceForDanglingFiles.test.ts
@@ -68,7 +68,7 @@ describe("VsCodeResourceContentServiceForDanglingFiles", () => {
 
     expect(resource1Content).not.toBeNull();
     expect(resource1Content?.normalizedPosixPathRelativeToTheWorkspaceRoot).toBe(resource1Path);
-    expect(resource1Content?.type).toBe(ContentType.TEXT);
+    expect(resource1Content?.type).toBe("text");
     expect(resource1Content?.content).toBe("content for resource 1");
 
     const resource2Path = "resource2.txt";
@@ -76,15 +76,15 @@ describe("VsCodeResourceContentServiceForDanglingFiles", () => {
 
     expect(resource2Content).not.toBeNull();
     expect(resource2Content?.normalizedPosixPathRelativeToTheWorkspaceRoot).toBe(resource2Path);
-    expect(resource2Content?.type).toBe(ContentType.TEXT);
+    expect(resource2Content?.type).toBe("text");
     expect(resource2Content?.content).toBe("content for resource 2");
 
     const iconPath = "icon.png";
-    const iconContent = await resourceContentService.get(iconPath, { type: ContentType.BINARY });
+    const iconContent = await resourceContentService.get(iconPath, { type: "binary" });
 
     expect(iconContent).not.toBeNull();
     expect(iconContent?.normalizedPosixPathRelativeToTheWorkspaceRoot).toBe(iconPath);
-    expect(iconContent?.type).toBe(ContentType.BINARY);
+    expect(iconContent?.type).toBe("binary");
     expect(iconContent?.content).not.toBeNull();
   });
 
@@ -98,15 +98,15 @@ describe("VsCodeResourceContentServiceForDanglingFiles", () => {
 
     expect(txtResourceContent).not.toBeNull();
     expect(txtResourceContent?.normalizedPosixPathRelativeToTheWorkspaceRoot).toBe(txtResourcePath);
-    expect(txtResourceContent?.type).toBe(ContentType.TEXT);
+    expect(txtResourceContent?.type).toBe("text");
     expect(txtResourceContent?.content).toBe(undefined);
 
     const binaryPath = "icon.png";
-    const binaryContent = await resourceContentService.get(binaryPath, { type: ContentType.BINARY });
+    const binaryContent = await resourceContentService.get(binaryPath, { type: "binary" });
 
     expect(binaryContent).not.toBeNull();
     expect(binaryContent?.normalizedPosixPathRelativeToTheWorkspaceRoot).toBe(binaryPath);
-    expect(binaryContent?.type).toBe(ContentType.BINARY);
+    expect(binaryContent?.type).toBe("binary");
     expect(binaryContent?.content).toBe(undefined);
   });
 });

--- a/packages/workspace/src/api/ContentType.ts
+++ b/packages/workspace/src/api/ContentType.ts
@@ -17,7 +17,4 @@
  * under the License.
  */
 
-export enum ContentType {
-  TEXT = "text",
-  BINARY = "binary",
-}
+export type ContentType = "text" | "binary";

--- a/packages/workspace/src/api/ResourceContent.ts
+++ b/packages/workspace/src/api/ResourceContent.ts
@@ -23,6 +23,6 @@ export class ResourceContent {
   constructor(
     public readonly normalizedPosixPathRelativeToTheWorkspaceRoot: string,
     public readonly content: string | undefined,
-    public readonly type: ContentType = ContentType.TEXT
+    public readonly type: ContentType = "text"
   ) {}
 }

--- a/packages/workspaces-git-fs/src/worker/WorkspacesWorkerApiImpl.ts
+++ b/packages/workspaces-git-fs/src/worker/WorkspacesWorkerApiImpl.ts
@@ -178,12 +178,12 @@ export class WorkspacesWorkerApiImpl implements WorkspacesWorkerApi {
           return new ResourceContent(
             args.relativePath,
             file.content ? Buffer.from(file.content).toString("base64") : "",
-            ContentType.BINARY
+            "binary"
           );
         }
 
         // "text" is the default
-        return new ResourceContent(args.relativePath, decoder.decode(file.content), ContentType.TEXT);
+        return new ResourceContent(args.relativePath, decoder.decode(file.content), "text");
       } catch (e) {
         console.error(e);
         throw e;


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1475

Replaces `ContentType` enum with a `type`. This allows library consumers to use simple strings instead of enum values.

This was necessary because the enum belongs to a dependency and typescript doesn't export it with the final code.