### PR TITLE
NO-ISSUE: Add light gray color to overflow scroll bar for new Test Scenario and DMN Editors

### DIFF
--- a/packages/dmn-editor/src/DmnEditor.css
+++ b/packages/dmn-editor/src/DmnEditor.css
@@ -20,7 +20,7 @@
 /* (begin) global */
 .kie-dmn-editor--root {
   height: 100%;
-  scrollbar-color: var(--vscode-scrollbarSlider-background) #f1f1f1;
+  scrollbar-color: rgba(121, 121, 121, 0.4) #f1f1f1;
 }
 
 .kie-tools--dmn-editor--diagram-container {

--- a/packages/dmn-editor/src/DmnEditor.css
+++ b/packages/dmn-editor/src/DmnEditor.css
@@ -20,6 +20,7 @@
 /* (begin) global */
 .kie-dmn-editor--root {
   height: 100%;
+  scrollbar-color: var(--vscode-scrollbarSlider-background) #f1f1f1;
 }
 
 .kie-tools--dmn-editor--diagram-container {

--- a/packages/scesim-editor/src/TestScenarioEditor.css
+++ b/packages/scesim-editor/src/TestScenarioEditor.css
@@ -44,6 +44,10 @@
   margin-top: 50px;
 }
 
+.kie-scesim-editor--root {
+  scrollbar-color: var(--vscode-scrollbarSlider-background) #f1f1f1;
+}
+
 .kie-scesim-editor--scenario-table-container {
   overflow: auto;
 }

--- a/packages/scesim-editor/src/TestScenarioEditor.css
+++ b/packages/scesim-editor/src/TestScenarioEditor.css
@@ -45,7 +45,7 @@
 }
 
 .kie-scesim-editor--root {
-  scrollbar-color: var(--vscode-scrollbarSlider-background) #f1f1f1;
+  scrollbar-color: rgba(121, 121, 121, 0.4) #f1f1f1;
 }
 
 .kie-scesim-editor--scenario-table-container {

--- a/packages/scesim-editor/src/TestScenarioEditor.tsx
+++ b/packages/scesim-editor/src/TestScenarioEditor.tsx
@@ -415,7 +415,11 @@ export const TestScenarioEditorInternal = ({
   console.trace("[TestScenarioEditorInternal] File Status: " + TestScenarioFileStatus[scesimFileStatus]);
 
   return (
-    <div ref={testScenarioEditorRootElementRef} data-testid="kie-scesim-editor--container">
+    <div
+      ref={testScenarioEditorRootElementRef}
+      className="kie-scesim-editor--root"
+      data-testid="kie-scesim-editor--container"
+    >
       {(() => {
         switch (scesimFileStatus) {
           case TestScenarioFileStatus.EMPTY:


### PR DESCRIPTION
## Description
This PR sets a light gray color to the overflow scroll bar, preventing channels with dark theme to set it to black.


### DMN Editor Before
![image](https://github.com/user-attachments/assets/6a8741ce-445c-43a6-ac0b-2fecf30486b5)


### DMN Editor After
![image](https://github.com/user-attachments/assets/918cb426-fe13-432f-944e-63f92d2f2dc6)


### Scesim Editor Before
![image](https://github.com/user-attachments/assets/eeeeabfc-8f1d-45a3-a0e2-ba1d02ef2f46)


### Scesim Editor After
![image](https://github.com/user-attachments/assets/13e1e2cf-a3ba-4945-99cf-e0e83285329c)

