### PR TITLE
kie-issues#1592: Custom Item Definitions shows <Undefined> type on the new DMN Editor

### DIFF
--- a/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypeName.tsx
@@ -32,6 +32,7 @@ import { InlineFeelNameInput, OnInlineFeelNameRenamed } from "../feel/InlineFeel
 import { useExternalModels } from "../includedModels/DmnEditorDependenciesContext";
 import { State } from "../store/Store";
 import { DmnBuiltInDataType } from "@kie-tools/boxed-expression-component/dist/api";
+import { isStruct } from "./DataTypeSpec";
 
 export function DataTypeName({
   isReadOnly,
@@ -137,7 +138,7 @@ export function DataTypeName({
           />
           {!isEditingLabel && (
             <TypeRefLabel
-              typeRef={itemDefinition.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined}
+              typeRef={isStruct(itemDefinition) ? "" : itemDefinition.typeRef?.__$$text ?? DmnBuiltInDataType.Undefined}
               isCollection={itemDefinition["@_isCollection"]}
               relativeToNamespace={relativeToNamespace}
             />


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1592 Custom Item Definitions shows <Undefined> type on the new DMN Editor Data Types tab
Before fix:
<img width="883" alt="Screenshot 2025-01-09 at 11 16 12 AM" src="https://github.com/user-attachments/assets/095dec19-032e-4894-bde2-dd91416da36d" />

After fix:
![Uploading Screenshot 2025-01-09 at 11.16.35 AM.png…]()
