### PR TITLE
kie-issues#1870: New Test Scenario Editor: Add error page for invalid scesim file

### DIFF
--- a/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
@@ -52,7 +52,6 @@ export type TestScenarioEditorRootProps = {
 };
 
 export type TestScenarioEditorRootState = {
-  error: Error | undefined;
   externalModelsByNamespace: TestScenarioEditor.ExternalDmnsIndex;
   externalModelsManagerDoneBootstraping: boolean;
   isReadOnly: boolean;
@@ -74,7 +73,6 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
     props.exposing(this);
     this.testScenarioEditorRef = React.createRef();
     this.state = {
-      error: undefined,
       externalModelsByNamespace: new Map(),
       externalModelsManagerDoneBootstraping: false,
       isReadOnly: props.isReadOnly,
@@ -115,7 +113,8 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
     openFileNormalizedPosixPathRelativeToTheWorkspaceRoot: string,
     content: string
   ): Promise<void> {
-    const marshaller = this.getMarshaller(content);
+    const marshaller = getMarshaller(content || EMPTY_ONE_EIGHT);
+    const scesimModel = marshaller.parser.parse();
 
     // Save stack
     let savedStackPointer: SceSimModel[] = [];
@@ -129,6 +128,16 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
         pointer: 0,
       };
     });
+
+    if (
+      !scesimModel ||
+      !scesimModel.ScenarioSimulationModel ||
+      scesimModel.ScenarioSimulationModel["parsererror" as keyof typeof scesimModel.ScenarioSimulationModel]
+    ) {
+      throw new Error(
+        "Impossibile to correctly parse the provided scesim file. Most likely, the XML structure of the file is invalid."
+      );
+    }
 
     // Wait the external manager models to load.
     await this.externalModelsManagerDoneBootstraping.promise;
