### PR TITLE
[kie-issues#1789] CVE fix for path-to-regexp

### DIFF
--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -74,7 +74,7 @@
     "cors": "^2.8.5",
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^5.0.1",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
     "https-browserify": "^1.0.0",

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -86,7 +86,7 @@
     "cors": "^2.8.5",
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^5.0.1",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "file-loader": "^6.2.0",
     "filemanager-webpack-plugin": "^7.0.0",
     "graphql": "14.3.1",

--- a/packages/sonataflow-dev-app/package.json
+++ b/packages/sonataflow-dev-app/package.json
@@ -28,7 +28,7 @@
     "babel-jest": "^25.5.1",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "express-rate-limit": "^7.4.0",
     "graphql": "14.3.1",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8665,7 +8665,7 @@ importers:
         version: 5.3.3
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(encoding@0.1.13)(express@4.21.1)(graphql@14.3.1)
+        version: 3.13.0(encoding@0.1.13)(express@4.21.2)(graphql@14.3.1)
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -8688,8 +8688,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
@@ -8930,7 +8930,7 @@ importers:
         version: 8.3.0
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(encoding@0.1.13)(express@4.21.1)(graphql@14.3.1)
+        version: 3.13.0(encoding@0.1.13)(express@4.21.2)(graphql@14.3.1)
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -8953,8 +8953,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
@@ -9011,7 +9011,7 @@ importers:
         version: 8.0.0(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
       swagger-ui-express:
         specifier: ^5.0.0
-        version: 5.0.0(express@4.21.1)
+        version: 5.0.0(express@4.21.2)
       ts-loader:
         specifier: ^9.4.2
         version: 9.4.2(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
@@ -12100,7 +12100,7 @@ importers:
         version: link:../root-env
       apollo-server-express:
         specifier: ^3.13.0
-        version: 3.13.0(encoding@0.1.13)(express@4.21.1)(graphql@14.3.1)
+        version: 3.13.0(encoding@0.1.13)(express@4.21.2)(graphql@14.3.1)
       babel-jest:
         specifier: ^25.5.1
         version: 25.5.1(@babel/core@7.24.9)
@@ -12111,11 +12111,11 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       express-rate-limit:
         specifier: ^7.4.0
-        version: 7.4.0(express@4.21.1)
+        version: 7.4.0(express@4.21.2)
       graphql:
         specifier: 14.3.1
         version: 14.3.1
@@ -12130,7 +12130,7 @@ importers:
         version: 3.1.4
       swagger-ui-express:
         specifier: ^5.0.0
-        version: 5.0.0(express@4.21.1)
+        version: 5.0.0(express@4.21.2)
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -23946,10 +23946,6 @@ packages:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
 
-  express@4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
-    engines: {node: '>= 0.10.0'}
-
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -27520,9 +27516,6 @@ packages:
   path-temp@2.0.0:
     resolution: {integrity: sha512-92olbatybjsHTGB2CUnAM7s0mU/27gcMfLNA7t09UftndUdxywlQKur3fzXEPpfLrgZD3I2Bt8+UmiL7YDEgXQ==}
     engines: {node: '>=8.15'}
-
-  path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -44996,7 +44989,7 @@ snapshots:
     dependencies:
       graphql: 14.3.1
 
-  apollo-server-express@3.13.0(encoding@0.1.13)(express@4.21.1)(graphql@14.3.1):
+  apollo-server-express@3.13.0(encoding@0.1.13)(express@4.21.2)(graphql@14.3.1):
     dependencies:
       '@types/accepts': 1.3.7
       '@types/body-parser': 1.19.2
@@ -45008,7 +45001,7 @@ snapshots:
       apollo-server-types: 3.8.0(encoding@0.1.13)(graphql@14.3.1)
       body-parser: 1.20.3
       cors: 2.8.5
-      express: 4.21.1
+      express: 4.21.2
       graphql: 14.3.1
       parseurl: 1.3.3
     transitivePeerDependencies:
@@ -49132,9 +49125,9 @@ snapshots:
 
   exponential-backoff@3.1.1: {}
 
-  express-rate-limit@7.4.0(express@4.21.1):
+  express-rate-limit@7.4.0(express@4.21.2):
     dependencies:
-      express: 4.21.1
+      express: 4.21.2
 
   express@4.19.2:
     dependencies:
@@ -49164,42 +49157,6 @@ snapshots:
       safe-buffer: 5.2.1
       send: 0.18.0
       serve-static: 1.15.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  express@4.21.1:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.3
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.1
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.10
-      proxy-addr: 2.0.7
-      qs: 6.13.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -54048,8 +54005,6 @@ snapshots:
     dependencies:
       unique-string: 2.0.0
 
-  path-to-regexp@0.1.10: {}
-
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@0.1.7: {}
@@ -56789,9 +56744,9 @@ snapshots:
 
   swagger-ui-dist@5.11.2: {}
 
-  swagger-ui-express@5.0.0(express@4.21.1):
+  swagger-ui-express@5.0.0(express@4.21.2):
     dependencies:
-      express: 4.21.1
+      express: 4.21.2
       swagger-ui-dist: 5.11.2
 
   swap-case@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,8 +2350,8 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       express:
-        specifier: ^4.21.1
-        version: 4.21.1
+        specifier: ^4.21.2
+        version: 4.21.2
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -23950,6 +23950,10 @@ packages:
     resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
     engines: {node: '>= 0.10.0'}
 
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -27519,6 +27523,9 @@ packages:
 
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -41499,7 +41506,7 @@ snapshots:
       ejs: 3.1.9
       esbuild: 0.18.20
       esbuild-plugin-alias: 0.2.1
-      express: 4.21.1
+      express: 4.21.2
       find-cache-dir: 3.3.1
       fs-extra: 11.2.0
       process: 0.11.10
@@ -41521,7 +41528,7 @@ snapshots:
       ejs: 3.1.9
       esbuild: 0.18.20
       esbuild-plugin-alias: 0.2.1
-      express: 4.21.1
+      express: 4.21.2
       find-cache-dir: 3.3.1
       fs-extra: 11.2.0
       process: 0.11.10
@@ -41543,7 +41550,7 @@ snapshots:
       ejs: 3.1.9
       esbuild: 0.18.20
       esbuild-plugin-alias: 0.2.1
-      express: 4.21.1
+      express: 4.21.2
       find-cache-dir: 3.3.1
       fs-extra: 11.2.0
       process: 0.11.10
@@ -41580,7 +41587,7 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20))
-      express: 4.21.1
+      express: 4.21.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20))
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20))
@@ -41640,7 +41647,7 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
-      express: 4.21.1
+      express: 4.21.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
@@ -41693,7 +41700,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       es-module-lexer: 1.4.1
-      express: 4.21.1
+      express: 4.21.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.94.0(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0))
@@ -41743,7 +41750,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
       es-module-lexer: 1.4.1
