### PR TITLE
kie-tools-issues#2988: "Command Line Too Long" Error in pnpm partitioning on Windows CI

### DIFF
--- a/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
+++ b/.github/supporting-files/ci/build-partitioning/build_partitioning.ts
@@ -41,6 +41,7 @@ const {
     headSha: __ARG_headSha,
     graphJsonPath: __ARG_graphJsonPath,
     partition: __ARG_partitionFilePaths,
+    tmpPartitionFilterPath: __ARG_tmpPartitionFilterPath,
   },
 } = parseArgs({
   args: Bun.argv,
@@ -51,6 +52,7 @@ const {
     forceFull: { type: "string" },
     outputPath: { type: "string" },
     partition: { type: "string", multiple: true },
+    tmpPartitionFilterPath: { type: "string", default: "/tmp/partition-filter.txt" },
   },
   strict: true,
   allowPositionals: true,
@@ -78,11 +80,13 @@ process.exit(0);
 async function getPartitions(): Promise<Array<None | Full | Partial>> {
   console.log(``);
   console.log(`[build-partitioning] --- Summary ---`);
-  console.log(`[build-partitioning] graphJsonPath: ${__ARG_graphJsonPath}`);
-  console.log(`[build-partitioning] baseSha:       ${__ARG_baseSha}`);
-  console.log(`[build-partitioning] headSha:       ${__ARG_headSha}`);
-  console.log(`[build-partitioning] forceFull:     ${forceFull}`);
-  console.log(`[build-partitioning] outputPath:    ${__ARG_outputPath}`);
+  console.log(`[build-partitioning] graphJsonPath:            ${__ARG_graphJsonPath}`);
+  console.log(`[build-partitioning] baseSha:                  ${__ARG_baseSha}`);
+  console.log(`[build-partitioning] headSha:                  ${__ARG_headSha}`);
+  console.log(`[build-partitioning] forceFull:                ${forceFull}`);
+  console.log(`[build-partitioning] outputPath:               ${__ARG_outputPath}`);
+  console.log(`[build-partitioning] partition:                ${__ARG_partitionFilePaths}`);
+  console.log(`[build-partitioning] tmpPartitionFilterPath:   ${__ARG_tmpPartitionFilterPath}`);
   console.log(`[build-partitioning] ---------------`);
   console.log(``);
 
@@ -272,8 +276,12 @@ async function getDirsOfDependencies(leafPackageNames: Set<string>) {
     return new Set<string>();
   }
   const packagesFilter = [...leafPackageNames].map((pkgName) => `-F ${pkgName}...`).join(" ");
+
+  // creating a file for the filters is required by windows CI to avoid the error "command line too long"
+  fs.writeFileSync(__ARG_tmpPartitionFilterPath, packagesFilter);
+
   return new Set(
-    stdoutArray(execSync(`bash -c "pnpm ${packagesFilter} exec bash -c pwd"`).toString()) //
+    stdoutArray(execSync(`bash -c "pnpm $(cat ${__ARG_tmpPartitionFilterPath}) exec bash -c pwd"`).toString()) //
       .map((pkgDir) => convertToPosixPathRelativeToRepoRoot(pkgDir))
   );
 }

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -84,6 +84,7 @@ jobs:
 
           bun ./.github/supporting-files/ci/build-partitioning/build_partitioning.ts \
             --outputPath='/tmp/partitions.json' \
+            --tmpPartitionFilterPath='/tmp/partition-filter.txt' \
             --forceFull='${{ !github.event.pull_request }}' \
             --baseSha='${{ steps.checkout_pr.outputs.base_sha }}' \
             --headSha='${{steps.checkout_pr.outputs.head_sha }}' \


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/2988

**Description:**
On a downstream repository, we have the error below on Windows CI only because the generated pnpm filter exceeded the limit. This issue could potentially happen on upstream.

```
 [build-partitioning] 'Partial' build of './.github/supporting-files/ci/partitions/partition1.txt': Optimal build check ((✅))
The command line is too long.
271 |   if (leafPackageNames.size === 0) {
272 |     return new Set<string>();
273 |   }
274 |   const packagesFilter = [...leafPackageNames].map((pkgName) => `-F ${pkgName}...`).join(" ");
275 |   return new Set(
276 |     stdoutArray(execSync(`bash -c "pnpm ${packagesFilter} exec bash -c pwd"`).toString()) //
                      ^
error: The command line is too long.
```

Full logs: https://github.com/kubesmarts/kie-tools/actions/runs/13756276822/job/38464143033
