### PR TITLE
NO-ISSUE: Fix TaskForm `transitions` API call when running the jBPM Dev UI in a different host/origin

### DIFF
--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -22,7 +22,7 @@ quarkus.http.cors=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 
-quarkus.http.host=127.0.0.1
+quarkus.http.host=0.0.0.0
 quarkus.http.port=8080
 quarkus.http.root-path=/kie
 quarkus.http.non-application-root-path=/kie/q
@@ -35,11 +35,11 @@ quarkus.kogito.devservices.enabled=false
 quarkus.devservices.enabled=false
 
 # Kogito-service
-kogito.service.url=http://127.0.0.1:8080/kie
+kogito.service.url=http://0.0.0.0:8080/kie
 
 #Job-service
-kogito.jobs-service.url=http://127.0.0.1:8080/kie
-kogito.data-index.url=http://127.0.0.1:8080/kie
+kogito.jobs-service.url=http://0.0.0.0:8080/kie
+kogito.data-index.url=http://0.0.0.0:8080/kie
 
 quarkus.kogito.data-index.graphql.ui.always-include=true
 

--- a/packages/jbpm-quarkus-devui/package.json
+++ b/packages/jbpm-quarkus-devui/package.json
@@ -25,7 +25,9 @@
     "quarkus:dev": "run-script-os",
     "quarkus:dev:darwin:linux": "mvn clean package quarkus:dev -DskipTests",
     "quarkus:dev:win32": "mvn clean package quarkus:dev `-DskipTests",
-    "start": "pnpm build:dev && mvn -f ./dev/pom.xml quarkus:dev"
+    "start": "run-script-os",
+    "start:darwin:linux": "pnpm build:dev && mvn -f ./dev/pom.xml quarkus:dev",
+    "start:win32": "pnpm build:dev && mvn -f ./dev/pom.xml quarkus:dev -Dquarkus.http.host=127.0.0.1  -Dkogito.service.url=http://127.0.0.1:8080/kie -Dkogito.jobs-service.url=http://127.0.0.1:8080/kie -Dkogito.data-index.urll=http://127.0.0.1:8080/kie"
   },
   "dependencies": {
     "@kie-tools/maven-base": "workspace:*"

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/TaskFormContextProvider.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/TaskFormContextProvider.tsx
@@ -25,9 +25,12 @@ import {
 
 export const TaskFormContextProvider: React.FC = ({ children }) => {
   const appContext = useDevUIAppContext();
+  const baseUrl = appContext.transformQuarkusUrl(
+    `${appContext.getQuarkusAppOrigin()}${appContext.getQuarkusAppRootPath()}`
+  );
 
   return (
-    <TaskFormContext.Provider value={new TaskFormGatewayApiImpl(() => appContext.getCurrentUser())}>
+    <TaskFormContext.Provider value={new TaskFormGatewayApiImpl(() => appContext.getCurrentUser(), baseUrl)}>
       {children}
     </TaskFormContext.Provider>
   );

--- a/packages/runtime-tools-process-webapp-components/src/TaskForms/TaskFormGatewayApi.ts
+++ b/packages/runtime-tools-process-webapp-components/src/TaskForms/TaskFormGatewayApi.ts
@@ -36,12 +36,24 @@ export interface TaskFormGatewayApi {
 }
 
 export class TaskFormGatewayApiImpl implements TaskFormGatewayApi {
-  constructor(private readonly getCurrentUser: () => User) {}
+  constructor(
+    private readonly getCurrentUser: () => User,
+    private baseUrl?: string
+  ) {}
+
+  replaceEndpointBaseUrl(endpoint: string) {
+    if (this.baseUrl) {
+      const originalUrl = new URL(endpoint);
+      const newUrl = new URL(originalUrl.pathname, this.baseUrl);
+      return `${newUrl.toString()}${originalUrl.search}`;
+    }
+    return endpoint;
+  }
 
   submitTaskForm(endpoint: string, transition: UserTaskTransitionInfo, headers?: any) {
     return new Promise<any>((resolve, reject) => {
       axios
-        .post(endpoint, transition, {
+        .post(this.replaceEndpointBaseUrl(endpoint), transition, {
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
@@ -62,7 +74,7 @@ export class TaskFormGatewayApiImpl implements TaskFormGatewayApi {
   fetchTaskFormSchema(endpoint: string, headers?: any) {
     return new Promise<Record<string, any>>((resolve, reject) => {
       axios
-        .get(endpoint, {
+        .get(this.replaceEndpointBaseUrl(endpoint), {
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
@@ -83,7 +95,7 @@ export class TaskFormGatewayApiImpl implements TaskFormGatewayApi {
   fetchTaskTransitionPhases(endpoint: string, headers?: any) {
     return new Promise<string[]>((resolve, reject) => {
       axios
-        .get(endpoint, {
+        .get(this.replaceEndpointBaseUrl(endpoint), {
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",


### PR DESCRIPTION
- Replaces the baseUrl of the endpoint for the `transitions` request with the current origin baseUrl, just like all other API calls;
- Also fixes the dev app to run on both WSL and Windows.