### PR TITLE
NO-ISSUE: CI partitioning script was leaving out the last package

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -182,7 +182,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
   const chunkSize = 50;
   for (let i = 0; i < changedPackagesNames.length; i += chunkSize) {
     changedPackagesNamesChunks.push(
-      changedPackagesNames.slice(i, Math.min(i + chunkSize, changedPackagesNames.length - 1))
+      changedPackagesNames.slice(i, Math.min(i + chunkSize, changedPackagesNames.length))
     );
   }
 
@@ -215,7 +215,7 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
       }
 
       const changedSourcePathsInPartition = changedPackagesDirs.filter((path) =>
-        [...partition.dirs].some((partitionDir) => path.startsWith(`${partitionDir}`))
+        [...partition.dirs].some((partitionDir) => path === partitionDir)
       );
 
       if (changedSourcePathsInPartition.length === 0) {
@@ -268,6 +268,9 @@ async function getPartitions(): Promise<Array<None | Full | Partial>> {
 }
 
 async function getDirsOfDependencies(leafPackageNames: Set<string>) {
+  if (leafPackageNames.size === 0) {
+    return new Set<string>();
+  }
   const packagesFilter = [...leafPackageNames].map((pkgName) => `-F ${pkgName}...`).join(" ");
   return new Set(
     stdoutArray(execSync(`bash -c "pnpm ${packagesFilter} exec bash -c pwd"`).toString()) //


### PR DESCRIPTION
> The slice() method of [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) instances returns a [shallow copy](https://developer.mozilla.org/en-US/docs/Glossary/Shallow_copy) of a portion of an array into a new array object selected from start to end (end not included) where start and end represent the index of items in that array.

`(end not included)` <- Looks like I missed that 😬 


The other changes were not causing issues but could in the future! Especially the `partitionDir` comparison, as `startsWith` was returning `true` when checking `packages/dmn-marshaller` against `packages/dmn-marshaller-backend-compatibility-tester`.