### PR TITLE
NO-ISSUE: Add default user groups for applications with jBPM Dev UI

### DIFF
--- a/packages/dev-deployment-kogito-quarkus-blank-app/src/main/resources/application.properties
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/src/main/resources/application.properties
@@ -25,3 +25,5 @@ kogito.service.url=http://localhost:8080
 
 quarkus.http.host=0.0.0.0
 quarkus.devservices.enabled=false
+
+jbpm.devui.users.jdoe.groups=admin,HR,IT

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -52,4 +52,4 @@ quarkus.flyway.baseline-version=0.0
 quarkus.flyway.locations=classpath:/db/migration,classpath:/db/jobs-service,classpath:/db/data-audit/postgresql
 quarkus.flyway.table=FLYWAY_RUNTIME_SERVICE
 
-%dev.jbpm.devui.users.jdoe.groups=admin,HR,IT
+jbpm.devui.users.jdoe.groups=admin,HR,IT

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
@@ -116,3 +116,4 @@ kogito.data-index.url=http://0.0.0.0:8080
 %dev.quarkus.dev-ui.cors.enabled=false
 %dev.quarkus.swagger-ui.always-include=true
 %dev.quarkus.kogito.data-index.graphql.ui.always-include=true
+%dev.jbpm.devui.users.jdoe.groups=admin,HR,IT


### PR DESCRIPTION
This is a temporary fix for the changes introduced in:
- https://github.com/apache/incubator-kie-tools/pull/2814
- https://github.com/apache/incubator-kie-tools/pull/2731

When opening the jBPM Dev UI in the browser, specifically the Tasks page, without having the user groups defined in the application properties, we get this error, and the rendering breaks (blank screen):
```
TaskInboxPage.tsx:36 Uncaught TypeError: Cannot read properties of undefined (reading 'id')
    at TaskInboxPage (TaskInboxPage.tsx:36:51)
```

Some refactorings to the TaskInboxPage component were made in this PR [1], and they should fix this issue permanently.

[1] https://github.com/apache/incubator-kie-tools/pull/2758