### PR TITLE
NO-ISSUE: Remove unnecessary version on `quarkus-maven-plugin` from `process-security` example

### DIFF
--- a/examples/process-security/kie-service-1/pom.xml
+++ b/examples/process-security/kie-service-1/pom.xml
@@ -178,7 +178,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
         <executions>
           <execution>
             <goals>

--- a/examples/process-security/kie-service-2/pom.xml
+++ b/examples/process-security/kie-service-2/pom.xml
@@ -178,7 +178,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
         <executions>
           <execution>
             <goals>

--- a/examples/process-security/kie-service-3/pom.xml
+++ b/examples/process-security/kie-service-3/pom.xml
@@ -167,7 +167,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${version.quarkus}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Simple cleanup.