### PR TITLE
Improve compatibility of BPMN and DMN VS Code extensions with `src/main/resources/META-INF/processSVG` directory

### DIFF
--- a/packages/bpmn-vscode-extension/README.md
+++ b/packages/bpmn-vscode-extension/README.md
@@ -34,11 +34,11 @@ Create and edit BPMN and BPMN2 files.
 
 ### Settings
 
-| Setting                           | Description                                               | Default value                                               |
-| --------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
-| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                                                     |
-| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}.svg`                            |
-| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${workspaceFolder}/src/main/resources/META-INF/processSVG` |
+| Setting                           | Description                                               | Default value                                                                                                                |
+| --------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                                                                                                                      |
+| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}.svg`                                                                                             |
+| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources` |
 
 The `kogito.bpmn.svgFilenameTemplate` and `kogito.bpmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/bpmn-vscode-extension/README.md
+++ b/packages/bpmn-vscode-extension/README.md
@@ -34,11 +34,11 @@ Create and edit BPMN and BPMN2 files.
 
 ### Settings
 
-| Setting                           | Description                                               | Default value                        |
-| --------------------------------- | --------------------------------------------------------- | ------------------------------------ |
-| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                              |
-| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${fileDirname}`                     |
+| Setting                           | Description                                               | Default value                                               |
+| --------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
+| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                                                     |
+| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}.svg`                            |
+| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${workspaceFolder}/src/main/resources/META-INF/processSVG` |
 
 The `kogito.bpmn.svgFilenameTemplate` and `kogito.bpmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/bpmn-vscode-extension/README.md
+++ b/packages/bpmn-vscode-extension/README.md
@@ -34,11 +34,11 @@ Create and edit BPMN and BPMN2 files.
 
 ### Settings
 
-| Setting                           | Description                                               | Default value                                                                                                                |
-| --------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                                                                                                                      |
-| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}.svg`                                                                                             |
-| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources` |
+| Setting                           | Description                                               | Default value                                                                                             |
+| --------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `kogito.bpmn.runOnSave`           | Execute a command on each save operation of the BPMN file | _empty_                                                                                                   |
+| `kogito.bpmn.svgFilenameTemplate` | Filename template to be used when generating SVG files    | `${fileBasenameNoExtension}.svg`                                                                          |
+| `kogito.bpmn.svgFilePath`         | Where to save generated SVG files                         | `${fileDirname}` or `src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources` |
 
 The `kogito.bpmn.svgFilenameTemplate` and `kogito.bpmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -83,12 +83,12 @@
           "type": "string"
         },
         "kogito.bpmn.svgFilePath": {
-          "default": "${workspaceFolder}/src/main/resources/META-INF/processSVG",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/processSVG`)",
+          "default": "",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`)",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}.svg",
+          "default": "",
           "markdownDescription": "Filename template to be used when generating SVG files for BPMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         }

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -84,7 +84,7 @@
         },
         "kogito.bpmn.svgFilePath": {
           "default": "",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`)",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`)",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {

--- a/packages/bpmn-vscode-extension/package.json
+++ b/packages/bpmn-vscode-extension/package.json
@@ -83,13 +83,13 @@
           "type": "string"
         },
         "kogito.bpmn.svgFilePath": {
-          "default": "${fileDirname}",
-          "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`).",
+          "default": "${workspaceFolder}/src/main/resources/META-INF/processSVG",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/processSVG`)",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}-svg.svg",
-          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`).",
+          "default": "${fileBasenameNoExtension}.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files for BPMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         }
       },

--- a/packages/dmn-vscode-extension/README.md
+++ b/packages/dmn-vscode-extension/README.md
@@ -43,11 +43,11 @@ DMN files must be inside a `src/` folder on your Workspace to be visible on the 
 
 ### Settings
 
