### PR TITLE
kie-issues#2466: Serverless Logic Web Tools: Runtime Tools settings doesn't validate the data index url.

### DIFF
--- a/packages/runtime-tools-swf-gateway-api/src/gatewayApi/apis.tsx
+++ b/packages/runtime-tools-swf-gateway-api/src/gatewayApi/apis.tsx
@@ -729,3 +729,22 @@ export const saveFormContent = (formName: string, content: FormContent): Promise
       .catch((error) => reject(error));
   });
 };
+
+export async function verifyDataIndex(dataIndexUrl?: string): Promise<boolean> {
+  if (!dataIndexUrl) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(dataIndexUrl, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+      body: '{"query":""}',
+    });
+    return response.status === 200;
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
@@ -71,6 +71,7 @@ interface AppDictionary extends ReferenceDictionary {
       validationError: string;
       connectionError: string;
       configExpiredWarning: string;
+      validDataIndexURLError: string;
     };
     confirmModal: {
       title: string;

--- a/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
@@ -71,7 +71,6 @@ interface AppDictionary extends ReferenceDictionary {
       validationError: string;
       connectionError: string;
       configExpiredWarning: string;
-      validDataIndexURLError: string;
     };
     confirmModal: {
       title: string;
@@ -104,6 +103,12 @@ interface AppDictionary extends ReferenceDictionary {
     virtualServiceRegistry: {
       dependencyWarning: string;
       dependencyWarningTooltip: string;
+    };
+  };
+  RuntimeToolsSettings: {
+    configModal: {
+      validDataIndexURLError: string;
+      dataIndexConnectionError: string;
     };
   };
 }

--- a/packages/serverless-logic-web-tools/src/i18n/locales/de.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/locales/de.ts
@@ -73,7 +73,6 @@ export const de: AppI18n = {
       validationError: "Sie müssen alle erforderlichen Felder ausfüllen, bevor Sie fortfahren können.",
       connectionError: "Verbindung abgelehnt. Bitte überprüfen Sie die angegebenen Informationen.",
       configExpiredWarning: "Token oder Konto ist abgelaufen. Bitte aktualisieren Sie Ihre Konfiguration.",
-      validDataIndexURLError: "Bitte geben Sie eine gültige Datenindex-URL ein.",
     },
     confirmModal: {
       title: "Bereitstellen",
@@ -111,6 +110,12 @@ export const de: AppI18n = {
       dependencyWarning: "Es gibt Abhängigkeiten von fremden Arbeitsbereichen!",
       dependencyWarningTooltip:
         "Modelle in diesem Arbeitsbereich können von Bereitstellungen aus anderen Arbeitsbereichen abhängen.",
+    },
+  },
+  RuntimeToolsSettings: {
+    configModal: {
+      validDataIndexURLError: "Bitte geben Sie eine gültige Datenindex-URL ein.",
+      dataIndexConnectionError: "Verbindung abgelehnt. Bitte überprüfen Sie die bereitgestellten Informationen.",
     },
   },
 };

