### PR TITLE
NO-ISSUE: Replace new Test Scenario editor  `console.log` and `console.trace` to `console.debug`

### DIFF
--- a/packages/scesim-editor/src/TestScenarioEditor.tsx
+++ b/packages/scesim-editor/src/TestScenarioEditor.tsx
@@ -218,7 +218,7 @@ function TestScenarioMainPanel() {
       return;
     }
     commandsRef.current.toggleTestScenarioDock = async () => {
-      console.trace("Test Scenario Editor: COMMANDS: Toggle dock panel...");
+      console.debug("Test Scenario Editor: COMMANDS: Toggle dock panel...");
       testScenarioEditorStoreApi.setState((state) => {
         state.navigation.dock.isOpen = !state.navigation.dock.isOpen;
       });
@@ -332,7 +332,7 @@ export const TestScenarioEditorInternal = ({
   onModelChange,
   onModelDebounceStateChanged,
 }: TestScenarioEditorProps & { forwardRef?: React.Ref<TestScenarioEditorRef> }) => {
-  console.trace("[TestScenarioEditorInternal] Component creation ...");
+  console.debug("[TestScenarioEditorInternal] Component creation ...");
 
   const scesim = useTestScenarioEditorStore((s) => s.scesim);
   const testScenarioEditorStoreApi = useTestScenarioEditorStoreApi();
@@ -346,7 +346,7 @@ export const TestScenarioEditorInternal = ({
     forwardRef,
     () => ({
       reset: () => {
-        console.trace("[TestScenarioEditorInternal: Reset called!");
+        console.debug("[TestScenarioEditorInternal: Reset called!");
         const state = testScenarioEditorStoreApi.getState();
         state.dispatch(state).navigation.reset();
       },
@@ -361,11 +361,11 @@ export const TestScenarioEditorInternal = ({
     testScenarioEditorStoreApi.setState((state) => {
       // Avoid unecessary state updates
       if (model === state.scesim.model) {
-        console.trace("[TestScenarioEditorInternal]: useEffectAfterFirstRender called, but the models are the same!");
+        console.debug("[TestScenarioEditorInternal]: useEffectAfterFirstRender called, but the models are the same!");
         return;
       }
 
-      console.trace("[TestScenarioEditorInternal]: Model updated!");
+      console.debug("[TestScenarioEditorInternal]: Model updated!");
 
       state.scesim.model = model;
       testScenarioEditorModelBeforeEditingRef.current = model;
@@ -384,8 +384,7 @@ export const TestScenarioEditorInternal = ({
       }
 
       onModelDebounceStateChanged?.(true);
-      console.trace("[TestScenarioEditorInternal: Debounce State changed!");
-      console.trace(scesim.model);
+      console.debug("[TestScenarioEditorInternal: Debounce State changed!", scesim.model);
       onModelChange?.(scesim.model);
     }, 500);
 
@@ -412,7 +411,7 @@ export const TestScenarioEditorInternal = ({
     }
   }, [scesim]);
 
-  console.trace("[TestScenarioEditorInternal] File Status: " + TestScenarioFileStatus[scesimFileStatus]);
+  console.debug("[TestScenarioEditorInternal] File Status: ", TestScenarioFileStatus[scesimFileStatus]);
 
   return (
     <div ref={testScenarioEditorRootElementRef} data-testid="kie-scesim-editor--container">
@@ -462,8 +461,7 @@ export const TestScenarioEditorInternal = ({
 
 export const TestScenarioEditor = React.forwardRef(
   (props: TestScenarioEditorProps, ref: React.Ref<TestScenarioEditorRef>) => {
-    console.trace("[TestScenarioEditor] Component creation ... ");
-    console.trace(props.model);
+    console.debug("[TestScenarioEditor] Component creation ... ", props.model);
 
     const store = useMemo(
       () => createTestScenarioEditorStore(props.model, new ComputedStateCache<Computed>(INITIAL_COMPUTED_CACHE)),

--- a/packages/scesim-editor/src/creation/TestScenarioCreationPanel.tsx
+++ b/packages/scesim-editor/src/creation/TestScenarioCreationPanel.tsx
@@ -78,8 +78,10 @@ function TestScenarioCreationPanel() {
       ({ canceled }) => {
         onRequestExternalModelsAvailableToInclude?.()
           .then((dmnModelNormalizedPosixPathRelativePaths) => {
-            console.trace("[TestScenarioCreationPanel] The below external DMN models have been found");
-            console.trace(dmnModelNormalizedPosixPathRelativePaths);
+            console.debug(
+              "[TestScenarioCreationPanel] The below external DMN models have been found ",
+              dmnModelNormalizedPosixPathRelativePaths
+            );
 
             if (canceled.get()) {
               setAllDmnModelNormalizedPosixRelativePaths(undefined);
@@ -113,8 +115,10 @@ function TestScenarioCreationPanel() {
 
         onRequestExternalModelByPath(selectedDmnModelPathRelativeToThisScesim)
           .then((externalDMNModel) => {
-            console.trace("[TestScenarioCreationPanel] The below external DMN model have been loaded");
-            console.trace(externalDMNModel);
+            console.debug(
+              "[TestScenarioCreationPanel] The below external DMN model have been loaded ",
+              externalDMNModel
+            );
 
             if (canceled.get() || !externalDMNModel) {
               setSelectedDmnModel(undefined);
@@ -197,7 +201,7 @@ function TestScenarioCreationPanel() {
                 id="dmn-select"
                 name="dmn-select"
                 onChange={(dmnModelPathRelativeToThisScesim) => {
-                  console.trace(`[TestScenarioCreationPanel] Selected path ${dmnModelPathRelativeToThisScesim}`);
+                  console.debug(`[TestScenarioCreationPanel] Selected path ${dmnModelPathRelativeToThisScesim}`);
                   setSelectedDmnModelPathRelativeToThisScesim(dmnModelPathRelativeToThisScesim);
                 }}
                 value={selectedDmnModelPathRelativeToThisScesim}

--- a/packages/scesim-editor/src/drawer/TestScenarioDrawerDataSelectorPanel.tsx
+++ b/packages/scesim-editor/src/drawer/TestScenarioDrawerDataSelectorPanel.tsx
@@ -227,10 +227,8 @@ function TestScenarioDataSelectorPanel() {
 
   useEffect(() => {
     console.debug("========SELECTOR PANEL USE EFFECT===========");
-    console.debug("Selected Column:");
-    console.debug(selectedColumnMetadata);
-    console.debug("All Data Objects:");
-    console.debug(dataObjects);
+    console.debug("Selected Column:", selectedColumnMetadata);
+    console.debug("All Data Objects:", dataObjects);
 
     /**
      * Case 1: No columns selected OR a column of OTHER type (eg. Description column).
@@ -278,8 +276,7 @@ function TestScenarioDataSelectorPanel() {
         };
       });
       console.debug("Case 2");
-      console.debug("Filtered Data Objects:");
-      console.debug(filteredDataObjects);
+      console.debug("Filtered Data Objects:", filteredDataObjects);
       console.debug("=============USE EFFECT END===============");
       return;
     }

--- a/packages/scesim-editor/src/drawer/TestScenarioDrawerSettingsPanel.tsx
+++ b/packages/scesim-editor/src/drawer/TestScenarioDrawerSettingsPanel.tsx
@@ -88,8 +88,10 @@ function TestScenarioDrawerSettingsPanel() {
         }
         onRequestExternalModelByPath(selectedDmnPathRelativeToThisScesim)
           .then((externalDmnModel) => {
-            console.trace("[TestScenarioDrawerSettingsPanel] The below external DMN model have been loaded");
-            console.trace(externalDmnModel);
+            console.debug(
+              "[TestScenarioDrawerSettingsPanel] The below external DMN model have been loaded ",
+              externalDmnModel
+            );
 
             if (canceled.get() || !externalDmnModel) {
               setSelectedDmnModel(undefined);
@@ -177,7 +179,7 @@ function TestScenarioDrawerSettingsPanel() {
                 throw new Error(`Invalid path for an included model ${JSON.stringify(path)}`);
               }
               setSelectedDmnPathRelativeToThisScesim(path);
-              console.trace(path);
+              console.debug("[TestScenarioDrawerSettingsPanel] Selected path: ", path);
             }}
             validated={isSelectedDmnValid ? undefined : "error"}
             value={isSelectedDmnValid ? settingsModel.dmnFilePath?.__$$text : undefined}

--- a/packages/scesim-editor/src/store/TestScenarioEditorStore.ts
+++ b/packages/scesim-editor/src/store/TestScenarioEditorStore.ts
@@ -123,8 +123,7 @@ export const defaultStaticState = (): Omit<State, "computed" | "dispatch" | "sce
 });
 
 export function createTestScenarioEditorStore(model: SceSimModel, computedCache: ComputedStateCache<Computed>) {
-  console.trace("[TestScenarioEditorStore] Creating store with above model and empty cache ");
-  console.trace(model);
+  console.debug("[TestScenarioEditorStore] Creating store with above model and empty cache ", model);
 
   const { ...defaultState } = defaultStaticState();
   return create(

--- a/packages/scesim-editor/src/table/TestScenarioTable.tsx
+++ b/packages/scesim-editor/src/table/TestScenarioTable.tsx
@@ -822,7 +822,7 @@ function TestScenarioTable({
 
   const onHeaderClick = useCallback(
     (columnKey: string) => {
-      console.log(columnKey);
+      console.debug("[TestScenarioTable] columnKey: ", columnKey);
       if (
         columnKey == TestScenarioTableColumnHeaderGroup.EXPECT ||
         columnKey == TestScenarioTableColumnHeaderGroup.GIVEN


### PR DESCRIPTION
Using the new Test Scenario editor shows many logs in the developer tools, this PR put all logs in the "Verbose" category.