### PR TITLE
kie-issues#1864: Renaming a Decision node using the Boxed Expression Editor makes DMN model invalid by breaking Decision Table

### DIFF
--- a/packages/boxed-expression-component/src/contextMenu/PopoverMenu/PopoverMenu.tsx
+++ b/packages/boxed-expression-component/src/contextMenu/PopoverMenu/PopoverMenu.tsx
@@ -119,10 +119,15 @@ export const PopoverMenu = React.forwardRef(
 
     const onHideCallback: PopoverProps["onHide"] = useCallback(
       (tip): void => {
-        onHide();
-        setCurrentlyOpenContextMenu(undefined);
+        // This validation is to prevent this code of being called twice, because if the user clicks outside the
+        // Boxed Expression component the onHide() is called again by the Popover which is listen to clicks
+        // on the document to close all opened popups.
+        if (currentlyOpenContextMenu) {
+          onHide();
+          setCurrentlyOpenContextMenu(undefined);
+        }
       },
-      [onHide, setCurrentlyOpenContextMenu]
+      [currentlyOpenContextMenu, onHide, setCurrentlyOpenContextMenu]
     );
 
     useImperativeHandle(

--- a/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableMenu.tsx
+++ b/packages/boxed-expression-component/src/expressionVariable/ExpressionVariableMenu.tsx
@@ -153,12 +153,7 @@ export function ExpressionVariableMenu({
     }
     saveExpression();
     popoverMenuRef?.current?.setIsVisible(false);
-    // We reset the expression name to its default because the name change could be canceled outside.
-    // If we don't reset it, we will keep it an outdated name.
-    // If the change is confirmed, then the selectExpressionName will be updated to the new one in the next
-    // render of this component.
-    setExpressionName(selectedExpressionName);
-  }, [saveExpression, selectedExpressionName]);
+  }, [saveExpression]);
 
   const onCancel = useCallback(() => {
     cancelEdit.current = true;
@@ -167,8 +162,11 @@ export function ExpressionVariableMenu({
   }, [resetFormData]);
 
   const onShown = useCallback(() => {
+    // We need to refresh the expression name from the selectedExpressionName,
+    // otherwise it will show the older name set in expressionName.
+    setExpressionName(selectedExpressionName);
     expressionNameRef.current?.focus();
-  }, []);
+  }, [selectedExpressionName]);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/packages/dmn-feel-antlr4-parser/src/parser/Expression.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/Expression.ts
@@ -35,7 +35,9 @@ export class Expression {
   }
 
   public applyChangesToExpressionSource() {
-    this.source.text = { __$$text: this._fullExpression };
+    if (this.source.text) {
+      this.source.text = { __$$text: this._fullExpression };
+    }
   }
 
   public renameIdentifier(identifier: Identifier, newName: String) {


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1864


https://github.com/user-attachments/assets/96b8d900-a291-4904-876c-0e7344a50123

