### PR TITLE
NO-ISSUE: Fix Storybook static web application build

### DIFF
--- a/packages/boxed-expression-component/package.json
+++ b/packages/boxed-expression-component/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "rimraf dist && pnpm copy:css && tsc -p tsconfig.json",
     "build:prod": "rimraf dist && pnpm copy:css && pnpm lint && tsc -p tsconfig.json && pnpm test && pnpm test-e2e",
-    "build:storybook": "storybook build -o dist-storybook",
+    "build:storybook": "rimraf dist-storybook && NODE_ENV=development storybook build -o dist-storybook",
     "copy:css": "copyfiles -u 1 \"src/**/*.{sass,scss,css}\" dist/",
     "deploy": "gh-pages -d dist-dev",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",

--- a/packages/dmn-editor/package.json
+++ b/packages/dmn-editor/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build:dev": "rimraf dist && pnpm copy:css && tsc -p tsconfig.json",
     "build:prod": "rimraf dist && pnpm copy:css && pnpm lint && tsc -p tsconfig.json && pnpm test-e2e && pnpm test",
-    "build:storybook": "storybook build -o dist-storybook",
+    "build:storybook": "rimraf dist-storybook && NODE_ENV=development storybook build -o dist-storybook",
     "copy:css": "copyfiles -u 1 \"src/**/*.{sass,scss,css}\" dist/",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "start": "run-script-os",

--- a/packages/scesim-editor/package.json
+++ b/packages/scesim-editor/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "rimraf dist && tsc -p tsconfig.json",
     "build:prod": "rimraf dist && pnpm lint && tsc -p tsconfig.json && pnpm test-e2e",
-    "build:storybook": "storybook build -o dist-storybook",
+    "build:storybook": "rimraf dist-storybook && NODE_ENV=development storybook build -o dist-storybook",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "start": "run-script-os",

--- a/packages/storybook-base/src/config/baseConfig.ts
+++ b/packages/storybook-base/src/config/baseConfig.ts
@@ -60,7 +60,9 @@ export const baseConfig: (
       path.dirname(require.resolve("@storybook/addon-webpack5-compiler-babel/package.json")),
     ],
     webpackFinal: async (config) => {
-      return merge(config, common);
+      // Preserve Storybook output configurations
+      const commonConfig = { ...common, output: undefined };
+      return merge(config, commonConfig);
     },
   };
 };


### PR DESCRIPTION
Storybook gives an option to build its application so it can be deployed. Currently, we merge the webpack common configuration with Stotybook's. The `output` config was preventing Storybook from generating some files during build time. Additionally added `rimraf dist-storybook` to perform a cleanup before the build, and the `NODE_ENV=development` to prevent a warning message. 