--- a/packages/serverless-logic-web-tools/src/i18n/locales/de.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/locales/de.ts
@@ -73,6 +73,7 @@ export const de: AppI18n = {
       validationError: "Sie müssen alle erforderlichen Felder ausfüllen, bevor Sie fortfahren können.",
       connectionError: "Verbindung abgelehnt. Bitte überprüfen Sie die angegebenen Informationen.",
       configExpiredWarning: "Token oder Konto ist abgelaufen. Bitte aktualisieren Sie Ihre Konfiguration.",
+      validDataIndexURLError: "Bitte geben Sie eine gültige Datenindex-URL ein.",
     },
     confirmModal: {
       title: "Bereitstellen",

--- a/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
@@ -71,7 +71,6 @@ export const en: AppI18n = {
       validationError: "You must fill out all required fields before you can proceed.",
       connectionError: "Connection refused. Please check the information provided.",
       configExpiredWarning: "Token or account expired. Please update your configuration.",
-      validDataIndexURLError: "Please enter a valid Data Index URL.",
     },
     confirmModal: {
       title: "Deploy",
@@ -107,6 +106,12 @@ export const en: AppI18n = {
     virtualServiceRegistry: {
       dependencyWarning: "Has foreign workspace dependencies!",
       dependencyWarningTooltip: "Models in this workspace may depend on deployments from other workspaces.",
+    },
+  },
+  RuntimeToolsSettings: {
+    configModal: {
+      validDataIndexURLError: "Please enter a valid Data Index URL.",
+      dataIndexConnectionError: "Connection refused. Please check the information provided.",
     },
   },
 };

--- a/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
@@ -71,6 +71,7 @@ export const en: AppI18n = {
       validationError: "You must fill out all required fields before you can proceed.",
       connectionError: "Connection refused. Please check the information provided.",
       configExpiredWarning: "Token or account expired. Please update your configuration.",
+      validDataIndexURLError: "Please enter a valid Data Index URL.",
     },
     confirmModal: {
       title: "Deploy",

--- a/packages/serverless-logic-web-tools/src/settings/runtimeTools/RuntimeToolsSettings.tsx
+++ b/packages/serverless-logic-web-tools/src/settings/runtimeTools/RuntimeToolsSettings.tsx
@@ -62,12 +62,11 @@ export function RuntimeToolsSettings(props: SettingsPageProps) {
   const settingsDispatch = useSettingsDispatch();
   const [config, setConfig] = useState(settings.runtimeTools.config);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isDataIndexUrlValidated, setDataIndexUrlValidated] = useState(FormValiationOptions.INITIAL);
-  const [isDataIndexUrlVerified, setisDataIndexUrlVerified] = useState(FormValiationOptions.INITIAL);
+  const [isConfigValidated, setConfigValidated] = useState(FormValiationOptions.INITIAL);
   const [dataIndexUrlAvailable, setDataIndexUrlAvailable] = useState<boolean>(false);
 
   useEffect(() => {
-    setDataIndexUrlValidated(FormValiationOptions.INITIAL);
+    setConfigValidated(FormValiationOptions.INITIAL);
   }, [config]);
 
   const handleModalToggle = useCallback(() => {
@@ -100,13 +99,13 @@ export function RuntimeToolsSettings(props: SettingsPageProps) {
     };
     const isDataIndexUrlVerified = await verifyDataIndex(config.dataIndexUrl);
     if (!isDataIndexUrlValid(config.dataIndexUrl)) {
-      setDataIndexUrlValidated(FormValiationOptions.INVALID);
+      setConfigValidated(FormValiationOptions.INVALID);
       return;
     } else {
       if (isDataIndexUrlVerified == true) {
         setDataIndexUrlAvailable(true);
       } else {
-        setisDataIndexUrlVerified(FormValiationOptions.CONNECTION_ERROR);
+        setConfigValidated(FormValiationOptions.CONNECTION_ERROR);
         return;
       }
     }
@@ -175,7 +174,7 @@ export function RuntimeToolsSettings(props: SettingsPageProps) {
           appendTo={props.pageContainerRef.current || document.body}
         >
           <Form>
-            {isDataIndexUrlValidated === FormValiationOptions.INVALID && (
+            {isConfigValidated === FormValiationOptions.INVALID && (
               <FormAlert>
                 <Alert
                   variant="danger"
@@ -186,7 +185,7 @@ export function RuntimeToolsSettings(props: SettingsPageProps) {
                 />
               </FormAlert>
             )}
-            {isDataIndexUrlVerified === FormValiationOptions.CONNECTION_ERROR && (
+            {isConfigValidated === FormValiationOptions.CONNECTION_ERROR && (
               <FormAlert>
                 <Alert
                   variant="danger"

--- a/packages/serverless-logic-web-tools/src/url/index.ts
+++ b/packages/serverless-logic-web-tools/src/url/index.ts
@@ -27,10 +27,10 @@ export function removeTrailingSlashFromUrl(url: string): string {
   return url.replace(/\/$/, "");
 }
 
-export function validDataIndexUrl(url: string): boolean {
+export function isDataIndexUrlValid(url: string): boolean {
   try {
-    new URL(url);
-    return true;
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
   } catch (_) {
     return false;
   }

--- a/packages/serverless-logic-web-tools/tests/url/dataIndexValidUrl.test.ts
+++ b/packages/serverless-logic-web-tools/tests/url/dataIndexValidUrl.test.ts
@@ -17,15 +17,15 @@
  * under the License.
  */
 
-import { validDataIndexUrl } from "../../src/url";
+import { isDataIndexUrlValid } from "../../src/url";
 
-describe("removeTrailingSlash", () => {
+describe("isDataIndexUrlValid", () => {
   it.each([
+    ["http://example.com", true],
     ["http://example.com/", true],
     ["https://example.com/", true],
-    ["loremIpsum", false],
-    ["google.com", false],
-  ])("should validate the data index URL", (inputUrl, isValidUrl) => {
-    expect(validDataIndexUrl(inputUrl)).toBe(isValidUrl);
+    ["ftps://example.com/", false],
+  ])("the data index URL %s validation should be %s", (inputUrl, isValidUrl) => {
+    expect(isDataIndexUrlValid(inputUrl)).toBe(isValidUrl);
   });
 });

--- a/packages/serverless-logic-web-tools/tests/url/dataIndexValidUrl.test.ts
+++ b/packages/serverless-logic-web-tools/tests/url/dataIndexValidUrl.test.ts
@@ -17,21 +17,15 @@
  * under the License.
  */
 
-/**
- * Remove the trailing slash from an URL if it exists.
- *
- * @param url -
- * @returns
- */
-export function removeTrailingSlashFromUrl(url: string): string {
-  return url.replace(/\/$/, "");
-}
+import { validDataIndexUrl } from "../../src/url";
 
-export function validDataIndexUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch (_) {
-    return false;
-  }
-}
+describe("removeTrailingSlash", () => {
+  it.each([
+    ["http://example.com/", true],
+    ["https://example.com/", true],
+    ["loremIpsum", false],
+    ["google.com", false],
+  ])("should validate the data index URL", (inputUrl, isValidUrl) => {
+    expect(validDataIndexUrl(inputUrl)).toBe(isValidUrl);
+  });
+});

--- a/packages/sonataflow-deployment-webapp/src/context/AppContextProvider.tsx
+++ b/packages/sonataflow-deployment-webapp/src/context/AppContextProvider.tsx
@@ -19,9 +19,10 @@
 
 import React, { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { DEFAULT_APPDATA_VALUES } from "../AppConstants";
-import { AppData, verifyDataIndex } from "../data";
+import { AppData } from "../data";
 import { useAppDataPromise } from "../hooks/useAppDataPromise";
 import { AppContext } from "./AppContext";
+import { verifyDataIndex } from "@kie-tools/runtime-tools-swf-gateway-api/src/gatewayApi/apis";
 
 export function AppContextProvider(props: PropsWithChildren<{}>) {
   const appDataPromise = useAppDataPromise();

--- a/packages/sonataflow-deployment-webapp/src/data/index.ts
+++ b/packages/sonataflow-deployment-webapp/src/data/index.ts
@@ -29,22 +29,3 @@ export async function fetchAppData(): Promise<AppData> {
   const response = await fetch(routes.dataJson.path({}));
   return (await response.json()) as AppData;
 }
-
-export async function verifyDataIndex(dataIndexUrl?: string): Promise<boolean> {
-  if (!dataIndexUrl) {
-    return false;
-  }
-
-  try {
-    const response = await fetch(dataIndexUrl, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-      body: '{"query":""}',
-    });
-    return response.status === 200;
-  } catch (e) {
-    return false;
-  }
-}


### PR DESCRIPTION
Closes [apache/incubator/kie-issues#2466](https://github.com/apache/incubator-kie-tools/issues/2466)

**Description:**
The data index url is now validated and if its invalid an alert is shown.

**How to test:**

- Navigate to `serverless-logic-web-tools` package
- Execute the command `pnpm start`
- Click on this link to set your data index url and validate it [Runtime tools settings page](https://localhost:9020/#/settings/runtime-tools)

**Preview:**

https://github.com/user-attachments/assets/a1ce2a91-7185-4a71-a223-4f13c0bb366d

