### PR TITLE
kie-issues#1808: New Test Scenario and DMN Editors in built project load DMN models twice

### DIFF
--- a/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
@@ -41,6 +41,7 @@ import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-co
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 
 export const EXTERNAL_MODELS_SEARCH_GLOB_PATTERN = "**/*.{dmn,pmml}";
+export const TARGET_DIRECTORY = "target/classes/";
 
 export const EMPTY_DMN = () => `<?xml version="1.0" encoding="UTF-8"?>
 <definitions
@@ -230,8 +231,8 @@ export class DmnEditorRoot extends React.Component<DmnEditorRootProps, DmnEditor
     });
 
     return list.normalizedPosixPathsRelativeToTheWorkspaceRoot.flatMap((p) =>
-      // Do not show this DMN on the list
-      p === this.state.openFileNormalizedPosixPathRelativeToTheWorkspaceRoot
+      // Do not show this DMN on the list and filter out assets into target/classes directory
+      p === this.state.openFileNormalizedPosixPathRelativeToTheWorkspaceRoot || p.includes(TARGET_DIRECTORY)
         ? []
         : __path.relative(__path.dirname(this.state.openFileNormalizedPosixPathRelativeToTheWorkspaceRoot!), p)
     );
@@ -604,7 +605,11 @@ function ExternalModelsManager({
         for (let i = 0; i < list.normalizedPosixPathsRelativeToTheWorkspaceRoot.length; i++) {
           const normalizedPosixPathRelativeToTheWorkspaceRoot = list.normalizedPosixPathsRelativeToTheWorkspaceRoot[i];
 
-          if (normalizedPosixPathRelativeToTheWorkspaceRoot === thisDmnsNormalizedPosixPathRelativeToTheWorkspaceRoot) {
+          // Do not show this DMN on the list and filter out assets into target/classes directory
+          if (
+            normalizedPosixPathRelativeToTheWorkspaceRoot === thisDmnsNormalizedPosixPathRelativeToTheWorkspaceRoot ||
+            normalizedPosixPathRelativeToTheWorkspaceRoot.includes(TARGET_DIRECTORY)
+          ) {
             continue;
           }
 

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
@@ -38,6 +38,7 @@ import { getMarshaller, SceSimMarshaller, SceSimModel } from "@kie-tools/scesim-
 import { EMPTY_ONE_EIGHT } from "@kie-tools/scesim-editor/dist/resources/EmptyScesimFile";
 
 export const DMN_MODELS_SEARCH_GLOB_PATTERN = "**/*.dmn";
+export const TARGET_DIRECTORY = "target/classes/";
 
 export type TestScenarioEditorRootProps = {
   exposing: (s: TestScenarioEditorRoot) => void;
@@ -215,7 +216,10 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
       });
 
       return list.normalizedPosixPathsRelativeToTheWorkspaceRoot.flatMap((p) =>
-        __path.relative(__path.dirname(this.state.openFileNormalizedPosixPathRelativeToTheWorkspaceRoot!), p)
+        // Filter out assets into target/classes directory
+        p.includes(TARGET_DIRECTORY)
+          ? []
+          : __path.relative(__path.dirname(this.state.openFileNormalizedPosixPathRelativeToTheWorkspaceRoot!), p)
       );
     };
 
@@ -415,9 +419,8 @@ function ExternalModelsManager({
         for (let i = 0; i < list.normalizedPosixPathsRelativeToTheWorkspaceRoot.length; i++) {
           const normalizedPosixPathRelativeToTheWorkspaceRoot = list.normalizedPosixPathsRelativeToTheWorkspaceRoot[i];
 
-          if (
-            normalizedPosixPathRelativeToTheWorkspaceRoot === thisScesimNormalizedPosixPathRelativeToTheWorkspaceRoot
-          ) {
+          // Filter out assets into target/classes directory
+          if (normalizedPosixPathRelativeToTheWorkspaceRoot.includes(TARGET_DIRECTORY)) {
             continue;
           }
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1808

All resources in the `target/classes` directory should be filtered out

<img width="1490" alt="Screenshot 2025-02-25 at 09 20 41" src="https://github.com/user-attachments/assets/05204c1a-3134-43d9-be10-14151e311cce" />

