### PR TITLE
[NO-ISSUE] Upgrade FEEL namespaces when automatically upgrading DMN models to newer versions on `dmn-marshaller`

### DIFF
--- a/packages/dmn-marshaller/src/index.ts
+++ b/packages/dmn-marshaller/src/index.ts
@@ -75,7 +75,7 @@ import { DMN13__tDefinitions } from "./schemas/dmn-1_3/ts-gen/types";
 import { DMN14__tDefinitions } from "./schemas/dmn-1_4/ts-gen/types";
 import { DMN15__tDefinitions } from "./schemas/dmn-1_5/ts-gen/types";
 import { ns as kie10ns } from "./schemas/kie-1_0/ts-gen/meta";
-import { LEGACY_KIE_NS__PRE_GWT_REMOVAL } from "./kie-extensions";
+import { KIE_NS, LEGACY_KIE_NS__PRE_GWT_REMOVAL } from "./kie-extensions";
 
 import "./kie-extensions"; // Necessary to include the type extensions and patch the ns maps. Do not remove.
 
@@ -194,6 +194,8 @@ export const DMN_PARSERS: Record<DmnVersions, XmlParserTs<any>> = {
   }),
 };
 
+const FEEL_NS = "feel:";
+
 export const FEEL_NAMESPACES: Record<DmnVersions, string> = {
   "1.0": "http://www.omg.org/spec/FEEL/20140401",
   "1.1": "http://www.omg.org/spec/FEEL/20140401",
@@ -204,23 +206,28 @@ export const FEEL_NAMESPACES: Record<DmnVersions, string> = {
 };
 
 const feel12ns = new Map<string, string>([
-  ["feel:", FEEL_NAMESPACES["1.2"]],
-  [FEEL_NAMESPACES["1.2"], "feel:"],
+  [FEEL_NS, FEEL_NAMESPACES["1.2"]],
+  [FEEL_NAMESPACES["1.2"], FEEL_NS],
 ]);
 
 const feel13ns = new Map<string, string>([
-  ["feel:", FEEL_NAMESPACES["1.3"]],
-  [FEEL_NAMESPACES["1.3"], "feel:"],
+  [FEEL_NS, FEEL_NAMESPACES["1.3"]],
+  [FEEL_NAMESPACES["1.3"], FEEL_NS],
 ]);
 
 const feel14ns = new Map<string, string>([
-  ["feel:", FEEL_NAMESPACES["1.4"]],
-  [FEEL_NAMESPACES["1.4"], "feel:"],
+  [FEEL_NS, FEEL_NAMESPACES["1.4"]],
+  [FEEL_NAMESPACES["1.4"], FEEL_NS],
 ]);
 
 const feel15ns = new Map<string, string>([
-  ["feel:", FEEL_NAMESPACES["1.5"]],
-  [FEEL_NAMESPACES["1.5"], "feel:"],
+  [FEEL_NS, FEEL_NAMESPACES["1.5"]],
+  [FEEL_NAMESPACES["1.5"], FEEL_NS],
+]);
+
+const kie10nsRelativeToDmns = new Map<string, string>([
+  [kie10ns.get("")!, KIE_NS],
+  [KIE_NS, kie10ns.get("")!],
 ]);
 
 export const DMN_VERSIONS_TIMELINE: DmnVersions[] = ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5"];
@@ -558,7 +565,7 @@ export function upgrade13to14(dmn13: { definitions: DMN13__tDefinitions }): { de
     getNsDeclarationPropName({
       namespace: kie10ns.get("")!,
       atInstanceNs: instanceNs,
-      fallingBackToNs: kie10ns,
+      fallingBackToNs: kie10nsRelativeToDmns,
     })
   ] = kie10ns.get("")!;
 
@@ -612,7 +619,7 @@ export function upgrade14to15(dmn14: { definitions: DMN14__tDefinitions }): { de
     getNsDeclarationPropName({
       namespace: kie10ns.get("")!,
       atInstanceNs: instanceNs,
-      fallingBackToNs: kie10ns,
+      fallingBackToNs: kie10nsRelativeToDmns,
     })
   ] = kie10ns.get("")!;
 

--- a/packages/dmn-marshaller/src/index.ts
+++ b/packages/dmn-marshaller/src/index.ts
@@ -203,6 +203,11 @@ export const FEEL_NAMESPACES: Record<DmnVersions, string> = {
   "1.5": "https://www.omg.org/spec/DMN/20230324/FEEL/",
 };
 
+const feel12ns = new Map<string, string>([
+  ["feel:", FEEL_NAMESPACES["1.2"]],
+  [FEEL_NAMESPACES["1.2"], "feel:"],
+]);
+
 const feel13ns = new Map<string, string>([
   ["feel:", FEEL_NAMESPACES["1.3"]],
   [FEEL_NAMESPACES["1.3"], "feel:"],
@@ -499,10 +504,7 @@ export function upgrade12to13(dmn12: { definitions: DMN12__tDefinitions }): { de
     getNsDeclarationPropName({
       namespace: FEEL_NAMESPACES["1.2"],
       atInstanceNs: instanceNs,
-      fallingBackToNs: new Map<string, string>([
-        ["feel:", FEEL_NAMESPACES["1.2"]],
-        [FEEL_NAMESPACES["1.2"], "feel:"],
-      ]),
+      fallingBackToNs: feel12ns,
     })
   ] = FEEL_NAMESPACES["1.3"];
 

--- a/packages/dmn-marshaller/src/index.ts
+++ b/packages/dmn-marshaller/src/index.ts
@@ -479,6 +479,18 @@ export function upgrade12to13(dmn12: { definitions: DMN12__tDefinitions }): { de
     })
   ] = kie10ns.get("")!;
 
+  // Upgrade FEEL namespace
+  dmn12.definitions[
+    getNsDeclarationPropName({
+      namespace: FEEL_NAMESPACES["1.2"],
+      atInstanceNs: instanceNs,
+      fallingBackToNs: new Map<string, string>([
+        ["feel:", FEEL_NAMESPACES["1.2"]],
+        [FEEL_NAMESPACES["1.2"], "feel:"],
+      ]),
+    })
+  ] = FEEL_NAMESPACES["1.3"];
+
   if (dmn12.definitions["@_typeLanguage"] === FEEL_NAMESPACES["1.2"]) {
     dmn12.definitions["@_typeLanguage"] = FEEL_NAMESPACES["1.3"];
   }
@@ -515,6 +527,18 @@ export function upgrade13to14(dmn13: { definitions: DMN13__tDefinitions }): { de
     })
   ] = dmn14ns.get("dmndi:")!;
 
