### PR TITLE
[10.0.x] NO-ISSUE: Fix sonataflow {builder,devmode} image release jobs

### DIFF
--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-builder
@@ -122,7 +122,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        defaultSettingsFile = 'packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/settings.xml'
+                        defaultSettingsFile = 'packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/maven-m2-repo-via-http-settings.xml.envsubst'
                         sh """#!/bin/bash -el
                         rm -rf "${defaultSettingsFile}"
                         cp "${env.MAVEN_SETTINGS_PATH}" "${defaultSettingsFile}"

--- a/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kogito-swf-devmode
@@ -122,7 +122,7 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     script {
-                        defaultSettingsFile = 'packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/settings.xml'
+                        defaultSettingsFile = 'packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/maven-m2-repo-via-http-settings.xml.envsubst'
                         sh """#!/bin/bash -el
                         rm -rf "${defaultSettingsFile}"
                         cp "${env.MAVEN_SETTINGS_PATH}" "${defaultSettingsFile}"


### PR DESCRIPTION
This PR is a follow up on: https://github.com/apache/incubator-kie-tools/pull/2616.

It changes the maven settings file that is used during the sonataflow images build.