### PR TITLE
NO-ISSUE: Add support for external proxies in the `cors-proxy` service.

### DIFF
--- a/packages/cors-proxy-image/README.md
+++ b/packages/cors-proxy-image/README.md
@@ -28,19 +28,19 @@ This package contains the `Containerfile` and scripts to build a container image
 Enable the image to be built:
 
 ```bash
-$ export KIE_TOOLS_BUILD__buildContainerImages=true
+export KIE_TOOLS_BUILD__buildContainerImages=true
 ```
 
 The image name, tags and port can be customized by setting the following environment variables:
 
 ```bash
-$ export CORS_PROXY_IMAGE__imageRegistry=<registry>
-$ export CORS_PROXY_IMAGE__imageAccount=<account>
-$ export CORS_PROXY_IMAGE__imageName=<image-name>
-$ export CORS_PROXY_IMAGE__imageBuildTag=<image-tag>
-$ export CORS_PROXY_IMAGE__imagePort=<port>
-$ export CORS_PROXY_IMAGE__imageOrigin=<origin>
-$ export CORS_PROXY_IMAGE__imageVerbose=<verbose>
+export CORS_PROXY_IMAGE__imageRegistry=<registry>
+export CORS_PROXY_IMAGE__imageAccount=<account>
+export CORS_PROXY_IMAGE__imageName=<image-name>
+export CORS_PROXY_IMAGE__imageBuildTag=<image-tag>
+export CORS_PROXY_IMAGE__imagePort=<port>
+export CORS_PROXY_IMAGE__imageOrigin=<origin>
+export CORS_PROXY_IMAGE__imageVerbose=<verbose>
 ```
 
 Default values can be found [here](./env/index.js).
@@ -48,13 +48,13 @@ Default values can be found [here](./env/index.js).
 After setting up the environment variables, run the following in the root folder of the repository to build the package:
 
 ```bash
-$ pnpm @kie-tools/cors-proxy-image... build:prod
+pnpm @kie-tools/cors-proxy-image... build:prod
 ```
 
 Then check out the image:
 
 ```bash
-$ docker images
+docker images
 ```
 
 ## Run
@@ -62,10 +62,36 @@ $ docker images
 Start up a new container with:
 
 ```bash
-$ docker run -p 8080:8080 -i --rm docker.io/apache/incubator-kie-cors-proxy:latest
+docker run -p 8080:8080 -i --rm docker.io/apache/incubator-kie-cors-proxy:main
 ```
 
 The service will be up at http://localhost:8080