-| Setting                          | Description                                              | Default value                                                                                                                |
-| -------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                                                                                                                      |
-| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}.svg`                                                                                             |
-| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources` |
+| Setting                          | Description                                              | Default value                                                                                             |
+| -------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                                                                                                   |
+| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}.svg`                                                                          |
+| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${fileDirname}` or `src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources` |
 
 The `kogito.dmn.svgFilenameTemplate` and `kogito.dmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/dmn-vscode-extension/README.md
+++ b/packages/dmn-vscode-extension/README.md
@@ -43,11 +43,11 @@ DMN files must be inside a `src/` folder on your Workspace to be visible on the 
 
 ### Settings
 
-| Setting                          | Description                                              | Default value                        |
-| -------------------------------- | -------------------------------------------------------- | ------------------------------------ |
-| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                              |
-| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}-svg.svg` |
-| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${fileDirname}`                     |
+| Setting                          | Description                                              | Default value                                                |
+| -------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------ |
+| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                                                      |
+| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}.svg`                             |
+| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` |
 
 The `kogito.dmn.svgFilenameTemplate` and `kogito.dmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/dmn-vscode-extension/README.md
+++ b/packages/dmn-vscode-extension/README.md
@@ -43,11 +43,11 @@ DMN files must be inside a `src/` folder on your Workspace to be visible on the 
 
 ### Settings
 
-| Setting                          | Description                                              | Default value                                                |
-| -------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------ |
-| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                                                      |
-| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}.svg`                             |
-| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` |
+| Setting                          | Description                                              | Default value                                                                                                                |
+| -------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `kogito.dmn.runOnSave`           | Execute a command on each save operation of the DMN file | _empty_                                                                                                                      |
+| `kogito.dmn.svgFilenameTemplate` | Filename template to be used when generating SVG files   | `${fileBasenameNoExtension}.svg`                                                                                             |
+| `kogito.dmn.svgFilePath`         | Where to save generated SVG files                        | `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources` |
 
 The `kogito.dmn.svgFilenameTemplate` and `kogito.dmn.svgFilePath` settings accept the following variables as tokens:
 

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -93,12 +93,12 @@
           "type": "string"
         },
         "kogito.dmn.svgFilePath": {
-          "default": "${workspaceFolder}/src/main/resources/META-INF/decisionSVG",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/decisionSVG`).",
+          "default": "",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}.svg",
+          "default": "",
           "markdownDescription": "Filename template to be used when generating SVG files for DMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         }

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -94,7 +94,7 @@
         },
         "kogito.dmn.svgFilePath": {
           "default": "",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
+          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -93,13 +93,13 @@
           "type": "string"
         },
         "kogito.dmn.svgFilePath": {
-          "default": "${fileDirname}",
-          "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`).",
+          "default": "${workspaceFolder}/src/main/resources/META-INF/decisionSVG",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/decisionSVG`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}-svg.svg",
-          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`).",
+          "default": "${fileBasenameNoExtension}.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files for DMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         }
       },

