### PR TITLE
NO-ISSUE: Moving `sonataflow-management-console-image` to partition1.txt

### DIFF
--- a/.github/supporting-files/ci/partitions/partition1.txt
+++ b/.github/supporting-files/ci/partitions/partition1.txt
@@ -9,3 +9,4 @@ chrome-extension-serverless-workflow-editor
 vscode-extension-dashbuilder-editor
 yard-vscode-extension
 swf-vscode-extension
+@kie-tools/sonataflow-management-console-image


### PR DESCRIPTION
Partition 1 is kind of dedicated to SonataFlow/Serverless Workflow stuff, and partition N already has too many things.