### PR TITLE
NO-ISSUE: Support deleting variables from the process instance in the jBPM Dev UI and Management Console

### DIFF
--- a/packages/runtime-tools-management-console-webapp/webpack.config.js
+++ b/packages/runtime-tools-management-console-webapp/webpack.config.js
@@ -145,6 +145,9 @@ module.exports = async (webpackEnv) => {
       },
       allowedHosts: "all",
     },
+    watchOptions: {
+      poll: 1000,
+    },
   });
 };
 

--- a/packages/runtime-tools-process-enveloped-components/src/processDetails/envelope/components/ProcessVariables/ProcessVariables.tsx
+++ b/packages/runtime-tools-process-enveloped-components/src/processDetails/envelope/components/ProcessVariables/ProcessVariables.tsx
@@ -48,7 +48,7 @@ const ProcessVariables: React.FC<ProcessVariablesProps & OUIAProps> = ({
 }) => {
   const handleVariablesChange = useCallback(
     (e) => {
-      setUpdateJson((currentUpdateJson) => ({ ...currentUpdateJson, ...e.updated_src }));
+      setUpdateJson(e.updated_src);
       setDisplayLabel(true);
     },
     [setDisplayLabel, setUpdateJson]


### PR DESCRIPTION
Now, the component passes the entire JSON object change to the query, instead of merging the old JSON with the new one.

Also in this PR:
- Unrelated, but an option was added to the webpack dev server to make stopping it faster.