-      express: 4.21.1
+      express: 4.21.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.1)(webpack@5.94.0)))
@@ -41793,7 +41800,7 @@ snapshots:
       constants-browserify: 1.0.0
       css-loader: 6.7.1(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)))
       es-module-lexer: 1.4.1
-      express: 4.21.1
+      express: 4.21.2
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.3)(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)))
       fs-extra: 11.1.1
       html-webpack-plugin: 5.5.3(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)))
@@ -41863,7 +41870,7 @@ snapshots:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.21.1
+      express: 4.21.2
       find-up: 5.0.0
       fs-extra: 11.1.1
       get-npm-tarball-url: 2.0.3
@@ -41912,7 +41919,7 @@ snapshots:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.21.1
+      express: 4.21.2
       find-up: 5.0.0
       fs-extra: 11.1.1
       get-npm-tarball-url: 2.0.3
@@ -41961,7 +41968,7 @@ snapshots:
       detect-indent: 6.1.0
       envinfo: 7.8.1
       execa: 5.1.1
-      express: 4.21.1
+      express: 4.21.2
       find-up: 5.0.0
       fs-extra: 11.1.1
       get-npm-tarball-url: 2.0.3
@@ -42204,7 +42211,7 @@ snapshots:
       cli-table3: 0.6.1
       compression: 1.7.4
       detect-port: 1.5.1
-      express: 4.21.1
+      express: 4.21.2
       fs-extra: 11.2.0
       globby: 11.1.0
       ip: 2.0.0
@@ -42253,7 +42260,7 @@ snapshots:
       cli-table3: 0.6.1
       compression: 1.7.4
       detect-port: 1.5.1
-      express: 4.21.1
+      express: 4.21.2
       fs-extra: 11.2.0
       globby: 11.1.0
       ip: 2.0.0
@@ -42302,7 +42309,7 @@ snapshots:
       cli-table3: 0.6.1
       compression: 1.7.4
       detect-port: 1.5.1
-      express: 4.21.1
+      express: 4.21.2
       fs-extra: 11.2.0
       globby: 11.1.0
       ip: 2.0.0
@@ -49201,6 +49208,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -54007,6 +54050,8 @@ snapshots:
 
   path-to-regexp@0.1.10: {}
 
+  path-to-regexp@0.1.12: {}
+
   path-to-regexp@0.1.7: {}
 
   path-to-regexp@1.9.0:
@@ -54643,7 +54688,7 @@ snapshots:
 
   qs@6.11.0:
     dependencies:
-      side-channel: 1.0.4
+      side-channel: 1.0.6
 
   qs@6.11.2:
     dependencies:
@@ -58648,7 +58693,7 @@ snapshots:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.21.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1789
Upgrading express to 4.21.2 to resolve path-to-regexp-0.1.10 CVE issue