@@ -167,20 +176,6 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
 
   public get model(): SceSimModel | undefined {
     return this.state.stack[this.state.pointer];
-  }
-
-  // Internal methods
-
-  private getMarshaller(content: string) {
-    try {
-      return getMarshaller(content || EMPTY_ONE_EIGHT);
-    } catch (e) {
-      this.setState((s) => ({
-        ...s,
-        error: e,
-      }));
-      throw e;
-    }
   }
 
   private setExternalModelsByNamespace = (externalModelsByNamespace: TestScenarioEditor.ExternalDmnsIndex) => {
@@ -310,7 +305,6 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
   public render() {
     return (
       <>
-        {this.state.error && <TestScenarioMarshallerFallbackError error={this.state.error} />}
         {this.model && (
           <>
             <TestScenarioEditor.TestScenarioEditor
@@ -502,19 +496,4 @@ function ExternalModelsManager({
   ]);
 
   return <></>;
-}
-
-function TestScenarioMarshallerFallbackError({ error }: { error: Error }) {
-  return (
-    <Flex justifyContent={{ default: "justifyContentCenter" }} style={{ marginTop: "100px" }}>
-      <EmptyState style={{ maxWidth: "1280px" }}>
-        <EmptyStateIcon icon={() => <div style={{ fontSize: "3em" }}>😕</div>} />
-        <Title size={"lg"} headingLevel={"h4"}>
-          Unable to open file.
-        </Title>
-        <br />
-        <EmptyStateBody>Error details: {error.message}</EmptyStateBody>
-      </EmptyState>
-    </Flex>
-  );
 }

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
@@ -356,11 +356,11 @@ function ExternalModelsManager({
   externalModelsManagerDoneBootstraping: PromiseImperativeHandle<void>;
 }) {
   const targetNamespace = useMemo(() => {
-    if (model?.ScenarioSimulationModel?.settings?.dmnNamespace?.__$$text) {
+    if (model.ScenarioSimulationModel?.settings?.dmnNamespace?.__$$text) {
       return model.ScenarioSimulationModel.settings.dmnNamespace.__$$text;
     }
     return null;
-  }, [model.ScenarioSimulationModel.settings]);
+  }, [model.ScenarioSimulationModel?.settings?.dmnNamespace]);
 
   const [externalUpdatesCount, setExternalUpdatesCount] = useState(0);
 

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
@@ -356,9 +356,6 @@ function ExternalModelsManager({
   externalModelsManagerDoneBootstraping: PromiseImperativeHandle<void>;
 }) {
   const targetNamespace = useMemo(() => {
-    // if (model.ScenarioSimulationModel.settings.type?.__$$text !== "DMN") {
-    //   return null;
-    // }
     if (model?.ScenarioSimulationModel?.settings?.dmnNamespace?.__$$text) {
       return model.ScenarioSimulationModel.settings.dmnNamespace.__$$text;
     }

--- a/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
+++ b/packages/scesim-editor-envelope/src/TestScenarioEditorRoot.tsx
@@ -27,9 +27,6 @@ import {
 import { generateUuid } from "@kie-tools/boxed-expression-component/dist/api";
 import { ResourceContent, SearchType, WorkspaceChannelApi, WorkspaceEdit } from "@kie-tools-core/workspace/dist/api";
 import { KeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService";
-import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
-import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
-import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { domParser } from "@kie-tools/xml-parser-ts";
 import { normalize } from "@kie-tools/dmn-marshaller/dist/normalization/normalize";
 import { getMarshaller as getDmnMarshaller } from "@kie-tools/dmn-marshaller";
@@ -123,7 +120,7 @@ export class TestScenarioEditorRoot extends React.Component<TestScenarioEditorRo
     this.setState((prev) => {
       savedStackPointer = [...prev.stack];
       return {
-        stack: [marshaller.parser.parse()],
+        stack: [scesimModel],
         openFileNormalizedPosixPathRelativeToTheWorkspaceRoot,
         pointer: 0,
       };
@@ -359,11 +356,11 @@ function ExternalModelsManager({
   externalModelsManagerDoneBootstraping: PromiseImperativeHandle<void>;
 }) {
   const targetNamespace = useMemo(() => {
-    if (model.ScenarioSimulationModel.settings.type?.__$$text !== "DMN") {
-      return null;
-    }
-    if (model.ScenarioSimulationModel.settings.dmnNamespace?.__$$text) {
-      return model.ScenarioSimulationModel.settings.dmnNamespace?.__$$text;
+    // if (model.ScenarioSimulationModel.settings.type?.__$$text !== "DMN") {
+    //   return null;
+    // }
+    if (model?.ScenarioSimulationModel?.settings?.dmnNamespace?.__$$text) {
+      return model.ScenarioSimulationModel.settings.dmnNamespace.__$$text;
     }
     return null;
   }, [model.ScenarioSimulationModel.settings]);

--- a/packages/scesim-editor/src/TestScenarioEditor.tsx
+++ b/packages/scesim-editor/src/TestScenarioEditor.tsx
@@ -73,6 +73,7 @@ import {
 } from "./externalModels/TestScenarioEditorDependenciesContext";
 import { useEffectAfterFirstRender } from "./hook/useEffectAfterFirstRender";
 import { INITIAL_COMPUTED_CACHE } from "./store/computed/initial";
+import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 
 /* Constants */
 
@@ -316,13 +317,16 @@ function TestScenarioParserErrorPanel({
   parserErrorMessage: string;
 }) {
   return (
-    <EmptyState>
-      <EmptyStateIcon icon={ErrorIcon} />
-      <Title headingLevel="h4" size="lg">
-        {parserErrorTitle}
-      </Title>
-      <EmptyStateBody>{parserErrorMessage}</EmptyStateBody>
-    </EmptyState>
+    <Flex justifyContent={{ default: "justifyContentCenter" }} style={{ marginTop: "100px" }}>
+      <EmptyState style={{ maxWidth: "1280px" }}>
+        <EmptyStateIcon icon={() => <div style={{ fontSize: "3em" }}>😕</div>} />
+        <Title size={"lg"} headingLevel={"h4"}>
+          {parserErrorTitle}
+        </Title>
+        <br />
+        <EmptyStateBody>Error details: {parserErrorMessage}</EmptyStateBody>
+      </EmptyState>
+    </Flex>
   );
 }
 

--- a/packages/scesim-editor/src/TestScenarioEditor.tsx
+++ b/packages/scesim-editor/src/TestScenarioEditor.tsx
@@ -36,6 +36,7 @@ import { Alert } from "@patternfly/react-core/dist/js/components/Alert";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { Drawer, DrawerContent, DrawerContentBody } from "@patternfly/react-core/dist/js/components/Drawer";
 import { EmptyState, EmptyStateBody, EmptyStateIcon } from "@patternfly/react-core/dist/js/components/EmptyState";
+import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Icon } from "@patternfly/react-core/dist/js/components/Icon";
 import { Spinner } from "@patternfly/react-core/dist/js/components/Spinner";
 import { Tabs, Tab, TabTitleIcon, TabTitleText } from "@patternfly/react-core/dist/js/components/Tabs";
@@ -43,7 +44,6 @@ import { Tabs, Tab, TabTitleIcon, TabTitleText } from "@patternfly/react-core/di
 import { Title } from "@patternfly/react-core/dist/js/components/Title";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 
-import ErrorIcon from "@patternfly/react-icons/dist/esm/icons/error-circle-o-icon";
 import TableIcon from "@patternfly/react-icons/dist/esm/icons/table-icon";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
@@ -73,7 +73,6 @@ import {
 } from "./externalModels/TestScenarioEditorDependenciesContext";
 import { useEffectAfterFirstRender } from "./hook/useEffectAfterFirstRender";
 import { INITIAL_COMPUTED_CACHE } from "./store/computed/initial";
-import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 
 /* Constants */
 

--- a/packages/scesim-editor/src/TestScenarioEditor.tsx
+++ b/packages/scesim-editor/src/TestScenarioEditor.tsx
@@ -395,9 +395,13 @@ export const TestScenarioEditorInternal = ({
   }, [onModelChange, scesim.model]);
 
   const scesimFileStatus = useMemo(() => {
-    if (scesim.model.ScenarioSimulationModel) {
+    if (scesim) {
       const parserErrorField = "parsererror" as keyof typeof scesim.model.ScenarioSimulationModel;
-      if (scesim.model.ScenarioSimulationModel[parserErrorField]) {
+      if (
+        !scesim.model ||
+        !scesim.model.ScenarioSimulationModel ||
+        scesim.model.ScenarioSimulationModel[parserErrorField]
+      ) {
         return TestScenarioFileStatus.ERROR;
       }
       if (scesim.model.ScenarioSimulationModel["@_version"] != CURRENT_SUPPORTED_VERSION) {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1870

<img width="822" alt="Screenshot 2025-03-11 at 14 39 43" src="https://github.com/user-attachments/assets/bd43a71f-794b-4cf5-b93e-aa497272a9d6" />

In case of invalid scesim, now an error message is shown in the editor.
Removed `TestScenarioMarshallerFallbackError` component, which is a duplicate of a component already present in the `TestScenarioEditor` root component.