### PR TITLE
NO-ISSUE: Disable 'merge' option for PRs after SonataFlow Operator migration is done

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,5 +17,5 @@
 github:
   enabled_merge_buttons:
     squash: true
-    merge: true
+    merge: false
     rebase: false


### PR DESCRIPTION
We should only use Squash when merging PRs. If there's a special case we can revisit this file anytime.