### PR TITLE
[serverless-logic-web-tools] NO-ISSUE: Use env vars instead hardcoded repository url

### DIFF
--- a/packages/serverless-logic-web-tools/env/index.js
+++ b/packages/serverless-logic-web-tools/env/index.js
@@ -41,6 +41,14 @@ module.exports = composeEnv(
         default: version,
         description: "Version of the application",
       },
+      SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg: {
+        default: "kiegroup",
+        description: "Org owner for `kiegroup/kie-samples` repository",
+      },
+      SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName: {
+        default: "kie-samples",
+        description: "Repository name for `kiegroup/kie-samples` repository",
+      },
       SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef: {
         default: "main",
         description: "Tag/branch to fetch samples from `kiegroup/kie-samples` repository",
@@ -99,6 +107,8 @@ module.exports = composeEnv(
             tag: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag),
           },
           corsProxyUrl: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__corsProxyUrl),
+          samplesRepositoryOrg: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg),
+          samplesRepositoryName: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName),
           samplesRepositoryRef: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef),
         },
       };

--- a/packages/serverless-logic-web-tools/src/samples/SampleConstants.ts
+++ b/packages/serverless-logic-web-tools/src/samples/SampleConstants.ts
@@ -33,8 +33,8 @@ export const resolveSampleFsMountPoint = (appVersion: string) => {
 };
 
 export const KIE_SAMPLES_REPOSITORY_INFO: SamplesRepositoryInfo = {
-  org: "kiegroup",
-  name: "kie-samples",
+  org: process.env["WEBPACK_REPLACE__samplesRepositoryOrg"]!,
+  name: process.env["WEBPACK_REPLACE__samplesRepositoryName"]!,
   ref: process.env["WEBPACK_REPLACE__samplesRepositoryRef"]!,
   paths: {
     samplesFolder: "samples",

--- a/packages/serverless-logic-web-tools/webpack.config.ts
+++ b/packages/serverless-logic-web-tools/webpack.config.ts
@@ -110,6 +110,8 @@ export default async (webpackEnv: any, webpackArgv: any) => {
             WEBPACK_REPLACE__devModeImageFullUrl: `${swfDevModeImageRegistry}/${swfDevModeImageAccount}/${swfDevModeImageName}:${swfDevModeImageTag}`,
             WEBPACK_REPLACE__dashbuilderViewerImageFullUrl: `${dashbuilderViewerImageRegistry}/${dashbuilderViewerImageAccount}/${dashbuilderViewerImageName}:${dashbuilderViewerImageTag}`,
             WEBPACK_REPLACE__corsProxyUrl: buildEnv.serverlessLogicWebTools.corsProxyUrl,
+            WEBPACK_REPLACE__samplesRepositoryOrg: buildEnv.serverlessLogicWebTools.samplesRepositoryOrg,
+            WEBPACK_REPLACE__samplesRepositoryName: buildEnv.serverlessLogicWebTools.samplesRepositoryName,
             WEBPACK_REPLACE__samplesRepositoryRef: buildEnv.serverlessLogicWebTools.samplesRepositoryRef,
           }),
           new CopyPlugin({


### PR DESCRIPTION
The vars to build the kie-samples repository URL were hardcoded and this PR implemented the use of 2 env vars:
- SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg
- SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName

We don't have an issue for this but I'm available to create a one.

**How to test:**
- build `serverless-logic-web-tools`
- start the package with: 
`SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg="kubesmarts" SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName="sandbox-catalog" SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef="main" pnpm start`
- start `cors-proxy` in a different terminal
- Open Chrome and the Developer Tools in incognito mode to force the samples to be downloaded
- Browse https://localhost:9020/#/sample-catalog 
- The "Network" tab in the Developer Tools should show some downloads from:
https://api.github.com/repos/kubesmarts/sandbox-catalog/...