### PR TITLE
NO-ISSUE: fix issue when using image digest in Operator Makefile

### DIFF
--- a/packages/sonataflow-operator/Makefile
+++ b/packages/sonataflow-operator/Makefile
@@ -64,13 +64,15 @@ BUILDER ?= docker
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
+IMG_TAG_SEP = :
 USE_IMAGE_DIGESTS ?= false
 ifeq ($(USE_IMAGE_DIGESTS), true)
 	BUNDLE_GEN_FLAGS += --use-image-digests
+	IMG_TAG_SEP = @
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
+IMG ?= $(IMAGE_TAG_BASE)$(IMG_TAG_SEP)$(IMAGE_TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26
 


### PR DESCRIPTION
When using a digest for the operator (USE_IMAGE_DIGESTS=true), the separator between the image name and the tag should be an `@` instead of a `:`