### PR TITLE
NO-ISSUE: Bump `xstream` to version `1.4.21`

### DIFF
--- a/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
@@ -54,6 +54,9 @@
     <version.maven.jar.plugin>3.4.1</version.maven.jar.plugin>
     <version.maven.clean.plugin>3.4.0</version.maven.clean.plugin>
     <version.codehaus.flatten.plugin>1.6.0</version.codehaus.flatten.plugin>
+    <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
+      When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
+    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
 
     <!-- Config -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -87,6 +90,13 @@
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-with-drools-quarkus</artifactId>
         <version>${version.org.kie.kogito}</version>
+      </dependency>
+      <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
+           When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>${version.com.thoughtworks.xstream}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -241,7 +241,7 @@
     <version.com.google.guava>32.1.3-jre</version.com.google.guava>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
-    <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.enforce-managed-deps-rule>1.3</version.enforce-managed-deps-rule>
     <version.enfore-victims-rule>1.3.4</version.enfore-victims-rule>
     <version.illegal-transitive-dependency-check>1.7.4</version.illegal-transitive-dependency-check>


### PR DESCRIPTION
The current xstream 1.4.20 is affected by [CVE-2024-47072](https://x-stream.github.io/CVE-2024-47072.html).
Updating xstream to ´1.4.21´ resolves the CVE