+  // Upgrade FEEL namespace
+  dmn13.definitions[
+    getNsDeclarationPropName({
+      namespace: FEEL_NAMESPACES["1.3"],
+      atInstanceNs: instanceNs,
+      fallingBackToNs: new Map<string, string>([
+        ["feel:", FEEL_NAMESPACES["1.3"]],
+        [FEEL_NAMESPACES["1.3"], "feel:"],
+      ]),
+    })
+  ] = FEEL_NAMESPACES["1.4"];
+
   if (dmn13.definitions["@_typeLanguage"] === FEEL_NAMESPACES["1.3"]) {
     dmn13.definitions["@_typeLanguage"] = FEEL_NAMESPACES["1.4"];
   }
@@ -550,6 +574,18 @@ export function upgrade14to15(dmn14: { definitions: DMN14__tDefinitions }): { de
       fallingBackToNs: dmn14ns,
     })
   ] = dmn15ns.get("dmndi:")!;
+
+  // Upgrade FEEL namespace
+  dmn14.definitions[
+    getNsDeclarationPropName({
+      namespace: FEEL_NAMESPACES["1.4"],
+      atInstanceNs: instanceNs,
+      fallingBackToNs: new Map<string, string>([
+        ["feel:", FEEL_NAMESPACES["1.4"]],
+        [FEEL_NAMESPACES["1.4"], "feel:"],
+      ]),
+    })
+  ] = FEEL_NAMESPACES["1.5"];
 
   if (dmn14.definitions["@_typeLanguage"] === FEEL_NAMESPACES["1.4"]) {
     dmn14.definitions["@_typeLanguage"] = FEEL_NAMESPACES["1.5"];

--- a/packages/dmn-marshaller/src/index.ts
+++ b/packages/dmn-marshaller/src/index.ts
@@ -203,6 +203,21 @@ export const FEEL_NAMESPACES: Record<DmnVersions, string> = {
   "1.5": "https://www.omg.org/spec/DMN/20230324/FEEL/",
 };
 
+const feel13ns = new Map<string, string>([
+  ["feel:", FEEL_NAMESPACES["1.3"]],
+  [FEEL_NAMESPACES["1.3"], "feel:"],
+]);
+
+const feel14ns = new Map<string, string>([
+  ["feel:", FEEL_NAMESPACES["1.4"]],
+  [FEEL_NAMESPACES["1.4"], "feel:"],
+]);
+
+const feel15ns = new Map<string, string>([
+  ["feel:", FEEL_NAMESPACES["1.5"]],
+  [FEEL_NAMESPACES["1.5"], "feel:"],
+]);
+
 export const DMN_VERSIONS_TIMELINE: DmnVersions[] = ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5"];
 export const DMN_LATEST_VERSION = "1.5" as const;
 export type DmnLatestMarshaller = DmnMarshaller15;
@@ -470,7 +485,7 @@ export function upgrade12to13(dmn12: { definitions: DMN12__tDefinitions }): { de
     })
   ] = dmn13ns.get("dmndi:")!;
 
