### PR TITLE
NO-ISSUE: Dev deployment DMN form webapp not working when Dev deployment contains BPMN models

### DIFF
--- a/packages/dev-deployment-dmn-form-webapp/src/DmnDevDeploymentFormWebAppDataApi.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnDevDeploymentFormWebAppDataApi.tsx
@@ -37,17 +37,25 @@ export async function fetchAppData(args: { quarkusAppOrigin: string; quarkusAppP
     await fetch(routes.quarkusApp.openApiJson.path({}, args.quarkusAppOrigin, args.quarkusAppPath))
   ).json();
 
-  // Append origin to schema $refs
+  // Append origin to schema $refs, but only on DMN paths
+  //
+  // It's important to skip paths not ending on `/dmnresult` because the application
+  // being deployed may have other paths that we don't control, and not all of them
+  // will have valid JSON Schemas.
   Object.keys(openApiSpec.paths).forEach((modelPath) => {
-    const inputSetSchemaRef = openApiSpec.paths[modelPath]?.post.requestBody.content["application/json"].schema.$ref;
-    const outputSetSchemaRef =
-      openApiSpec.paths[modelPath]?.post.responses.default?.content["application/json"].schema.$ref;
+    if (!modelPath.endsWith("/dmnresult")) {
+      return;
+    }
 
+    const inputSetSchemaRef =
+      openApiSpec.paths?.[modelPath]?.post?.requestBody?.content?.["application/json"]?.schema?.$ref;
     if (inputSetSchemaRef) {
       openApiSpec.paths[modelPath].post.requestBody.content["application/json"].schema.$ref =
         `${args.quarkusAppOrigin}${inputSetSchemaRef}`;
     }
 
+    const outputSetSchemaRef =
+      openApiSpec.paths?.[modelPath]?.post?.responses?.default?.content?.["application/json"]?.schema?.$ref;
     if (outputSetSchemaRef) {
       openApiSpec.paths[modelPath].post.responses.default.content["application/json"].schema.$ref =
         `${args.quarkusAppOrigin}${outputSetSchemaRef}`;


### PR DESCRIPTION
The Dev deployment DMN form webapp was expecting an application that only contained DMN endpoints on its Open API spec. When adding a BPMN model, the `/forms/*` APIs as well as User Tasks and Domain APIs are included in the app too, making this assumption fail.

The fix is to filter and manipulate only the endpoints that are interesting for the DMN form to render.