--- a/packages/dmn-vscode-extension/package.json
+++ b/packages/dmn-vscode-extension/package.json
@@ -62,18 +62,6 @@
   "contributes": {
     "commands": [
       {
-        "command": "extension.kogito.getPreviewSvgDmn",
-        "icon": {
-          "dark": "./static/svg-icon-dark.png",
-          "light": "./static/svg-icon-light.png"
-        },
-        "title": "Generate DMN Editor preview SVG (classic)"
-      },
-      {
-        "command": "extension.kogito.silentlyGenerateSvgDmn",
-        "title": "Generate DMN Editor preview SVG (classic) without any notification"
-      },
-      {
         "command": "extension.kie.tools.generatePreviewSvgDmn",
         "icon": {
           "dark": "./static/svg-icon-dark.png",
@@ -84,6 +72,18 @@
       {
         "command": "extension.kie.tools.silentlyGenerateSvgDmn",
         "title": "Generate DMN preview SVG without any notification"
+      },
+      {
+        "command": "extension.kogito.getPreviewSvgDmn",
+        "icon": {
+          "dark": "./static/svg-icon-dark.png",
+          "light": "./static/svg-icon-light.png"
+        },
+        "title": "Generate DMN Editor preview SVG (classic)"
+      },
+      {
+        "command": "extension.kogito.silentlyGenerateSvgDmn",
+        "title": "Generate DMN Editor preview SVG (classic) without any notification"
       }
     ],
     "configuration": {
@@ -94,7 +94,7 @@
         },
         "kogito.dmn.svgFilePath": {
           "default": "",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {
@@ -107,22 +107,22 @@
     },
     "customEditors": [
       {
-        "displayName": "KIE DMN/Test Scenario Editors (classic)",
-        "selector": [
-          {
-            "filenamePattern": "*.{dmn,scesim}"
-          }
-        ],
-        "viewType": "kieKogitoWebviewEditorsDmn"
-      },
-      {
-        "displayName": "KIE DMN/Test Scenario Editors",
+        "displayName": "Apache KIE DMN/Test Scenario Editors",
         "selector": [
           {
             "filenamePattern": "*.{dmn,scesim}"
           }
         ],
         "viewType": "kieToolsDmnEditor"
+      },
+      {
+        "displayName": "Apache KIE DMN/Test Scenario Editors (classic)",
+        "selector": [
+          {
+            "filenamePattern": "*.{dmn,scesim}"
+          }
+        ],
+        "viewType": "kieKogitoWebviewEditorsDmn"
       }
     ],
     "javaExtensions": [
@@ -180,6 +180,7 @@
     }
   },
   "activationEvents": [
+    "onCustomEditor:kieToolsDmnEditor",
     "onCustomEditor:kieKogitoWebviewEditorsDmn"
   ],
   "icon": "icon.png",

--- a/packages/extended-services-vscode-extension/package.json
+++ b/packages/extended-services-vscode-extension/package.json
@@ -60,13 +60,13 @@
   "contributes": {
     "commands": [
       {
-        "category": "Extended-Services",
+        "category": "Apache KIE Extended Services",
         "command": "extended-services-vscode-extension.startExtendedServices",
         "title": "Connect Apache KIE™ Extended Services",
         "when": "extended-services-vscode-extension.connected"
       },
       {
-        "category": "Extended-Services",
+        "category": "Apache KIE Extended-Services",
         "command": "extended-services-vscode-extension.stopExtendedServices",
         "title": "Disconnect Apache KIE™ Extended Services"
       }

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -119,13 +119,13 @@
           "type": "string"
         },
         "kogito.bpmn.svgFilePath": {
-          "default": "${fileDirname}",
-          "markdownDescription": "Where to save generated SVG files (defaults to same path as .bpmn file: `${fileDirname}`).",
+          "default": "${workspaceFolder}/src/main/resources/META-INF/processSVG",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/processSVG`).",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}-svg.svg",
-          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`).",
+          "default": "${fileBasenameNoExtension}.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files for BPMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         },
         "kogito.dmn.runOnSave": {
@@ -134,13 +134,13 @@
           "type": "string"
         },
         "kogito.dmn.svgFilePath": {
-          "default": "${fileDirname}",
-          "markdownDescription": "Where to save generated SVG files (defaults to same path as .dmn file: `${fileDirname}`).",
+          "default": "${workspaceFolder}/src/main/resources/META-INF/decisionSVG",
+          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/decisionSVG`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}-svg.svg",
-          "markdownDescription": "Filename template to be used when generating SVG files (defaults to `${fileBasenameNoExtension}-svg.svg`).",
+          "default": "${fileBasenameNoExtension}.svg",
+          "markdownDescription": "Filename template to be used when generating SVG files for DMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         }
       },

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -120,7 +120,7 @@
         },
         "kogito.bpmn.svgFilePath": {
           "default": "",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`).",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {
@@ -135,7 +135,7 @@
         },
         "kogito.dmn.svgFilePath": {
           "default": "",
-          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
+          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${fileDirname}` or `src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {

--- a/packages/kie-editors-dev-vscode-extension/package.json
+++ b/packages/kie-editors-dev-vscode-extension/package.json
@@ -119,12 +119,12 @@
           "type": "string"
         },
         "kogito.bpmn.svgFilePath": {
-          "default": "${workspaceFolder}/src/main/resources/META-INF/processSVG",
-          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/processSVG`).",
+          "default": "",
+          "markdownDescription": "Where to save generated SVG files for BPMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/processSVG` if BPMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.bpmn.svgFilenameTemplate": {
-          "default": "${fileBasenameNoExtension}.svg",
+          "default": "",
           "markdownDescription": "Filename template to be used when generating SVG files for BPMN models. (defaults to `${fileBasenameNoExtension}.svg`).",
           "type": "string"
         },
@@ -134,8 +134,8 @@
           "type": "string"
         },
         "kogito.dmn.svgFilePath": {
-          "default": "${workspaceFolder}/src/main/resources/META-INF/decisionSVG",
-          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${workspaceFolder}/src/main/resources/META-INF/decisionSVG`).",
+          "default": "",
+          "markdownDescription": "Where to save generated SVG files for DMN models. (defaults to `${fileDirname}` or `${workspaceFolder}/src/main/resources/META-INF/decisionSVG` if DMN model is inside `src/main/resources`).",
           "type": "string"
         },
         "kogito.dmn.svgFilenameTemplate": {

--- a/packages/vscode-extension/src/VsCodeRecommendation.ts
+++ b/packages/vscode-extension/src/VsCodeRecommendation.ts
@@ -24,7 +24,7 @@ export class VsCodeRecommendation {
     const message =
       "There is another extension available that might help you.\n" +
       "Click [here](command:vscode-extension.installExtendedServices) to install it.";
-    const action = "Install Extended-Services VS Code Extension";
+    const action = "Install Apache KIE™ Extended Services for VS Code";
 
     const disposable = vscode.commands.registerCommand("vscode-extension.installExtendedServices", () => {
       vscode.env.openExternal(vscode.Uri.parse("vscode:extension/kie-group.extended-services-vscode-extension"));

--- a/packages/vscode-extension/src/generateSvg.ts
+++ b/packages/vscode-extension/src/generateSvg.ts
@@ -76,12 +76,21 @@ export async function generateSvg(args: {
 
   const svgFileName = getInterpolatedConfigurationValue({
     currentFileAbsolutePosixPath: editor.document.document.uri.path,
-    value:
-      definitelyPosixPath(svgFilenameTemplate) || `${configurationTokenKeys["${fileBasenameNoExtension}"]}-svg.svg`,
+    value: definitelyPosixPath(svgFilenameTemplate) || `${configurationTokenKeys["${fileBasenameNoExtension}"]}.svg`,
   });
+
+  const defaultSvgDirname =
+    fileType === "bpmn" || fileType === "bpmn2" // force line-break;
+      ? "processSVG"
+      : fileType === "dmn"
+        ? "decisionSVG"
+        : "anySVG";
+
   const svgFilePath = getInterpolatedConfigurationValue({
     currentFileAbsolutePosixPath: editor.document.document.uri.path,
-    value: definitelyPosixPath(svgFilePathTemplate) || `${configurationTokenKeys["${fileDirname}"]}`,
+    value:
+      definitelyPosixPath(svgFilePathTemplate) ||
+      `${configurationTokenKeys["${workspaceFolder}"]}/src/main/resources/META-INF/${defaultSvgDirname}"`,
   });
 
   const svgUri = editor.document.document.uri.with({ path: __path.posix.resolve(svgFilePath, svgFileName) });


### PR DESCRIPTION
This is compatible with how the Kogito Process SVG Add-on works, making it automatic to have SVGs displayed both on jBPM Quarkus Dev UI and Management Console.

1. The default configuration now is an empty string, which allows the auto-detection of where to put the generated SVG file:
    - If the BPMN/DMN model is inside a `src/main/resources/{nested**}` structure, the SVG file is saved to `META-INF/processSVG/{nested**}`. With {nested**} being 0 or more directories.
    - If the BPMN/DMN model is outside a `src/main/resources` structure, the SVG file is saved to the same directory of the BPMN/DMN model.

2. The default name of the SVG file also changed from `${fileBasenameNoExtension}-svg.svg` to `${fileBasenameNoExtension}.svg`, removing the `-svg` suffix.

---

Also:
- Made the new DMN/Test Scenario Editors the default on `dmn-vscode-extension` and `kie-editors-dev-vscode-extension`.
- Fixed the name of Extended Services extension/commands.