### PR TITLE
NO-ISSUE: Fix `jbpm-quarkus-devui` `start` script for Windows

### DIFF
--- a/examples/process-compact-architecture/package.json
+++ b/examples/process-compact-architecture/package.json
@@ -24,7 +24,7 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "start": "run-script-os",
     "start:darwin:linux": "mvn quarkus:dev -DskipTests -Pdevelopment",
-    "start:win32": "mvn quarkus:dev -DskipTests -Pdevelopment",
+    "start:win32": "pnpm powershell mvn quarkus:dev `-DskipTests `-Pdevelopment",
     "startContainers": "run-script-os || pnpm run stopContainers",
     "startContainers:darwin:linux": "mvn clean install -Pcontainer && cd ./docker-compose && sh startContainers.sh",
     "startContainers:win32": "echo Running containers example is not supported on Windows",

--- a/examples/process-compact-architecture/package.json
+++ b/examples/process-compact-architecture/package.json
@@ -24,7 +24,7 @@
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "start": "run-script-os",
     "start:darwin:linux": "mvn quarkus:dev -DskipTests -Pdevelopment",
-    "start:win32": "mvn quarkus:dev `-DskipTests `-Pdevelopment",
+    "start:win32": "mvn quarkus:dev -DskipTests -Pdevelopment",
     "startContainers": "run-script-os || pnpm run stopContainers",
     "startContainers:darwin:linux": "mvn clean install -Pcontainer && cd ./docker-compose && sh startContainers.sh",
     "startContainers:win32": "echo Running containers example is not supported on Windows",


### PR DESCRIPTION
The script was not working in Windows because of some single quotes.
It is working now.