### PR TITLE
NO-ISSUE: Fix `turbo ls` command with too many filters on the Windows runner in GitHub Actions

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -188,10 +188,10 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
 
   // Using a Set because it forces unique values, so no need to deduplicate.
   const affectedPackageDirsInAllPartitionsSet = new Set<string>();
-  for (let packagesNameChunk of changedPackagesNamesChunks) {
+  for (let packagesNamesChunk of changedPackagesNamesChunks) {
     await JSON.parse(
       execSync(
-        `bash -c "turbo ls ${packagesNameChunk.map((packageName) => `-F '...${packageName}'`).join(" ")} --output json"`
+        `bash -c "turbo ls ${packagesNamesChunk.map((packageName) => `-F '...${packageName}'`).join(" ")} --output json"`
       ).toString()
     ).packages.items.forEach((item: { path: string }) => {
       affectedPackageDirsInAllPartitionsSet.add(convertToPosixPathRelativeToRepoRoot(item.path));

--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -173,9 +173,10 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
     __PACKAGES_ROOT_PATHS.every((rootPath) => !path.startsWith(rootPath))
   );
 
-  // On Windows there's a 8191 character limit for commands.
-  // To circunvent this we break the package list in chunks, run turbo ls, and then merge them to a final list.
-  // Chunk size is defined as 50. This is arbitrary value.
+  // On Windows there's a 8191 character limit for commands in PowerShell.
+  // See https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation
+  // To circunvent this, we break the package list in chunks, run turbo ls, and then merge them all to a final list.
+  // Chunk size is defined as 50. This is an arbitrary value.
   // If each package name has 100 characters, 50 of them is 5000 characters, making the final command less than 8191.
   const changedPackagesNamesChunks: string[][] = [];
   const chunkSize = 50;
@@ -197,13 +198,6 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
     });
   }
   const affectedPackageDirsInAllPartitions = Array.from(affectedPackageDirsInAllPartitionsSet);
-
-  console.log({
-    changedPackagesNames,
-    changedPackagesNamesChunks,
-    affectedPackageDirsInAllPartitionsSet,
-    affectedPackageDirsInAllPartitions,
-  });
 
   return await Promise.all(
     partitionDefinitions.map(async (partition) => {


### PR DESCRIPTION
Error example: https://github.com/apache/incubator-kie-tools/actions/runs/11152313129/job/30997685586?pr=2635#step:8:414
`error: The command line is too long.`

This is because Windows has a character limit for commands in the terminal: https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation

The change introduced in this PR breaks the single long command into smaller ones and then merges the results.





ᵍᵒᵗᵗᵃ ˡᵒᵛᵉ ᵂᶦⁿᵈᵒʷˢ