### PR TITLE
[NO-ISSUE] Fix netty-related CVE (`CVE-2025-25193` & `CVE-2025-24970`).

### DIFF
--- a/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-kogito-quarkus-blank-app/pom.xml
@@ -50,9 +50,6 @@
     <version.maven.resources.plugin>3.3.1</version.maven.resources.plugin>
     <version.maven.site.plugin>3.21.0</version.maven.site.plugin>
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
-    <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
-      When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
-    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
 
     <!-- Config -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -64,6 +61,7 @@
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
     <version.commons-io>2.16.1</version.commons-io>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
+    <version.io.netty>4.1.118.Final</version.io.netty>
   </properties>
 
   <dependencyManagement>
@@ -87,12 +85,17 @@
         <artifactId>jbpm-with-drools-quarkus</artifactId>
         <version>${version.org.kie.kogito}</version>
       </dependency>
-      <!-- Temporary declaring xstream dependency, a version (1.4.20) is transitively imported by Quarkus 3.8 affected by CVE
-           When upgrading Quarkus (> 3.15.x) to a new version, please evaluate if this exclusion can be removed   -->
+
+      <!-- Increasing netty-handler and netty-common version to fix CVE-2025-25193 & CVE-2025-24970 -->
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>${version.com.thoughtworks.xstream}</version>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${version.io.netty}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Remove unnecessary `xstream` dependency after Quarkus `3.15.3` upgrade.

Continuation of: https://github.com/apache/incubator-kie-tools/pull/2947