### PR TITLE
NO-ISSUE [serverless-workflow-diagram-editor] bump j2cl-tools bom to 0.4

### DIFF
--- a/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/appformer-bom/pom.xml
@@ -59,7 +59,7 @@
 
   <properties>
     <sonar.skip>true</sonar.skip>
-    <version.j2cl.tools>0.1</version.j2cl.tools>
+    <version.j2cl.tools>0.4</version.j2cl.tools>
   </properties>
 
   <dependencyManagement>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-bom/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-bom/pom.xml
@@ -59,7 +59,7 @@
 
   <properties>
     <sonar.skip>true</sonar.skip>
-    <j2cl.tools.version>0.1</j2cl.tools.version>
+    <j2cl.tools.version>0.4</j2cl.tools.version>
   </properties>
 
   <dependencyManagement>

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/main/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/ViewEventHandlerManager.java
@@ -167,7 +167,7 @@ public class ViewEventHandlerManager {
         JsIteratorIterable<JsArray<HandlerRegistration>> regs = registrationsByType.values();
         registrationsByType.forEach(new JsMap.ForEachCallbackFn<ViewEventType, JsArray<HandlerRegistration>>() {
             @Override
-            public Object onInvoke(JsArray<HandlerRegistration> p0, ViewEventType p1, JsMap<? extends ViewEventType, ? extends JsArray<HandlerRegistration>> p2) {
+            public Object onInvoke(JsArray<HandlerRegistration> p0, ViewEventType p1) {
                 removeHandlers(p0);
                 return null;
             }

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeViewTest.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-lienzo/src/test/java/org/kie/workbench/common/stunner/client/lienzo/shape/view/wires/WiresContainerShapeViewTest.java
@@ -23,6 +23,8 @@ package org.kie.workbench.common.stunner.client.lienzo.shape.view.wires;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import elemental2.core.JsMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.client.shape.HasChildren;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
+@WithClassesToStub(JsMap.class)
 public class WiresContainerShapeViewTest {
 
     @Mock

--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/jsadapter/JsDefinitionAdapter.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/definition/jsadapter/JsDefinitionAdapter.java
@@ -97,7 +97,7 @@ public class JsDefinitionAdapter implements DefinitionAdapter<Object> {
     public String[] getPropertyFields(Object pojo) {
         // Exclude native js object properties and functions
         return JsObject.getOwnPropertyNames(pojo)
-                .filter((prop, i, jsArray) -> (!(prop.contains("__") || Reflect.get(pojo, prop) instanceof Function)))
+                .filter((prop, i) -> (!(prop.contains("__") || Reflect.get(pojo, prop) instanceof Function)))
                 .asArray(new String[0]);
     }
 

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/tools/client/NObjectJSO.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/tools/client/NObjectJSO.java
@@ -20,14 +20,14 @@ import elemental2.core.Global;
 import elemental2.core.JsIterable;
 import elemental2.core.JsIteratorIterable;
 import elemental2.core.JsMap;
-import elemental2.core.JsMap.JsIterableTypeParameterArrayUnionType;
+import elemental2.core.ReadonlyMap;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
 
 @JsType(isNative = true, name = "Map", namespace = JsPackage.GLOBAL)
-public class NObjectJSO implements JsIterable<JsIterableTypeParameterArrayUnionType<String, ?>[]> {
+public class NObjectJSO implements JsIterable<ReadonlyMap.JsIterableTypeParameterArrayUnionType<String, ?>[]> {
 
     @JsOverlay
     public static final NObjectJSO make() {

--- a/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/tools/client/collection/NFastStringMap.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-core/src/main/java/com/ait/lienzo/tools/client/collection/NFastStringMap.java
@@ -19,8 +19,7 @@ package com.ait.lienzo.tools.client.collection;
 import elemental2.core.JsIterable;
 import elemental2.core.JsIteratorIterable;
 import elemental2.core.JsMap;
-import elemental2.core.JsMap.EntriesJsIteratorIterableTypeParameterArrayUnionType;
-import elemental2.core.JsMap.JsIterableTypeParameterArrayUnionType;
+import elemental2.core.ReadonlyMap;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
@@ -32,7 +31,7 @@ import jsinterop.annotations.JsType;
  */
 
 @JsType(isNative = true, name = "Map", namespace = JsPackage.GLOBAL)
-public final class NFastStringMap<V> implements JsIterable<JsIterableTypeParameterArrayUnionType<String, V>[]> {
+public final class NFastStringMap<V> implements JsIterable<ReadonlyMap.JsIterableTypeParameterArrayUnionType<String, V>[]> {
 
     public NFastStringMap() {
     }
@@ -109,7 +108,7 @@ public final class NFastStringMap<V> implements JsIterable<JsIterableTypeParamet
     public native boolean delete(String key);
 
     public native JsIteratorIterable<
-            EntriesJsIteratorIterableTypeParameterArrayUnionType<String, V>[]>
+            ReadonlyMap.EntriesJsIteratorIterableTypeParameterArrayUnionType<String, V>[]>
     entries();
 
     public native Object forEach(

--- a/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/DomGlobal.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/DomGlobal.java
@@ -55,7 +55,7 @@ public class DomGlobal {
     }
 
     public static final Promise<ImageBitmap> createImageBitmap(Blob image) {
-        return new Promise<ImageBitmap>((resolve, reject) ->
+        return new Promise<>((resolve, reject) ->
                                                 new ImageBitmap() {
                                                     @Override
                                                     public int getHeight() {
@@ -65,6 +65,10 @@ public class DomGlobal {
                                                     @Override
                                                     public int getWidth() {
                                                         return 0;
+                                                    }
+                                                  @Override
+                                                    public void close() {
+                                                      // Do nothing
                                                     }
                                                 }
         );

--- a/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/JsMap.java
+++ b/packages/serverless-workflow-diagram-editor/lienzo-tests/src/main/java/com/ait/lienzo/test/stub/overlays/JsMap.java
@@ -56,7 +56,7 @@ public class JsMap<KEY, VALUE> {
         return mock(JsIteratorIterable.class);
     }
 
-    public Object forEach(elemental2.core.JsMap.ForEachCallbackFn<? super KEY, ? super VALUE> callback) {
-        return mock(Object.class);
+    public void forEach(elemental2.core.ReadonlyMap.ForEachCallbackFn<? super KEY, ? super VALUE> callback) {
+        mock(Object.class);
     }
 }

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -145,8 +145,8 @@
 
     <!-- General -->
     <version.checkstyle>8.29</version.checkstyle>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
     <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -186,7 +186,7 @@
 
     <!-- Third party Libraries -->
     <version.ch.qos.logback>1.3.12</version.ch.qos.logback>
-    <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
+    <version.com.google.elemental2>1.2.3</version.com.google.elemental2>
     <version.jsinterop.annotations>2.0.0</version.jsinterop.annotations>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
@@ -213,8 +213,8 @@
     <version.org.uberfire.patternfly>7.74.1.Final</version.org.uberfire.patternfly>
 
     <!-- J2CL -->
-    <version.j2cl>0.11.0-9336533b6</version.j2cl>
-    <version.j2cl.maven.plugin>0.23.0</version.j2cl.maven.plugin>
+    <version.j2cl>v20241110-1</version.j2cl>
+    <version.j2cl.maven.plugin>0.23.2</version.j2cl.maven.plugin>
 
     <!-- Test Libraries -->
     <version.io.github.bonigarcia>5.7.0</version.io.github.bonigarcia>


### PR DESCRIPTION
This PR updates to the latest available versions:

- elemental2 to version 1.2.3
- closure-compiler to the version from 2024-11-06
- j2cl to the version from 2024-11-10
- j2cl-maven-plugin to the latest version with significantly faster rebuilds
- Additionally, bugs have been fixed.
- java 11 source level supported by default