### PR TITLE
NO-ISSUE: Disable AppArmor allowing unpriviledge user namespace to fix VS Code E2E tests

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -246,6 +246,11 @@ runs:
           libxml2-utils > /dev/null 2>&1
         fi
 
+    - name: "Allow unprivileged user namespace (Ubuntu Only)"
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
     - name: "Update bash for macOS (macOS Only)"
       shell: bash
       if: runner.os == 'macOS'


### PR DESCRIPTION
AppArmor prevents the `vscode-extension-tester` to open folders [1]. The `runner-images` repo already have an issue to disable the AppArmor by default [2].


[1] https://github.com/redhat-developer/vscode-extension-tester/issues/1496
[2] https://github.com/actions/runner-images/issues/10015