### PR TITLE
Kie issues#1466-A Decision Table with a single output column shouldn't have a name

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -76,6 +76,9 @@ enum DecisionTableColumnType {
   OutputClause = "output",
   Annotation = "annotation",
 }
+const singleOutputColumn = {
+  name: "Output-1",
+};
 
 export const DECISION_TABLE_INPUT_DEFAULT_VALUE = "-";
 export const DECISION_TABLE_OUTPUT_DEFAULT_VALUE = "";
@@ -289,7 +292,7 @@ export function DecisionTableExpression({
         ...value,
         minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
         width: getOutputWidth(index, widths)?.width,
-        label: value["@_name"],
+        label: value["@_name"] ?? singleOutputColumn.name,
       })),
       ...(decisionTableExpression.annotation ?? []).map((value, index) => ({
         ...value,
@@ -352,8 +355,8 @@ export function DecisionTableExpression({
         id: outputClause["@_id"],
         label:
           decisionTableExpression.output?.length == 1
-            ? decisionTableExpression["@_label"] ?? DEFAULT_EXPRESSION_VARIABLE_NAME
-            : outputClause["@_name"] ?? outputClause["@_label"] ?? DEFAULT_EXPRESSION_VARIABLE_NAME,
+            ? ""
+            : outputClause["@_name"] ?? outputClause["@_label"] ?? singleOutputColumn.name,
         dataType:
           decisionTableExpression.output?.length == 1
             ? decisionTableExpression["@_typeRef"] ?? DmnBuiltInDataType.Undefined

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -332,9 +332,9 @@ export function JavaFunctionExpression({
         // Class
         if (u.rowIndex === 0) {
           setExpression((prev: Normalized<BoxedFunctionJava>) => {
-            clazz.expression = {
+            const newExpression = {
               ...clazz.expression,
-              __$$element: "literalExpression",
+              __$$element: "literalExpression" as const,
               text: {
                 __$$text: u.value,
               },
@@ -346,7 +346,13 @@ export function JavaFunctionExpression({
               expression: {
                 __$$element: "context",
                 ...context,
-                contextEntry: [clazz, method],
+                contextEntry: [
+                  {
+                    ...clazz,
+                    expression: newExpression,
+                  },
+                  method,
+                ],
               },
             };
 
@@ -356,9 +362,9 @@ export function JavaFunctionExpression({
         // Method
         else if (u.rowIndex === 1) {
           setExpression((prev: Normalized<BoxedFunctionJava>) => {
-            method.expression = {
+            const newExpression = {
               ...method.expression,
-              __$$element: "literalExpression",
+              __$$element: "literalExpression" as const,
               "@_id": method.expression["@_id"] ?? generateUuid(),
               text: {
                 __$$text: u.value,
@@ -371,7 +377,13 @@ export function JavaFunctionExpression({
               expression: {
                 __$$element: "context",
                 ...context,
-                contextEntry: [clazz, method],
+                contextEntry: [
+                  clazz,
+                  {
+                    ...method,
+                    expression: newExpression,
+                  },
+                ],
               },
             };
             return ret;

--- a/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
+++ b/packages/dmn-editor/src/boxedExpressions/getDefaultBoxedExpression.tsx
@@ -277,7 +277,15 @@ export function getDefaultBoxedExpression({
       "@_typeRef": typeRef,
       "@_hitPolicy": "UNIQUE",
       input,
-      output,
+      output: output.map((out) => {
+        if (output.length > 1) {
+          return {
+            ...out,
+          };
+        } else {
+          return { ...out, "@_name": undefined };
+        }
+      }),
       annotation: [
         {
           "@_name": "Annotations",

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
@@ -45,7 +45,9 @@ export function DecisionTableOutputHeaderCell(props: {
   const activeDrgElementId = useDmnEditorStore((s) => s.boxedExpressionEditor.activeDrgElementId);
   const { dmnEditorRootElementRef } = useDmnEditor();
   const { externalModelsByNamespace } = useExternalModels();
-
+  const singleOutputColumn = {
+    name: "Output-1",
+  };
   const node = useDmnEditorStore((s) =>
     s
       .computed(s)
@@ -172,18 +174,22 @@ export function DecisionTableOutputHeaderCell(props: {
           />
         </>
       )}
-      <NameField
-        alternativeFieldName={root?.output.length === 1 ? "Column Name" : undefined}
-        isReadOnly={props.isReadOnly}
-        id={cell["@_id"]!}
-        name={cell?.["@_name"] ?? ""}
-        getAllUniqueNames={getAllUniqueNames}
-        onChange={(newName) =>
-          updater((dmnObject) => {
-            dmnObject["@_name"] = newName;
-          })
-        }
-      />
+      {root?.output && root.output.length > 1 ? (
+        <NameField
+          alternativeFieldName={undefined}
+          isReadOnly={props.isReadOnly}
+          id={cell["@_id"]!}
+          name={cell?.["@_name"] ?? singleOutputColumn.name}
+          getAllUniqueNames={getAllUniqueNames}
+          onChange={(newName) =>
+            updater((dmnObject) => {
+              dmnObject["@_name"] = newName;
+            })
+          }
+        />
+      ) : (
+        ""
+      )}
       <TypeRefField
         alternativeFieldName={root?.output.length === 1 ? "Column Type" : undefined}
         isReadOnly={cellMustHaveSameTypeAsRoot ? true : props.isReadOnly}


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1466 - A Decision Table with a single output column shouldn't have a name

Before fix:
<img width="971" alt="Screenshot 2025-01-03 at 7 07 52 PM" src="https://github.com/user-attachments/assets/72518c3a-f6c2-4914-b96e-69e782920fac" />
<img width="492" alt="Screenshot 2025-01-03 at 7 08 28 PM" src="https://github.com/user-attachments/assets/5acd6748-f4de-46dc-b47b-f0fec64c8168" />

After fix:

<img width="792" alt="Screenshot 2025-01-03 at 7 09 20 PM" src="https://github.com/user-attachments/assets/46a8ac47-6e3e-472a-aec5-4d06c51095a4" />
<img width="495" alt="Screenshot 2025-01-03 at 7 09 46 PM" src="https://github.com/user-attachments/assets/ba56a8fe-ae36-497d-9d31-ec1f4af413fb" />

