### PR TITLE
NO-ISSUE: Fix netty-related CVE. Unify versions to 4.1.118.Final

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -126,9 +126,6 @@
     <!-- Quarkus -->
     <version.quarkus>3.15.3</version.quarkus>
 
-    <!-- Netty override -->
-    <version.io.netty>4.1.118.Final</version.io.netty>
-
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>
     <version.org.apache.commons.commons-compress>1.26.1</version.org.apache.commons.commons-compress>
@@ -142,6 +139,7 @@
     <version.org.kie.j2cl.tools.yaml.mapper>0.4</version.org.kie.j2cl.tools.yaml.mapper>
     <version.j2cl.maven.plugin>0.23.0</version.j2cl.maven.plugin>
     <version.jacoco.maven.plugin>0.8.12</version.jacoco.maven.plugin>
+    <version.io.netty>4.1.118.Final</version.io.netty>
   </properties>
 
   <dependencyManagement>

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -126,6 +126,9 @@
     <!-- Quarkus -->
     <version.quarkus>3.15.3</version.quarkus>
 
+    <!-- Netty override -->
+    <version.io.netty>4.1.118.Final</version.io.netty>
+
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>
     <version.org.apache.commons.commons-compress>1.26.1</version.org.apache.commons.commons-compress>
@@ -207,6 +210,17 @@
       </dependency>
 
       <!-- 3rd party -->
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
 
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Unify netty-handler and netty-common versions to 4.1.118-Final

Relates to https://github.com/apache/incubator-kie-optaplanner/pull/3169