### PR TITLE
NO-ISSUE: Skip partial builds when no filters specified

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -134,7 +134,7 @@ jobs:
           eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} --workspace-concurrency=1 build:prod"
 
       - name: "PARTIAL → Build upstream"
-        if: steps.setup_build_mode.outputs.mode == 'partial'
+        if: steps.setup_build_mode.outputs.mode == 'partial' && steps.setup_build_mode.outputs.upstreamPnpmFilterString != ""
         shell: bash
         env:
           KIE_TOOLS_BUILD__buildContainerImages: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -134,7 +134,7 @@ jobs:
           eval "pnpm ${{ steps.setup_build_mode.outputs.fullBuildPnpmFilterString }} --workspace-concurrency=1 build:prod"
 
       - name: "PARTIAL → Build upstream"
-        if: steps.setup_build_mode.outputs.mode == 'partial' && steps.setup_build_mode.outputs.upstreamPnpmFilterString != ""
+        if: steps.setup_build_mode.outputs.mode == 'partial' && steps.setup_build_mode.outputs.upstreamPnpmFilterString != ''
         shell: bash
         env:
           KIE_TOOLS_BUILD__buildContainerImages: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Partial builds are sometimes failing, due to not having any filters populated. This PR addresses this by skipping the upstream partial build when upstreamPnpmFilterString=""
![image](https://github.com/user-attachments/assets/4936cc90-21db-4bcc-940f-4ad8aeb3d672)
