### PR TITLE
[incubator-kie-issues#1786] Excluding commons-net from gwt-dev. Declaring managed version 3.9.0

### DIFF
--- a/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-processors-tests/pom.xml
+++ b/packages/dashbuilder/appformer/uberfire-workbench/uberfire-workbench-processors-tests/pom.xml
@@ -65,6 +65,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/pom.xml
+++ b/packages/dashbuilder/dashbuilder-runtime-parent/dashbuilder-runtime-client/pom.xml
@@ -275,10 +275,19 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.mortbay.jasper</groupId>
           <artifactId>apache-el</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
     </dependency>
 
     <dependency>

--- a/packages/stunner-editors/appformer-bom/pom.xml
+++ b/packages/stunner-editors/appformer-bom/pom.xml
@@ -308,6 +308,10 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
@@ -205,6 +205,12 @@
       <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-testing/pom.xml
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-testing/pom.xml
@@ -199,6 +199,12 @@
       <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>

--- a/packages/stunner-editors/errai-cdi/errai-cdi-client/pom.xml
+++ b/packages/stunner-editors/errai-cdi/errai-cdi-client/pom.xml
@@ -172,6 +172,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/errai-cdi/errai-cdi-shared/pom.xml
+++ b/packages/stunner-editors/errai-cdi/errai-cdi-shared/pom.xml
@@ -117,6 +117,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>javax.servlet-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/packages/stunner-editors/errai-codegen-gwt/pom.xml
+++ b/packages/stunner-editors/errai-codegen-gwt/pom.xml
@@ -67,6 +67,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/packages/stunner-editors/errai-codegen/pom.xml
+++ b/packages/stunner-editors/errai-codegen/pom.xml
@@ -135,6 +135,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>apache-jsp</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/packages/stunner-editors/errai-common/pom.xml
+++ b/packages/stunner-editors/errai-common/pom.xml
@@ -67,7 +67,16 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
     </dependency>
 
     <dependency>

--- a/packages/stunner-editors/errai-config/pom.xml
+++ b/packages/stunner-editors/errai-config/pom.xml
@@ -65,6 +65,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/packages/stunner-editors/errai-data-binding/pom.xml
+++ b/packages/stunner-editors/errai-data-binding/pom.xml
@@ -89,6 +89,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/errai-ioc/pom.xml
+++ b/packages/stunner-editors/errai-ioc/pom.xml
@@ -146,6 +146,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/errai-ui/pom.xml
+++ b/packages/stunner-editors/errai-ui/pom.xml
@@ -140,6 +140,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/errai-validation/pom.xml
+++ b/packages/stunner-editors/errai-validation/pom.xml
@@ -83,6 +83,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-webapp-kogito-runtime/pom.xml
@@ -369,6 +369,10 @@
           <groupId>org.mortbay.jasper</groupId>
           <artifactId>apache-el</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
@@ -198,6 +198,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/pom.xml
@@ -108,6 +108,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-kogito-runtime/pom.xml
@@ -432,6 +432,10 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
       <scope>provided</scope>
     </dependency>

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-marshalling/pom.xml
@@ -168,6 +168,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/packages/stunner-editors/lienzo-tests/pom.xml
+++ b/packages/stunner-editors/lienzo-tests/pom.xml
@@ -79,6 +79,12 @@
     <dependency>
       <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -216,6 +216,7 @@
     <version.ch.qos.logback>1.3.12</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.com.google.guava>32.1.3-jre</version.com.google.guava>
+    <version.commons.net>3.9.0</version.commons.net>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
@@ -416,6 +417,12 @@
       </dependency>
 
       <dependency>
+        <groupId>commons-net</groupId>
+        <artifactId>commons-net</artifactId>
+        <version>${version.commons.net}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.gwtproject</groupId>
         <artifactId>gwt-dev</artifactId>
         <version>${version.org.gwtproject}</version>
@@ -427,6 +434,10 @@
           <exclusion>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1786