### PR TITLE
[NO-ISSUE] Always switch to Editor tab when programmatically opening a Boxed Expression in the DMN Editor

### DIFF
--- a/packages/dmn-editor/src/DmnEditor.tsx
+++ b/packages/dmn-editor/src/DmnEditor.tsx
@@ -222,6 +222,7 @@ export const DmnEditorInternal = ({
       },
       openBoxedExpressionEditor: (nodeId: string) => {
         dmnEditorStoreApi.setState((state) => {
+          state.navigation.tab = DmnEditorTab.EDITOR;
           state.dispatch(state).boxedExpressionEditor.open(nodeId);
         });
       },


### PR DESCRIPTION
If the DMN Editor is in the Data Types or Included Models tab when the "openBoxedExpressionEditor" method is called, it will look like it was a no-op, so settings the correct tab is important to make sure this action always puts the Boxed Expression Editor in the foreground.