### PR TITLE
kie-issues#1490: Use `turbo`'s diffing algorithm to know which packages are affected by changes to `pnpm-lock.yaml`, avoiding FULL builds

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -56,7 +56,7 @@ const {
   allowPositionals: true,
 });
 
-const cwd = execSync("bash -c pwd").toString().trim();
+const absolutePosixWorkspaceRootPath = execSync("bash -c pwd").toString().trim();
 
 const __ARG_forceFull = forceFull === "true";
 
@@ -143,7 +143,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
 
   const allPackageDirs = new Set(
     stdoutArray(await execSync(`bash -c "pnpm -F !${__ROOT_PKG_NAME}... exec bash -c pwd"`).toString()).map((pkgDir) =>
-      convertToPosixStylePath(pkgDir)
+      convertToPosixPathRelativeToWorkspaceRoot(pkgDir)
     )
   );
 
@@ -158,7 +158,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
   const changedPackages: Array<{ path: string; name: string }> = JSON.parse(
     execSync(`bash -c "turbo ls --filter='[${__ARG_baseSha}...${__ARG_headSha}]' --output json"`).toString()
   ).packages.items.map((item: { path: string; name: string }) => ({
-    path: convertToPosixStylePath(item.path),
+    path: convertToPosixPathRelativeToWorkspaceRoot(item.path),
     name: item.name,
   }));
 
@@ -179,7 +179,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
     ).toString()
   )
     .packages.items.map((item: { path: string }) => item.path)
-    .map((pkgDir) => convertToPosixStylePath(pkgDir));
+    .map((pkgDir) => convertToPosixPathRelativeToWorkspaceRoot(pkgDir));
 
   return await Promise.all(
     partitionDefinitions.map(async (partition) => {
@@ -196,15 +196,9 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
         };
       }
 
-      console.log("[build-partitioning] Changed package dirs in Partition:");
-      console.log(new Set(changedPackagesDirs));
-
       const changedSourcePathsInPartition = changedPackagesDirs.filter((path) =>
         [...partition.dirs].some((partitionDir) => path.startsWith(`${partitionDir}`))
       );
-
-      console.log("[build-partitioning] Changed source paths in Partition:");
-      console.log(new Set(changedSourcePathsInPartition));
 
       if (changedSourcePathsInPartition.length === 0) {
         console.log(`[build-partitioning] 'None' build of '${partition.name}'.`);
@@ -229,7 +223,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
       );
 
       console.log(
-        `[build-partitioning]: Building ${relevantPackageNamesInPartition.size}/${partition.dirs.size}/${allPackageDirs.size} packages.`
+        `[build-partitioning] Building ${relevantPackageNamesInPartition.size}/${partition.dirs.size}/${allPackageDirs.size} packages.`
       );
       console.log(relevantPackageNamesInPartition);
 
@@ -259,11 +253,17 @@ async function getDirsOfDependencies(leafPackageNames: Set<string>) {
   const packagesFilter = [...leafPackageNames].map((pkgName) => `-F ${pkgName}...`).join(" ");
   return new Set(
     stdoutArray(execSync(`bash -c "pnpm ${packagesFilter} exec bash -c pwd"`).toString()) //
-      .map((pkgDir) => convertToPosixStylePath(pkgDir))
+      .map((pkgDir) => convertToPosixPathRelativeToWorkspaceRoot(pkgDir))
   );
 }
 
-function convertToPosixStylePath(pathString: string) {
-  const alreadyRelativePath = !pathString.startsWith(path.sep) && !pathString.startsWith(path.posix.sep);
-  return `${alreadyRelativePath ? pathString : path.relative(cwd, pathString)}`.split(path.sep).join(path.posix.sep);
+function convertToPosixPathRelativeToWorkspaceRoot(targetPath: string) {
+  // If it's not an absolute path we can assume it's relative to the workspace root (the current directory).
+  const isTargetPathRelativeToWorkspaceRoot =
+    !targetPath.startsWith(path.sep) && !targetPath.startsWith(path.posix.sep) && !path.isAbsolute(targetPath);
+
+  // Replace separators to make sure they are posix style.
+  return `${isTargetPathRelativeToWorkspaceRoot ? targetPath : path.relative(absolutePosixWorkspaceRootPath, targetPath)}`
+    .split(path.sep)
+    .join(path.posix.sep);
 }

--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -259,11 +259,10 @@ async function getDirsOfDependencies(leafPackageNames: Set<string>) {
 
 function convertToPosixPathRelativeToWorkspaceRoot(targetPath: string) {
   // If it's not an absolute path we can assume it's relative to the workspace root (the current directory).
-  const isTargetPathRelativeToWorkspaceRoot =
-    !targetPath.startsWith(path.sep) && !targetPath.startsWith(path.posix.sep) && !path.isAbsolute(targetPath);
+  const isTargetPathAbsolute = targetPath.startsWith(path.sep) || targetPath.startsWith(path.posix.sep);
 
   // Replace separators to make sure they are posix style.
-  return `${isTargetPathRelativeToWorkspaceRoot ? targetPath : path.relative(absolutePosixWorkspaceRootPath, targetPath)}`
+  return `${isTargetPathAbsolute ? path.relative(absolutePosixWorkspaceRootPath, targetPath) : targetPath}`
     .split(path.sep)
     .join(path.posix.sep);
 }

--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -56,7 +56,7 @@ const {
   allowPositionals: true,
 });
 
-const absolutePosixWorkspaceRootPath = execSync("bash -c pwd").toString().trim();
+const absolutePosixRepoRootPath = execSync("bash -c pwd").toString().trim();
 
 const __ARG_forceFull = forceFull === "true";
 
@@ -143,7 +143,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
 
   const allPackageDirs = new Set(
     stdoutArray(await execSync(`bash -c "pnpm -F !${__ROOT_PKG_NAME}... exec bash -c pwd"`).toString()).map((pkgDir) =>
-      convertToPosixPathRelativeToWorkspaceRoot(pkgDir)
+      convertToPosixPathRelativeToRepoRoot(pkgDir)
     )
   );
 
@@ -158,7 +158,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
   const changedPackages: Array<{ path: string; name: string }> = JSON.parse(
     execSync(`bash -c "turbo ls --filter='[${__ARG_baseSha}...${__ARG_headSha}]' --output json"`).toString()
   ).packages.items.map((item: { path: string; name: string }) => ({
-    path: convertToPosixPathRelativeToWorkspaceRoot(item.path),
+    path: convertToPosixPathRelativeToRepoRoot(item.path),
     name: item.name,
   }));
 
@@ -179,7 +179,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
     ).toString()
   )
     .packages.items.map((item: { path: string }) => item.path)
