### PR TITLE
[kie-issues#1755] - Display the correct git URL when creating a snippet, gist, or repo in the online editor

### DIFF
--- a/packages/online-editor/src/editor/Toolbar/GitIntegration/CreateGistOrSnippetModal.tsx
+++ b/packages/online-editor/src/editor/Toolbar/GitIntegration/CreateGistOrSnippetModal.tsx
@@ -75,7 +75,7 @@ export const CreateGistOrSnippetModal = (props: {
   const [isGistOrSnippetLoading, setGistOrSnippetLoading] = useState(false);
 
   const {
-    alerts: { successfullyUpdatedGistOrSnippetAlert, errorAlert },
+    alerts: { successfullyCreatedGistOrSnippetAlert, errorAlert },
   } = useGitIntegration();
 
   const createGitHubGist: () => Promise<CreateGistOrSnippetResponse> = useCallback(async () => {
@@ -132,7 +132,7 @@ If you are, it means that creating this Snippet failed and it can safely be dele
       return (e.name = "https" && e.href.startsWith("https"));
     })[0].href;
 
-    return { cloneUrl, htmlUrl: json.links.html };
+    return { cloneUrl, htmlUrl: json.links.html.href };
   }, [bitbucketClient, env.KIE_SANDBOX_APP_NAME, isPrivate, props.workspace.name, selectedOrganization]);
 
   const createGistOrSnippet = useCallback(async () => {
@@ -214,8 +214,8 @@ If you are, it means that creating this Snippet failed and it can safely be dele
       });
 
       props.onClose();
-      successfullyUpdatedGistOrSnippetAlert.show({ url: gistOrSnippet.cloneUrl });
-      props.onSuccess?.({ url: gistOrSnippet.cloneUrl });
+      props.onSuccess?.({ url: gistOrSnippet.htmlUrl });
+      successfullyCreatedGistOrSnippetAlert.show({ url: gistOrSnippet.htmlUrl });
       return;
     } catch (err) {
       setError(err);
@@ -233,7 +233,7 @@ If you are, it means that creating this Snippet failed and it can safely be dele
     workspaces,
     props,
     gitConfig,
-    successfullyUpdatedGistOrSnippetAlert,
+    successfullyCreatedGistOrSnippetAlert,
     errorAlert,
   ]);
 

--- a/packages/online-editor/src/editor/Toolbar/GitIntegration/GitIntegrationAlerts.tsx
+++ b/packages/online-editor/src/editor/Toolbar/GitIntegration/GitIntegrationAlerts.tsx
@@ -225,12 +225,12 @@ export function useGitIntegrationAlerts(workspace: ActiveWorkspace) {
 
   const successfullyCreatedGistOrSnippetAlert = useGlobalAlert(
     useCallback(
-      ({ close }) => {
+      ({ close }, staticArgs?: { url: string }) => {
         if (!isGistLikeWorkspaceKind(workspace.descriptor.origin.kind)) {
           return <></>;
         }
 
-        const gistOrSnippetUrl = workspace.descriptor.origin.url;
+        const gistOrSnippetUrl = staticArgs?.url || workspace.descriptor.origin.url;
         return (
           <Alert
             variant="success"


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1755

* Send the correct URL to the alert
* Call the correct alert
* Use the provided URL if available

The code has been using `successfullyUpdatedGistOrSnippetAlert` instead of `successfullyCreatedGistOrSnippetAlert`. The alert was also not setup to properly make use of the provided URL when the alert was shown.