### PR TITLE
kie-tools-issues#2761: [Serverless Logic Web Tools] Devmode deployment URL redirection

### DIFF
--- a/packages/serverless-logic-web-tools/src/editor/hooks/useDeployDropdownItems.tsx
+++ b/packages/serverless-logic-web-tools/src/editor/hooks/useDeployDropdownItems.tsx
@@ -234,7 +234,7 @@ export function useDeployDropdownItems(props: Props) {
           return;
         }
         uploadToDevModeSuccessAlert.close();
-        devModeReadyAlert.show({ routeUrl: devMode.endpoints!.base, filePaths: result.uploadedPaths });
+        devModeReadyAlert.show({ routeUrl: devMode.endpoints!.swfDevUi, filePaths: result.uploadedPaths });
         window.clearInterval(fetchDevModeDeploymentTask);
       }, FETCH_DEV_MODE_DEPLOYMENT_POLLING_TIME);
     } else {

--- a/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
+++ b/packages/serverless-logic-web-tools/src/openshift/dropdown/OpenShiftDeploymentDropdownItem.tsx
@@ -67,8 +67,8 @@ export function OpenShiftDeploymentDropdownItem(props: Props) {
 
   const onDeploymentClicked = useCallback(() => {
     const endpoints = buildEndpoints(props.deployment.routeUrl);
-    window.open(endpoints.base, "_blank");
-  }, [props.deployment.routeUrl]);
+    window.open(props.deployment.devMode ? endpoints.swfDevUi : endpoints.base, "_blank");
+  }, [props.deployment.devMode, props.deployment.routeUrl]);
 
   const onRestoreClicked = useCallback(async () => {
     if (isRestoring) {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/2761

**Description:**
When deploying a devmode environment, clicking on the "Go to Serverless Workflow Dev UI" link opens the deployment at the root / instead of the expected /q/dev-ui.

Expected Behavior
The link should ideally redirect to /q/dev-ui/org.apache.kie.sonataflow.sonataflow-quarkus-devui/workflows for a better user experience.

**Notes:**
When you open the Dev UI, a CORS issue will block the Dev UI on Chrome. 
This has been fixed [here](https://github.com/apache/incubator-kie-tools/pull/2856) and the image should be pushed next Monday.
In the meantime, you can open the Dev UI on Firefox.