### PR TITLE
NO-ISSUE: In AJV v8 the `validation` object `dataPath` property was renamed to `instancePath` 

### DIFF
--- a/packages/form/src/FormHook.tsx
+++ b/packages/form/src/FormHook.tsx
@@ -99,12 +99,12 @@ export function useForm<Input extends Record<string, any>, Schema extends Record
         (infos: any, detail: any) => {
           if (detail.keyword === "type") {
             // If it's a type error, it's handled by replacing the current value with a undefined value.
-            const formFieldPath = dataPathToFormFieldPath(detail.dataPath);
+            const formFieldPath = dataPathToFormFieldPath(detail.instancePath);
             infos.changes = [...infos.changes, [formFieldPath, undefined]];
             return infos;
           } else if (detail.keyword === "enum") {
             // A enum error is caused by a type error.
-            const formFieldPath = dataPathToFormFieldPath(detail.dataPath);
+            const formFieldPath = dataPathToFormFieldPath(detail.instancePath);
             infos.changes = [...infos.changes, [formFieldPath, undefined]];
             return infos;
           }


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/apache/incubator-kie-tools/pull/2600. AJV v8 renamed `dataPath` property to `instancePath` [1]. This causes the DMN Runner to break when using collection ItemDefinitions.

[1] https://ajv.js.org/v6-to-v8-migration.html#new-features