-  // Upgrade KIE namespace
+  // Upgrade or add KIE namespace if not there yet
   dmn12.definitions[
     getNsDeclarationPropName({
       namespace: LEGACY_KIE_NS__PRE_GWT_REMOVAL,
@@ -532,12 +547,18 @@ export function upgrade13to14(dmn13: { definitions: DMN13__tDefinitions }): { de
     getNsDeclarationPropName({
       namespace: FEEL_NAMESPACES["1.3"],
       atInstanceNs: instanceNs,
-      fallingBackToNs: new Map<string, string>([
-        ["feel:", FEEL_NAMESPACES["1.3"]],
-        [FEEL_NAMESPACES["1.3"], "feel:"],
-      ]),
+      fallingBackToNs: feel13ns,
     })
   ] = FEEL_NAMESPACES["1.4"];
+
+  // Add KIE namespace if not there yet.
+  dmn13.definitions[
+    getNsDeclarationPropName({
+      namespace: kie10ns.get("")!,
+      atInstanceNs: instanceNs,
+      fallingBackToNs: kie10ns,
+    })
+  ] = kie10ns.get("")!;
 
   if (dmn13.definitions["@_typeLanguage"] === FEEL_NAMESPACES["1.3"]) {
     dmn13.definitions["@_typeLanguage"] = FEEL_NAMESPACES["1.4"];
@@ -580,12 +601,18 @@ export function upgrade14to15(dmn14: { definitions: DMN14__tDefinitions }): { de
     getNsDeclarationPropName({
       namespace: FEEL_NAMESPACES["1.4"],
       atInstanceNs: instanceNs,
-      fallingBackToNs: new Map<string, string>([
-        ["feel:", FEEL_NAMESPACES["1.4"]],
-        [FEEL_NAMESPACES["1.4"], "feel:"],
-      ]),
+      fallingBackToNs: feel14ns,
     })
   ] = FEEL_NAMESPACES["1.5"];
+
+  // Add KIE namespace if not there yet.
+  dmn14.definitions[
+    getNsDeclarationPropName({
+      namespace: kie10ns.get("")!,
+      atInstanceNs: instanceNs,
+      fallingBackToNs: kie10ns,
+    })
+  ] = kie10ns.get("")!;
 
   if (dmn14.definitions["@_typeLanguage"] === FEEL_NAMESPACES["1.4"]) {
     dmn14.definitions["@_typeLanguage"] = FEEL_NAMESPACES["1.5"];

--- a/packages/dmn-marshaller/tests/automaticMigrations.test.ts
+++ b/packages/dmn-marshaller/tests/automaticMigrations.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { DMN_LATEST_VERSION, DmnVersions, FEEL_NAMESPACES, getMarshaller } from "@kie-tools/dmn-marshaller";
+import { ns as dmn15ns } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/meta";
+
+const files: Array<{ path: string; version: DmnVersions; upgradeTo: DmnVersions }> = [
+  { path: "../tests-data--manual/other/attachment.dmn", version: "1.2", upgradeTo: "1.3" },
+  { path: "../tests-data--manual/other/empty13.dmn", version: "1.3", upgradeTo: "1.4" },
+  { path: "../tests-data--manual/other/sample12.dmn", version: "1.2", upgradeTo: "1.5" },
+  { path: "../tests-data--manual/other/weird.dmn", version: "1.2", upgradeTo: "1.4" },
+  {
+    path: "../tests-data--manual/dmn-1_4--examples/Chapter 11 Example 1 Originations/Chapter 11 Example.dmn",
+    version: "1.4",
+    upgradeTo: "1.4",
+  },
+];
+
+describe("migrations", () => {
+  for (const file of files) {
+    test(`to latest (${path.basename(file.path)})`, () => {
+      const xml = fs.readFileSync(path.join(__dirname, file.path), "utf-8");
+      const marshaller = getMarshaller(xml, { upgradeTo: "latest" });
+      expect(marshaller.originalVersion).toStrictEqual(file.version);
+      expect(marshaller.version).toStrictEqual(DMN_LATEST_VERSION);
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(FEEL_NAMESPACES[DMN_LATEST_VERSION])!)).toStrictEqual(
+        FEEL_NAMESPACES[DMN_LATEST_VERSION]
+      );
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(dmn15ns.get("")!)!)).toStrictEqual(dmn15ns.get(""));
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(dmn15ns.get("dmndi:")!)!)).toStrictEqual(
+        dmn15ns.get("dmndi:")
+      );
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(dmn15ns.get("dc:")!)!)).toStrictEqual(
+        dmn15ns.get("dc:")
+      );
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(dmn15ns.get("di:")!)!)).toStrictEqual(
+        dmn15ns.get("di:")
+      );
+      expect(marshaller.instanceNs.get(marshaller.instanceNs.get(dmn15ns.get("kie:")!)!)).toStrictEqual(
+        dmn15ns.get("kie:")
+      );
+    });
+
+    test(`to specific (${path.basename(file.path)} --> ${file.upgradeTo})`, () => {
+      const xml = fs.readFileSync(path.join(__dirname, file.path), "utf-8");
+      const marshaller = getMarshaller(xml, { upgradeTo: file.upgradeTo });
+      expect(marshaller.originalVersion).toStrictEqual(file.version);
+      expect(marshaller.version).toStrictEqual(file.upgradeTo);
+      expect((marshaller.parser.parse() as any).definitions["@_xmlns:feel"]).toStrictEqual(
+        FEEL_NAMESPACES[file.upgradeTo]
+      );
+    });
+  }
+});


### PR DESCRIPTION
There's a new validation on the backend side so the `dmn-marshaller` package needs to be compatible with it.