### PR TITLE
[kie-issues-1787] Updating logback to 1.5.16

### DIFF
--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -94,7 +94,7 @@
     <version.org.infinispan.protostream>4.6.2.Final</version.org.infinispan.protostream>
 
     <!-- Newer version in kie-parent causes ServiceLoader error -->
-    <version.ch.qos.logback>1.5.13</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>
     <version.org.uberfire.latestFinal.release>1.4.0.Final</version.org.uberfire.latestFinal.release>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -185,7 +185,7 @@
     <version.zanata.plugin>2.3.0</version.zanata.plugin>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.5.13</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
     <version.com.google.elemental2>1.2.3</version.com.google.elemental2>
     <version.jsinterop.annotations>2.0.0</version.jsinterop.annotations>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -213,7 +213,7 @@
     <version.zanata.plugin>2.3.0</version.zanata.plugin>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.5.13</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.com.google.guava>32.1.3-jre</version.com.google.guava>
     <version.commons.codec>1.13</version.commons.codec>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1787

SpringBoot support, which Gabrielle is working on, will be using 1.5.16. This sets the version to the same across the board.