### PR TITLE
kie-issues#1750: Try Maven Central before hitting `repository.apache.org`

### DIFF
--- a/packages/kn-plugin-workflow/pkg/command/quarkus/quarkus_project.go
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/quarkus_project.go
@@ -154,6 +154,7 @@ func manipulatePomToKogito(filename string, cfg CreateQuarkusProjectConfig) erro
 
 	//add apache repository after profiles declaration
 	var repositories = []Repository{
+		{Id: "central", Name: "Central Repository", Url: "https://repo.maven.apache.org/maven2"},
 		{Id: "apache-public-repository-group", Name: "Apache Public Repository Group", Url: "https://repository.apache.org/content/groups/public/"},
 		{Id: "apache-snapshot-repository-group", Name: "Apache Snapshot Repository Group", Url: "https://repository.apache.org/content/groups/snapshots/"},
 	}

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-expected.xml_no_auto_formatting
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/testdata/pom1-expected.xml_no_auto_formatting
@@ -185,6 +185,11 @@
     </profiles>
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
             <id>apache-public-repository-group</id>
             <name>Apache Public Repository Group</name>
             <url>https://repository.apache.org/content/groups/public/</url>

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/settings.xml
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/maven/settings.xml
@@ -19,6 +19,14 @@
       <id>kogito-images</id>
       <repositories>
         <repository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+        <repository>
           <id>apache-public-repository-group</id>
           <name>Apache Public Repository Group</name>
           <url>https://repository.apache.org/content/groups/public/</url>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/1750

GitHub Actions builds are hitting the rule from
https://infra.apache.org/infra-ban.html that disallows excessive 404's on repository.apache.org, causing them to get banned.

This change should make various builds check Maven Central before checking `repository.apache.org`, which hopefully should help.