### PR TITLE
NO-ISSUE: Change `maven-base` to let pre-existing `.mvn/maven.config` files take precedence over default and package-specific configs

### DIFF
--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -175,21 +175,18 @@ module.exports = {
       .trim()
       .split("\n")
       .map((l) => l.trim())
-      .join("\n");
+      .join("\n")
+      .trim();
 
-    const newMavenConfigString = `${originalMvnConfigString ? `\n${originalMvnConfigString}\n` : ``}
-${trimmedMavenConfigString.trim()}`;
+    const newMavenConfigString =
+      (args?.ignoreDefault ? "" : `${DEFAULT_MAVEN_CONFIG}\n`) +
+      (trimmedMavenConfigString ? `${trimmedMavenConfigString}\n` : "") +
+      (originalMvnConfigString ? `${originalMvnConfigString}\n` : "");
 
     console.info(`[maven-base] Writing '${MVN_CONFIG_FILE_PATH}'...`);
     console.info(newMavenConfigString);
 
-    const defaultMavenConfigString = args?.ignoreDefault
-      ? ""
-      : `
-
-${DEFAULT_MAVEN_CONFIG}`;
-
-    fs.writeFileSync(MVN_CONFIG_FILE_PATH, `${newMavenConfigString}${defaultMavenConfigString}`);
+    fs.writeFileSync(MVN_CONFIG_FILE_PATH, newMavenConfigString);
     console.timeEnd(`[maven-base] Configuring Maven through .mvn/maven.config...`);
   },
 };

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -146,10 +146,10 @@ module.exports = {
   /**
    * Writes to `.mvn/maven.config` idempotently, preserving what was there before this function was called.
    *
-   * @param mavenConfigString New-line-separated string containing arguments to the `mvn` command.
+   * @param pkgSpecificMvnConfigString New-line-separated string containing arguments to the `mvn` command.
    * @param args An object with a `ignoreDefault: boolean` property.
    */
-  setupMavenConfigFile: (mavenConfigString, args) => {
+  setupMavenConfigFile: (pkgSpecificMvnConfigString, args) => {
     console.info(`[maven-base] Configuring Maven through .mvn/maven.config...`);
     console.time(`[maven-base] Configuring Maven through .mvn/maven.config...`);
 
@@ -171,21 +171,21 @@ module.exports = {
     console.info(`${originalMvnConfigString}` || "<empty>");
     fs.writeFileSync(MVN_CONFIG_ORIGINAL_FILE_PATH, originalMvnConfigString);
 
-    const packageSpecificMavenConfigString = mavenConfigString
+    const sanitizedPkgSpecificMvnConfigString = pkgSpecificMvnConfigString
       .trim()
       .split("\n")
-      .map((l) => l.trim())
+      .map((line) => line.trim())
       .join("\n");
 
-    const newMavenConfigString =
+    const newMvnConfigString =
       (args?.ignoreDefault ? "" : `${DEFAULT_MAVEN_CONFIG}\n`) +
-      (packageSpecificMavenConfigString ? `${packageSpecificMavenConfigString}\n` : "") +
+      (sanitizedPkgSpecificMvnConfigString ? `${sanitizedPkgSpecificMvnConfigString}\n` : "") +
       (originalMvnConfigString ? `${originalMvnConfigString}\n` : "");
 
     console.info(`[maven-base] Writing '${MVN_CONFIG_FILE_PATH}'...`);
-    console.info(newMavenConfigString);
+    console.info(newMvnConfigString);
 
-    fs.writeFileSync(MVN_CONFIG_FILE_PATH, newMavenConfigString);
+    fs.writeFileSync(MVN_CONFIG_FILE_PATH, newMvnConfigString);
     console.timeEnd(`[maven-base] Configuring Maven through .mvn/maven.config...`);
   },
 };

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -171,16 +171,15 @@ module.exports = {
     console.info(`${originalMvnConfigString}` || "<empty>");
     fs.writeFileSync(MVN_CONFIG_ORIGINAL_FILE_PATH, originalMvnConfigString);
 
-    const trimmedMavenConfigString = mavenConfigString
+    const packageSpecificMavenConfigString = mavenConfigString
       .trim()
       .split("\n")
       .map((l) => l.trim())
-      .join("\n")
-      .trim();
+      .join("\n");
 
     const newMavenConfigString =
       (args?.ignoreDefault ? "" : `${DEFAULT_MAVEN_CONFIG}\n`) +
-      (trimmedMavenConfigString ? `${trimmedMavenConfigString}\n` : "") +
+      (packageSpecificMavenConfigString ? `${packageSpecificMavenConfigString}\n` : "") +
       (originalMvnConfigString ? `${originalMvnConfigString}\n` : "");
 
     console.info(`[maven-base] Writing '${MVN_CONFIG_FILE_PATH}'...`);


### PR DESCRIPTION
This new strategy allows for overriding `DEFAULT_MAVEN_CONFIG` or package-specific configurations, like the location of `settings.xml`, for example.