### PR TITLE
kie-issues#1690: Apache KIE trademark character missing on Extended Services VS Code Extension's name

### DIFF
--- a/packages/extended-services-java/pom.xml
+++ b/packages/extended-services-java/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.kie.tools</groupId>
   <artifactId>extended-services-java</artifactId>
 
-  <name>KIE Tools :: KIE Sandbox :: Extended Services Quarkus app</name>
+  <name>KIE Tools :: Extended Services Quarkus app</name>
   <description
   >Quarkus-based application that wraps Kogito JIT Executor for consumption as a KIE Sandbox backend.</description>
 

--- a/packages/extended-services-vscode-extension/package.json
+++ b/packages/extended-services-vscode-extension/package.json
@@ -53,7 +53,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "Apache KIE Extended Services",
+  "displayName": "Apache KIE™ Extended Services",
   "categories": [
     "Other"
   ],
@@ -62,13 +62,13 @@
       {
         "category": "Extended-Services",
         "command": "extended-services-vscode-extension.startExtendedServices",
-        "title": "Connect Apache KIE Extended-Services",
+        "title": "Connect Apache KIE™ Extended Services",
         "when": "extended-services-vscode-extension.connected"
       },
       {
         "category": "Extended-Services",
         "command": "extended-services-vscode-extension.stopExtendedServices",
-        "title": "Disconnect Apache KIE Extended-Services"
+        "title": "Disconnect Apache KIE™ Extended Services"
       }
     ],
     "configuration": {
@@ -94,7 +94,7 @@
           "type": "string"
         }
       },
-      "title": "Apache KIE Extended Services"
+      "title": "Apache KIE™ Extended Services"
     },
     "icons": {
       "extended-services-connected": {
@@ -102,14 +102,14 @@
           "fontCharacter": "\\E000",
           "fontPath": "./static/extended-services-font.woff"
         },
-        "description": "Connected to the Apache KIE Extended-Services"
+        "description": "Connected to the Apache KIE™ Extended Services"
       },
       "extended-services-disconnected": {
         "default": {
           "fontCharacter": "\\E001",
           "fontPath": "./static/extended-services-font.woff"
         },
-        "description": "Apache KIE Extended-Services are Disconnected"
+        "description": "Apache KIE™ Extended Services are Disconnected"
       }
     },
     "languages": [

--- a/packages/extended-services-vscode-extension/src/Validator.ts
+++ b/packages/extended-services-vscode-extension/src/Validator.ts
@@ -22,7 +22,7 @@ import * as validationRequests from "./requests/ValidationRequests";
 import * as validationResponse from "./requests/ValidationResponse";
 import * as vscode from "vscode";
 
-const source: string = "Apache KIE Extended Services";
+const source: string = "Apache KIE™ Extended Services";
 
 function createBPMNDiagnostics(validationResponses: validationResponse.BPMNValidationResponse[]): vscode.Diagnostic[] {
   return validationResponses.map((validationResponse) => {

--- a/packages/extended-services-vscode-extension/src/configurations/Configuration.ts
+++ b/packages/extended-services-vscode-extension/src/configurations/Configuration.ts
@@ -57,7 +57,7 @@ function fetchConnectionHeartbeatIntervalinSecs(): number {
 function fetchExtendedServicesURL(): URL {
   const extendedServicesURL = vscode.workspace.getConfiguration().get<string>(extendedServicesURLID);
   if (!extendedServicesURL) {
-    throw new Error("Extended Services URL configuration not found");
+    throw new Error("URL configuration not found");
   }
 
   try {

--- a/packages/extended-services-vscode-extension/src/extension/extension-browser.ts
+++ b/packages/extended-services-vscode-extension/src/extension/extension-browser.ts
@@ -59,7 +59,7 @@ function initializeVSCodeElements() {
 
   statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   statusBarItem.text = "$(extended-services-disconnected)";
-  statusBarItem.tooltip = "Apache KIE Extended Services are not connected. \n" + "Click to connect.";
+  statusBarItem.tooltip = "Apache KIE™ Extended Services is not connected. \n" + "Click to connect.";
   statusBarItem.command = startExtendedServicesCommandUID;
   statusBarItem.hide();
 
@@ -171,7 +171,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (configuration) {
       validate(configuration);
       statusBarItem.text = "$(extended-services-connected)";
-      statusBarItem.tooltip = "Apache KIE Extended Services are connected. Click to disconnect.";
+      statusBarItem.tooltip = "Apache KIE™ Extended Services is connected. Click to disconnect.";
       statusBarItem.command = stopExtendedServicesCommandUID;
     }
   });
@@ -184,7 +184,7 @@ export function activate(context: vscode.ExtensionContext) {
   connection.subscribeDisconnected(() => {
     vscode.commands.executeCommand("setContext", connectedEnablementUID, false);
     statusBarItem.text = "$(extended-services-disconnected)";
-    statusBarItem.tooltip = "Apache KIE Extended Services are not connected. Click to connect.";
+    statusBarItem.tooltip = "Apache KIE™ Extended Services is not connected. Click to connect.";
     statusBarItem.command = startExtendedServicesCommandUID;
     diagnosticCollection.clear();
   });

--- a/packages/extended-services-vscode-extension/src/extension/extension-main.ts
+++ b/packages/extended-services-vscode-extension/src/extension/extension-main.ts
@@ -217,7 +217,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (configuration) {
       validate(configuration);
       statusBarItem.text = "$(extended-services-connected)";
-      statusBarItem.tooltip = "Apache KIE Extended Services are connected. Click to disconnect.";
+      statusBarItem.tooltip = "Apache KIE™ Extended Services are connected. Click to disconnect.";
       statusBarItem.command = stopExtendedServicesCommandUID;
     }
   });
@@ -230,7 +230,7 @@ export function activate(context: vscode.ExtensionContext) {
   connection.subscribeDisconnected(() => {
     vscode.commands.executeCommand("setContext", connectedEnablementUID, false);
     statusBarItem.text = "$(extended-services-disconnected)";
-    statusBarItem.tooltip = "Apache KIE Extended Services are not connected. Click to connect.";
+    statusBarItem.tooltip = "Apache KIE™ Extended Services are not connected. Click to connect.";
     statusBarItem.command = startExtendedServicesCommandUID;
     diagnosticCollection.clear();
   });

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -88,7 +88,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE Serverless Workflow Editor",
+  "displayName": "Apache KIE™ Serverless Workflow Editor",
   "categories": [
     "Other"
   ],

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -88,7 +88,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "Apache KIE™ Serverless Workflow Editor",
+  "displayName": "KIE Serverless Workflow Editor",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1690