### PR TITLE
kie-tools-issues#2582: [serverless-logic-web-tools] CORS on Dev Mode deployment on OpenShift

### DIFF
--- a/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
+++ b/packages/serverless-logic-web-tools-swf-deployment-quarkus-app/src/main/resources/application.properties
@@ -20,6 +20,7 @@
 quarkus.swagger-ui.always-include=true
 quarkus.http.cors=true
 quarkus.http.cors.origins=*
+quarkus.dev-ui.cors.enabled=false
 quarkus.http.host=0.0.0.0
 quarkus.http.enable-compression=true
 quarkus.http.port=8080

--- a/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui/src/main/resources/application.properties
+++ b/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui/src/main/resources/application.properties
@@ -16,3 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+quarkus.http.cors=true
+quarkus.http.cors.origins=*
+quarkus.dev-ui.cors.enabled=false


### PR DESCRIPTION
**Closes** https://github.com/apache/incubator-kie-tools/issues/2582
This PR also align SLWT configuration with Sandbox Deployments

**Description:**
Using https://start.kubesmarts.org/dev/# with the Dev Mode Deployment on OpenShift we have a CORS error and Quarkus Dev UI, not just the SonataFlow Dev UI, cannot open.

**How to test:**
- https://start.kubesmarts.org/dev/
- Deploy a DevMode deployment
- On OCP select the deployment
- Edit Deployment
- Change the image to use:
 quay.io/fabrizio_antonangeli/incubator-kie-serverless-logic-web-tools-swf-dev-mode:kie-tools-issues-2582
- Apply the settings