-    .map((pkgDir) => convertToPosixPathRelativeToWorkspaceRoot(pkgDir));
+    .map((pkgDir) => convertToPosixPathRelativeToRepoRoot(pkgDir));
 
   return await Promise.all(
     partitionDefinitions.map(async (partition) => {
@@ -253,16 +253,16 @@ async function getDirsOfDependencies(leafPackageNames: Set<string>) {
   const packagesFilter = [...leafPackageNames].map((pkgName) => `-F ${pkgName}...`).join(" ");
   return new Set(
     stdoutArray(execSync(`bash -c "pnpm ${packagesFilter} exec bash -c pwd"`).toString()) //
-      .map((pkgDir) => convertToPosixPathRelativeToWorkspaceRoot(pkgDir))
+      .map((pkgDir) => convertToPosixPathRelativeToRepoRoot(pkgDir))
   );
 }
 
-function convertToPosixPathRelativeToWorkspaceRoot(targetPath: string) {
-  // If it's not an absolute path we can assume it's relative to the workspace root (the current directory).
+function convertToPosixPathRelativeToRepoRoot(targetPath: string) {
+  // If it's not an absolute path we can assume it's relative to the repository root (the current directory).
   const isTargetPathAbsolute = targetPath.startsWith(path.sep) || targetPath.startsWith(path.posix.sep);
 
   // Replace separators to make sure they are posix style.
-  return `${isTargetPathAbsolute ? path.relative(absolutePosixWorkspaceRootPath, targetPath) : targetPath}`
+  return `${isTargetPathAbsolute ? path.relative(absolutePosixRepoRootPath, targetPath) : targetPath}`
     .split(path.sep)
     .join(path.posix.sep);
 }

--- a/.github/supporting-files/ci/build-partitioning/globals.ts
+++ b/.github/supporting-files/ci/build-partitioning/globals.ts
@@ -22,7 +22,7 @@ import * as fs from "fs";
 
 export const __ROOT_PKG_NAME = "kie-tools-root";
 
-export const __PACKAGES_ROOT_DIRS = ["packages", "examples"];
+export const __PACKAGES_ROOT_PATHS = ["packages/", "examples/", "repo/", "pnpm-lock.yaml"];
 
 export const __NON_SOURCE_FILES_PATTERNS = stdoutArray(
   fs.readFileSync(path.resolve(__dirname, "../patterns/non-source-files-patterns.txt"), "utf-8")

--- a/.github/supporting-files/ci/build-partitioning/globals.ts
+++ b/.github/supporting-files/ci/build-partitioning/globals.ts
@@ -22,6 +22,14 @@ import * as fs from "fs";
 
 export const __ROOT_PKG_NAME = "kie-tools-root";
 
+/**
+ * Root paths that can be ignored when checking individual changed files.
+ *
+ * `packages/` for the kie-tools packages, analysed by `turbo ls`.
+ * `examples/` for the kie-tools examples, analysed by `turbo ls`.
+ * `repo/` for the dependency graph. No PR should update the repository dependency graph by itself.
+ * `pnpm-lock.yaml` is the lockfile for the repository dependencies, also analysed by `turbo ls`.
+ */
 export const __PACKAGES_ROOT_PATHS = ["packages/", "examples/", "repo/", "pnpm-lock.yaml"];
 
 export const __NON_SOURCE_FILES_PATTERNS = stdoutArray(

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -93,6 +93,8 @@ jobs:
 
           npm -g uninstall bun turbo
 
+          rm turbo.json
+
           echo "mode=$(jq --raw-output '.[${{ matrix.partition }}].mode' /tmp/partitions.json)" >> $GITHUB_OUTPUT
           echo "bootstrapPnpmFilterString=$(jq --raw-output '.[${{ matrix.partition }}].bootstrapPnpmFilterString' /tmp/partitions.json)" >> $GITHUB_OUTPUT
           echo "fullBuildPnpmFilterString=$(jq --raw-output '.[${{ matrix.partition }}].fullBuildPnpmFilterString' /tmp/partitions.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -76,7 +76,11 @@ jobs:
         shell: bash
         run: |
 
-          npm -g install bun@1.1.6
+          npm -g install bun@1.1.6 turbo@2.1.2
+
+          echo '{}' > turbo.json
+
+          turbo telemetry disable
 
           bun ./.github/supporting-files/ci/build-partitioning/build_partitioning.ts \
             --outputPath='/tmp/partitions.json' \
@@ -87,7 +91,7 @@ jobs:
             --partition='./.github/supporting-files/ci/partitions/partition0.txt' \
             --partition='./.github/supporting-files/ci/partitions/partition1.txt'
 
-          npm -g uninstall bun
+          npm -g uninstall bun turbo
 
           echo "mode=$(jq --raw-output '.[${{ matrix.partition }}].mode' /tmp/partitions.json)" >> $GITHUB_OUTPUT
           echo "bootstrapPnpmFilterString=$(jq --raw-output '.[${{ matrix.partition }}].bootstrapPnpmFilterString' /tmp/partitions.json)" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,7 @@ packages/python-venv/venv
 
 # devbox
 .devbox
+
+# turbo
+.turbo
+turbo.json

--- a/devbox.json
+++ b/devbox.json
@@ -15,7 +15,8 @@
     "DEVBOX_COREPACK_ENABLED": "true",
     "GOFLAGS": "-modcacherw",
     "GOPATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs",
-    "PATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin:$PATH"
+    "PNPM_HOME": "$DEVBOX_PROJECT_ROOT/.devbox/pnpm-store",
+    "PATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin:$DEVBOX_PROJECT_ROOT/.devbox/pnpm-store:$PATH"
   },
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -304,7 +304,7 @@
     },
     "python@3.12.2": {
       "last_modified": "2024-03-22T11:26:23Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#python312",
       "source": "devbox-search",
       "version": "3.12.2",


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1490

Unlike `pnpm`, `turbo` can detect what packages were affected by the changes to the `pnpm-lock.yaml` file. This is important because we can trigger the PARTIAL CI build instead of FULL builds when the `pnpm-lock.yaml` file is changed in a PR, making PR checks faster.

This PR also introduces the `PNPM_HOME` env var to the `devbox` setup, guaranteeing that `pnpm` uses the same store for local and global packages.

**NOTE.: When running `pnpm bootstrap` you may be asked to reinstall packages to the new store. Just type `y` and `pnpm` will deal with it.**

Here are some test PRs to validate the new diffing strategy with `turbo`:

- Changes to the lockfile only: https://github.com/thiagoelg/kie-tools/pull/39
- Adding a new package: https://github.com/thiagoelg/kie-tools/pull/40
- Simple change to a single package: https://github.com/thiagoelg/kie-tools/pull/38