### PR TITLE
[10.0.x] NO-ISSUE: Missing KIE Sandbox Quarkus Accelerator Jenkins job and checksum files content fixes

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
+++ b/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
@@ -110,7 +110,7 @@ pipeline {
                 dir('kie-sandbox-quarkus-accelerator') {
                     script {
                         githubUtils.createTag("${params.TAG_NAME}")
-                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfCIGithubCredentialsId}")
                     }
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
+++ b/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Library('jenkins-pipeline-shared-libraries')_
+
+pipeline {
+    agent {
+        docker {
+            image 'docker.io/apache/incubator-kie-tools-ci-build:main'
+            args '--shm-size=2g --privileged --group-add docker'
+            label util.avoidFaultyNodes()
+        }
+    }
+
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    parameters {
+        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.X)', trim: true)
+        string(name: 'RELEASE_VERSION', description: 'Release version', trim: true)
+        string(name: 'TAG_NAME', description: 'Tag name to be created', trim: true)
+    }
+
+    stages {
+        stage('Load local shared scripts') {
+            steps {
+                script {
+                    pipelineVars = load '.ci/jenkins/shared-scripts/pipelineVars.groovy'
+                    githubUtils = load '.ci/jenkins/shared-scripts/githubUtils.groovy'
+                }
+            }
+        }
+
+        stage('Clean workspace') {
+            steps {
+                cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+            }
+        }
+
+        stage('Checkout kie-sandbox-quarkus-accelerator') {
+            steps {
+                dir('kie-sandbox-quarkus-accelerator') {
+                    script {
+                        githubUtils.checkoutRepo(
+                            'http://github.com/apache/incubator-kie-sandbox-quarkus-accelerator.git',
+                            "${params.BRANCH_NAME}",
+                            "${pipelineVars.kieToolsBotGithubCredentialsId}"
+                        )
+                    }
+                }
+            }
+        }
+
+        stage('Setup Git repository') {
+            steps {
+                dir('kie-sandbox-quarkus-accelerator') {
+                    script {
+                        sh """#!/bin/bash -el
+                        git config user.email asf-ci-kie@jenkins.kie.apache.org
+                        git config user.name asf-ci-kie
+                        git checkout ${params.BRANCH_NAME}
+                        """.trim()
+                    }
+                }
+            }
+        }
+
+        stage('Update kogito BOM version') {
+            steps {
+                dir('kie-sandbox-quarkus-accelerator') {
+                    script {
+                        sh """#!/bin/bash -el
+                        mvn versions:set-property -Dproperty=kogito.bom.version -DnewVersion=${params.RELEASE_VERSION}
+                        """.trim()
+                    }
+                }
+            }
+        }
+
+        stage('Commit changes') {
+            steps {
+                dir('kie-sandbox-quarkus-accelerator') {
+                    script {
+                        sh """#!/bin/bash -el
+                        git add .
+                        git commit --allow-empty -am "Apache KIE ${params.RELEASE_VERSION} release"
+                        """.trim()
+                    }
+                }
+            }
+        }
+
+        stage('Create a new tag') {
+            steps {
+                dir('kie-sandbox-quarkus-accelerator') {
+                    script {
+                        githubUtils.createTag("${params.TAG_NAME}")
+                        githubUtils.pushObject('origin', "${params.TAG_NAME}", "${pipelineVars.asfGithubPushCredentialsId}")
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs(deleteDirs: true, disableDeferredWipeout: true)
+        }
+    }
+}

--- a/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
+++ b/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
@@ -20,7 +20,7 @@
 pipeline {
     agent {
         docker {
-            image 'docker.io/apache/incubator-kie-tools-ci-build:main'
+            image 'docker.io/apache/incubator-kie-tools-ci-build:10.0.999'
             args '--shm-size=2g --privileged --group-add docker'
             label util.avoidFaultyNodes()
         }

--- a/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
+++ b/.ci/jenkins/Jenkinsfile.release-candidate.quarkus-accelerator
@@ -31,7 +31,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.X)', trim: true)
+        string(name: 'BRANCH_NAME', description: 'Set the Git branch to checkout (0.0.999)', trim: true)
         string(name: 'RELEASE_VERSION', description: 'Release version', trim: true)
         string(name: 'TAG_NAME', description: 'Tag name to be created', trim: true)
     }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.chrome-extensions
@@ -376,12 +376,14 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.CHROME_EXTENSION_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.CHROME_EXTENSION_EDITORS_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SWF_CHROME_EXTENSION_EDITORS_RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.CHROME_EXTENSION_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.SWF_CHROME_EXTENSION_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.CHROME_EXTENSION_EDITORS_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.SWF_CHROME_EXTENSION_EDITORS_RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.cors-proxy
@@ -199,9 +199,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dashbuilder-viewer-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-base-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-dmn-form-webapp-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-kogito-quarkus-blank-app-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.dev-deployment-upload-service
@@ -216,12 +216,14 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_ARM64_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_MAC_X86_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_LINUX_X86_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.DEV_DEPLOYMENT_UPLOAD_SERVICE_WINDOWS_X86_RELEASE_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.extended-services
@@ -155,9 +155,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${RELEASE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -228,9 +228,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-extended-services
@@ -199,9 +199,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox-helm-chart
@@ -177,9 +177,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${RELEASE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${RELEASE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kn-plugin-workflow
@@ -236,12 +236,14 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.KN_PLUGIN_LINUX_X86_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.KN_PLUGIN_MACOS_ARM_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.KN_PLUGIN_MACOS_X86_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.KN_PLUGIN_WINDOWS_X86_RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-management-console
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-serverless-operator
@@ -224,10 +224,12 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                        releaseUtils.signArtifact("${env.RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -204,9 +204,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -204,9 +204,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-task-console
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.npm-packages
@@ -172,9 +172,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -214,9 +214,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-base-builder-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-builder-image
@@ -191,9 +191,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.serverless-logic-web-tools-swf-dev-mode-image
@@ -175,9 +175,11 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.RELEASE_IMAGE_TAR_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.RELEASE_IMAGE_TAR_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.standalone-editors-cdn
@@ -192,10 +192,12 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.BUSINESS_AUTOMATION_STANDALONE_RELEASE_ZIP_FILE}")
+                        releaseUtils.signArtifact("${env.SONATAFLOW_STANDALONE_RELEASE_ZIP_FILE}")
+                    }
                 }
             }
         }

--- a/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.vscode-extensions-prod
@@ -338,17 +338,19 @@ pipeline {
                 expression { !params.DRY_RUN && params.RELEASE_CANDIDATE_VERSION != '' }
             }
             steps {
-                script {
-                    releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
-                    releaseUtils.signArtifact("${env.RELEASE_ARTIFACTS_DIR}/${env.EXTENDED_SERVICES_VSCODE_EXTENSION_RELEASE_FILE}")
+                dir("${env.RELEASE_ARTIFACTS_DIR}") {
+                    script {
+                        releaseUtils.setupSigningKey("${pipelineVars.asfReleaseGPGKeyCredentialsId}")
+                        releaseUtils.signArtifact("${env.BPMN_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.DMN_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.PMML_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.DASHBUILDER_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.SONATAFLOW_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.YARD_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.KOGITO_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.BUSINESS_AUTOMATION_BUNDLE_VSCODE_EXTENSION_RELEASE_FILE}")
+                        releaseUtils.signArtifact("${env.EXTENDED_SERVICES_VSCODE_EXTENSION_RELEASE_FILE}")
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds a missing release candidate job for the KIE Sandbox Quarkus accelerator project.

It also fixes an issue where the release artifacts checksum files (.sha512) have the full path of the actual release file where it should only have the filename, causing the checksum verification to fail.

wrong checksum file contents:
`3957b6375d9a58f5944406c7fa9ab10e38619131681a9894f6bd9261ec8d57195a0921bd52a5c3bca4bfa94991672027aa95559489f811940216e3fa91e2bf0c  /home/jenkins/jenkins-agent/workspace/KIE/kie-tools/kie-tools-release-jobs/vscode-extensions-prod/release-artifacts/incubator-kie-10.0.0-rc1-bpmn-vscode-extension.vsix`

correct checksum file contents:
`3957b6375d9a58f5944406c7fa9ab10e38619131681a9894f6bd9261ec8d57195a0921bd52a5c3bca4bfa94991672027aa95559489f811940216e3fa91e2bf0c incubator-kie-10.0.0-rc1-bpmn-vscode-extension.vsix`

