### PR TITLE
kie-issues#2679: [SonataFlow] SonataFlow Management Console on KIE Tools daily dev job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.daily-dev-publish
+++ b/.ci/jenkins/Jenkinsfile.daily-dev-publish
@@ -145,6 +145,11 @@ pipeline {
         SONATAFLOW_DEVMODE_IMAGE__name = 'incubator-kie-sonataflow-devmode'
         SONATAFLOW_DEVMODE_IMAGE__buildTag = "${params.BRANCH_NAME}"
 
+        SONATAFLOW_MANAGEMENT_CONSOLE__registry = 'docker.io'
+        SONATAFLOW_MANAGEMENT_CONSOLE__account = 'apache'
+        SONATAFLOW_MANAGEMENT_CONSOLE__name = 'incubator-kie-sonataflow-management-console'
+        SONATAFLOW_MANAGEMENT_CONSOLE__buildTag = "${params.BRANCH_NAME}"
+
         SONATAFLOW_OPERATOR__registry = 'docker.io'
         SONATAFLOW_OPERATOR__account = 'apache'
         SONATAFLOW_OPERATOR__name = 'incubator-kie-sonataflow-operator'
@@ -266,6 +271,21 @@ pipeline {
                         "${env.SONATAFLOW_DEVMODE_IMAGE__account}",
                         "${env.SONATAFLOW_DEVMODE_IMAGE__name}",
                         "${env.SONATAFLOW_DEVMODE_IMAGE__buildTag}",
+                        "${pipelineVars.dockerHubUserCredentialsId}",
+                        "${pipelineVars.dockerHubTokenCredentialsId}"
+                    )
+                }
+            }
+        }
+
+        stage('Push sonataflow-management-console to Docker Hub') {
+            steps {
+                script {
+                    dockerUtils.pushImageToRegistry(
+                        "${env.SONATAFLOW_MANAGEMENT_CONSOLE__registry}",
+                        "${env.SONATAFLOW_MANAGEMENT_CONSOLE__account}",
+                        "${env.SONATAFLOW_MANAGEMENT_CONSOLE__name}",
+                        "${env.SONATAFLOW_MANAGEMENT_CONSOLE__buildTag}",
                         "${pipelineVars.dockerHubUserCredentialsId}",
                         "${pipelineVars.dockerHubTokenCredentialsId}"
                     )


### PR DESCRIPTION
**Closes** https://github.com/apache/incubator-kie-tools/issues/2679

:exclamation: Please do not merge until the repository is created. See [INFRA-26213](https://issues.apache.org/jira/browse/INFRA-26213) :exclamation: 

**Description:**
After the repo is created on dockerhub we need to update the KIE Tools daily dev job and add the image env vars and the the docker push command for SonataFlow Management Console.
See: https://github.com/apache/incubator-kie-tools/blob/main/.ci/jenkins/Jenkinsfile.daily-dev-publish
Discussion: apache/incubator-kie-kogito-docs#674 (comment)

@rodrigonull are there any other places which I need to update?