### PR TITLE
[Incubator-kie-issues#1314] @kie-tools/jbpm-quarkus-devui: Wrong behaviors on the Error notification in Start Process Form component 

### DIFF
--- a/packages/runtime-tools-components/src/common/components/FormNotification/FormNotification.tsx
+++ b/packages/runtime-tools-components/src/common/components/FormNotification/FormNotification.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { Alert, AlertActionCloseButton, AlertActionLink } from "@patternfly/react-core/dist/js/components/Alert";
 import { componentOuiaProps, OUIAProps } from "../../ouiaTools";
 
@@ -42,6 +42,10 @@ export const FormNotification: React.FC<IOwnProps & OUIAProps> = ({ notification
   const variant = notification.type === "error" ? "danger" : "success";
 
   const [showDetails, setShowDetails] = useState<boolean>(false);
+  const content = useMemo(
+    () => showDetails && notification.details && <p>{notification.details}</p>,
+    [showDetails, notification.details]
+  );
   return (
     <Alert
       isInline
@@ -66,7 +70,7 @@ export const FormNotification: React.FC<IOwnProps & OUIAProps> = ({ notification
       actionClose={<AlertActionCloseButton onClose={notification.close} />}
       {...componentOuiaProps(ouiaId, "form-notification-alert", ouiaSafe)}
     >
-      {showDetails && notification.details && <p>{notification.details}</p>}
+      {content}
     </Alert>
   );
 };

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessFormContainer/ProcessFormContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessFormContainer/ProcessFormContainer.tsx
@@ -57,7 +57,9 @@ const ProcessFormContainer: React.FC<ProcessFormContainerProps & OUIAProps> = ({
               onSubmitSuccess(id);
             })
             .catch((error) => {
-              const message = error.response ? error.response.data : error.message;
+              const message = error.response
+                ? ` ${error.message}   ' ${error.response.request.statusText} '`
+                : error.message;
               onSubmitError(message);
             });
         },

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessFormContainer/ProcessFormContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessFormContainer/ProcessFormContainer.tsx
@@ -57,9 +57,7 @@ const ProcessFormContainer: React.FC<ProcessFormContainerProps & OUIAProps> = ({
               onSubmitSuccess(id);
             })
             .catch((error) => {
-              const message = error.response
-                ? ` ${error.message}   ' ${error.response.request.statusText} '`
-                : error.message;
+              const message = error.response ? `${error.response.statusText} : ${error.message}` : error.message;
               onSubmitError(message);
             });
         },

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
@@ -72,18 +72,21 @@ const ProcessFormPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
             goToProcessDefinition();
           },
         },
-        {
-          label: "Go to Process details",
-          onClick: () => {
-            setNotification(null);
-            goToProcessDetails();
-          },
-        },
       ],
       close: () => {
         setNotification(null);
       },
     });
+    return (
+      <>
+        {processId && (
+          <div>
+            <label>Go to Process details</label>
+            <button onClick={handleClick}>Click Here</button>
+          </div>
+        )}
+      </>
+    );
   };
 
   const onSubmitSuccess = (id: string): void => {
@@ -95,6 +98,11 @@ const ProcessFormPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
   const onSubmitError = (details?: string) => {
     const message = "Failed to start the process.";
     showNotification("error", message, details);
+  };
+
+  const handleClick = () => {
+    setNotification(null);
+    goToProcessDetails();
   };
 
   return (

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Card, CardBody } from "@patternfly/react-core/dist/js/components/Card";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import ProcessFormContainer from "../../containers/ProcessFormContainer/ProcessFormContainer";
@@ -49,10 +49,6 @@ const ProcessFormPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
 
   const goToProcessDefinition = () => {
     history.push("/Processes");
-  };
-
-  const goToProcessDetails = () => {
-    history.push(`/Process/${processId}`);
   };
 
   const showNotification = (
@@ -100,10 +96,13 @@ const ProcessFormPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
     showNotification("error", message, details);
   };
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
+    const goToProcessDetails = () => {
+      history.push(`/Process/${processId}`);
+    };
     setNotification(null);
     goToProcessDetails();
-  };
+  }, [setNotification, history, processId]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1314

Fixed code so as to meet the following acceptance criteria mentioned in the issue.
 Verify that the component gets the right information from the channel if an error happened after submit.
 Make View Details show extra information if available, if not possible just hide it.
 Make Go to Process Details only visible if there's a processId
 Make ProcessDetails page more robust and don't break if no processId is provided in the URL