### PR TITLE
[kie-issues#1723] Allow dot character in metadata attributes

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
@@ -74,7 +74,7 @@ public class MetaDataListItemWidgetViewImpl implements MetaDataListItemWidgetVie
 
     @PostConstruct
     public void init() {
-        attribute.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        attribute.setRegExp(StringUtils.ALPHA_NUM_HYPHEN_UNDERSCORE_DOT_REGEXP,
                             StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
                             StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
@@ -74,7 +74,7 @@ public class MetaDataListItemWidgetViewImpl implements MetaDataListItemWidgetVie
 
     @PostConstruct
     public void init() {
-        attribute.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
+        attribute.setRegExp(StringUtils.ALPHA_NUM_REGEXP,
                             StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
                             StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/metaDataEditor/MetaDataListItemWidgetViewImpl.java
@@ -74,7 +74,7 @@ public class MetaDataListItemWidgetViewImpl implements MetaDataListItemWidgetVie
 
     @PostConstruct
     public void init() {
-        attribute.setRegExp(StringUtils.ALPHA_NUM_REGEXP,
+        attribute.setRegExp(StringUtils.ALPHA_NUM_UNDERSCORE_DOT_REGEXP,
                             StunnerFormsClientFieldsConstants.CONSTANTS.Removed_invalid_characters_from_name(),
                             StunnerFormsClientFieldsConstants.CONSTANTS.Invalid_character_in_name());
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.stunner.core.util.Patterns;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
+    public static final String ALPHA_NUM_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
     public static final String ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP = "^[a-zA-Z0-9<>,\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
     public static final RegExp EXPRESSION = RegExp.compile(Patterns.EXPRESSION);

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -36,7 +36,7 @@ import org.kie.workbench.common.stunner.core.util.Patterns;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
-    public static final String ALPHA_NUM_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
+    public static final String ALPHA_NUM_HYPHEN_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
     public static final String ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP = "^[a-zA-Z0-9<>,\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
     public static final RegExp EXPRESSION = RegExp.compile(Patterns.EXPRESSION);

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/main/java/org/kie/workbench/common/stunner/bpmn/client/forms/util/StringUtils.java
@@ -36,7 +36,6 @@ import org.kie.workbench.common.stunner.core.util.Patterns;
 public class StringUtils {
 
     public static final String ALPHA_NUM_REGEXP = "^[a-zA-Z0-9\\-\\_]*$";
-    public static final String ALPHA_NUM_UNDERSCORE_DOT_REGEXP = "^[a-zA-Z0-9\\-\\_\\.]*$";
     public static final String ALPHA_NUM_UNDERSCORE_DOT_GT_LT_REGEXP = "^[a-zA-Z0-9<>,\\_\\.]*$";
     public static final String ALPHA_NUM_SPACE_REGEXP = "^[a-zA-Z0-9\\-\\_\\ ]*$";
     public static final RegExp EXPRESSION = RegExp.compile(Patterns.EXPRESSION);


### PR DESCRIPTION
As a result of the work in https://github.com/apache/incubator-kie-kogito-runtimes/pull/3740, the jbpm.enable.multi.con flag needs to be defines as process metadata attribute. However, the process designer does not allow the dot (.) character in the name of metadata attributes.

In order for users to define this process metadata attribute in the designer, it needs to be renamed in using only allowed characters.

Closes: https://github.com/apache/incubator-kie-issues/issues/1723