### PR TITLE
NO-ISSUE: Fix git user config for daily-dev-publish build steps in Jenkins

### DIFF
--- a/.ci/jenkins/Jenkinsfile.daily-dev-publish
+++ b/.ci/jenkins/Jenkinsfile.daily-dev-publish
@@ -230,6 +230,8 @@ pipeline {
             steps {
                 dir('kie-tools') {
                     sh """#!/bin/bash -el
+                    git config user.email asf-ci-kie@jenkins.kie.apache.org
+                    git config user.name asf-ci-kie
                     export WEBPACK__minimize=true
                     export WEBPACK__tsLoaderTranspileOnly=false
                     export CHROME_EXTENSION__routerTargetOrigin=https://apache.github.io


### PR DESCRIPTION
The daily-dev-publish build is failing due to missing git user configuration:

```
> @kie-tools/kie-sandbox-accelerator-quarkus@0.0.0 _build-step:setup-git-repo-bare /home/jenkins/workspace/KIE/kie-tools/main/kie-tools-daily-dev-publish/kie-tools/packages/kie-sandbox-accelerator-quarkus
> mkdirp ./dist-dev/git-repo-bare.git && cd ./dist-dev/git-repo-bare.git && git init --bare && git --bare update-server-info && mv hooks/post-update.sample hooks/post-update

hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /home/jenkins/workspace/KIE/kie-tools/main/kie-tools-daily-dev-publish/kie-tools/packages/kie-sandbox-accelerator-quarkus/dist-dev/git-repo-bare.git/

> @kie-tools/kie-sandbox-accelerator-quarkus@0.0.0 _build-step:setup-git-repo-content /home/jenkins/workspace/KIE/kie-tools/main/kie-tools-daily-dev-publish/kie-tools/packages/kie-sandbox-accelerator-quarkus
> mkdirp ./dist-dev/git-repo-content && cpy './dist/git-repo-content/**' ./dist-dev/git-repo-content && cd ./dist-dev/git-repo-content && git init --initial-branch main && git remote add repo ../git-repo-bare.git && git add . && git commit -m 'Single commit' && git push repo main

Initialized empty Git repository in /home/jenkins/workspace/KIE/kie-tools/main/kie-tools-daily-dev-publish/kie-tools/packages/kie-sandbox-accelerator-quarkus/dist-dev/git-repo-content/.git/
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'nonrootuser@18ca75c6d4fc.(none)')
 ELIFECYCLE  Command failed with exit code 128.
 ELIFECYCLE  Command failed with exit code 128.
/home/jenkins/workspace/KIE/kie-tools/main/kie-tools-daily-dev-publish/kie-tools/packages/kie-sandbox-accelerator-quarkus:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @kie-tools/kie-sandbox-accelerator-quarkus@0.0.0 build:prod: `pnpm run _build && pnpm run test`
Exit status 128
```

This change should fix it, but I could not run the pipeline from my fork to test it.