### PR TITLE
NO-ISSUE: Fix jbpm-compact-architecture-example

### DIFF
--- a/examples/jbpm-compact-architecture-example/docker-compose/startContainers.sh
+++ b/examples/jbpm-compact-architecture-example/docker-compose/startContainers.sh
@@ -4,15 +4,15 @@ PROFILE="full"
 
 echo "This script requires this example's app to have been compiled with 'mvn clean package -Pcontainer'"
 echo "==="
-echo "Using profile '${PROFILE}'..."
 
 PROJECT_VERSION=$(cd ../ && mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 KOGITO_MANAGEMENT_CONSOLE_IMAGE=$(cd ../ && mvn help:evaluate -Dexpression=kogito.management-console.image -q -DforceStdout)
 
 if [ -n "$1" ]; then
-  if [[ ("$1" == "full") || ("$1" == "infra") || ("$1" == "example-only")]];
+        if [ "$1" = "full" ] || [ "$1" = "infra" ] || [ "$1" = "example-only" ];
   then
     PROFILE="$1"
+    echo "Using profile '${PROFILE}'..."
   else
     echo "Unknown docker profile '$1'. The supported profiles are:"
     echo "* 'infra': Use this profile to start only the minimum infrastructure to run the example (postgresql, data-index & jobs-service)."
@@ -26,10 +26,13 @@ echo "PROJECT_VERSION=${PROJECT_VERSION}" > ".env"
 echo "KOGITO_MANAGEMENT_CONSOLE_IMAGE=${KOGITO_MANAGEMENT_CONSOLE_IMAGE}" >> ".env"
 echo "COMPOSE_PROFILES='${PROFILE}'" >> ".env"
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
    echo "DOCKER_GATEWAY_HOST=kubernetes.docker.internal" >> ".env"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-   echo "DOCKER_GATEWAY_HOST=172.17.0.1" >> ".env"
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+   echo "DOCKER_GATEWAY_HOST=172.17.0.1" >> ".env";
+else
+   echo "Unknown uname: $(uname)"
+   exit 1
 fi
 
 if [ ! -d "./svg" ]


### PR DESCRIPTION
- `startServices.sh` script was using BASH specific syntax and kept failing on Ubuntu, because in Ubuntu `sh` defaults to DASH
- minor adjustments