### PR TITLE
NO-ISSUE: Bump `maven-surefire-plugin` from `3.2.5` to `3.5.0`

### DIFF
--- a/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/pom.xml
+++ b/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/pom.xml
@@ -43,7 +43,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.remote.resources.plugin.version>3.2.0</maven.remote.resources.plugin.version>
     <maven.jar.plugin.version>3.4.1</maven.jar.plugin.version>

--- a/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
@@ -43,7 +43,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.remote.resources.plugin.version>3.2.0</maven.remote.resources.plugin.version>
     <maven.jar.plugin.version>3.4.1</maven.jar.plugin.version>

--- a/packages/jbpm-quarkus-devui/dev/pom.xml
+++ b/packages/jbpm-quarkus-devui/dev/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.remote.resources.plugin.version>3.2.0</maven.remote.resources.plugin.version>
     <maven.jar.plugin.version>3.4.1</maven.jar.plugin.version>

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-expected.xml_no_auto_formatting
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-expected.xml_no_auto_formatting
@@ -13,7 +13,7 @@
         <quarkus.platform.group-id>org.quarkus.fake</quarkus.platform.group-id>
         <quarkus.platform.version>0.0.1</quarkus.platform.version>
         <skipITs>true</skipITs>
-        <surefire-plugin.version>3.2.5</surefire-plugin.version>
+        <surefire-plugin.version>3.5.0</surefire-plugin.version>
         <kie.version>0.0.0</kie.version>
         <kie.tooling.version>0.0.0</kie.tooling.version>
     </properties>

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-input.xml_no_auto_formatting
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-input.xml_no_auto_formatting
@@ -15,7 +15,7 @@
     <quarkus.platform.group-id>org.quarkus.fake</quarkus.platform.group-id>
     <quarkus.platform.version>0.0.1</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -107,7 +107,7 @@
     <version.resources.plugin>3.2.0</version.resources.plugin>
     <version.flatten.plugin>1.6.0</version.flatten.plugin>
     <version.junit>4.13.2</version.junit>
-    <surefire-plugin.version>3.2.5</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
     <quarkus.platform.version>3.8.6</quarkus.platform.version>
     <version.org.kie.kogito>999-20240905-SNAPSHOT</version.org.kie.kogito>
     <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>


### PR DESCRIPTION
Upgrading to address medium CVEs.