### PR TITLE
[kogito-data-index-image] - Fix #2723: Transfer ownership to kogito user

### DIFF
--- a/packages/kogito-data-index-ephemeral-image/resources/incubator-kie-kogito-data-index-ephemeral-image.yaml
+++ b/packages/kogito-data-index-ephemeral-image/resources/incubator-kie-kogito-data-index-ephemeral-image.yaml
@@ -52,8 +52,8 @@ modules:
     - name: org.kie.kogito.dynamic.resources
     - name: org.kie.kogito.launch.scripts
     - name: org.kie.kogito.dataindex.ephemeral
-    - name: org.kie.kogito.dataindex.common
     - name: org.kie.kogito.security.custom.truststores
+    - name: org.kie.kogito.dataindex.common
 
 ports:
   - value: 8080

--- a/packages/kogito-data-index-ephemeral-image/resources/modules/kogito-data-index-ephemeral/configure
+++ b/packages/kogito-data-index-ephemeral-image/resources/modules/kogito-data-index-ephemeral/configure
@@ -23,4 +23,5 @@ SCRIPT_DIR=$(dirname "${0}")
 ADDED_DIR="${SCRIPT_DIR}"/added
 
 cp -v "${ADDED_DIR}"/kogito-app-launch.sh "${KOGITO_HOME}"
+
 chmod +x-w "${KOGITO_HOME}"/kogito-app-launch.sh

--- a/packages/kogito-data-index-postgresql-image/resources/incubator-kie-kogito-data-index-postgresql-image.yaml
+++ b/packages/kogito-data-index-postgresql-image/resources/incubator-kie-kogito-data-index-postgresql-image.yaml
@@ -18,7 +18,7 @@
 #
 schema_version: 1
 
-name: "docker.io/apache/incubator-kie-kogito-data-index-ephemeral"
+name: "docker.io/apache/incubator-kie-kogito-data-index-postgresql"
 version: "main"
 from: "registry.access.redhat.com/ubi8/openjdk-17-runtime:1.20"
 description: "Runtime image for Kogito Data Index Service for PostgreSQL persistence provider"
@@ -54,8 +54,8 @@ modules:
     - name: org.kie.kogito.dynamic.resources
     - name: org.kie.kogito.launch.scripts
     - name: org.kie.kogito.dataindex.postgresql
-    - name: org.kie.kogito.dataindex.common
     - name: org.kie.kogito.security.custom.truststores
+    - name: org.kie.kogito.dataindex.common
 
 run:
   workdir: "/home/kogito"

--- a/packages/kogito-data-index-postgresql-image/resources/modules/kogito-data-index-postgresql/configure
+++ b/packages/kogito-data-index-postgresql-image/resources/modules/kogito-data-index-postgresql/configure
@@ -23,4 +23,5 @@ SCRIPT_DIR=$(dirname "${0}")
 ADDED_DIR="${SCRIPT_DIR}"/added
 
 cp -v "${ADDED_DIR}"/kogito-app-launch.sh "${KOGITO_HOME}"
+
 chmod +x-w "${KOGITO_HOME}"/kogito-app-launch.sh

--- a/packages/sonataflow-image-common/resources/modules/kogito-data-index-common/configure
+++ b/packages/sonataflow-image-common/resources/modules/kogito-data-index-common/configure
@@ -26,4 +26,6 @@ mkdir -p "${KOGITO_HOME}"/launch
 mkdir -p "${KOGITO_HOME}"/data/protobufs/
 
 cp -v "${ADDED_DIR}"/kogito-data-index-common.sh "${KOGITO_HOME}"/launch
-chmod +x-w "${KOGITO_HOME}"/launch/kogito-data-index-common.sh
+
+chown -R ${USER_ID}:0 "${KOGITO_HOME}"
+chmod -R ug+rwX "${KOGITO_HOME}"

--- a/packages/sonataflow-image-common/resources/modules/kogito-jobs-service-common/configure
+++ b/packages/sonataflow-image-common/resources/modules/kogito-jobs-service-common/configure
@@ -25,5 +25,5 @@ ADDED_DIR="${SCRIPT_DIR}"/added
 
 cp -Rv "${ADDED_DIR}"/launch/* "${KOGITO_HOME}"/launch/
 
-chown -R 1001:0 "${KOGITO_HOME}"
+chown -R ${USER_ID}:0 "${KOGITO_HOME}"
 chmod -R ug+rwX "${KOGITO_HOME}"


### PR DESCRIPTION
Fix #2723 

I've also removed the `1001` magic number reference from the other modules and aligned the permissions in the other packages.