### PR TITLE
[incubator-kie-issues-1618] Fix NOTICE year with range

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache KIE
-Copyright 2024 The Apache Software Foundation
+Copyright 2023-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
- https://github.com/apache/incubator-kie-issues/issues/1618

NOTICE year should be a range. e.g. `2023-2024`, because Apache KIE started in 2023.