### PR TITLE
kie-tools-issues#2584: Make `private` members to be `protected` for `DefaultVsCodeKieEditorChannelApiImpl`

### DIFF
--- a/packages/vscode-extension/src/DefaultVsCodeKieEditorChannelApiImpl.ts
+++ b/packages/vscode-extension/src/DefaultVsCodeKieEditorChannelApiImpl.ts
@@ -44,14 +44,14 @@ import { getNormalizedPosixPathRelativeToWorkspaceRoot, getWorkspaceRoot } from 
 
 export class DefaultVsCodeKieEditorChannelApiImpl implements KogitoEditorChannelApi, JavaCodeCompletionChannelApi {
   constructor(
-    private readonly editor: VsCodeKieEditorController,
-    private readonly resourceContentService: ResourceContentService,
-    private readonly vscodeWorkspace: VsCodeWorkspaceChannelApiImpl,
-    private readonly backendProxy: BackendProxy,
-    private readonly vscodeNotifications: VsCodeNotificationsChannelApiImpl,
-    private readonly javaCodeCompletionApi: JavaCodeCompletionApi,
-    private readonly viewType: string,
-    private readonly i18n: I18n<VsCodeI18n>
+    protected readonly editor: VsCodeKieEditorController,
+    protected readonly resourceContentService: ResourceContentService,
+    protected readonly vscodeWorkspace: VsCodeWorkspaceChannelApiImpl,
+    protected readonly backendProxy: BackendProxy,
+    protected readonly vscodeNotifications: VsCodeNotificationsChannelApiImpl,
+    protected readonly javaCodeCompletionApi: JavaCodeCompletionApi,
+    protected readonly viewType: string,
+    protected readonly i18n: I18n<VsCodeI18n>
   ) {}
 
   public async kogitoWorkspace_newEdit(workspaceEdit: WorkspaceEdit) {


### PR DESCRIPTION
### Context
Expose constructor parameters to subclasses of the `DefaultVsCodeKieEditorChannelApiImpl` class.

### Notes
This is not urgent by any means, so if accepted, please feel free to merge it at your best convenience.

fix: https://github.com/apache/incubator-kie-tools/issues/2584