### PR TITLE
[sonataflow-operator] NO-ISSUE: reapply format after running controller config update

### DIFF
--- a/packages/sonataflow-operator/hack/bump-version.sh
+++ b/packages/sonataflow-operator/hack/bump-version.sh
@@ -45,6 +45,5 @@ node -p "require('replace-in-file').sync({ from: /\boperatorVersion = .*/g, to: 
 node -p "require('replace-in-file').sync({ from: /\btagVersion = .*/g, to: 'tagVersion = \"${imageTag}\"', files: ['version/version.go'] });"
 
 make generate-all
-make vet
 
 echo "Version bumped to ${version}"

--- a/packages/sonataflow-operator/package.json
+++ b/packages/sonataflow-operator/package.json
@@ -31,7 +31,7 @@
     "image:bundle:build:darwin:win32": "echo 'Build Operator bundle image not supported on Windows and macOS'",
     "image:bundle:build:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --bool \"$(build-env containerImages.build)\" --then \"make bundle bundle-build\"",
     "install": "run-script-os",
-    "install:darwin:linux": "rimraf bin && go work sync && go mod tidy && pnpm controllers:update:cfg && pnpm bump-version && pnpm format",
+    "install:darwin:linux": "rimraf bin && go work sync && go mod tidy && pnpm controllers:update:cfg && pnpm format && pnpm bump-version && pnpm format",
     "install:win32": "echo 'Install not supported on Windows'",
     "test": "run-script-os",
     "test:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"make test\"",


### PR DESCRIPTION
In this PR, we added a new `pnpm format` after running `pnpm controllers:update:cfg` in the install step. This way prettier seems to run deterministically. 