### PR TITLE
kie-issues#1679 : If the bottom of the overlay panel is close to editor bottom, it adds a vertical overflow after toggling an option

### DIFF
--- a/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
+++ b/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
@@ -49,7 +49,7 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
       if (currentHeight + yPos >= availableHeight) {
         overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
         overlayPanelContainer.current.style.overflowY = "auto";
-      } else {
+      } else if (overlayPanelContainer.current.style.height != "auto") {
         overlayPanelContainer.current.style.overflowY = "hidden";
         overlayPanelContainer.current.style.height = "auto";
       }

--- a/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
+++ b/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
@@ -43,18 +43,19 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
   const overlayPanelContainer = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     if (overlayPanelContainer.current && availableHeight) {
-      const bounds = overlayPanelContainer.current.getBoundingClientRect();
-      const currentHeight = bounds.height;
-      const yPos = bounds.y;
-      if (currentHeight + yPos >= availableHeight) {
-        overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
-        overlayPanelContainer.current.style.overflowY = "auto";
-      } else if (overlayPanelContainer.current.style.height != "auto") {
-        overlayPanelContainer.current.style.overflowY = "hidden";
-        overlayPanelContainer.current.style.height = "auto";
+      if (!(overlayPanelContainer.current.scrollHeight > availableHeight)) {
+        if (overlayPanelContainer.current.style.height !== "auto") {
+          overlayPanelContainer.current.style.overflowY = "hidden";
+          overlayPanelContainer.current.style.height = "auto";
+        }
+      } else {
+        if (overlayPanelContainer.current.style.height !== availableHeight - BOTTOM_MARGIN + "px") {
+          overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
+          overlayPanelContainer.current.style.overflowY = "auto";
+        }
       }
     }
-  });
+  }, [availableHeight]);
 
   return (
     <div ref={overlayPanelContainer}>

--- a/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
+++ b/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
@@ -48,9 +48,10 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
       const yPos = bounds.y;
       if (currentHeight + yPos >= availableHeight) {
         overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
-        overlayPanelContainer.current.style.overflowY = "scroll";
+        overlayPanelContainer.current.style.overflowY = "auto";
       } else {
-        overlayPanelContainer.current.style.overflowY = "visible";
+        overlayPanelContainer.current.style.overflowY = "hidden";
+        overlayPanelContainer.current.style.height = "auto";
       }
     }
   });

--- a/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
+++ b/packages/dmn-editor/src/overlaysPanel/OverlaysPanel.tsx
@@ -43,16 +43,15 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
   const overlayPanelContainer = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     if (overlayPanelContainer.current && availableHeight) {
-      if (!(overlayPanelContainer.current.scrollHeight > availableHeight)) {
-        if (overlayPanelContainer.current.style.height !== "auto") {
-          overlayPanelContainer.current.style.overflowY = "hidden";
-          overlayPanelContainer.current.style.height = "auto";
-        }
-      } else {
-        if (overlayPanelContainer.current.style.height !== availableHeight - BOTTOM_MARGIN + "px") {
-          overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
-          overlayPanelContainer.current.style.overflowY = "auto";
-        }
+      if (overlayPanelContainer.current.scrollHeight <= availableHeight) {
+        overlayPanelContainer.current.style.overflowY = "hidden";
+        overlayPanelContainer.current.style.height = "auto";
+      } else if (
+        overlayPanelContainer.current.style.height !== availableHeight - BOTTOM_MARGIN + "px" &&
+        overlayPanelContainer.current.style.height !== "auto"
+      ) {
+        overlayPanelContainer.current.style.height = availableHeight - BOTTOM_MARGIN + "px";
+        overlayPanelContainer.current.style.overflowY = "auto";
       }
     }
   }, [availableHeight]);


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1679 - If the bottom of the overlay panel is close to editor bottom, it adds a vertical overflow after toggling an option