+
+## Running with an external proxy
+
+When starting the container, pass the `HTTP_PROXY`/`HTTPS_PROXY` environment variable pointing to the URL of your proxy service:
+
+```bash
+docker run -p 8080:8080 -i --rm -e HTTPS_PROXY=<YOUR_PROXY_URL> docker.io/apache/incubator-kie-cors-proxy:main
+```
+
+While testing you might want to use a local proxy server with a local certificate, like [mitmproxy](https://mitmproxy.org/).
+
+After installing mitmproxy and starting it, run the `cors-proxy` container passing the `HTTPS_PROXY` and `NODE_EXTRA_CA_CERTS` environment variables to configure the proxy. Remember to mount a volume with the certificate inside of the container.
+
+Start the mitmproxy service:
+
+```bash
+mitmweb --set listen_port=<PORT> --showhost
+```
+
+Run the cors-proxy container:
+
+```bash
+docker run --rm -it --network host -e HTTPS_PROXY=http://localhost:<PORT> -e NODE_EXTRA_CA_CERTS=/tmp/certificates/mitmproxy-ca-cert.pem -v ~/.mitmproxy:/tmp/certificates -d -p 8080:8080 docker.io/apache/incubator-kie-cors-proxy:main
+```
+
+> Note that we are using `--network host` in this case because the proxy service is running locally and we want the cors-proxy service to reach it.
 
 ---
 

--- a/packages/cors-proxy/README.md
+++ b/packages/cors-proxy/README.md
@@ -27,20 +27,22 @@ The `cors-proxy` can be configured via environment variables:
 - CORS_PROXY_ORIGIN: Sets the value of the 'Access-Control-Allow-Origin' header. Defaults to `*`.
 - CORS_PROXY_VERBOSE: Allows the proxy to run in verbose mode... useful to trace requests on development environments. Defaults to `false`
 - CORS_PROXY_USE_HTTP_FOR_HOSTS: Comma-separated list of hosts that should use the `http` protocol for proxied requests. Defaults to an empty list.
+- HTTP_PROXY or HTTPS_PROXY: Url of a proxy that will be used to proxy the requests `cors-proxy` is already proxying.
+- NODE_EXTRA_CA_CERTS: This is used by NodeJS itself to add cartificates to the chain. See more at https://nodejs.org/api/cli.html#node_extra_ca_certsfile
 
 For example:
 
 ```bash
-$ export CORS_PROXY_HTTP_PORT=8080
-$ export CORS_PROXY_ORIGIN=*
-$ export CORS_PROXY_VERBOSE=false
-$ export CORS_PROXY_USE_HTTP_FOR_HOSTS="localhost:8080,localhost:8081"
+export CORS_PROXY_HTTP_PORT=8080
+export CORS_PROXY_ORIGIN=*
+export CORS_PROXY_VERBOSE=false
+export CORS_PROXY_USE_HTTP_FOR_HOSTS="localhost:8080,localhost:8081"
 ```
 
 # Build
 
 ```bash
-$ pnpm -F @kie-tools/cors-proxy... build:prod
+pnpm -F @kie-tools/cors-proxy... build:prod
 ```
 
 # Running `cors-proxy`
@@ -48,25 +50,53 @@ $ pnpm -F @kie-tools/cors-proxy... build:prod
 After building the package and setting up the environment variables, in the package folder run the following command:
 
 ```bash
-$ node ./dist/index.js
+node ./dist/index.js
 ```
 
 # Running `cors-proxy` in dev mode.
 
 ```bash
-$ pnpm -F @kie-tools/cors-proxy start
+pnpm -F @kie-tools/cors-proxy start
 ```
 
 You can also use the following envs to configure `cors-proxy` when starting in dev-mode:
 
 ```bash
-$ export CORS_PROXY__port=*
-$ export CORS_PROXY__origin=*
-$ export CORS_PROXY__verbose=false
-$ export CORS_PROXY__useHttpForHosts="localhost:8080,localhost:8081"
+export CORS_PROXY__port=*
+export CORS_PROXY__origin=*
+export CORS_PROXY__verbose=false
+export CORS_PROXY__useHttpForHosts="localhost:8080,localhost:8081"
 ```
 
 Default values can be found [here](./env/index.js).
+
+# Running `cors-proxy` with a proxy
+
+Have a remote or local proxy service for testing. We recommend [mitmproxy](https://mitmproxy.org/), as it's local and easy to configure.
+
+Start it with: (you might need sudo)
+
+```bash
+mitmweb --set listen_port=<PORT> --showhost
+```
+
+Now set the HTTPS_PROXY and NODE_EXTRA_CA_CERTS environment variables before starting the `cors-proxy` service:
+
+```bash
+export HTTPS_PROXY=http://localhost:<PORT
+export NODE_EXTRA_CA_CERTS=~/.mitmproxy/mitmproxy-ca-cert.pem
+```
+
+> `~/.mitmproxy/mitmproxy-ca-cert.pem` is the default location for the certifcate. For more information check https://docs.mitmproxy.org/stable/concepts-certificates/#about-certificates
+
+Set the rest of the environment variables and start the `cors-proxy` service:
+
+```bash
+export CORS_PROXY__port=*
+export CORS_PROXY__origin=*
+
+pnpm -F @kie-tools/cors-proxy start
+```
 
 ---
 

--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2422,6 +2422,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -57539,7 +57542,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 22.10.7
-      acorn: 8.10.0
+      acorn: 8.12.1
       acorn-walk: 8.2.0
       arg: 4.1.0
       create-require: 1.1.1
@@ -59003,7 +59006,7 @@ snapshots:
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)
+      webpack-cli: 4.10.0(webpack@5.94.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
Adds support for external proxies while using the cors-proxy service.

The `cors-proxy` service will read the `HTTPS_PROXY` environment variable and use it to create an HTTP(S) agent to proxy the requests. If the variable is not set, `cors-proxy` will behave the same as before.

The READMEs for the `cors-proxy` and `cors-proxy-image` packages were updated to explain the usage of this environment variable and guide developers on how to test this feature locally using [mitmproxy](https://mitmproxy.org/).