### PR TITLE
kie-issues#1716: Serverless Workflow VS Code Extension should have `Apache KIE™` prefix instead of just `KIE` on its displayName

### DIFF
--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -88,7 +88,7 @@
   "engines": {
     "vscode": "^1.67.0"
   },
-  "displayName": "KIE Serverless Workflow Editor",
+  "displayName": "Apache KIE™ Serverless Workflow Editor",
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1716