### PR TITLE
kie-issues#1488: Importing `drools-build-parent` in Jbang script to enforce usage of correct depencendies version

### DIFF
--- a/packages/dmn-marshaller-backend-compatibility-tester/package.json
+++ b/packages/dmn-marshaller-backend-compatibility-tester/package.json
@@ -25,7 +25,7 @@
     "prefetch": "node dist/dependenciesFetch.js"
   },
   "dependencies": {
-    "@jbangdev/jbang": "0.2.0"
+    "@jbangdev/jbang": "0.2.3"
   },
   "devDependencies": {
     "@kie-tools/root-env": "workspace:*",

--- a/packages/dmn-marshaller-backend-compatibility-tester/src/DmnMarshallerBackendCompatibilityTesterScript.java
+++ b/packages/dmn-marshaller-backend-compatibility-tester/src/DmnMarshallerBackendCompatibilityTesterScript.java
@@ -20,6 +20,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 17
 //REPOS mavencentral,apache=https://repository.apache.org/content/groups/public/
+//DEPS org.kie:drools-build-parent:${kogito-runtime.version}@pom
 //DEPS ch.qos.logback:logback-classic:1.2.13
 //DEPS info.picocli:picocli:4.7.5
 //DEPS org.slf4j:slf4j-simple:2.0.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3885,8 +3885,8 @@ importers:
   packages/dmn-marshaller-backend-compatibility-tester:
     dependencies:
       '@jbangdev/jbang':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.3
+        version: 0.2.3
     devDependencies:
       '@kie-tools/root-env':
         specifier: workspace:*
@@ -16745,8 +16745,8 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jbangdev/jbang@0.2.0':
-    resolution: {integrity: sha512-Ixo6/Y5sXKmNjYlf03xws79siAGEvrZPgNAlSCXK9DZ8xH7hkzdZ0AwE5QDSaMmOwy/yUrLhPhjojwg+WhyBMg==}
+  '@jbangdev/jbang@0.2.3':
+    resolution: {integrity: sha512-fGkNarIf9HmxlbWNFLlNLYgahwz5SKwQ8NEstB7tnLEkoZqLCyjt+Z0Hr/WntWSFGSzJeezgQKJJg4so6OA6YA==}
 
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -37818,7 +37818,7 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jbangdev/jbang@0.2.0':
+  '@jbangdev/jbang@0.2.3':
     dependencies:
       shelljs: 0.8.5
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1488

In this PR:
- Import the `drools-build-parent` as a direct dependency in the script to point to the correct versions, to fix the issue described in the ticket
- Update Jbang to the latest 0.23.0 version.
