### PR TITLE
[NO-ISSUE] Small cosmetic changes to DMN Editor highlights and rename modal

### DIFF
--- a/packages/dmn-editor/src/evaluationHighlights/EvaluationHighlightsBadge.tsx
+++ b/packages/dmn-editor/src/evaluationHighlights/EvaluationHighlightsBadge.tsx
@@ -30,7 +30,7 @@ export function EvaluationHighlightsBadge() {
     <aside className={"kie-dmn-editor--evaluation-highlights-panel-toggle"}>
       <Label
         icon={isEvaluationHighlightsEnabled ? <OnIcon /> : <OffIcon />}
-        color={isEvaluationHighlightsEnabled ? "green" : "grey"}
+        color={isEvaluationHighlightsEnabled ? "purple" : "grey"}
         onClick={() => {
           dmnEditorStoreApi.setState((state) => {
             state.diagram.overlays.enableEvaluationHighlights = !state.diagram.overlays.enableEvaluationHighlights;

--- a/packages/dmn-editor/src/refactor/RefactorConfirmationDialog.tsx
+++ b/packages/dmn-editor/src/refactor/RefactorConfirmationDialog.tsx
@@ -51,6 +51,7 @@ export function RefactorConfirmationDialog({
       isOpen={isRefactorModalOpen}
       showClose={true}
       onClose={onCancel}
+      title={"Renaming identifier"}
       actions={[
         <Button key="confirm" variant={ButtonVariant.primary} onClick={onConfirmExpressionRefactor}>
           Yes, rename and replace
@@ -58,19 +59,39 @@ export function RefactorConfirmationDialog({
         <Button key="rename" variant={ButtonVariant.secondary} onClick={onConfirmRenameOnly}>
           No, just rename
         </Button>,
-        <Button key="cancel" variant={ButtonVariant.danger} onClick={onCancel}>
+        <Button key="cancel" variant={ButtonVariant.link} onClick={onCancel}>
           Cancel
         </Button>,
       ]}
     >
-      The identifier `{fromName ?? "<undefined>"}` was renamed to `{toName ?? "<undefined>"}`.
+      The identifier{" "}
+      <pre style={{ display: "inline" }}>
+        {'"'}
+        {fromName ?? "<undefined>"}
+        {'"'}
+      </pre>{" "}
+      was renamed to{" "}
+      <pre style={{ display: "inline" }}>
+        {'"'}
+        {toName ?? "<undefined>"}
+        {'"'}
+      </pre>
+      , and it is used by one or more expressions.
       <br />
       <br />
-      This identifier is used in one or more expressions.
-      <br />
-      <br />
-      Would you like to automatically replace all instances of `{fromName ?? "<undefined>"}` with `
-      {toName ?? "<undefined>"}`?
+      Would you like to automatically replace all occurrences of{" "}
+      <pre style={{ display: "inline" }}>
+        {'"'}
+        {fromName ?? "<undefined>"}
+        {'"'}
+      </pre>{" "}
+      with{" "}
+      <pre style={{ display: "inline" }}>
+        {'"'}
+        {toName ?? "<undefined>"}
+        {'"'}
+      </pre>
+      ?
     </Modal>
   );
 }

--- a/packages/form-dmn/src/FormDmnOutputs.tsx
+++ b/packages/form-dmn/src/FormDmnOutputs.tsx
@@ -272,7 +272,7 @@ export function FormDmnOutputs({ openEvaluationTab, openBoxedExpressionEditor, .
             onAnimationEnd={(e) => onAnimationEnd(e, index)}
           >
             <CardTitle>
-              <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}>
+              <Flex justifyContent={{ default: "justifyContentSpaceBetween" }} flexWrap={{ default: "nowrap" }}>
                 <Title headingLevel={"h2"}>{dmnFormResult.decisionName}</Title>
                 {onOpenBoxedExpressionEditor !== undefined && (
                   <Button


### PR DESCRIPTION
- Indicator of highlights is now purple, like the rest of the UI elements of the feature
- The up-arrow to open Boxed Expression in the DMN Runner output cards are not wrapped anymore when the columns are too narrow.
- The renaming modal now has cleaner text and the Cancel button is not red anymore.