### PR TITLE
NO-ISSUE: Bump vsce to `3.2.1` version

### DIFF
--- a/examples/micro-frontends-multiplying-architecture-base64png-editor-vscode-extension/package.json
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor-vscode-extension/package.json
@@ -31,7 +31,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
     "webpack": "^5.94.0",

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view-vscode-extension/package.json
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view-vscode-extension/package.json
@@ -30,7 +30,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
     "webpack": "^5.94.0",

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/vscode-java-code-completion-extension-plugin": "workspace:*",
     "@types/vscode": "1.67.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "copy-webpack-plugin": "^11.0.0",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/vscode-java-code-completion-extension-plugin": "workspace:*",
     "@types/vscode": "1.67.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^11.0.0",
     "process": "^0.11.10",

--- a/packages/extended-services-vscode-extension/package.json
+++ b/packages/extended-services-vscode-extension/package.json
@@ -41,7 +41,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "copy-webpack-plugin": "^11.0.0",
     "node-fetch": "^3.3.1",
     "rimraf": "^3.0.2",

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -62,7 +62,7 @@
     "@types/vscode": "1.67.0",
     "@vscode/test-electron": "^2.3.6",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "chai": "^4.3.10",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/pmml-vscode-extension/package.json
+++ b/packages/pmml-vscode-extension/package.json
@@ -40,7 +40,7 @@
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "file-loader": "^6.2.0",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",

--- a/packages/serverless-workflow-vscode-extension/package.json
+++ b/packages/serverless-workflow-vscode-extension/package.json
@@ -65,7 +65,7 @@
     "@types/vscode": "1.67.0",
     "@vscode/test-electron": "^2.3.6",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "chai": "^4.3.10",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/vscode-extension-dashbuilder-editor/package.json
+++ b/packages/vscode-extension-dashbuilder-editor/package.json
@@ -55,7 +55,7 @@
     "@types/selenium-webdriver": "^4.1.27",
     "@types/vscode": "1.67.0",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "chai": "^4.3.10",
     "copy-webpack-plugin": "^11.0.0",
     "cpr": "^3.0.1",

--- a/packages/vscode-extension-kie-ba-bundle/package.json
+++ b/packages/vscode-extension-kie-ba-bundle/package.json
@@ -28,7 +28,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "rimraf": "^3.0.2",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.10.0",

--- a/packages/vscode-extension-kogito-bundle/package.json
+++ b/packages/vscode-extension-kogito-bundle/package.json
@@ -28,7 +28,7 @@
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
     "@types/vscode": "1.67.0",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "rimraf": "^3.0.2",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.10.0",

--- a/packages/yard-vscode-extension/package.json
+++ b/packages/yard-vscode-extension/package.json
@@ -58,7 +58,7 @@
     "@types/vscode": "1.67.0",
     "@vscode/test-electron": "^2.3.6",
     "@vscode/test-web": "^0.0.30",
-    "@vscode/vsce": "^2.22.0",
+    "@vscode/vsce": "^3.2.1",
     "chai": "^4.3.10",
     "cpr": "^3.0.1",
     "mocha": "^10.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,58 +181,6 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(webpack-sources@3.2.3)(webpack@5.94.0(webpack-cli@4.10.0))
 
-  examples/base64png-editor-vscode-extension:
-    dependencies:
-      '@kie-tools-core/editor':
-        specifier: workspace:*
-        version: link:../../packages/editor
-      '@kie-tools-core/i18n':
-        specifier: workspace:*
-        version: link:../../packages/i18n
-      '@kie-tools-core/patternfly-base':
-        specifier: workspace:*
-        version: link:../../packages/patternfly-base
-      '@kie-tools-core/vscode-extension':
-        specifier: workspace:*
-        version: link:../../packages/vscode-extension
-      '@kie-tools-examples/base64png-editor':
-        specifier: workspace:*
-        version: link:../base64png-editor
-    devDependencies:
-      '@kie-tools-core/webpack-base':
-        specifier: workspace:*
-        version: link:../../packages/webpack-base
-      '@kie-tools/root-env':
-        specifier: workspace:*
-        version: link:../../packages/root-env
-      '@kie-tools/tsconfig':
-        specifier: workspace:*
-        version: link:../../packages/tsconfig
-      '@types/vscode':
-        specifier: 1.67.0
-        version: 1.67.0
-      '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
-      typescript:
-        specifier: ^5.5.3
-        version: 5.5.3
-      webpack:
-        specifier: ^5.94.0
-        version: 5.94.0(webpack-cli@4.10.0)
-      webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)
-      webpack-dev-server:
-        specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.94.0)
-      webpack-merge:
-        specifier: ^5.9.0
-        version: 5.9.0
-
   examples/bpmn-editor-classic-on-webapp:
     devDependencies:
       '@kie-tools-core/editor':
