### PR TITLE
NO-ISSUE: Authenticate directly from the IdP when using quarkus-oidc-proxy with the Management Console

### DIFF
--- a/packages/runtime-tools-management-console-webapp/README.md
+++ b/packages/runtime-tools-management-console-webapp/README.md
@@ -42,7 +42,7 @@ Add the `quarkus-oidc-proxy` extension to your `pom.xml` to proxy the Identity P
 <dependency>
   <groupId>io.quarkiverse.oidc-proxy</groupId>
   <artifactId>quarkus-oidc-proxy</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
 </dependency>
 ```
 
@@ -58,10 +58,8 @@ quarkus.oidc.auth-server-url=<IDENTITY_PROVIDER_URL>
 quarkus.oidc.discovery-enabled=true
 quarkus.oidc.tenant-enabled=true
 quarkus.oidc.application-type=service
-quarkus.oidc.client-id=<CLIENT_ID> # Can be the same as the Management Console
-
-# Quarkus OIDC Proxy
-quarkus.oidc-proxy.external-client-id=<CLIENT_ID>
+quarkus.oidc.client-id=<CLIENT_ID> # Usually a client specific to your application
+quarkus.oidc.credentials.secret=<CLIENT_SECRET> # The secret configured in your Identity Provider for the client used
 
 # Authenticated and public paths
 quarkus.http.auth.permission.authenticated.paths=/*

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/keycloak/realm.json
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/keycloak/realm.json
@@ -646,6 +646,95 @@
       "optionalClientScopes": ["address", "phone", "offline_access", "organization", "microprofile-jwt"]
     },
     {
+      "clientId": "management-console-dev-service",
+      "name": "Management Console Dev Service",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "management-console-dev-service-secret",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1739999396",
+        "backchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": ["web-origins", "acr", "roles", "profile", "basic", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access", "organization", "microprofile-jwt"],
+      "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+      }
+    },
+    {
       "id": "837e0b7e-6f80-4c3c-83e7-1274787fa2e9",
       "clientId": "realm-management",
       "name": "${client_realm-management}",

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.quarkiverse.oidc-proxy</groupId>
       <artifactId>quarkus-oidc-proxy</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
@@ -37,13 +37,20 @@ quarkus.oidc.enabled=true
 quarkus.oidc.auth-server-url=http://localhost:${dev-webapp.idp.port}/realms/management-console-dev-webapp-realm
 quarkus.oidc.discovery-enabled=true
 quarkus.oidc.tenant-enabled=true
-quarkus.oidc.client-id=management-console-dev-webapp
-quarkus.oidc-proxy.external-client-id=management-console-dev-webapp
+# quarkus.oidc.client-id=management-console-dev-webapp
+# quarkus-oidc-proxy can't handle different clients (confidential and public)
+# so we're using the same client on both applications for now.
+quarkus.oidc.client-id=management-console-dev-service
+quarkus.oidc.credentials.secret=management-console-dev-service-secret
 quarkus.oidc.application-type=service
 quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 quarkus.http.auth.permission.public.paths=/q/*,/docs/*
 quarkus.http.auth.permission.public.policy=permit
+
+# Quarkus OIDC Proxy
+# quarkus.oidc-proxy.external-client-id=management-console-dev-webapp
+# quarkus.oidc-proxy.external-client-secret=management-console-dev-service-secret
 
 quarkus.http.cors=true
 quarkus.http.cors.origins=*

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
@@ -37,9 +37,6 @@ quarkus.oidc.enabled=true
 quarkus.oidc.auth-server-url=http://localhost:${dev-webapp.idp.port}/realms/management-console-dev-webapp-realm
 quarkus.oidc.discovery-enabled=true
 quarkus.oidc.tenant-enabled=true
-# quarkus.oidc.client-id=management-console-dev-webapp
-# quarkus-oidc-proxy can't handle different clients (confidential and public)
-# so we're using the same client on both applications for now.
 quarkus.oidc.client-id=management-console-dev-service
 quarkus.oidc.credentials.secret=management-console-dev-service-secret
 quarkus.oidc.application-type=service
@@ -47,10 +44,6 @@ quarkus.http.auth.permission.authenticated.paths=/*
 quarkus.http.auth.permission.authenticated.policy=authenticated
 quarkus.http.auth.permission.public.paths=/q/*,/docs/*
 quarkus.http.auth.permission.public.policy=permit
-
-# Quarkus OIDC Proxy
-# quarkus.oidc-proxy.external-client-id=management-console-dev-webapp
-# quarkus.oidc-proxy.external-client-secret=management-console-dev-service-secret
 
 quarkus.http.cors=true
 quarkus.http.cors.origins=*

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionApi.ts
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionApi.ts
@@ -31,7 +31,8 @@ export const AUTH_SESSIONS_VERSION_NUMBER = 1;
 export const AUTH_SESSIONS_FS_NAME_WITH_VERSION = `${AUTH_SESSIONS_FS_NAME}_v${AUTH_SESSIONS_VERSION_NUMBER.toString()}`;
 
 export const AUTH_SESSION_TEMP_OPENID_AUTH_DATA_STORAGE_KEY = "temporaryOpenIdAuthData";
-export const AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT = "q/oidc/.well-known/openid-configuration";
+export const AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT = "q/oidc";
+export const AUTH_SESSION_RUNTIME_AUTH_SERVER_OPENID_CONFIGURATION_PATH = ".well-known/openid-configuration";
 
 export function mapSerializer(_: string, value: any) {
   if (value instanceof Map) {

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
@@ -255,11 +255,6 @@ export class AuthSessionsService {
       return Promise.resolve(authSession);
     }
 
-    // const runtimeOidcProxyUrl = new URL(
-    //   path.join(new URL(temporaryAuthSessionData.runtimeUrl).pathname, AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT),
-    //   temporaryAuthSessionData.runtimeUrl
-    // );
-
     const issuer = new URL(temporaryAuthSessionData.serverMetadata.issuer);
 
     const config = new client.Configuration(temporaryAuthSessionData.serverMetadata, temporaryAuthSessionData.clientId);

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
@@ -19,6 +19,7 @@
 
 import * as client from "openid-client";
 import {
+  AUTH_SESSION_RUNTIME_AUTH_SERVER_OPENID_CONFIGURATION_PATH,
   AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT,
   AUTH_SESSION_TEMP_OPENID_AUTH_DATA_STORAGE_KEY,
   AUTH_SESSIONS_VERSION_NUMBER,
@@ -36,9 +37,15 @@ import { v4 as uuid } from "uuid";
 
 export class AuthSessionsService {
   static async getIdentityProviderConfig(args: { authServerUrl: string; clientId: string }) {
-    const authUrl = new URL(args.authServerUrl);
-    const options = authUrl.protocol === "http:" ? { execute: [client.allowInsecureRequests] } : {};
-    const config: client.Configuration = await client.discovery(authUrl, args.clientId, undefined, undefined, options);
+    const issuerUrl = new URL(args.authServerUrl);
+    const options = issuerUrl.protocol === "http:" ? { execute: [client.allowInsecureRequests] } : {};
+    const config: client.Configuration = await client.discovery(
+      issuerUrl,
+      args.clientId,
+      undefined,
+      undefined,
+      options
+    );
     return config;
   }
 
@@ -57,8 +64,7 @@ export class AuthSessionsService {
      */
     const code_verifier = client.randomPKCECodeVerifier();
     const code_challenge = await client.calculatePKCECodeChallenge(code_verifier);
-    // TODO: quarkus-oidc-proxy doesn't support nonce
-    // let nonce: string | undefined = undefined;
+    let nonce: string | undefined = undefined;
 
     // redirect user to as.authorization_endpoint
     const parameters: OidcAuthUrlParameters = {
@@ -68,20 +74,18 @@ export class AuthSessionsService {
       code_challenge,
       code_challenge_method,
       state: uuid(),
-      // TODO: quarkus-oidc-proxy doesn't support prompt
-      // ...(args.forceLoginPrompt ? { prompt: "login" } : {}),
+      ...(args.forceLoginPrompt ? { prompt: "login" } : {}),
     };
 
-    // TODO: quarkus-oidc-proxy doesn't support nonce
-    // /**
-    //  * We cannot be sure the AS supports PKCE so we're going to use nonce too. Use
-    //  * of PKCE is backwards compatible even if the AS doesn't support it which is
-    //  * why we're using it regardless.
-    //  */
-    // if (!args.config.serverMetadata().supportsPKCE()) {
-    //   nonce = client.randomNonce();
-    //   parameters.nonce = nonce;
-    // }
+    /**
+     * We cannot be sure the AS supports PKCE so we're going to use nonce too. Use
+     * of PKCE is backwards compatible even if the AS doesn't support it which is
+     * why we're using it regardless.
+     */
+    if (!args.config.serverMetadata().supportsPKCE()) {
+      nonce = client.randomNonce();
+      parameters.nonce = nonce;
+    }
 
     return parameters;
   }
@@ -109,14 +113,18 @@ export class AuthSessionsService {
     window.location.href = redirectTo.href;
   }
 
-  static async getIdentityProviderUrl(runtimeUrl: string) {
-    const newPath = path.join(new URL(runtimeUrl).pathname, AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT);
-    const oidcUrl = new URL(newPath, runtimeUrl);
-    const response = await fetch(oidcUrl);
+  static async getIssuerUrlFromOidcProxy(runtimeUrl: string) {
+    const newPath = path.join(
+      new URL(runtimeUrl).pathname,
+      AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT,
+      AUTH_SESSION_RUNTIME_AUTH_SERVER_OPENID_CONFIGURATION_PATH
+    );
+    const oidcProxyUrl = new URL(newPath, runtimeUrl);
+    const response = await fetch(oidcProxyUrl);
     if (response.status !== 200) {
       throw new Error("No authentication endpoint found.");
     }
-    return oidcUrl;
+    return new URL((await response.json()).issuer);
   }
 
   static async checkIfAuthenticationRequired(runtimeUrl: string): Promise<
@@ -127,10 +135,10 @@ export class AuthSessionsService {
     | { isAuthenticationRequired: false }
   > {
     try {
-      const oidcUrl = await AuthSessionsService.getIdentityProviderUrl(runtimeUrl);
+      const issuerUrl = await AuthSessionsService.getIssuerUrlFromOidcProxy(runtimeUrl);
       return {
         isAuthenticationRequired: true,
-        authServerUrl: oidcUrl.toString(),
+        authServerUrl: issuerUrl.toString(),
       };
     } catch (authServerError) {
       // Maybe not required?
@@ -247,13 +255,15 @@ export class AuthSessionsService {
       return Promise.resolve(authSession);
     }
 
-    const runtimeOidcProxyUrl = new URL(
-      path.join(new URL(temporaryAuthSessionData.runtimeUrl).pathname, AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT),
-      temporaryAuthSessionData.runtimeUrl
-    );
+    // const runtimeOidcProxyUrl = new URL(
+    //   path.join(new URL(temporaryAuthSessionData.runtimeUrl).pathname, AUTH_SESSION_RUNTIME_AUTH_SERVER_URL_ENDPOINT),
+    //   temporaryAuthSessionData.runtimeUrl
+    // );
+
+    const issuer = new URL(temporaryAuthSessionData.serverMetadata.issuer);
 
     const config = new client.Configuration(temporaryAuthSessionData.serverMetadata, temporaryAuthSessionData.clientId);
-    if (runtimeOidcProxyUrl.protocol === "http:") {
+    if (issuer.protocol === "http:") {
       client.allowInsecureRequests(config);
     }
 
@@ -262,8 +272,7 @@ export class AuthSessionsService {
     const tokens = await client.authorizationCodeGrant(config, currentUrl, {
       pkceCodeVerifier: temporaryAuthSessionData.parameters.code_verifier,
       expectedState: temporaryAuthSessionData.parameters.state,
-      // TODO: quarkus-oidc-proxy doesn't support nonce
-      // expectedNonce: temporaryAuthSessionData.parameters.nonce,
+      expectedNonce: temporaryAuthSessionData.parameters.nonce,
       idTokenExpected: true,
     });
 
@@ -290,7 +299,7 @@ export class AuthSessionsService {
       tokens,
       claims,
       runtimeUrl: temporaryAuthSessionData.runtimeUrl,
-      issuer: runtimeOidcProxyUrl.toString(),
+      issuer: issuer.toString(),
       userInfo: userInfo,
       status: AuthSessionStatus.VALID,
       createdAtDateISO: new Date(Date.now()).toISOString(),

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/components/NewAuthSessionModal.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/components/NewAuthSessionModal.tsx
@@ -147,8 +147,7 @@ export const NewAuthSessionModal: React.FC<Props> = ({ onAddAuthSession }) => {
         >
           <TextInput id="url" aria-label="URL" tabIndex={2} onChange={setRuntimeUrl} placeholder="Enter a URL..." />
         </FormGroup>
-        {/* TODO: quarkus-oidc-proxy doesn't support prompt */}
-        {/* <FormGroup
+        <FormGroup
           isRequired={false}
           helperText={
             "Check this box if you are connecting to a secured runtime and intend to use a different user than the one currently logged in to your Identity Provider."
@@ -167,7 +166,7 @@ export const NewAuthSessionModal: React.FC<Props> = ({ onAddAuthSession }) => {
             }
             tabIndex={3}
           />
-        </FormGroup> */}
+        </FormGroup>
 
         <ActionGroup>
           <Button


### PR DESCRIPTION
With this change the authentication process in the Management Console bypasses the quarkus-oidc-proxy endpoints, only using `/q/oidc/.well-known/openid-configuration` to fetch the issuer URL (Identity Provider URL).

This also fixes https://github.com/apache/incubator-kie-issues/issues/1830