### PR TITLE
NO-ISSUE: Fixes `pnpm start` in jbpm-quarkus-dev-ui

### DIFF
--- a/packages/jbpm-quarkus-devui/dev/pom.xml
+++ b/packages/jbpm-quarkus-devui/dev/pom.xml
@@ -174,58 +174,6 @@
         <directory>src/main/resources</directory>
       </resource>
     </resources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-compress</artifactId>
-            </dependency>
-            <dependency>
-              <groupId>org.iq80.snappy</groupId>
-              <artifactId>snappy</artifactId>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <artifactId>maven-remote-resources-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-compress</artifactId>
-            </dependency>
-            <dependency>
-              <groupId>org.iq80.snappy</groupId>
-              <artifactId>snappy</artifactId>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.iq80.snappy</groupId>
-              <artifactId>snappy</artifactId>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.iq80.snappy</groupId>
-              <artifactId>snappy</artifactId>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-compress</artifactId>
-            </dependency>
-          </dependencies>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This PR fixes the following error message after trying to run `jbpm-quarkus-dev-ui`.

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-remote-resources-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 195, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-remote-resources-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 199, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-surefire-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 217, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-surefire-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 221, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-jar-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 208, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-site-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 182, column 25
[ERROR] 'build.plugins.plugin[org.apache.maven.plugins:maven-site-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 186, column 25
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.kie.kogito:jbpm-quarkus-devui-dev-app:0.0.0 (E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml) has 7 errors
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-remote-resources-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 195, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-remote-resources-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 199, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-surefire-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 217, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-surefire-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 221, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-jar-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 208, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-site-plugin].dependencies.dependency.version' for org.apache.commons:commons-compress:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 182, column 25
[ERROR]     'build.plugins.plugin[org.apache.maven.plugins:maven-site-plugin].dependencies.dependency.version' for org.iq80.snappy:snappy:jar is missing. @ org.kie.kogito:jbpm-quarkus-devui-dev-app:${revision}, E:\Sources\CLEAN\incubator-kie-tools\packages\jbpm-quarkus-devui\dev\pom.xml, line 186, column 25
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
 ELIFECYCLE  Command failed with exit code 1.
```

Sequence of commands to reproduce the issue:
`pnpm bootstrap`
`pnpm -F jbpm-quarkus-dev-ui... build:dev`
`pnpm -F jbpm-quarkus-devui start`