### PR TITLE
[10.0.x] NO-ISSUE: Bump 'actions/upload-artifact' to v4

### DIFF
--- a/.github/actions/upload-ci-reports-and-artifacts/action.yml
+++ b/.github/actions/upload-ci-reports-and-artifacts/action.yml
@@ -59,7 +59,7 @@ runs:
         ls -la $RUNNER_TEMP
 
     - name: "Upload tests reports"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ runner.os }}_${{ inputs.partition_index }}__tests-reports
@@ -67,7 +67,7 @@ runs:
           ${{ runner.temp }}/tests-reports.zip
 
     - name: "Upload end-to-end tests reports"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ runner.os }}_${{ inputs.partition_index }}__end-to-end-tests-reports
@@ -75,7 +75,7 @@ runs:
           ${{ runner.temp }}/end-to-end-tests-reports.zip
 
     - name: "Upload end-to-end tests artifacts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ runner.os }}_${{ inputs.partition_index }}__end-to-end-tests-artifacts
@@ -83,7 +83,7 @@ runs:
           ${{ runner.temp }}/end-to-end-tests-artifacts.zip
 
     - name: "Upload build artifacts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ runner.os }}_${{ inputs.partition_index }}__build-artifacts


### PR DESCRIPTION
Cherry-pick of #2745 
The version 3 is being deprecated. See more details here:
- https://github.com/actions/upload-artifact/blob/main/README.md

The breaking changes:
- https://github.com/actions/upload-artifact/blob/main/README.md#breaking-changes

does not seem to be blocking us from bumping the version. However, we should compare the artifacts amount and size before and after this bump to be 100% sure. Furthermore, we already use 'actions/upload-artifact@v4'.