### PR TITLE
NO-ISSUE: install libraries in CI docker image

### DIFF
--- a/.ci/incubator-kie-tools-ci-build.Dockerfile
+++ b/.ci/incubator-kie-tools-ci-build.Dockerfile
@@ -44,6 +44,7 @@ unzip \
 bzip2 \
 xvfb \
 fluxbox \
+rsync \
 subversion && \
 apt-get clean autoclean && apt-get autoremove --yes && \
 rm -rf /var/lib/{apt,cache,log}/

--- a/.ci/incubator-kie-tools-ci-build.Dockerfile
+++ b/.ci/incubator-kie-tools-ci-build.Dockerfile
@@ -28,6 +28,7 @@ libglvnd0 \
 libbtrfs-dev \
 libgpgme-dev \
 libdevmapper-dev \
+libxml2-utils \
 python3 \
 python3-pip \
 python3-dev \


### PR DESCRIPTION
Adding missing library to provide xmllint which is needed in jenkins CI jobs:
```
/home/jenkins/jenkins-agent/workspace/_ci-jobs_kie-tools-ci-build_main@2/kie-tools/packages/sonataflow-image-common/resources/modules/kogito-maven/common/tests/bats/maven-settings.bats: line 272: xmllint: command not found</failure>
```