### PR TITLE
NO-ISSUE: Do not use -ntp on Maven commands

### DIFF
--- a/.ci/jenkins/shared-scripts/buildUtils.groovy
+++ b/.ci/jenkins/shared-scripts/buildUtils.groovy
@@ -51,7 +51,6 @@ def setupPnpm(String mavenSettingsFileId = '') {
     pnpm config set network-timeout 1000000
     pnpm -r exec 'bash' '-c' 'mkdir .mvn'
     pnpm -r exec 'bash' '-c' 'echo -B > .mvn/maven.config'
-    pnpm -r exec 'bash' '-c' 'echo -ntp >> .mvn/maven.config'
     pnpm -r exec 'bash' '-c' 'echo -Xmx2g > .mvn/jvm.config'
     """.trim()
 

--- a/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
+++ b/packages/dev-deployment-kogito-quarkus-blank-app-image/Containerfile
@@ -30,7 +30,7 @@ COPY --chown=$USER_ID:$USER_ID dist-dev/quarkus-app $HOME_PATH/app/
 COPY --chown=$USER_ID:$USER_ID dist-dev/settings.xml /tmp/kogito/.m2/settings.xml
 
 # Pre-populate local Maven repository for faster startup
-RUN ./mvnw clean package -B -nsu -ntp --settings /tmp/kogito/.m2/settings.xml -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
+RUN ./mvnw clean package -B -nsu --settings /tmp/kogito/.m2/settings.xml -Dmaven.test.skip -Dmaven.repo.local=/tmp/kogito/.m2/repository -Dquarkus.http.non-application-root-path=${ROOT_PATH}/q -Dquarkus.http.root-path=${ROOT_PATH} \
   && chgrp -R 0 $HOME_PATH/app && chmod -R g=u $HOME_PATH/app && chgrp -R 0 /tmp/kogito && chmod -R g=u /tmp/kogito && chgrp -R 0 /.m2 && chmod -R g=u /.m2
 
 USER $USER_ID

--- a/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
+++ b/packages/maven-m2-repo-via-http-image/settings.xml.envsubst
@@ -25,10 +25,12 @@
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </releases>
           <snapshots>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </snapshots>
         </repository>
       </repositories>
@@ -42,10 +44,12 @@
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </releases>
           <snapshots>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/packages/serverless-logic-web-tools-swf-builder-image/Containerfile
+++ b/packages/serverless-logic-web-tools-swf-builder-image/Containerfile
@@ -27,5 +27,5 @@ RUN rm .dockerignore .gitignore README.md \
   && rm -rf .mvn/ src/main/java/ \
   && mvn quarkus:add-extension -Dextensions="quarkus-jsonp,quarkus-smallrye-openapi,quarkus-resteasy,smallrye-health" \
   && echo -e '\nquarkus.http.enable-compression=true\nquarkus.swagger-ui.always-include=true\nquarkus.http.host=0.0.0.0\nquarkus.http.cors=true\nquarkus.http.cors.origins=*\nkogito.service.url=http://localhost:8080' >> src/main/resources/application.properties \
-  && mvn clean package -B -ntp \
+  && mvn clean package -B \
   && rm -rf target/

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/Containerfile
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/Containerfile
@@ -34,7 +34,6 @@ RUN chown kogito /home/kogito/.m2 && \
   mvn clean package \
   quarkus:go-offline \
   -B \
-  -ntp \
   -s /home/kogito/.m2/settings.xml \
   -Dmaven.test.skip \
   -Dmaven.repo.local=/home/kogito/.m2/repository \

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/entrypoint.sh
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/entrypoint.sh
@@ -26,7 +26,7 @@ cd /tmp/app/serverless-logic-web-tools-swf-deployment-quarkus-app
 
 mvn quarkus:dev \
   -nsu \
-  -ntp \
+  -B \
   -o \
   -s /home/kogito/.m2/settings.xml \
   -Ddebug=false \

--- a/packages/sonataflow-builder-image/test-resources/tests/features/sonataflow-builder.feature
+++ b/packages/sonataflow-builder-image/test-resources/tests/features/sonataflow-builder.feature
@@ -12,7 +12,6 @@ Feature: Serverless Workflow builder images
       | wait                 | 480               |
       | request_method       | GET               |
       | expected_status_code | 200               |
-    And container log should contain --no-transfer-progress
     And container log should contain -Duser.home=/home/kogito
     And container log should match regex Installed features:.*kogito-serverless-workflow
     And container log should match regex Installed features:.*kie-addon-knative-eventing-extension

--- a/packages/sonataflow-devmode-image/test-resources/tests/features/sonataflow-devmode.feature
+++ b/packages/sonataflow-devmode-image/test-resources/tests/features/sonataflow-devmode.feature
@@ -12,7 +12,6 @@ Feature: Serverless Workflow devmode images
       | wait                 | 480               |
       | request_method       | GET               |
       | expected_status_code | 200               |
-    And container log should contain --no-transfer-progress
     And container log should contain -Duser.home=/home/kogito -o
     And container log should contain -Dquarkus.test.continuous-testing=disabled
     And container log should match regex Installed features:.*kogito-serverless-workflow

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/added/configure-maven.sh
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/added/configure-maven.sh
@@ -127,7 +127,7 @@ function configure_mirrors() {
 
 function configure_maven_download_output() {
     if [ "${MAVEN_DOWNLOAD_OUTPUT}" != "true" ]; then
-        export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} --no-transfer-progress"
+        export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND}"
     fi
 }
 

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/maven-m2-repo-via-http-settings.xml.envsubst
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/maven-m2-repo-via-http-settings.xml.envsubst
@@ -34,9 +34,59 @@
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
+          </snapshots>
+        </repository>
+        <repository>
+          <id>apache.snapshots</id>
+          <name>Apache Snapshot Repository</name>
+          <url>https://repository.apache.org/snapshots</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>apache-public-repository-group</id>
+          <name>Apache Public Repository Group</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBOSS Public Repository Group</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
             <updatePolicy>never</updatePolicy>
           </snapshots>
         </repository>
@@ -51,57 +101,34 @@
           <releases>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </releases>
           <snapshots>
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
+            <checksumPolicy>ignore</checksumPolicy> <!-- was already checked when downloaded on host machine -->
           </snapshots>
         </pluginRepository>
-      </pluginRepositories>
-    </profile>
-
-    <profile>
-      <id>kogito-images</id>
-      <repositories>
-        <repository>
-          <id>apache-public-repository-group</id>
-          <name>Apache Public Repository Group</name>
-          <url>https://repository.apache.org/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </snapshots>
-        </repository>
-        <!-- ### configured repositories ### -->
-      </repositories>
-
-      <pluginRepositories>
         <pluginRepository>
           <id>apache-public-repository-group</id>
           <name>Apache Public Repository Group</name>
           <url>https://repository.apache.org/content/groups/public/</url>
           <layout>default</layout>
           <releases>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
             <updatePolicy>never</updatePolicy>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
             <updatePolicy>never</updatePolicy>
           </snapshots>
         </pluginRepository>
-        <!-- ### configured plugin repositories ### -->
       </pluginRepositories>
     </profile>
   </profiles>
+
   <activeProfiles>
     <!-- ### extra maven profile ### -->
-    <activeProfile>kogito-images</activeProfile>
-    <activeProfile>kie-tools--maven-m2-repo-via-http-allowed-profile</activeProfile>
+    <activeProfile>kie-tools--maven-m2-repo-via-http-allowed-profile</activeProfile>  
   </activeProfiles>
 </settings>

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/tests/bats/maven-settings.bats
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/tests/bats/maven-settings.bats
@@ -163,16 +163,6 @@ function _generate_random_id() {
     [ "${expected}" = "${result}" ]
 }
 
-@test "test maven download output logs when MAVEN_DOWNLOAD_OUTPUT is not true" {
-    prepareEnv
-    configure_maven_download_output
-    expected=" --no-transfer-progress"
-    result="${MAVEN_ARGS_APPEND}"
-    echo "expected=${expected}"
-    echo "result=${result}"
-    [ "${expected}" = "${result}" ]
-}
-
 @test "test maven download output logs when MAVEN_DOWNLOAD_OUTPUT is true" {
     prepareEnv
     MAVEN_DOWNLOAD_OUTPUT="true"

--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/add-extension.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/add-extension.sh
@@ -42,7 +42,7 @@ fi
 
 "${MAVEN_HOME}"/bin/mvn -B ${MAVEN_ARGS_APPEND} \
     -nsu \
-    -ntp \
+    -B \
     -s "${MAVEN_SETTINGS_PATH}" \
     -DplatformVersion="${QUARKUS_PLATFORM_VERSION}" \
     -Dextensions="${extensions}" \

--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/build-app.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/build-app.sh
@@ -59,7 +59,7 @@ cd ${KOGITO_HOME}/serverless-workflow-project
 
 "${MAVEN_HOME}"/bin/mvn -B ${MAVEN_ARGS_APPEND} \
     -nsu \
-    -ntp \
+    -B \
     -s "${MAVEN_SETTINGS_PATH}" \
     -DskipTests \
     -Dquarkus.container-image.build=false \

--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
@@ -36,7 +36,7 @@ source "${script_dir_path}"/configure-jvm-mvn.sh
 
 "${MAVEN_HOME}"/bin/mvn -B ${MAVEN_ARGS_APPEND} \
   -nsu \
-  -ntp \
+  -B \
   -s "${MAVEN_SETTINGS_PATH}" \
   io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_PLATFORM_VERSION}":create ${QUARKUS_CREATE_ARGS} \
   -DprojectGroupId="${PROJECT_GROUP_ID}" \
@@ -131,7 +131,7 @@ fi
 #   https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html
 "${MAVEN_HOME}"/bin/mvn -B ${MAVEN_ARGS_APPEND} \
   -nsu \
-  -ntp \
+  -B \
   -s "${MAVEN_SETTINGS_PATH}" \
   -DskipTests=true \
   -Dmaven.javadoc.skip=true \
@@ -142,6 +142,6 @@ fi
 # clean up
 "${MAVEN_HOME}"/bin/mvn -B ${MAVEN_ARGS_APPEND} \
   -nsu \
-  -ntp \
+  -B \
   -s "${MAVEN_SETTINGS_PATH}" \
   clean

--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
@@ -135,6 +135,8 @@ fi
   -s "${MAVEN_SETTINGS_PATH}" \
   -DskipTests=true \
   -Dmaven.javadoc.skip=true \
+  -Dhttp.keepAlive=false \
+  -Dmaven.wagon.http.pool=false \
   clean dependency:go-offline io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_PLATFORM_VERSION}":go-offline install
 
 # clean up

--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/added/create-app.sh
@@ -135,8 +135,6 @@ fi
   -s "${MAVEN_SETTINGS_PATH}" \
   -DskipTests=true \
   -Dmaven.javadoc.skip=true \
-  -Dhttp.keepAlive=false \
-  -Dmaven.wagon.http.pool=false \
   clean dependency:go-offline io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_PLATFORM_VERSION}":go-offline install
 
 # clean up

--- a/packages/sonataflow-image-common/resources/scripts/setup-maven.sh
+++ b/packages/sonataflow-image-common/resources/scripts/setup-maven.sh
@@ -48,26 +48,6 @@ configure
 
 export MAVEN_OPTIONS="${MAVEN_OPTIONS} -s ${maven_settings_path}"
 
-# Add NPM registry if needed
-if [ ! -z "${NPM_REGISTRY_URL}" ]; then
-    echo "enabling npm repository: ${NPM_REGISTRY_URL}"
-    npm_profile="\
-<profile>\
-<id>internal-npm-registry</id>\
-<properties>\
-<npmRegistryURL>${NPM_REGISTRY_URL}</npmRegistryURL>\
-<yarnDownloadRoot>http://download.devel.redhat.com/rcm-guest/staging/rhba/dist/yarn/</yarnDownloadRoot>\
-<nodeDownloadRoot>http://download.devel.redhat.com/rcm-guest/staging/rhba/dist/node/</nodeDownloadRoot>\
-<npmDownloadRoot>http://download.devel.redhat.com/rcm-guest/staging/rhba/dist/npm/</npmDownloadRoot>\
-<pnpmDownloadRoot>http://download.devel.redhat.com/rcm-guest/staging/rhba/dist/pnpm/</pnpmDownloadRoot>\
-</properties>\
-</profile>\
-"   
-    sed -i.bak -E "s|(<!-- ### extra maven repositories ### -->)|\1\n${npm_profile}|" "${MAVEN_SETTINGS_PATH}"
-    sed -i.bak -E "s|(<!-- ### extra maven profile ### -->)|\1\n<activeProfile>internal-npm-registry</activeProfile>|" "${MAVEN_SETTINGS_PATH}"
-    
-    rm -rf "${MAVEN_SETTINGS_PATH}/*.bak"
-fi
 
 cat "${maven_settings_path}"
 


### PR DESCRIPTION
Doing so makes it obscure where dependencies are being downloaded from or even whether they're being downloaded at all. -B makes the logs not that long and I think it's a fate trade-off, at least until we have a solid base Maven repositories configuration shared between all packages.