### PR TITLE
NO-ISSUE: Expose own Shared values to Micro-frontends Multiplying Architecture Envelopes themselves

### DIFF
--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditor.tsx
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditor.tsx
@@ -41,7 +41,7 @@ const INITIAL_INVERT = "0";
  * envelopeContext All the features and information provided by the Apache KIE Tools Envelope.
  */
 interface Props {
-  envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
+  envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>;
 }
 
 /**

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditor.tsx
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditor.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { EditorApi, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
+import { EditorApi, KogitoEditorEnvelopeApi, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 import { EmptyState, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { Nav, NavItem, NavList } from "@patternfly/react-core/dist/js/components/Nav";
 import { Page } from "@patternfly/react-core/dist/js/components/Page";
@@ -41,7 +41,7 @@ const INITIAL_INVERT = "0";
  * envelopeContext All the features and information provided by the Apache KIE Tools Envelope.
  */
 interface Props {
-  envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>;
+  envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
 }
 
 /**

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorFactory.ts
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorFactory.ts
@@ -31,14 +31,14 @@ import { Base64PngEditorInterface } from "./Base64PngEditorInterface";
  * It tells which extension the Editor supports and how to create a new Editor
  */
 export class Base64PngEditorFactory
-  implements EditorFactory<Base64PngEditorInterface, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  implements EditorFactory<Base64PngEditorInterface, KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
 {
   public supports(fileExtension: string) {
     return fileExtension === "base64png";
   }
 
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     return Promise.resolve(new Base64PngEditorInterface(envelopeContext, initArgs));

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorFactory.ts
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorFactory.ts
@@ -21,6 +21,7 @@ import {
   EditorFactory,
   EditorInitArgs,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { Base64PngEditorInterface } from "./Base64PngEditorInterface";
@@ -29,13 +30,15 @@ import { Base64PngEditorInterface } from "./Base64PngEditorInterface";
  * Factory to be used by the Envelope to create a Base64 PNG Editor, It implements an EditorFactory.
  * It tells which extension the Editor supports and how to create a new Editor
  */
-export class Base64PngEditorFactory implements EditorFactory<Base64PngEditorInterface, KogitoEditorChannelApi> {
+export class Base64PngEditorFactory
+  implements EditorFactory<Base64PngEditorInterface, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+{
   public supports(fileExtension: string) {
     return fileExtension === "base64png";
   }
 
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ) {
     return Promise.resolve(new Base64PngEditorInterface(envelopeContext, initArgs));

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorInterface.tsx
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorInterface.tsx
@@ -24,6 +24,7 @@ import {
   EditorInitArgs,
   EditorTheme,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
@@ -59,7 +60,7 @@ export class Base64PngEditorInterface implements Editor {
   public af_componentTitle: "Base64 PNG Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<EditorApi>();

--- a/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorInterface.tsx
+++ b/examples/micro-frontends-multiplying-architecture-base64png-editor/src/Base64PngEditorInterface.tsx
@@ -60,7 +60,7 @@ export class Base64PngEditorInterface implements Editor {
   public af_componentTitle: "Base64 PNG Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<EditorApi>();

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/README.md
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/README.md
@@ -17,7 +17,7 @@
 
 # Example :: Micro-frontends Multiplying Architecture :: 'To do' List View on webapp
 
-This package contains a web application that features a 'To do' List View, a simple component wrapped inside an Envelope with a simple API for manging 'To do' items. It also features a very simple demo of Multiplying Architecture's Shared Value.
+This package contains a web application that features a 'To do' List View, a simple component wrapped inside an Envelope with a simple API for manging 'To do' items. It also features a very simple demo of Multiplying Architecture's Shared value.
 
 ### Building the dependencies
 

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/src/TodoListViewPage.tsx
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view-on-webapp/src/TodoListViewPage.tsx
@@ -24,11 +24,12 @@ import {
   EmbeddedTodoListRef,
 } from "@kie-tools-examples/micro-frontends-multiplying-architecture-todo-list-view/dist/embedded";
 import { Brand } from "@patternfly/react-core/dist/js/components/Brand";
+import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 import { Stack, StackItem } from "@patternfly/react-core/dist/js/layouts/Stack";
 import { Page, PageHeader, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button/Button";
 
-import { useStateAsSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
+import { useSharedValue, useStateAsSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
 
 export function TodoListViewPage() {
   const embeddedTodoListRef = useRef<EmbeddedTodoListRef>(null);
@@ -53,6 +54,10 @@ export function TodoListViewPage() {
     newItem,
     setNewItem,
     embeddedTodoListRef.current?.envelopeServer.shared.todoList__potentialNewItem
+  );
+
+  const [itemsCount, _] = useSharedValue(
+    embeddedTodoListRef.current?.envelopeServer.envelopeApi.shared.todoList__itemsCount
   );
 
   const apiImpl = useMemo(() => {
@@ -83,6 +88,12 @@ export function TodoListViewPage() {
             <Button variant={ButtonVariant.plain} onClick={embeddedTodoListRef.current?.markAllAsCompleted}>
               Mark all as completed
             </Button>
+          </StackItem>
+
+          <Divider />
+
+          <StackItem>
+            <span># of items: {itemsCount}</span>
           </StackItem>
         </Stack>
       }

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view/src/api/TodoListEnvelopeApi.ts
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view/src/api/TodoListEnvelopeApi.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { SharedValueProvider } from "@kie-tools-core/envelope-bus/dist/api";
+
 /**
  * Methods provided by the Envelope that can be consumed by the Channel.
  */
@@ -25,6 +27,7 @@ export interface TodoListEnvelopeApi {
   todoList__addItem(item: string): Promise<void>;
   todoList__getItems(): Promise<Item[]>;
   todoList__markAllAsCompleted(): void;
+  todoList__itemsCount(): SharedValueProvider<number>;
 }
 
 export interface Association {

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelope.tsx
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelope.tsx
@@ -53,8 +53,10 @@ export function init(args: { container: HTMLElement; bus: EnvelopeBus }) {
   const envelopeViewDelegate = async () => {
     const ref = React.createRef<TodoListEnvelopeViewApi>();
     return new Promise<() => TodoListEnvelopeViewApi>((res) => {
-      ReactDOM.render(<TodoListEnvelopeView ref={ref} channelApi={envelope.channelApi} />, args.container, () =>
-        res(() => ref.current!)
+      ReactDOM.render(
+        <TodoListEnvelopeView ref={ref} channelApi={envelope.channelApi} shared={envelope.shared} />,
+        args.container,
+        () => res(() => ref.current!)
       );
     });
   };

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeApiImpl.ts
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeApiImpl.ts
@@ -21,6 +21,7 @@ import { TodoListEnvelopeContext } from "./TodoListEnvelopeContext";
 import { Association, TodoListChannelApi, TodoListEnvelopeApi, TodoListInitArgs } from "../api";
 import { TodoListEnvelopeViewApi } from "./TodoListEnvelopeView";
 import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
+import { SharedValueProvider } from "@kie-tools-core/envelope-bus/dist/api";
 
 /**
  * Implements the TodoListEnvelopeApi.
@@ -73,5 +74,14 @@ export class TodoListEnvelopeApiImpl implements TodoListEnvelopeApi {
    */
   public todoList__markAllAsCompleted() {
     this.view().markAllAsCompleted();
+  }
+
+  /**
+   * Holds the current count of items in the list
+   */
+  public todoList__itemsCount(): SharedValueProvider<number> {
+    return {
+      defaultValue: 0,
+    };
   }
 }

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeView.tsx
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeView.tsx
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { ApiSharedValueConsumers, MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
 import * as React from "react";
-import { useCallback, useImperativeHandle, useMemo, useState } from "react";
-import { Item, TodoListChannelApi } from "../api";
+import { useCallback, useEffect, useImperativeHandle, useMemo, useState } from "react";
+import { Item, TodoListChannelApi, TodoListEnvelopeApi } from "../api";
 import "./styles.scss";
 import { useSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
 
@@ -33,6 +33,7 @@ export interface TodoListEnvelopeViewApi {
 
 interface Props {
   channelApi: MessageBusClientApi<TodoListChannelApi>;
+  shared: ApiSharedValueConsumers<TodoListEnvelopeApi>;
 }
 
 /**
@@ -88,7 +89,36 @@ export const TodoListEnvelopeView = React.forwardRef<TodoListEnvelopeViewApi, Pr
     [items]
   );
 
+  // State that is updated whenever the Channel changes the `potentialNewItem` Shared Value.
+  // Making the Envelope able to react to changes done to it.
   const [potentialNewItem, _] = useSharedValue(props.channelApi.shared.todoList__potentialNewItem);
+
+  // Keeps the `itemsCount` Shared Value current.
+  useEffect(() => {
+    props.shared.todoList__itemsCount.set(items.length);
+  }, [items.length, props.shared.todoList__itemsCount]);
+
+  // Handles set operations to `itemsCount` that do not match items.length.
+  // As a Channel also has write access to a Shared Value, there no way to tell if an
+  // invalid attempt to change this directly will be done, so we need to handle it properly.
+  useEffect(() => {
+    if (!props.shared.todoList__itemsCount) {
+      return;
+    }
+
+    const itemsCountSubs = props.shared.todoList__itemsCount.subscribe((newItemsCount) => {
+      if (newItemsCount !== items.length) {
+        console.log("Rejecting operation on `itemsCount` Shared Value because it doesn't match the actual value.");
+        props.shared.todoList__itemsCount.set(items.length); // Reverts whatever value was set.
+      } else {
+        // Ignore, itemsCount matches actual value.
+      }
+    });
+
+    return () => {
+      props.shared.todoList__itemsCount.unsubscribe(itemsCountSubs);
+    };
+  }, [items.length, props.shared.todoList__itemsCount]);
 
   return (
     <>

--- a/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeView.tsx
+++ b/examples/micro-frontends-multiplying-architecture-todo-list-view/src/envelope/TodoListEnvelopeView.tsx
@@ -89,17 +89,17 @@ export const TodoListEnvelopeView = React.forwardRef<TodoListEnvelopeViewApi, Pr
     [items]
   );
 
-  // State that is updated whenever the Channel changes the `potentialNewItem` Shared Value.
+  // State that is updated whenever the Channel changes the `potentialNewItem` Shared value.
   // Making the Envelope able to react to changes done to it.
   const [potentialNewItem, _] = useSharedValue(props.channelApi.shared.todoList__potentialNewItem);
 
-  // Keeps the `itemsCount` Shared Value current.
+  // Keeps the `itemsCount` Shared value current.
   useEffect(() => {
     props.shared.todoList__itemsCount.set(items.length);
   }, [items.length, props.shared.todoList__itemsCount]);
 
   // Handles set operations to `itemsCount` that do not match items.length.
-  // As a Channel also has write access to a Shared Value, there no way to tell if an
+  // As a Channel also has write access to a Shared value, there no way to tell if an
   // invalid attempt to change this directly will be done, so we need to handle it properly.
   useEffect(() => {
     if (!props.shared.todoList__itemsCount) {
@@ -108,7 +108,7 @@ export const TodoListEnvelopeView = React.forwardRef<TodoListEnvelopeViewApi, Pr
 
     const itemsCountSubs = props.shared.todoList__itemsCount.subscribe((newItemsCount) => {
       if (newItemsCount !== items.length) {
-        console.log("Rejecting operation on `itemsCount` Shared Value because it doesn't match the actual value.");
+        console.log("Rejecting operation on `itemsCount` Shared value because it doesn't match the actual value.");
         props.shared.todoList__itemsCount.set(items.length); // Reverts whatever value was set.
       } else {
         // Ignore, itemsCount matches actual value.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "on-affected": "pnpm -F '...[HEAD]'",
     "on-affected-only": "pnpm -F '...^[HEAD]'",
     "on-changed": "pnpm -F '[HEAD]'",
-    "on-changed-deps-only": "pnpm -F '[HEAD]^...'",
+    "on-changed-deps-only": "pnpm -F '[HEAD]^...' -F '![HEAD]'",
     "prepare": "husky install",
     "update-kogito-version-to": "kie-tools--update-kogito-version-to",
     "update-stream-name-to": "kie-tools--update-stream-name-to",

--- a/packages/dashbuilder-editor/src/editor/DashbuilderEditorFactory.ts
+++ b/packages/dashbuilder-editor/src/editor/DashbuilderEditorFactory.ts
@@ -25,10 +25,13 @@ import {
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { DashbuilderEditorChannelApi as DashbuilderEditorChannelApi } from "../api/DashbuilderEditorChannelApi";
+import { DashbuilderEditorEnvelopeApi } from "../api";
 
-export class DashbuilderEditorFactory implements EditorFactory<Editor, DashbuilderEditorChannelApi> {
+export class DashbuilderEditorFactory
+  implements EditorFactory<Editor, DashbuilderEditorEnvelopeApi, DashbuilderEditorChannelApi>
+{
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<DashbuilderEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<DashbuilderEditorEnvelopeApi, DashbuilderEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     return new DashbuilderEditorView(ctx, initArgs);

--- a/packages/dashbuilder-editor/src/editor/DashbuilderEditorView.tsx
+++ b/packages/dashbuilder-editor/src/editor/DashbuilderEditorView.tsx
@@ -23,6 +23,7 @@ import { DashbuilderEditor } from "./DashbuilderEditor";
 import { DashbuilderEditorChannelApi } from "../api/DashbuilderEditorChannelApi";
 import { DashbuilderEditorApi } from "../api/DashbuilderEditorApi";
 import { Position } from "monaco-editor";
+import { DashbuilderEditorEnvelopeApi } from "../api";
 
 export class DashbuilderEditorView implements DashbuilderEditorApi {
   private readonly editorRef: React.RefObject<DashbuilderEditorApi>;
@@ -31,7 +32,10 @@ export class DashbuilderEditorView implements DashbuilderEditorApi {
   public af_componentTitle: "Dashbuilder Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<DashbuilderEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      DashbuilderEditorEnvelopeApi,
+      DashbuilderEditorChannelApi
+    >,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<DashbuilderEditorApi>();

--- a/packages/dashbuilder-editor/src/impl/DashbuilderEditorEnvelopeApiImpl.ts
+++ b/packages/dashbuilder-editor/src/impl/DashbuilderEditorEnvelopeApiImpl.ts
@@ -28,7 +28,7 @@ export type DashbuilderEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   DashbuilderEditorEnvelopeApi,
   DashbuilderEditorChannelApi,
   EditorEnvelopeViewApi<DashbuilderEditorApi>,
-  KogitoEditorEnvelopeContextType<DashbuilderEditorChannelApi>
+  KogitoEditorEnvelopeContextType<DashbuilderEditorEnvelopeApi, DashbuilderEditorChannelApi>
 >;
 
 export class DashbuilderEditorEnvelopeApiImpl
@@ -37,7 +37,7 @@ export class DashbuilderEditorEnvelopeApiImpl
 {
   constructor(
     private readonly factoryArgs: DashbuilderEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<DashbuilderEditorApi, DashbuilderEditorChannelApi>
+    editorFactory: EditorFactory<DashbuilderEditorApi, DashbuilderEditorEnvelopeApi, DashbuilderEditorChannelApi>
   ) {
     super(factoryArgs, editorFactory);
   }

--- a/packages/dashbuilder-editor/src/monaco/DashbuilderMonacoEditor.tsx
+++ b/packages/dashbuilder-editor/src/monaco/DashbuilderMonacoEditor.tsx
@@ -26,6 +26,7 @@ import { EditorTheme } from "@kie-tools-core/editor/dist/api/EditorTheme";
 import { initCodeLenses } from "./augmentation/codeLenses";
 import { initAugmentationCommands } from "./augmentation/commands";
 import { initCompletion } from "./augmentation/completion";
+import { DashbuilderEditorEnvelopeApi } from "../api";
 
 interface Props {
   content: string;
@@ -39,7 +40,7 @@ const RefForwardingDashbuilderMonacoEditor: React.ForwardRefRenderFunction<
   Props
 > = ({ content, fileName, onContentChange, channelType }, forwardedRef) => {
   const container = useRef<HTMLDivElement>(null);
-  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<DashbuilderEditorChannelApi>();
+  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<DashbuilderEditorEnvelopeApi, DashbuilderEditorChannelApi>();
   const theme = EditorTheme.LIGHT;
 
   const controller: DashbuilderMonacoEditorApi = useMemo<DashbuilderMonacoEditorApi>(

--- a/packages/dashbuilder-viewer/src/envelope/DashbuilderViewerFactory.ts
+++ b/packages/dashbuilder-viewer/src/envelope/DashbuilderViewerFactory.ts
@@ -22,14 +22,17 @@ import {
   Editor,
   EditorFactory,
   EditorInitArgs,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { DashbuilderViewerChannelApi } from "./DashbuilderViewerChannelApi";
 import { getDashbuilderLanguageData, Resource } from "../api/DashbuilderLanguageData";
 
-export class DashbuilderViewerFactory implements EditorFactory<Editor, DashbuilderViewerChannelApi> {
+export class DashbuilderViewerFactory
+  implements EditorFactory<Editor, KogitoEditorEnvelopeApi, DashbuilderViewerChannelApi>
+{
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<DashbuilderViewerChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, DashbuilderViewerChannelApi>,
     initArgs: EditorInitArgs
   ) {
     appendLoaderContainer();

--- a/packages/dashbuilder-viewer/src/envelope/DashbuilderViewerView.tsx
+++ b/packages/dashbuilder-viewer/src/envelope/DashbuilderViewerView.tsx
@@ -22,6 +22,7 @@ import {
   EditorApi,
   EditorInitArgs,
   EditorTheme,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
@@ -36,7 +37,10 @@ export class DashbuilderViewerView implements Editor {
   public af_componentTitle: "Dashbuilder Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<DashbuilderViewerChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      KogitoEditorEnvelopeApi,
+      DashbuilderViewerChannelApi
+    >,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<EditorApi>();

--- a/packages/dmn-editor-envelope/src/DmnEditorEnvelopeApiFactory.ts
+++ b/packages/dmn-editor-envelope/src/DmnEditorEnvelopeApiFactory.ts
@@ -31,7 +31,7 @@ export type DmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   KogitoEditorEnvelopeApi,
   KogitoEditorChannelApi,
   EditorEnvelopeViewApi<Editor>,
-  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>
+  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
 >;
 
 export class DmnEditorEnvelopeApiImpl

--- a/packages/dmn-editor-envelope/src/DmnEditorEnvelopeApiFactory.ts
+++ b/packages/dmn-editor-envelope/src/DmnEditorEnvelopeApiFactory.ts
@@ -31,7 +31,7 @@ export type DmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   KogitoEditorEnvelopeApi,
   KogitoEditorChannelApi,
   EditorEnvelopeViewApi<Editor>,
-  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
 >;
 
 export class DmnEditorEnvelopeApiImpl

--- a/packages/dmn-editor-envelope/src/DmnEditorFactory.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorFactory.tsx
@@ -33,9 +33,9 @@ import { DmnEditorRoot } from "./DmnEditorRoot";
 import { ResourceContent, ResourcesList, WorkspaceEdit } from "@kie-tools-core/workspace/dist/api";
 import { useCallback } from "react";
 
-export class DmnEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi> {
+export class DmnEditorFactory implements EditorFactory<Editor, KogitoEditorEnvelopeApi, KogitoEditorChannelApi> {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new DmnEditorInterface(envelopeContext, initArgs));
@@ -49,7 +49,7 @@ export class DmnEditorInterface implements Editor {
   public af_componentTitle: "DMN Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     private readonly initArgs: EditorInitArgs
   ) {}
 
@@ -107,7 +107,7 @@ function DmnEditorRootWrapper({
   workspaceRootAbsolutePosixPath,
   isReadOnly,
 }: {
-  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
+  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>;
   exposing: (s: DmnEditorRoot) => void;
   workspaceRootAbsolutePosixPath: string;
   isReadOnly: boolean;

--- a/packages/dmn-editor-envelope/src/DmnEditorFactory.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorFactory.tsx
@@ -26,15 +26,16 @@ import {
   KogitoEditorChannelApi,
   EditorTheme,
   DEFAULT_WORKSPACE_ROOT_ABSOLUTE_POSIX_PATH,
+  KogitoEditorEnvelopeApi,
 } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { DmnEditorRoot } from "./DmnEditorRoot";
 import { ResourceContent, ResourcesList, WorkspaceEdit } from "@kie-tools-core/workspace/dist/api";
 import { useCallback } from "react";
 
-export class DmnEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi> {
+export class DmnEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi> {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new DmnEditorInterface(envelopeContext, initArgs));
@@ -48,7 +49,7 @@ export class DmnEditorInterface implements Editor {
   public af_componentTitle: "DMN Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     private readonly initArgs: EditorInitArgs
   ) {}
 
@@ -106,7 +107,7 @@ function DmnEditorRootWrapper({
   workspaceRootAbsolutePosixPath,
   isReadOnly,
 }: {
-  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>;
+  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
   exposing: (s: DmnEditorRoot) => void;
   workspaceRootAbsolutePosixPath: string;
   isReadOnly: boolean;

--- a/packages/dmn-editor-envelope/src/NewDmnEditorEnvelopeApiFactory.ts
+++ b/packages/dmn-editor-envelope/src/NewDmnEditorEnvelopeApiFactory.ts
@@ -29,7 +29,7 @@ export type NewDmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   NewDmnEditorEnvelopeApi,
   NewDmnEditorChannelApi,
   EditorEnvelopeViewApi<NewDmnEditorInterface>,
-  KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi>
+  KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>
 >;
 
 export class NewDmnEditorEnvelopeApiImpl

--- a/packages/dmn-editor-envelope/src/NewDmnEditorEnvelopeApiFactory.ts
+++ b/packages/dmn-editor-envelope/src/NewDmnEditorEnvelopeApiFactory.ts
@@ -29,7 +29,7 @@ export type NewDmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   NewDmnEditorEnvelopeApi,
   NewDmnEditorChannelApi,
   EditorEnvelopeViewApi<NewDmnEditorInterface>,
-  KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<NewDmnEditorEnvelopeApi, NewDmnEditorChannelApi>
 >;
 
 export class NewDmnEditorEnvelopeApiImpl

--- a/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
+++ b/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
@@ -24,10 +24,10 @@ import { DmnEditorInterface } from "./DmnEditorFactory";
 import { NewDmnEditorEnvelopeApi } from "./NewDmnEditorEnvelopeApi";
 
 export class NewDmnEditorFactory
-  implements EditorFactory<NewDmnEditorInterface, NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>
+  implements EditorFactory<NewDmnEditorInterface, NewDmnEditorEnvelopeApi, NewDmnEditorChannelApi>
 {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<NewDmnEditorEnvelopeApi, NewDmnEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<NewDmnEditorInterface> {
     return Promise.resolve(new NewDmnEditorInterface(envelopeContext, initArgs));

--- a/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
+++ b/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
@@ -21,10 +21,13 @@ import * as React from "react";
 import { EditorFactory, EditorInitArgs, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 import { NewDmnEditorChannelApi } from "./NewDmnEditorChannelApi";
 import { DmnEditorInterface } from "./DmnEditorFactory";
+import { NewDmnEditorEnvelopeApi } from "./NewDmnEditorEnvelopeApi";
 
-export class NewDmnEditorFactory implements EditorFactory<NewDmnEditorInterface, NewDmnEditorChannelApi> {
+export class NewDmnEditorFactory
+  implements EditorFactory<NewDmnEditorInterface, NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>
+{
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<NewDmnEditorChannelApi, NewDmnEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<NewDmnEditorInterface> {
     return Promise.resolve(new NewDmnEditorInterface(envelopeContext, initArgs));

--- a/packages/editor/src/api/EditorFactory.ts
+++ b/packages/editor/src/api/EditorFactory.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { EditorInitArgs } from "./KogitoEditorEnvelopeApi";
+import { EditorInitArgs, KogitoEditorEnvelopeApi } from "./KogitoEditorEnvelopeApi";
 import { Editor } from "./Editor";
 import { KogitoEditorEnvelopeContextType } from "./KogitoEditorEnvelopeContext";
 import { ApiDefinition } from "@kie-tools-core/envelope-bus/dist/api";
@@ -29,11 +29,15 @@ import { KogitoEditorChannelApi } from "./KogitoEditorChannelApi";
 export interface EditorFactory<
   E extends Editor,
   ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
+  EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
 > {
   /**
    * Returns an Editor instance.
    * @param envelopeContext The context to be used by Editor implementation.
    * @param initArgs Initial arguments required for the Editor to initialize itself properly.
    */
-  createEditor(envelopeContext: KogitoEditorEnvelopeContextType<ChannelApi>, initArgs: EditorInitArgs): Promise<E>;
+  createEditor(
+    envelopeContext: KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>,
+    initArgs: EditorInitArgs
+  ): Promise<E>;
 }

--- a/packages/editor/src/api/EditorFactory.ts
+++ b/packages/editor/src/api/EditorFactory.ts
@@ -28,8 +28,8 @@ import { KogitoEditorChannelApi } from "./KogitoEditorChannelApi";
  */
 export interface EditorFactory<
   E extends Editor,
-  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
   EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
+  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
 > {
   /**
    * Returns an Editor instance.
@@ -37,7 +37,7 @@ export interface EditorFactory<
    * @param initArgs Initial arguments required for the Editor to initialize itself properly.
    */
   createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<E>;
 }

--- a/packages/editor/src/api/KogitoEditorEnvelopeContext.ts
+++ b/packages/editor/src/api/KogitoEditorEnvelopeContext.ts
@@ -19,16 +19,19 @@
 
 import * as React from "react";
 import { useContext } from "react";
-import { ApiDefinition, MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { ApiDefinition, ApiSharedValueConsumers, MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
 import { KogitoEditorChannelApi } from "./KogitoEditorChannelApi";
 import { I18nService } from "@kie-tools-core/i18n/dist/envelope";
 import { OperatingSystem } from "@kie-tools-core/operating-system";
 import { KeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService";
 import { EditorTheme } from "./EditorTheme";
+import { KogitoEditorEnvelopeApi } from "./KogitoEditorEnvelopeApi";
 
 export interface KogitoEditorEnvelopeContextType<
   ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
+  EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
 > {
+  shared: ApiSharedValueConsumers<EnvelopeApi>;
   channelApi: MessageBusClientApi<ChannelApi>;
   operatingSystem?: OperatingSystem;
   services: {
@@ -38,10 +41,11 @@ export interface KogitoEditorEnvelopeContextType<
   supportedThemes: EditorTheme[];
 }
 
-export const KogitoEditorEnvelopeContext = React.createContext<KogitoEditorEnvelopeContextType<any>>({} as any);
+export const KogitoEditorEnvelopeContext = React.createContext<KogitoEditorEnvelopeContextType<any, any>>({} as any);
 
 export function useKogitoEditorEnvelopeContext<
   ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi> = KogitoEditorChannelApi,
+  EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi> = KogitoEditorEnvelopeApi,
 >() {
-  return useContext(KogitoEditorEnvelopeContext) as KogitoEditorEnvelopeContextType<ChannelApi>;
+  return useContext(KogitoEditorEnvelopeContext) as KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>;
 }

--- a/packages/editor/src/api/KogitoEditorEnvelopeContext.ts
+++ b/packages/editor/src/api/KogitoEditorEnvelopeContext.ts
@@ -28,8 +28,8 @@ import { EditorTheme } from "./EditorTheme";
 import { KogitoEditorEnvelopeApi } from "./KogitoEditorEnvelopeApi";
 
 export interface KogitoEditorEnvelopeContextType<
-  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
   EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
+  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
 > {
   shared: ApiSharedValueConsumers<EnvelopeApi>;
   channelApi: MessageBusClientApi<ChannelApi>;
@@ -44,8 +44,8 @@ export interface KogitoEditorEnvelopeContextType<
 export const KogitoEditorEnvelopeContext = React.createContext<KogitoEditorEnvelopeContextType<any, any>>({} as any);
 
 export function useKogitoEditorEnvelopeContext<
-  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi> = KogitoEditorChannelApi,
   EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi> = KogitoEditorEnvelopeApi,
+  ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi> = KogitoEditorChannelApi,
 >() {
-  return useContext(KogitoEditorEnvelopeContext) as KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>;
+  return useContext(KogitoEditorEnvelopeContext) as KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>;
 }

--- a/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
+++ b/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
@@ -45,7 +45,7 @@ export class KogitoEditorEnvelope<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<ChannelApi>
+      KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
     >,
     private readonly keyboardShortcutsService: KeyboardShortcutsService,
     private readonly i18nService: I18nService,
@@ -53,9 +53,10 @@ export class KogitoEditorEnvelope<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<ChannelApi>
+      KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
     >,
-    private readonly context: KogitoEditorEnvelopeContextType<ChannelApi> = {
+    private readonly context: KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi> = {
+      shared: envelope.shared,
       channelApi: envelope.channelApi,
       operatingSystem: getOperatingSystem(),
       services: {

--- a/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
+++ b/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
@@ -45,7 +45,7 @@ export class KogitoEditorEnvelope<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
+      KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>
     >,
     private readonly keyboardShortcutsService: KeyboardShortcutsService,
     private readonly i18nService: I18nService,
@@ -53,9 +53,9 @@ export class KogitoEditorEnvelope<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
+      KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>
     >,
-    private readonly context: KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi> = {
+    private readonly context: KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi> = {
       shared: envelope.shared,
       channelApi: envelope.channelApi,
       operatingSystem: getOperatingSystem(),

--- a/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
+++ b/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
@@ -53,9 +53,9 @@ export class KogitoEditorEnvelopeApiImpl<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+      KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
     >,
-    private readonly editorFactory: EditorFactory<E, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    private readonly editorFactory: EditorFactory<E, KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     private readonly i18n: I18n<EditorEnvelopeI18n> = new I18n<EditorEnvelopeI18n>(
       editorEnvelopeI18nDefaults,
       editorEnvelopeI18nDictionaries

--- a/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
+++ b/packages/editor/src/envelope/KogitoEditorEnvelopeApiImpl.ts
@@ -53,9 +53,9 @@ export class KogitoEditorEnvelopeApiImpl<
       EnvelopeApi,
       ChannelApi,
       EditorEnvelopeViewApi<E>,
-      KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>
+      KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
     >,
-    private readonly editorFactory: EditorFactory<E, KogitoEditorChannelApi>,
+    private readonly editorFactory: EditorFactory<E, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     private readonly i18n: I18n<EditorEnvelopeI18n> = new I18n<EditorEnvelopeI18n>(
       editorEnvelopeI18nDefaults,
       editorEnvelopeI18nDictionaries

--- a/packages/editor/src/envelope/index.ts
+++ b/packages/editor/src/envelope/index.ts
@@ -45,7 +45,7 @@ import { KeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dis
 export function init(args: {
   container: HTMLElement;
   bus: EnvelopeBus;
-  editorFactory: EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
+  editorFactory: EditorFactory<Editor, KogitoEditorEnvelopeApi, KogitoEditorChannelApi>;
   keyboardShortcutsService?: KeyboardShortcutsService;
 }) {
   initCustom({
@@ -69,7 +69,7 @@ export function initCustom<
     EnvelopeApi,
     ChannelApi,
     EditorEnvelopeViewApi<E>,
-    KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
+    KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>
   >;
   keyboardShortcutsService?: KeyboardShortcutsService;
 }) {
@@ -80,7 +80,7 @@ export function initCustom<
     EnvelopeApi,
     ChannelApi,
     EditorEnvelopeViewApi<E>,
-    KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
+    KogitoEditorEnvelopeContextType<EnvelopeApi, ChannelApi>
   >(args.bus);
 
   return new KogitoEditorEnvelope(args.apiImplFactory, keyboardShortcutsService, i18nService, envelope).start(

--- a/packages/editor/src/envelope/index.ts
+++ b/packages/editor/src/envelope/index.ts
@@ -45,7 +45,7 @@ import { KeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dis
 export function init(args: {
   container: HTMLElement;
   bus: EnvelopeBus;
-  editorFactory: EditorFactory<Editor, KogitoEditorChannelApi>;
+  editorFactory: EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
   keyboardShortcutsService?: KeyboardShortcutsService;
 }) {
   initCustom({
@@ -69,7 +69,7 @@ export function initCustom<
     EnvelopeApi,
     ChannelApi,
     EditorEnvelopeViewApi<E>,
-    KogitoEditorEnvelopeContextType<ChannelApi>
+    KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
   >;
   keyboardShortcutsService?: KeyboardShortcutsService;
 }) {
@@ -80,7 +80,7 @@ export function initCustom<
     EnvelopeApi,
     ChannelApi,
     EditorEnvelopeViewApi<E>,
-    KogitoEditorEnvelopeContextType<ChannelApi>
+    KogitoEditorEnvelopeContextType<ChannelApi, EnvelopeApi>
   >(args.bus);
 
   return new KogitoEditorEnvelope(args.apiImplFactory, keyboardShortcutsService, i18nService, envelope).start(

--- a/packages/editor/tests/envelope/utils.tsx
+++ b/packages/editor/tests/envelope/utils.tsx
@@ -20,6 +20,7 @@
 import {
   ChannelType,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContext,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
@@ -34,7 +35,11 @@ import {
   editorEnvelopeI18nDictionaries,
 } from "@kie-tools-core/editor/dist/envelope/i18n";
 
-export const DEFAULT_TESTING_ENVELOPE_CONTEXT: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi> = {
+export const DEFAULT_TESTING_ENVELOPE_CONTEXT: KogitoEditorEnvelopeContextType<
+  KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi
+> = {
+  shared: {} as any,
   channelApi: {} as any,
   services: {
     keyboardShortcuts: new DefaultKeyboardShortcutsService({} as any),
@@ -45,7 +50,7 @@ export const DEFAULT_TESTING_ENVELOPE_CONTEXT: KogitoEditorEnvelopeContextType<K
 
 export function usingEnvelopeContext(
   children: React.ReactElement,
-  ctx?: Partial<KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>>
+  ctx?: Partial<KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>>
 ) {
   const usedCtx = { ...DEFAULT_TESTING_ENVELOPE_CONTEXT, ...ctx };
   return {

--- a/packages/editor/tests/envelope/utils.tsx
+++ b/packages/editor/tests/envelope/utils.tsx
@@ -36,8 +36,8 @@ import {
 } from "@kie-tools-core/editor/dist/envelope/i18n";
 
 export const DEFAULT_TESTING_ENVELOPE_CONTEXT: KogitoEditorEnvelopeContextType<
-  KogitoEditorChannelApi,
-  KogitoEditorEnvelopeApi
+  KogitoEditorEnvelopeApi,
+  KogitoEditorChannelApi
 > = {
   shared: {} as any,
   channelApi: {} as any,
@@ -50,7 +50,7 @@ export const DEFAULT_TESTING_ENVELOPE_CONTEXT: KogitoEditorEnvelopeContextType<
 
 export function usingEnvelopeContext(
   children: React.ReactElement,
-  ctx?: Partial<KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>>
+  ctx?: Partial<KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>>
 ) {
   const usedCtx = { ...DEFAULT_TESTING_ENVELOPE_CONTEXT, ...ctx };
   return {

--- a/packages/envelope-bus/src/envelope/EnvelopeClient.ts
+++ b/packages/envelope-bus/src/envelope/EnvelopeClient.ts
@@ -40,6 +40,10 @@ export class EnvelopeClient<
     return this.manager.clientApi;
   }
 
+  public get shared() {
+    return this.manager.shared;
+  }
+
   constructor(
     private readonly bus: EnvelopeBus,
     private readonly envelopeId?: string

--- a/packages/envelope/src/Envelope.ts
+++ b/packages/envelope/src/Envelope.ts
@@ -50,6 +50,10 @@ export class Envelope<
     return this.envelopeClient.channelApi;
   }
 
+  public get shared() {
+    return this.envelopeClient.shared;
+  }
+
   public async start(
     viewDelegate: () => Promise<() => ViewType>,
     envelopeContext: ContextType,

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditorFactory.ts
@@ -37,11 +37,11 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class BpmnEditorFactory implements EditorFactory<BpmnEditor, BpmnEditorChannelApi, BpmnEditorEnvelopeApi> {
+export class BpmnEditorFactory implements EditorFactory<BpmnEditor, BpmnEditorEnvelopeApi, BpmnEditorChannelApi> {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<BpmnEditorChannelApi, KogitoEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, BpmnEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<BpmnEditor> {
     const dmnLs = new DmnLanguageService({

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEditorFactory.ts
@@ -18,8 +18,13 @@
  */
 
 import { GwtEditorWrapperFactory, XmlFormatter } from "../../common";
-import { BpmnEditorChannelApi, getBpmnLanguageData } from "../api";
-import { EditorFactory, EditorInitArgs, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
+import { BpmnEditorChannelApi, BpmnEditorEnvelopeApi, getBpmnLanguageData } from "../api";
+import {
+  EditorFactory,
+  EditorInitArgs,
+  KogitoEditorEnvelopeApi,
+  KogitoEditorEnvelopeContextType,
+} from "@kie-tools-core/editor/dist/api";
 import { BpmnEditor, BpmnEditorImpl } from "./BpmnEditor";
 import { DmnLanguageServiceExposedInteropApi } from "./exposedInteropApi/DmnLanguageServiceExposedInteropApi";
 import { DmnLanguageService } from "@kie-tools/dmn-language-service";
@@ -32,11 +37,11 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class BpmnEditorFactory implements EditorFactory<BpmnEditor, BpmnEditorChannelApi> {
+export class BpmnEditorFactory implements EditorFactory<BpmnEditor, BpmnEditorChannelApi, BpmnEditorEnvelopeApi> {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<BpmnEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<BpmnEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<BpmnEditor> {
     const dmnLs = new DmnLanguageService({

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type BpmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   BpmnEditorEnvelopeApi,
   BpmnEditorChannelApi,
   EditorEnvelopeViewApi<BpmnEditor>,
-  KogitoEditorEnvelopeContextType<BpmnEditorChannelApi>
+  KogitoEditorEnvelopeContextType<BpmnEditorChannelApi, BpmnEditorEnvelopeApi>
 >;
 
 export class BpmnEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/BpmnEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type BpmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   BpmnEditorEnvelopeApi,
   BpmnEditorChannelApi,
   EditorEnvelopeViewApi<BpmnEditor>,
-  KogitoEditorEnvelopeContextType<BpmnEditorChannelApi, BpmnEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<BpmnEditorEnvelopeApi, BpmnEditorChannelApi>
 >;
 
 export class BpmnEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/src/bpmn/envelope/vscode/VsCodeBpmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/vscode/VsCodeBpmnEditorFactory.ts
@@ -34,7 +34,7 @@ declare let window: CustomWindow;
 
 class JavaCodeCompletionService implements JavaCodeCompletionApi {
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<BpmnEditorEnvelopeApi, VsCodeBpmnEditorChannelApi>
   ) {}
   getAccessors(fqcn: string, query: string) {
     return this.envelopeContext.channelApi.requests.kogitoJavaCodeCompletion__getAccessors(fqcn, query);
@@ -48,12 +48,12 @@ class JavaCodeCompletionService implements JavaCodeCompletionApi {
 }
 
 export class VsCodeBpmnEditorFactory
-  implements EditorFactory<BpmnEditor, VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>
+  implements EditorFactory<BpmnEditor, BpmnEditorEnvelopeApi, VsCodeBpmnEditorChannelApi>
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<BpmnEditorEnvelopeApi, VsCodeBpmnEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<BpmnEditor> {
     window.envelope = {

--- a/packages/kie-bc-editors/src/bpmn/envelope/vscode/VsCodeBpmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/bpmn/envelope/vscode/VsCodeBpmnEditorFactory.ts
@@ -22,6 +22,7 @@ import { BpmnEditor } from "../BpmnEditor";
 import { JavaCodeCompletionApi } from "@kie-tools-core/vscode-java-code-completion/dist/api";
 import { BpmnEditorFactory } from "../BpmnEditorFactory";
 import { VsCodeBpmnEditorChannelApi } from "./VsCodeBpmnEditorChannelApi";
+import { BpmnEditorEnvelopeApi } from "../../api";
 
 export interface CustomWindow extends Window {
   envelope: {
@@ -32,7 +33,9 @@ export interface CustomWindow extends Window {
 declare let window: CustomWindow;
 
 class JavaCodeCompletionService implements JavaCodeCompletionApi {
-  constructor(private readonly envelopeContext: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi>) {}
+  constructor(
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>
+  ) {}
   getAccessors(fqcn: string, query: string) {
     return this.envelopeContext.channelApi.requests.kogitoJavaCodeCompletion__getAccessors(fqcn, query);
   }
@@ -44,11 +47,13 @@ class JavaCodeCompletionService implements JavaCodeCompletionApi {
   }
 }
 
-export class VsCodeBpmnEditorFactory implements EditorFactory<BpmnEditor, VsCodeBpmnEditorChannelApi> {
+export class VsCodeBpmnEditorFactory
+  implements EditorFactory<BpmnEditor, VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>
+{
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<VsCodeBpmnEditorChannelApi, BpmnEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<BpmnEditor> {
     window.envelope = {

--- a/packages/kie-bc-editors/src/common/GwtEditorWrapperFactory.ts
+++ b/packages/kie-bc-editors/src/common/GwtEditorWrapperFactory.ts
@@ -62,7 +62,7 @@ export interface CustomWindow extends Window {
 declare let window: CustomWindow;
 
 export class GwtEditorWrapperFactory<E extends GwtEditorWrapper>
-  implements EditorFactory<E, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  implements EditorFactory<E, KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
 {
   constructor(
     private readonly languageData: GwtLanguageData,
@@ -77,7 +77,7 @@ export class GwtEditorWrapperFactory<E extends GwtEditorWrapper>
   public gwtEditor: E;
 
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     this.kieBcEditorsI18n.setLocale(initArgs.initialLocale);
@@ -108,7 +108,7 @@ export class GwtEditorWrapperFactory<E extends GwtEditorWrapper>
   }
 
   private exposeEnvelopeContext(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     window.gwt = {

--- a/packages/kie-bc-editors/src/common/GwtEditorWrapperFactory.ts
+++ b/packages/kie-bc-editors/src/common/GwtEditorWrapperFactory.ts
@@ -23,6 +23,7 @@ import {
   EditorFactory,
   EditorInitArgs,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { I18n } from "@kie-tools-core/i18n/dist/core";
@@ -60,7 +61,9 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class GwtEditorWrapperFactory<E extends GwtEditorWrapper> implements EditorFactory<E, KogitoEditorChannelApi> {
+export class GwtEditorWrapperFactory<E extends GwtEditorWrapper>
+  implements EditorFactory<E, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+{
   constructor(
     private readonly languageData: GwtLanguageData,
     private readonly gwtEditorDelegate: (factory: GwtEditorWrapperFactory<E>, initArgs: EditorInitArgs) => E,
@@ -74,7 +77,7 @@ export class GwtEditorWrapperFactory<E extends GwtEditorWrapper> implements Edit
   public gwtEditor: E;
 
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ) {
     this.kieBcEditorsI18n.setLocale(initArgs.initialLocale);
@@ -105,7 +108,7 @@ export class GwtEditorWrapperFactory<E extends GwtEditorWrapper> implements Edit
   }
 
   private exposeEnvelopeContext(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ) {
     window.gwt = {

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEditorFactory.ts
@@ -32,11 +32,11 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class DmnEditorFactory implements EditorFactory<DmnEditor, DmnEditorChannelApi, DmnEditorEnvelopeApi> {
+export class DmnEditorFactory implements EditorFactory<DmnEditor, DmnEditorEnvelopeApi, DmnEditorChannelApi> {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<DmnEditorChannelApi, DmnEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<DmnEditorEnvelopeApi, DmnEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<DmnEditor> {
     const exposedInteropApi: CustomWindow["envelope"] = {

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEditorFactory.ts
@@ -18,7 +18,7 @@
  */
 
 import { GwtEditorWrapperFactory, XmlFormatter } from "../../common";
-import { DmnEditorChannelApi, getDmnLanguageData } from "../api";
+import { DmnEditorChannelApi, DmnEditorEnvelopeApi, getDmnLanguageData } from "../api";
 import { EditorFactory, EditorInitArgs, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 import { DmnEditor, DmnEditorImpl } from "./DmnEditor";
 import { PmmlEditorMarshallerExposedInteropApi } from "./exposedInteropApi/PmmlEditorMarshallerExposedInteropApi";
@@ -32,11 +32,11 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class DmnEditorFactory implements EditorFactory<DmnEditor, DmnEditorChannelApi> {
+export class DmnEditorFactory implements EditorFactory<DmnEditor, DmnEditorChannelApi, DmnEditorEnvelopeApi> {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<DmnEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<DmnEditorChannelApi, DmnEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<DmnEditor> {
     const exposedInteropApi: CustomWindow["envelope"] = {

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type DmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   DmnEditorEnvelopeApi,
   DmnEditorChannelApi,
   EditorEnvelopeViewApi<DmnEditor>,
-  KogitoEditorEnvelopeContextType<DmnEditorChannelApi, DmnEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<DmnEditorEnvelopeApi, DmnEditorChannelApi>
 >;
 
 export class DmnEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/DmnEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type DmnEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   DmnEditorEnvelopeApi,
   DmnEditorChannelApi,
   EditorEnvelopeViewApi<DmnEditor>,
-  KogitoEditorEnvelopeContextType<DmnEditorChannelApi>
+  KogitoEditorEnvelopeContextType<DmnEditorChannelApi, DmnEditorEnvelopeApi>
 >;
 
 export class DmnEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/src/dmn/envelope/vscode/VsCodeDmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/vscode/VsCodeDmnEditorFactory.ts
@@ -47,12 +47,12 @@ export interface CustomWindow extends Window {
 declare let window: CustomWindow;
 
 export class VsCodeDmnEditorFactory
-  implements EditorFactory<DmnEditor, VsCodeDmnEditorChannelApi, DmnEditorEnvelopeApi>
+  implements EditorFactory<DmnEditor, DmnEditorEnvelopeApi, VsCodeDmnEditorChannelApi>
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<VsCodeDmnEditorChannelApi, DmnEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<DmnEditorEnvelopeApi, VsCodeDmnEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<DmnEditor> {
     const exposedInteropApi: CustomWindow["envelope"] = {

--- a/packages/kie-bc-editors/src/dmn/envelope/vscode/VsCodeDmnEditorFactory.ts
+++ b/packages/kie-bc-editors/src/dmn/envelope/vscode/VsCodeDmnEditorFactory.ts
@@ -25,6 +25,7 @@ import {
   JavaCodeCompletionAccessor,
   JavaCodeCompletionClass,
 } from "@kie-tools-core/vscode-java-code-completion/dist/api";
+import { DmnEditorEnvelopeApi } from "../../api";
 
 /**
  * EXPOSED INTEROP API
@@ -45,11 +46,13 @@ export interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-export class VsCodeDmnEditorFactory implements EditorFactory<DmnEditor, VsCodeDmnEditorChannelApi> {
+export class VsCodeDmnEditorFactory
+  implements EditorFactory<DmnEditor, VsCodeDmnEditorChannelApi, DmnEditorEnvelopeApi>
+{
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<VsCodeDmnEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<VsCodeDmnEditorChannelApi, DmnEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<DmnEditor> {
     const exposedInteropApi: CustomWindow["envelope"] = {

--- a/packages/kie-bc-editors/src/scesim/envelope/SceSimEditorFactory.ts
+++ b/packages/kie-bc-editors/src/scesim/envelope/SceSimEditorFactory.ts
@@ -23,12 +23,12 @@ import { GwtEditorWrapperFactory, XmlFormatter } from "../../common";
 import { EditorFactory, EditorInitArgs, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 
 export class SceSimEditorFactory
-  implements EditorFactory<SceSimEditor, SceSimEditorChannelApi, SceSimEditorEnvelopeApi>
+  implements EditorFactory<SceSimEditor, SceSimEditorEnvelopeApi, SceSimEditorChannelApi>
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<SceSimEditorChannelApi, SceSimEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<SceSimEditorEnvelopeApi, SceSimEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<SceSimEditor> {
     const languageData = getSceSimLanguageData(initArgs.resourcesPathPrefix);

--- a/packages/kie-bc-editors/src/scesim/envelope/SceSimEditorFactory.ts
+++ b/packages/kie-bc-editors/src/scesim/envelope/SceSimEditorFactory.ts
@@ -18,15 +18,17 @@
  */
 
 import { SceSimEditor, SceSimEditorImpl } from "./SceSimEditor";
-import { getSceSimLanguageData, SceSimEditorChannelApi } from "../api";
+import { getSceSimLanguageData, SceSimEditorChannelApi, SceSimEditorEnvelopeApi } from "../api";
 import { GwtEditorWrapperFactory, XmlFormatter } from "../../common";
 import { EditorFactory, EditorInitArgs, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 
-export class SceSimEditorFactory implements EditorFactory<SceSimEditor, SceSimEditorChannelApi> {
+export class SceSimEditorFactory
+  implements EditorFactory<SceSimEditor, SceSimEditorChannelApi, SceSimEditorEnvelopeApi>
+{
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<SceSimEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<SceSimEditorChannelApi, SceSimEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<SceSimEditor> {
     const languageData = getSceSimLanguageData(initArgs.resourcesPathPrefix);

--- a/packages/kie-bc-editors/src/scesim/envelope/SceSimEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/scesim/envelope/SceSimEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type SceSimEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   SceSimEditorEnvelopeApi,
   SceSimEditorChannelApi,
   EditorEnvelopeViewApi<SceSimEditor>,
-  KogitoEditorEnvelopeContextType<SceSimEditorChannelApi, SceSimEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<SceSimEditorEnvelopeApi, SceSimEditorChannelApi>
 >;
 
 export class SceSimEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/src/scesim/envelope/SceSimEnvelopeApiFactory.ts
+++ b/packages/kie-bc-editors/src/scesim/envelope/SceSimEnvelopeApiFactory.ts
@@ -28,7 +28,7 @@ export type SceSimEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   SceSimEditorEnvelopeApi,
   SceSimEditorChannelApi,
   EditorEnvelopeViewApi<SceSimEditor>,
-  KogitoEditorEnvelopeContextType<SceSimEditorChannelApi>
+  KogitoEditorEnvelopeContextType<SceSimEditorChannelApi, SceSimEditorEnvelopeApi>
 >;
 
 export class SceSimEditorEnvelopeApiImpl

--- a/packages/kie-bc-editors/tests/GwtEditorWrapperFactory.test.ts
+++ b/packages/kie-bc-editors/tests/GwtEditorWrapperFactory.test.ts
@@ -107,6 +107,7 @@ describe("GwtEditorWrapperFactory", () => {
 
     const editorCreation = gwtEditorWrapperFactory.createEditor(
       {
+        shared: {} as any,
         channelApi: channelApiMock,
         services: {
           keyboardShortcuts: {} as any,

--- a/packages/pmml-editor/src/editor/PMMLEditorFactory.ts
+++ b/packages/pmml-editor/src/editor/PMMLEditorFactory.ts
@@ -24,13 +24,14 @@ import {
   EditorInitArgs,
   KogitoEditorEnvelopeContextType,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
 } from "@kie-tools-core/editor/dist/api";
 
 export const FACTORY_TYPE = "pmml";
 
-export class PMMLEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi> {
+export class PMMLEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi> {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new PMMLEditorInterface(envelopeContext));

--- a/packages/pmml-editor/src/editor/PMMLEditorFactory.ts
+++ b/packages/pmml-editor/src/editor/PMMLEditorFactory.ts
@@ -29,9 +29,9 @@ import {
 
 export const FACTORY_TYPE = "pmml";
 
-export class PMMLEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi> {
+export class PMMLEditorFactory implements EditorFactory<Editor, KogitoEditorEnvelopeApi, KogitoEditorChannelApi> {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new PMMLEditorInterface(envelopeContext));

--- a/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
+++ b/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
+import {
+  Editor,
+  KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
+  KogitoEditorEnvelopeContextType,
+} from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import * as React from "react";
 import { PMMLEditor } from "./PMMLEditor";
@@ -27,7 +32,9 @@ export class PMMLEditorInterface implements Editor {
   public af_componentId: "pmml-editor";
   public af_componentTitle: "PMML Editor";
 
-  constructor(private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>) {}
+  constructor(
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  ) {}
 
   public setContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): Promise<void> {
     return this.self.setContent(normalizedPosixPathRelativeToTheWorkspaceRoot, content);

--- a/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
+++ b/packages/pmml-editor/src/editor/PMMLEditorInterface.tsx
@@ -33,7 +33,7 @@ export class PMMLEditorInterface implements Editor {
   public af_componentTitle: "PMML Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
   ) {}
 
   public setContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): Promise<void> {

--- a/packages/pmml-editor/tests/editor/PMMLEditorFactory.test.ts
+++ b/packages/pmml-editor/tests/editor/PMMLEditorFactory.test.ts
@@ -33,7 +33,7 @@ import { I18nService } from "@kie-tools-core/i18n/dist/envelope";
 
 const channelApi = messageBusClientApiMock<KogitoEditorChannelApi>();
 
-const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi> = {
+const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi> = {
   shared: {} as any,
   channelApi: channelApi,
   operatingSystem: OperatingSystem.LINUX,

--- a/packages/pmml-editor/tests/editor/PMMLEditorFactory.test.ts
+++ b/packages/pmml-editor/tests/editor/PMMLEditorFactory.test.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_WORKSPACE_ROOT_ABSOLUTE_POSIX_PATH,
   Editor,
   KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { PMMLEditorFactory, PMMLEditorInterface } from "@kie-tools/pmml-editor";
@@ -32,7 +33,8 @@ import { I18nService } from "@kie-tools-core/i18n/dist/envelope";
 
 const channelApi = messageBusClientApiMock<KogitoEditorChannelApi>();
 
-const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi> = {
+const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi> = {
+  shared: {} as any,
   channelApi: channelApi,
   operatingSystem: OperatingSystem.LINUX,
   services: {

--- a/packages/pmml-editor/tests/editor/PMMLEditorInterface.test.ts
+++ b/packages/pmml-editor/tests/editor/PMMLEditorInterface.test.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 
-import { KogitoEditorChannelApi, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
+import {
+  KogitoEditorChannelApi,
+  KogitoEditorEnvelopeApi,
+  KogitoEditorEnvelopeContextType,
+} from "@kie-tools-core/editor/dist/api";
 import { render } from "@testing-library/react";
 import { ReactElement } from "react";
 import { PMMLEditor, PMMLEditorInterface } from "@kie-tools/pmml-editor";
@@ -28,7 +32,8 @@ import { I18nService } from "@kie-tools-core/i18n/dist/envelope";
 
 const channelApi = messageBusClientApiMock<KogitoEditorChannelApi>();
 
-const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi> = {
+const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi> = {
+  shared: {} as any,
   channelApi: channelApi,
   operatingSystem: OperatingSystem.LINUX,
   services: {

--- a/packages/pmml-editor/tests/editor/PMMLEditorInterface.test.ts
+++ b/packages/pmml-editor/tests/editor/PMMLEditorInterface.test.ts
@@ -32,7 +32,7 @@ import { I18nService } from "@kie-tools-core/i18n/dist/envelope";
 
 const channelApi = messageBusClientApiMock<KogitoEditorChannelApi>();
 
-const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi> = {
+const envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi> = {
   shared: {} as any,
   channelApi: channelApi,
   operatingSystem: OperatingSystem.LINUX,

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorEnvelopeApiFactory.ts
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorEnvelopeApiFactory.ts
@@ -31,7 +31,7 @@ export type TestScenarioEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   KogitoEditorEnvelopeApi,
   KogitoEditorChannelApi,
   EditorEnvelopeViewApi<Editor>,
-  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>
+  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
 >;
 
 export class TestScenarioEditorEnvelopeApiImpl

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorEnvelopeApiFactory.ts
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorEnvelopeApiFactory.ts
@@ -31,7 +31,7 @@ export type TestScenarioEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   KogitoEditorEnvelopeApi,
   KogitoEditorChannelApi,
   EditorEnvelopeViewApi<Editor>,
-  KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
 >;
 
 export class TestScenarioEditorEnvelopeApiImpl

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorFactory.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorFactory.tsx
@@ -34,10 +34,10 @@ import { ResourceContent, ResourcesList, WorkspaceEdit } from "@kie-tools-core/w
 import { TestScenarioEditorRoot } from "./TestScenarioEditorRoot";
 
 export class TestScenarioEditorFactory
-  implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+  implements EditorFactory<Editor, KogitoEditorEnvelopeApi, KogitoEditorChannelApi>
 {
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new TestScenarioEditorInterface(envelopeContext, initArgs));
@@ -51,7 +51,7 @@ export class TestScenarioEditorInterface implements Editor {
   public af_componentTitle: "Test Scenario Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>,
     private readonly initArgs: EditorInitArgs
   ) {}
 
@@ -109,7 +109,7 @@ function TestScenarioEditorRootWrapper({
   workspaceRootAbsolutePosixPath,
   isReadOnly,
 }: {
-  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
+  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, KogitoEditorChannelApi>;
   exposing: (s: TestScenarioEditorRoot) => void;
   workspaceRootAbsolutePosixPath: string;
   isReadOnly: boolean;

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorFactory.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorFactory.tsx
@@ -27,14 +27,17 @@ import {
   KogitoEditorChannelApi,
   EditorTheme,
   DEFAULT_WORKSPACE_ROOT_ABSOLUTE_POSIX_PATH,
+  KogitoEditorEnvelopeApi,
 } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { ResourceContent, ResourcesList, WorkspaceEdit } from "@kie-tools-core/workspace/dist/api";
 import { TestScenarioEditorRoot } from "./TestScenarioEditorRoot";
 
-export class TestScenarioEditorFactory implements EditorFactory<Editor, KogitoEditorChannelApi> {
+export class TestScenarioEditorFactory
+  implements EditorFactory<Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi>
+{
   public createEditor(
-    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ): Promise<Editor> {
     return Promise.resolve(new TestScenarioEditorInterface(envelopeContext, initArgs));
@@ -48,7 +51,7 @@ export class TestScenarioEditorInterface implements Editor {
   public af_componentTitle: "Test Scenario Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>,
     private readonly initArgs: EditorInitArgs
   ) {}
 
@@ -106,7 +109,7 @@ function TestScenarioEditorRootWrapper({
   workspaceRootAbsolutePosixPath,
   isReadOnly,
 }: {
-  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi>;
+  envelopeContext?: KogitoEditorEnvelopeContextType<KogitoEditorChannelApi, KogitoEditorEnvelopeApi>;
   exposing: (s: TestScenarioEditorRoot) => void;
   workspaceRootAbsolutePosixPath: string;
   isReadOnly: boolean;

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditor.tsx
@@ -64,7 +64,11 @@ import {
   useState,
 } from "react";
 import { Position } from "monaco-editor";
-import { ServerlessWorkflowCombinedEditorChannelApi, SwfPreviewOptions } from "../api";
+import {
+  ServerlessWorkflowCombinedEditorChannelApi,
+  ServerlessWorkflowCombinedEditorEnvelopeApi,
+  SwfPreviewOptions,
+} from "../api";
 import { useSwfDiagramEditorChannelApi } from "./hooks/useSwfDiagramEditorChannelApi";
 import { UseSwfTextEditorChannelApiArgs, useSwfTextEditorChannelApi } from "./hooks/useSwfTextEditorChannelApi";
 import { colorNodes } from "./helpers/ColorNodes";
@@ -106,7 +110,10 @@ const RefForwardingServerlessWorkflowCombinedEditor: ForwardRefRenderFunction<
   const [file, setFile] = useState<File | undefined>(undefined);
   const [embeddedTextEditorFile, setEmbeddedTextEditorFile] = useState<EmbeddedEditorFile>();
   const [embeddedDiagramEditorFile, setEmbeddedDiagramEditorFile] = useState<EmbeddedEditorFile>();
-  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<ServerlessWorkflowCombinedEditorChannelApi>();
+  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<
+    ServerlessWorkflowCombinedEditorEnvelopeApi,
+    ServerlessWorkflowCombinedEditorChannelApi
+  >();
   const [diagramEditorEnvelopeContent] = useSharedValue<string>(
     editorEnvelopeCtx.channelApi.shared.kogitoSwfGetDiagramEditorEnvelopeContent
   );

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorFactory.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorFactory.ts
@@ -23,14 +23,18 @@ import {
   EditorInitArgs,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
-import { ServerlessWorkflowCombinedEditorChannelApi } from "../api";
+import { ServerlessWorkflowCombinedEditorChannelApi, ServerlessWorkflowCombinedEditorEnvelopeApi } from "../api";
 import { ServerlessWorkflowCombinedEditorView } from "./ServerlessWorkflowCombinedEditorView";
 
 export class ServerlessWorkflowCombinedEditorFactory
-  implements EditorFactory<Editor, ServerlessWorkflowCombinedEditorChannelApi>
+  implements
+    EditorFactory<Editor, ServerlessWorkflowCombinedEditorChannelApi, ServerlessWorkflowCombinedEditorEnvelopeApi>
 {
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowCombinedEditorChannelApi,
+      ServerlessWorkflowCombinedEditorEnvelopeApi
+    >,
     initArgs: EditorInitArgs
   ) {
     return new ServerlessWorkflowCombinedEditorView(ctx, initArgs);

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorFactory.ts
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorFactory.ts
@@ -28,12 +28,12 @@ import { ServerlessWorkflowCombinedEditorView } from "./ServerlessWorkflowCombin
 
 export class ServerlessWorkflowCombinedEditorFactory
   implements
-    EditorFactory<Editor, ServerlessWorkflowCombinedEditorChannelApi, ServerlessWorkflowCombinedEditorEnvelopeApi>
+    EditorFactory<Editor, ServerlessWorkflowCombinedEditorEnvelopeApi, ServerlessWorkflowCombinedEditorChannelApi>
 {
   public async createEditor(
     ctx: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowCombinedEditorChannelApi,
-      ServerlessWorkflowCombinedEditorEnvelopeApi
+      ServerlessWorkflowCombinedEditorEnvelopeApi,
+      ServerlessWorkflowCombinedEditorChannelApi
     >,
     initArgs: EditorInitArgs
   ) {

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
@@ -20,7 +20,11 @@
 import { EditorInitArgs, EditorTheme, KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import * as React from "react";
-import { ServerlessWorkflowCombinedEditorApi, ServerlessWorkflowCombinedEditorChannelApi } from "../api";
+import {
+  ServerlessWorkflowCombinedEditorApi,
+  ServerlessWorkflowCombinedEditorChannelApi,
+  ServerlessWorkflowCombinedEditorEnvelopeApi,
+} from "../api";
 import { ServerlessWorkflowCombinedEditor } from "./ServerlessWorkflowCombinedEditor";
 import { Position } from "monaco-editor";
 
@@ -31,7 +35,10 @@ export class ServerlessWorkflowCombinedEditorView implements ServerlessWorkflowC
   public af_componentTitle: "Serverless Workflow Combined Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowCombinedEditorChannelApi,
+      ServerlessWorkflowCombinedEditorEnvelopeApi
+    >,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<ServerlessWorkflowCombinedEditorApi>();

--- a/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
+++ b/packages/serverless-workflow-combined-editor/src/editor/ServerlessWorkflowCombinedEditorView.tsx
@@ -36,8 +36,8 @@ export class ServerlessWorkflowCombinedEditorView implements ServerlessWorkflowC
 
   constructor(
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowCombinedEditorChannelApi,
-      ServerlessWorkflowCombinedEditorEnvelopeApi
+      ServerlessWorkflowCombinedEditorEnvelopeApi,
+      ServerlessWorkflowCombinedEditorChannelApi
     >,
     private readonly initArgs: EditorInitArgs
   ) {

--- a/packages/serverless-workflow-combined-editor/src/envelope/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/envelope/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
@@ -29,8 +29,8 @@ export type ServerlessWorkflowCombinedEnvelopeApiFactoryArgs = EnvelopeApiFactor
   ServerlessWorkflowCombinedEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowCombinedEditorApi>,
   KogitoEditorEnvelopeContextType<
-    ServerlessWorkflowCombinedEditorChannelApi,
-    ServerlessWorkflowCombinedEditorEnvelopeApi
+    ServerlessWorkflowCombinedEditorEnvelopeApi,
+    ServerlessWorkflowCombinedEditorChannelApi
   >
 >;
 
@@ -46,8 +46,8 @@ export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
     private readonly serverlessWorkflowArgs: ServerlessWorkflowCombinedEnvelopeApiFactoryArgs,
     editorFactory: EditorFactory<
       ServerlessWorkflowCombinedEditorApi,
-      ServerlessWorkflowCombinedEditorChannelApi,
-      ServerlessWorkflowCombinedEditorEnvelopeApi
+      ServerlessWorkflowCombinedEditorEnvelopeApi,
+      ServerlessWorkflowCombinedEditorChannelApi
     >
   ) {
     super(serverlessWorkflowArgs, editorFactory);

--- a/packages/serverless-workflow-combined-editor/src/envelope/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-combined-editor/src/envelope/ServerlessWorkflowCombinedEditorEnvelopeApiImpl.ts
@@ -28,7 +28,10 @@ export type ServerlessWorkflowCombinedEnvelopeApiFactoryArgs = EnvelopeApiFactor
   ServerlessWorkflowCombinedEditorEnvelopeApi,
   ServerlessWorkflowCombinedEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowCombinedEditorApi>,
-  KogitoEditorEnvelopeContextType<ServerlessWorkflowCombinedEditorChannelApi>
+  KogitoEditorEnvelopeContextType<
+    ServerlessWorkflowCombinedEditorChannelApi,
+    ServerlessWorkflowCombinedEditorEnvelopeApi
+  >
 >;
 
 export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
@@ -41,7 +44,11 @@ export class ServerlessWorkflowCombinedEditorEnvelopeApiImpl
 {
   constructor(
     private readonly serverlessWorkflowArgs: ServerlessWorkflowCombinedEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<ServerlessWorkflowCombinedEditorApi, ServerlessWorkflowCombinedEditorChannelApi>
+    editorFactory: EditorFactory<
+      ServerlessWorkflowCombinedEditorApi,
+      ServerlessWorkflowCombinedEditorChannelApi,
+      ServerlessWorkflowCombinedEditorEnvelopeApi
+    >
   ) {
     super(serverlessWorkflowArgs, editorFactory);
   }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/DiagramService.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/DiagramService.ts
@@ -20,13 +20,17 @@
 import { KogitoEditorEnvelopeContextType } from "@kie-tools-core/editor/dist/api";
 import { DiagramExposedInteropApi } from "./DiagramExposedInteropApi";
 import { ServerlessWorkflowDiagramEditorChannelApi } from "./ServerlessWorkflowDiagramEditorChannelApi";
+import { ServerlessWorkflowDiagramEditorEnvelopeApi } from "./ServerlessWorkflowDiagramEditorEnvelopeApi";
 
 /**
  * Class for diagram window interactions.
  */
 export class DiagramService implements DiagramExposedInteropApi {
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorChannelApi>
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >
   ) {}
 
   public onNodeSelected(nodeName: string) {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/api/DiagramService.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/api/DiagramService.ts
@@ -28,8 +28,8 @@ import { ServerlessWorkflowDiagramEditorEnvelopeApi } from "./ServerlessWorkflow
 export class DiagramService implements DiagramExposedInteropApi {
   constructor(
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      ServerlessWorkflowDiagramEditorChannelApi
     >
   ) {}
 

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
@@ -30,7 +30,7 @@ export type ServerlessWorkflowDiagramEnvelopeApiFactoryArgs = EnvelopeApiFactory
   ServerlessWorkflowDiagramEditorEnvelopeApi,
   ServerlessWorkflowDiagramEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowDiagramEditor>,
-  KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorChannelApi>
+  KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorChannelApi, ServerlessWorkflowDiagramEditorEnvelopeApi>
 >;
 
 export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
@@ -43,7 +43,11 @@ export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
 {
   constructor(
     private readonly serverlessWorkflowArgs: ServerlessWorkflowDiagramEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<ServerlessWorkflowDiagramEditor, ServerlessWorkflowDiagramEditorChannelApi>
+    editorFactory: EditorFactory<
+      ServerlessWorkflowDiagramEditor,
+      ServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >
   ) {
     super(serverlessWorkflowArgs, editorFactory);
   }

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorEnvelopeApiImpl.ts
@@ -30,7 +30,7 @@ export type ServerlessWorkflowDiagramEnvelopeApiFactoryArgs = EnvelopeApiFactory
   ServerlessWorkflowDiagramEditorEnvelopeApi,
   ServerlessWorkflowDiagramEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowDiagramEditor>,
-  KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorChannelApi, ServerlessWorkflowDiagramEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorEnvelopeApi, ServerlessWorkflowDiagramEditorChannelApi>
 >;
 
 export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
@@ -45,8 +45,8 @@ export class ServerlessWorkflowDiagramEditorEnvelopeApiImpl
     private readonly serverlessWorkflowArgs: ServerlessWorkflowDiagramEnvelopeApiFactoryArgs,
     editorFactory: EditorFactory<
       ServerlessWorkflowDiagramEditor,
-      ServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      ServerlessWorkflowDiagramEditorChannelApi
     >
   ) {
     super(serverlessWorkflowArgs, editorFactory);

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorFactory.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorFactory.ts
@@ -24,7 +24,11 @@ import {
   EditorTheme,
 } from "@kie-tools-core/editor/dist/api";
 import { GwtEditorWrapperFactory } from "@kie-tools/kie-bc-editors/dist/common";
-import { getServerlessWorkflowLanguageData, ServerlessWorkflowDiagramEditorChannelApi } from "../api";
+import {
+  getServerlessWorkflowLanguageData,
+  ServerlessWorkflowDiagramEditorChannelApi,
+  ServerlessWorkflowDiagramEditorEnvelopeApi,
+} from "../api";
 import { DiagramExposedInteropApi } from "../api/DiagramExposedInteropApi";
 import { DiagramService } from "../api/DiagramService";
 import {
@@ -41,12 +45,20 @@ export interface CustomWindow {
 declare let window: CustomWindow;
 
 export class ServerlessWorkflowDiagramEditorFactory
-  implements EditorFactory<ServerlessWorkflowDiagramEditor, ServerlessWorkflowDiagramEditorChannelApi>
+  implements
+    EditorFactory<
+      ServerlessWorkflowDiagramEditor,
+      ServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<ServerlessWorkflowDiagramEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >,
     initArgs: EditorInitArgs
   ): Promise<ServerlessWorkflowDiagramEditor> {
     window.envelope = {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorFactory.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/envelope/ServerlessWorkflowDiagramEditorFactory.ts
@@ -48,16 +48,16 @@ export class ServerlessWorkflowDiagramEditorFactory
   implements
     EditorFactory<
       ServerlessWorkflowDiagramEditor,
-      ServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      ServerlessWorkflowDiagramEditorChannelApi
     >
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
     ctx: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      ServerlessWorkflowDiagramEditorChannelApi
     >,
     initArgs: EditorInitArgs
   ): Promise<ServerlessWorkflowDiagramEditor> {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/vscode/envelope/VsCodeServerlessWorkflowDiagramEditorFactory.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/vscode/envelope/VsCodeServerlessWorkflowDiagramEditorFactory.ts
@@ -23,6 +23,7 @@ import { DiagramExposedInteropApi } from "../../api/DiagramExposedInteropApi";
 import { DiagramService } from "../../api/DiagramService";
 import { ServerlessWorkflowDiagramEditor, ServerlessWorkflowDiagramEditorFactory } from "../../envelope";
 import { VsCodeServerlessWorkflowDiagramEditorChannelApi } from "../api/VsCodeServerlessWorkflowDiagramEditorChannelApi";
+import { ServerlessWorkflowDiagramEditorEnvelopeApi } from "../../api";
 
 export interface CustomWindow extends Window {
   envelope: {
@@ -35,7 +36,10 @@ declare let window: CustomWindow;
 
 class JavaCodeCompletionService implements JavaCodeCompletionApi {
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<VsCodeServerlessWorkflowDiagramEditorChannelApi>
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      VsCodeServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >
   ) {}
   getAccessors(fqcn: string, query: string) {
     return this.envelopeContext.channelApi.requests.kogitoJavaCodeCompletion__getAccessors(fqcn, query);
@@ -49,12 +53,20 @@ class JavaCodeCompletionService implements JavaCodeCompletionApi {
 }
 
 export class VsCodeServerlessWorkflowDiagramEditorFactory
-  implements EditorFactory<ServerlessWorkflowDiagramEditor, VsCodeServerlessWorkflowDiagramEditorChannelApi>
+  implements
+    EditorFactory<
+      ServerlessWorkflowDiagramEditor,
+      VsCodeServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
-    ctx: KogitoEditorEnvelopeContextType<VsCodeServerlessWorkflowDiagramEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<
+      VsCodeServerlessWorkflowDiagramEditorChannelApi,
+      ServerlessWorkflowDiagramEditorEnvelopeApi
+    >,
     initArgs: EditorInitArgs
   ): Promise<ServerlessWorkflowDiagramEditor> {
     window.envelope = {

--- a/packages/serverless-workflow-diagram-editor-envelope/src/vscode/envelope/VsCodeServerlessWorkflowDiagramEditorFactory.ts
+++ b/packages/serverless-workflow-diagram-editor-envelope/src/vscode/envelope/VsCodeServerlessWorkflowDiagramEditorFactory.ts
@@ -37,8 +37,8 @@ declare let window: CustomWindow;
 class JavaCodeCompletionService implements JavaCodeCompletionApi {
   constructor(
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<
-      VsCodeServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      VsCodeServerlessWorkflowDiagramEditorChannelApi
     >
   ) {}
   getAccessors(fqcn: string, query: string) {
@@ -56,16 +56,16 @@ export class VsCodeServerlessWorkflowDiagramEditorFactory
   implements
     EditorFactory<
       ServerlessWorkflowDiagramEditor,
-      VsCodeServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      VsCodeServerlessWorkflowDiagramEditorChannelApi
     >
 {
   constructor(private readonly gwtEditorEnvelopeConfig: { shouldLoadResourcesDynamically: boolean }) {}
 
   public createEditor(
     ctx: KogitoEditorEnvelopeContextType<
-      VsCodeServerlessWorkflowDiagramEditorChannelApi,
-      ServerlessWorkflowDiagramEditorEnvelopeApi
+      ServerlessWorkflowDiagramEditorEnvelopeApi,
+      VsCodeServerlessWorkflowDiagramEditorChannelApi
     >,
     initArgs: EditorInitArgs
   ): Promise<ServerlessWorkflowDiagramEditor> {

--- a/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorFactory.ts
+++ b/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorFactory.ts
@@ -28,12 +28,12 @@ import { ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnv
 import { ServerlessWorkflowTextEditorView } from "./ServerlessWorkflowTextEditorView";
 
 export class ServerlessWorkflowTextEditorFactory
-  implements EditorFactory<Editor, ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi>
+  implements EditorFactory<Editor, ServerlessWorkflowTextEditorEnvelopeApi, ServerlessWorkflowTextEditorChannelApi>
 {
   public async createEditor(
     ctx: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowTextEditorChannelApi,
-      ServerlessWorkflowTextEditorEnvelopeApi
+      ServerlessWorkflowTextEditorEnvelopeApi,
+      ServerlessWorkflowTextEditorChannelApi
     >,
     initArgs: EditorInitArgs
   ) {

--- a/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorFactory.ts
+++ b/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorFactory.ts
@@ -24,14 +24,17 @@ import {
   EditorTheme,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
-import { ServerlessWorkflowTextEditorChannelApi } from "../api";
+import { ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi } from "../api";
 import { ServerlessWorkflowTextEditorView } from "./ServerlessWorkflowTextEditorView";
 
 export class ServerlessWorkflowTextEditorFactory
-  implements EditorFactory<Editor, ServerlessWorkflowTextEditorChannelApi>
+  implements EditorFactory<Editor, ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi>
 {
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorChannelApi>,
+    ctx: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowTextEditorChannelApi,
+      ServerlessWorkflowTextEditorEnvelopeApi
+    >,
     initArgs: EditorInitArgs
   ) {
     ctx.supportedThemes = [EditorTheme.LIGHT, EditorTheme.DARK];

--- a/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorView.tsx
+++ b/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorView.tsx
@@ -36,8 +36,8 @@ export class ServerlessWorkflowTextEditorView implements ServerlessWorkflowTextE
 
   constructor(
     private readonly envelopeContext: KogitoEditorEnvelopeContextType<
-      ServerlessWorkflowTextEditorChannelApi,
-      ServerlessWorkflowTextEditorEnvelopeApi
+      ServerlessWorkflowTextEditorEnvelopeApi,
+      ServerlessWorkflowTextEditorChannelApi
     >,
     private readonly initArgs: EditorInitArgs
   ) {

--- a/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorView.tsx
+++ b/packages/serverless-workflow-text-editor/src/editor/ServerlessWorkflowTextEditorView.tsx
@@ -21,7 +21,11 @@ import { EditorInitArgs, EditorTheme, KogitoEditorEnvelopeContextType } from "@k
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import { Position } from "monaco-editor";
 import * as React from "react";
-import { ServerlessWorkflowTextEditorApi, ServerlessWorkflowTextEditorChannelApi } from "../api";
+import {
+  ServerlessWorkflowTextEditorApi,
+  ServerlessWorkflowTextEditorChannelApi,
+  ServerlessWorkflowTextEditorEnvelopeApi,
+} from "../api";
 import { ServerlessWorkflowTextEditor } from "./ServerlessWorkflowTextEditor";
 
 export class ServerlessWorkflowTextEditorView implements ServerlessWorkflowTextEditorApi {
@@ -31,7 +35,10 @@ export class ServerlessWorkflowTextEditorView implements ServerlessWorkflowTextE
   public af_componentTitle: "Serverless Workflow Text Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<
+      ServerlessWorkflowTextEditorChannelApi,
+      ServerlessWorkflowTextEditorEnvelopeApi
+    >,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<ServerlessWorkflowTextEditorApi>();

--- a/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditor.tsx
+++ b/packages/serverless-workflow-text-editor/src/editor/textEditor/SwfTextEditor.tsx
@@ -26,7 +26,7 @@ import { initAugmentationCommands } from "./augmentation/commands";
 import { ChannelType, EditorTheme, useKogitoEditorEnvelopeContext } from "@kie-tools-core/editor/dist/api";
 import { useSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
 import { getFileLanguage } from "@kie-tools/serverless-workflow-language-service/dist/api";
-import { ServerlessWorkflowTextEditorChannelApi } from "../../api";
+import { ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi } from "../../api";
 import { editor } from "monaco-editor";
 
 interface Props {
@@ -43,7 +43,10 @@ const RefForwardingSwfTextEditor: React.ForwardRefRenderFunction<SwfTextEditorAp
   forwardedRef
 ) => {
   const container = useRef<HTMLDivElement>(null);
-  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<ServerlessWorkflowTextEditorChannelApi>();
+  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<
+    ServerlessWorkflowTextEditorEnvelopeApi,
+    ServerlessWorkflowTextEditorChannelApi
+  >();
   const [theme] = useSharedValue(editorEnvelopeCtx.channelApi?.shared.kogitoEditor_theme);
   const [services] = useSharedValue(editorEnvelopeCtx.channelApi?.shared.kogitoSwfServiceCatalog_services);
   const [serviceRegistriesSettings] = useSharedValue(

--- a/packages/serverless-workflow-text-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-text-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApiImpl.ts
@@ -31,7 +31,7 @@ export type ServerlessWorkflowTextEnvelopeApiFactoryArgs = EnvelopeApiFactoryArg
   ServerlessWorkflowTextEditorEnvelopeApi,
   ServerlessWorkflowTextEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowTextEditorApi>,
-  KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorEnvelopeApi, ServerlessWorkflowTextEditorChannelApi>
 >;
 
 export class ServerlessWorkflowTextEditorEnvelopeApiImpl
@@ -46,8 +46,8 @@ export class ServerlessWorkflowTextEditorEnvelopeApiImpl
     private readonly serverlessWorkflowArgs: ServerlessWorkflowTextEnvelopeApiFactoryArgs,
     editorFactory: EditorFactory<
       ServerlessWorkflowTextEditorApi,
-      ServerlessWorkflowTextEditorChannelApi,
-      ServerlessWorkflowTextEditorEnvelopeApi
+      ServerlessWorkflowTextEditorEnvelopeApi,
+      ServerlessWorkflowTextEditorChannelApi
     >
   ) {
     super(serverlessWorkflowArgs, editorFactory);

--- a/packages/serverless-workflow-text-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApiImpl.ts
+++ b/packages/serverless-workflow-text-editor/src/envelope/ServerlessWorkflowTextEditorEnvelopeApiImpl.ts
@@ -31,7 +31,7 @@ export type ServerlessWorkflowTextEnvelopeApiFactoryArgs = EnvelopeApiFactoryArg
   ServerlessWorkflowTextEditorEnvelopeApi,
   ServerlessWorkflowTextEditorChannelApi,
   EditorEnvelopeViewApi<ServerlessWorkflowTextEditorApi>,
-  KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorChannelApi>
+  KogitoEditorEnvelopeContextType<ServerlessWorkflowTextEditorChannelApi, ServerlessWorkflowTextEditorEnvelopeApi>
 >;
 
 export class ServerlessWorkflowTextEditorEnvelopeApiImpl
@@ -44,7 +44,11 @@ export class ServerlessWorkflowTextEditorEnvelopeApiImpl
 {
   constructor(
     private readonly serverlessWorkflowArgs: ServerlessWorkflowTextEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<ServerlessWorkflowTextEditorApi, ServerlessWorkflowTextEditorChannelApi>
+    editorFactory: EditorFactory<
+      ServerlessWorkflowTextEditorApi,
+      ServerlessWorkflowTextEditorChannelApi,
+      ServerlessWorkflowTextEditorEnvelopeApi
+    >
   ) {
     super(serverlessWorkflowArgs, editorFactory);
   }

--- a/packages/text-editor/src/editor/TextEditorFactory.ts
+++ b/packages/text-editor/src/editor/TextEditorFactory.ts
@@ -21,13 +21,17 @@ import {
   Editor,
   EditorFactory,
   EditorInitArgs,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { TextEditorChannelApi } from "../api";
 import { TextEditorView } from "./TextEditorView";
 
-export class TextEditorFactory implements EditorFactory<Editor, TextEditorChannelApi> {
-  public async createEditor(ctx: KogitoEditorEnvelopeContextType<TextEditorChannelApi>, initArgs: EditorInitArgs) {
+export class TextEditorFactory implements EditorFactory<Editor, TextEditorChannelApi, KogitoEditorEnvelopeApi> {
+  public async createEditor(
+    ctx: KogitoEditorEnvelopeContextType<TextEditorChannelApi, KogitoEditorEnvelopeApi>,
+    initArgs: EditorInitArgs
+  ) {
     return new TextEditorView(ctx, initArgs);
   }
 }

--- a/packages/text-editor/src/editor/TextEditorFactory.ts
+++ b/packages/text-editor/src/editor/TextEditorFactory.ts
@@ -27,9 +27,9 @@ import {
 import { TextEditorChannelApi } from "../api";
 import { TextEditorView } from "./TextEditorView";
 
-export class TextEditorFactory implements EditorFactory<Editor, TextEditorChannelApi, KogitoEditorEnvelopeApi> {
+export class TextEditorFactory implements EditorFactory<Editor, KogitoEditorEnvelopeApi, TextEditorChannelApi> {
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<TextEditorChannelApi, KogitoEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, TextEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     return new TextEditorView(ctx, initArgs);

--- a/packages/text-editor/src/editor/TextEditorView.tsx
+++ b/packages/text-editor/src/editor/TextEditorView.tsx
@@ -37,7 +37,7 @@ export class TextEditorView implements Editor {
   public af_componentTitle: "Text Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<TextEditorChannelApi, KogitoEditorEnvelopeApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<KogitoEditorEnvelopeApi, TextEditorChannelApi>,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<EditorApi>();

--- a/packages/text-editor/src/editor/TextEditorView.tsx
+++ b/packages/text-editor/src/editor/TextEditorView.tsx
@@ -22,6 +22,7 @@ import {
   EditorApi,
   EditorInitArgs,
   EditorTheme,
+  KogitoEditorEnvelopeApi,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
 import { Notification } from "@kie-tools-core/notifications/dist/api";
@@ -36,7 +37,7 @@ export class TextEditorView implements Editor {
   public af_componentTitle: "Text Editor";
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<TextEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<TextEditorChannelApi, KogitoEditorEnvelopeApi>,
     private readonly initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<EditorApi>();

--- a/packages/text-editor/src/editor/monaco/MonacoEditor.tsx
+++ b/packages/text-editor/src/editor/monaco/MonacoEditor.tsx
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import { ChannelType, EditorTheme, useKogitoEditorEnvelopeContext } from "@kie-tools-core/editor/dist/api";
+import {
+  ChannelType,
+  EditorTheme,
+  KogitoEditorEnvelopeApi,
+  useKogitoEditorEnvelopeContext,
+} from "@kie-tools-core/editor/dist/api";
 import { useSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
 import { editor } from "monaco-editor";
 import { extname } from "path";
@@ -50,7 +55,7 @@ const RefForwardingMonacoEditor: React.ForwardRefRenderFunction<MonacoEditorApi 
   forwardedRef
 ) => {
   const container = useRef<HTMLDivElement>(null);
-  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<TextEditorChannelApi>();
+  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<KogitoEditorEnvelopeApi, TextEditorChannelApi>();
   const [theme] = useSharedValue(editorEnvelopeCtx.channelApi?.shared.kogitoEditor_theme);
 
   const controller: MonacoEditorApi = useMemo<MonacoEditorApi>(() => {

--- a/packages/yard-editor/src/editor/YardEditorFactory.ts
+++ b/packages/yard-editor/src/editor/YardEditorFactory.ts
@@ -26,9 +26,9 @@ import {
 } from "@kie-tools-core/editor/dist/api";
 import { YardEditorChannelApi, YardEditorEnvelopeApi } from "../api";
 
-export class YardEditorFactory implements EditorFactory<Editor, YardEditorChannelApi, YardEditorEnvelopeApi> {
+export class YardEditorFactory implements EditorFactory<Editor, YardEditorEnvelopeApi, YardEditorChannelApi> {
   public async createEditor(
-    ctx: KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>,
+    ctx: KogitoEditorEnvelopeContextType<YardEditorEnvelopeApi, YardEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     return new YardEditorView(ctx, initArgs);

--- a/packages/yard-editor/src/editor/YardEditorFactory.ts
+++ b/packages/yard-editor/src/editor/YardEditorFactory.ts
@@ -24,10 +24,13 @@ import {
   EditorInitArgs,
   KogitoEditorEnvelopeContextType,
 } from "@kie-tools-core/editor/dist/api";
-import { YardEditorChannelApi } from "../api";
+import { YardEditorChannelApi, YardEditorEnvelopeApi } from "../api";
 
-export class YardEditorFactory implements EditorFactory<Editor, YardEditorChannelApi> {
-  public async createEditor(ctx: KogitoEditorEnvelopeContextType<YardEditorChannelApi>, initArgs: EditorInitArgs) {
+export class YardEditorFactory implements EditorFactory<Editor, YardEditorChannelApi, YardEditorEnvelopeApi> {
+  public async createEditor(
+    ctx: KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>,
+    initArgs: EditorInitArgs
+  ) {
     return new YardEditorView(ctx, initArgs);
   }
 }

--- a/packages/yard-editor/src/editor/YardEditorView.tsx
+++ b/packages/yard-editor/src/editor/YardEditorView.tsx
@@ -20,7 +20,7 @@ import { Editor, EditorInitArgs, EditorTheme, KogitoEditorEnvelopeContextType } 
 import { Notification } from "@kie-tools-core/notifications/dist/api";
 import * as React from "react";
 import { YardEditor } from "./YardEditor";
-import { YardEditorApi, YardEditorChannelApi } from "../api";
+import { YardEditorApi, YardEditorChannelApi, YardEditorEnvelopeApi } from "../api";
 import { Position } from "monaco-editor";
 import { validationPromise } from "@kie-tools/yard-validator/dist/";
 
@@ -33,7 +33,7 @@ export class YardEditorView implements Editor {
   private path: string;
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<YardEditorChannelApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>,
     initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<YardEditorApi>();

--- a/packages/yard-editor/src/editor/YardEditorView.tsx
+++ b/packages/yard-editor/src/editor/YardEditorView.tsx
@@ -33,7 +33,7 @@ export class YardEditorView implements Editor {
   private path: string;
 
   constructor(
-    private readonly envelopeContext: KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>,
+    private readonly envelopeContext: KogitoEditorEnvelopeContextType<YardEditorEnvelopeApi, YardEditorChannelApi>,
     initArgs: EditorInitArgs
   ) {
     this.editorRef = React.createRef<YardEditorApi>();

--- a/packages/yard-editor/src/impl/YardEditorEnvelopeApiImpl.ts
+++ b/packages/yard-editor/src/impl/YardEditorEnvelopeApiImpl.ts
@@ -27,7 +27,7 @@ export type YardEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   YardEditorEnvelopeApi,
   YardEditorChannelApi,
   EditorEnvelopeViewApi<YardEditorApi>,
-  KogitoEditorEnvelopeContextType<YardEditorChannelApi>
+  KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>
 >;
 
 export class YardEditorEnvelopeApiImpl
@@ -36,7 +36,7 @@ export class YardEditorEnvelopeApiImpl
 {
   constructor(
     private readonly factoryArgs: YardEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<YardEditorApi, YardEditorChannelApi>
+    editorFactory: EditorFactory<YardEditorApi, YardEditorChannelApi, YardEditorEnvelopeApi>
   ) {
     super(factoryArgs, editorFactory);
   }

--- a/packages/yard-editor/src/impl/YardEditorEnvelopeApiImpl.ts
+++ b/packages/yard-editor/src/impl/YardEditorEnvelopeApiImpl.ts
@@ -27,7 +27,7 @@ export type YardEnvelopeApiFactoryArgs = EnvelopeApiFactoryArgs<
   YardEditorEnvelopeApi,
   YardEditorChannelApi,
   EditorEnvelopeViewApi<YardEditorApi>,
-  KogitoEditorEnvelopeContextType<YardEditorChannelApi, YardEditorEnvelopeApi>
+  KogitoEditorEnvelopeContextType<YardEditorEnvelopeApi, YardEditorChannelApi>
 >;
 
 export class YardEditorEnvelopeApiImpl
@@ -36,7 +36,7 @@ export class YardEditorEnvelopeApiImpl
 {
   constructor(
     private readonly factoryArgs: YardEnvelopeApiFactoryArgs,
-    editorFactory: EditorFactory<YardEditorApi, YardEditorChannelApi, YardEditorEnvelopeApi>
+    editorFactory: EditorFactory<YardEditorApi, YardEditorEnvelopeApi, YardEditorChannelApi>
   ) {
     super(factoryArgs, editorFactory);
   }

--- a/packages/yard-editor/src/textEditor/YardTextEditor.tsx
+++ b/packages/yard-editor/src/textEditor/YardTextEditor.tsx
@@ -22,7 +22,7 @@ import { useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import { YardTextEditorController, YardTextEditorApi } from "./YardTextEditorController";
 import { ChannelType, EditorTheme, useKogitoEditorEnvelopeContext } from "@kie-tools-core/editor/dist/api";
 import { useSharedValue } from "@kie-tools-core/envelope-bus/dist/hooks";
-import { YardEditorChannelApi } from "../api";
+import { YardEditorChannelApi, YardEditorEnvelopeApi } from "../api";
 import { editor } from "monaco-editor";
 import { YardFile } from "../types";
 import { initCodeLenses } from "./augmentation/codeLenses";
@@ -42,7 +42,7 @@ const RefForwardingYardTextEditor: React.ForwardRefRenderFunction<YardTextEditor
   forwardedRef
 ) => {
   const container = useRef<HTMLDivElement>(null);
-  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<YardEditorChannelApi>();
+  const editorEnvelopeCtx = useKogitoEditorEnvelopeContext<YardEditorEnvelopeApi, YardEditorChannelApi>();
   const [theme] = useSharedValue(editorEnvelopeCtx.channelApi?.shared.kogitoEditor_theme);
 
   const controller: YardTextEditorApi = useMemo<YardTextEditorApi>(() => {


### PR DESCRIPTION
During @jomarko's work on 

- https://github.com/apache/incubator-kie-tools/pull/2918

[I mentioned](https://github.com/apache/incubator-kie-tools/pull/2918#issuecomment-2675804896) that this work was a great opportunity for using [Shared values](https://github.com/apache/incubator-kie-tools/pull/691). However, a Shared value owned by an Envelope was currently not being exposed to it via EnvelopeClient, and therefore couldn't be used by the components inside an Envelope.

Since for @jomarko's work, the state of which Boxed Expression is currently selected is _owned_ by the DMN Editor, it only made sense for the `dmn-editor-envelope` to own this Shared value. Investigating with him, we weren't able to find a way to consume it, then after insisting, I noticed that [EnvelopeServer](https://github.com/apache/incubator-kie-tools/blob/main/packages/envelope-bus/src/channel/EnvelopeServer.ts) was exposing its Shared values via the `shared` getter, but [EnvelopeClient](https://github.com/apache/incubator-kie-tools/blob/main/packages/envelope-bus/src/envelope/EnvelopeClient.ts) wasn't. This PR changes that.

More than making EnvelopeClient expose its Shared values, I'm also adding a new `shared` property to `KogitoEditorEnvelopeContextType` so that all Editors running inside Envelopes can access Shared values they might come to declare.

This PR turned out somewhat large, as lots of places needed the EnvelopeApi as a new type parameter, but real changes are in:
- `KogitoEditorEnvelopeContext.ts`
  - Adding a new `shared` property
- `EnvelopeClient.ts`; and
  - Adding a new `shared` getter
- `examples/micro-frontends-multiplying-architecture-todo-list-view`
  - Adding a new Shared value (`todoList__itemsCount`) to the Envelope, and consuming it in the Channel.

---
A simple video showcasing the new `itemsCount` Shared value owned by `TodoListEnvelopeApi`.

https://github.com/user-attachments/assets/da3f40fd-c0e9-4a6e-89cd-4bf6b82c72ef


---


Also in this PR:
- Fixing the top-level `on-changed-deps-only` script to always exclude changed packages, even if they're dependencies of other changed packages.