@@ -799,8 +747,8 @@ importers:
         specifier: 1.67.0
         version: 1.67.0
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1169,8 +1117,8 @@ importers:
         specifier: 1.67.0
         version: 1.67.0
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1506,55 +1454,6 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
-
-  examples/todo-list-view-vscode-extension:
-    dependencies:
-      '@kie-tools-core/envelope-bus':
-        specifier: workspace:*
-        version: link:../../packages/envelope-bus
-      '@kie-tools-core/vscode-extension':
-        specifier: workspace:*
-        version: link:../../packages/vscode-extension
-      '@kie-tools-examples/todo-list-view':
-        specifier: workspace:*
-        version: link:../todo-list-view
-    devDependencies:
-      '@kie-tools-core/patternfly-base':
-        specifier: workspace:*
-        version: link:../../packages/patternfly-base
-      '@kie-tools-core/webpack-base':
-        specifier: workspace:*
-        version: link:../../packages/webpack-base
-      '@kie-tools/root-env':
-        specifier: workspace:*
-        version: link:../../packages/root-env
-      '@kie-tools/tsconfig':
-        specifier: workspace:*
-        version: link:../../packages/tsconfig
-      '@types/vscode':
-        specifier: 1.67.0
-        version: 1.67.0
-      '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
-      typescript:
-        specifier: ^5.5.3
-        version: 5.5.3
-      webpack:
-        specifier: ^5.94.0
-        version: 5.94.0(webpack-cli@4.10.0)
-      webpack-cli:
-        specifier: ^4.10.0
-        version: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)
-      webpack-dev-server:
-        specifier: ^4.15.1
-        version: 4.15.1(webpack-cli@4.10.0)(webpack@5.94.0)
-      webpack-merge:
-        specifier: ^5.9.0
-        version: 5.9.0
 
   examples/uniforms-patternfly:
     dependencies:
@@ -2059,8 +1958,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.94.0(webpack-cli@4.10.0))
@@ -4975,8 +4874,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5350,8 +5249,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.94.0(webpack-cli@4.10.0))
@@ -6868,8 +6767,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       chai:
         specifier: ^4.3.10
         version: 4.3.10
@@ -8379,8 +8278,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.94.0(webpack-cli@4.10.0))
@@ -11879,8 +11778,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       chai:
         specifier: ^4.3.10
         version: 4.3.10
@@ -13419,8 +13318,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       chai:
         specifier: ^4.3.10
         version: 4.3.10
@@ -13491,8 +13390,8 @@ importers:
         specifier: 1.67.0
         version: 1.67.0
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -13527,8 +13426,8 @@ importers:
         specifier: 1.67.0
         version: 1.67.0
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -14279,8 +14178,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
       '@vscode/vsce':
-        specifier: ^2.22.0
-        version: 2.22.0
+        specifier: ^3.2.1
+        version: 3.2.1
       chai:
         specifier: ^4.3.10
         version: 4.3.10
@@ -43996,31 +43895,6 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.2
       '@vscode/vsce-sign-win32-x64': 2.0.2
 
-  '@vscode/vsce@2.22.0':
-    dependencies:
-      azure-devops-node-api: 11.0.1
-      chalk: 2.4.2
-      cheerio: 1.0.0-rc.10
-      commander: 6.2.1
-      glob: 7.2.3
-      hosted-git-info: 4.1.0
-      jsonc-parser: 3.2.0
-      leven: 3.1.0
-      markdown-it: 12.3.2
-      mime: 1.6.0
-      minimatch: 3.1.2
-      parse-semver: 1.1.1
-      read: 1.0.7
-      semver: 7.5.4
-      tmp: 0.2.1
-      typed-rest-client: 1.8.4
-      url-join: 4.0.1
-      xml2js: 0.5.0
-      yauzl: 2.10.0
-      yazl: 2.5.1
-    optionalDependencies:
-      keytar: 7.9.0
-
   '@vscode/vsce@3.2.1':
     dependencies:
       '@azure/identity': 4.3.0
@@ -49474,7 +49348,7 @@ snapshots:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
-      mime-types: 2.1.34
+      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -57732,7 +57606,7 @@ snapshots:
 
   typed-rest-client@1.8.4:
     dependencies:
-      qs: 6.11.2
+      qs: 6.13.0
       tunnel: 0.0.6
       underscore: 1.13.1
 


### PR DESCRIPTION
Successfully tested with `dmn-vscode-extension`