### PR TITLE
kie-issues#1770: Add User Task JPA dependency to `process-compact-architecture-example`

### DIFF
--- a/examples/process-compact-architecture/pom.xml
+++ b/examples/process-compact-architecture/pom.xml
@@ -120,6 +120,12 @@
       <groupId>org.kie</groupId>
       <artifactId>kogito-addons-quarkus-data-audit</artifactId>
     </dependency>
+
+    <!-- User Task persistence -->
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-addons-quarkus-usertask-storage-jpa</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1770

The following dependency should be added to the compact architecture example to showcase persistence of the User Task subystem:

    <!-- User Task persistence -->
    <dependency>
      <groupId>org.jbpm</groupId>
      <artifactId>jbpm-addons-quarkus-usertask-storage-jpa</artifactId>
    </dependency>
 

