### PR TITLE
NO-ISSUE: On KIE Sandbox, close navigation blocker modal after deleting the last editable file in a workspace

### DIFF
--- a/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
@@ -34,7 +34,7 @@ import {
 import { SaveIcon } from "@patternfly/react-icons/dist/js/icons/save-icon";
 import { useOnlineI18n } from "../../i18n";
 import { ExtendedServicesButtons } from "../ExtendedServices/ExtendedServicesButtons";
-import { useRoutes } from "../../navigation/Hooks";
+import { useNavigationBlockersBypass, useRoutes } from "../../navigation/Hooks";
 import { EmbeddedEditorRef } from "@kie-tools-core/editor/dist/embedded";
 import { useHistory } from "react-router";
 import { useWorkspaces, WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
@@ -137,6 +137,7 @@ export function EditorToolbarWithWorkspace(
     useEditorToolbarDispatchContext();
 
   useWorkspaceNavigationBlocker(props.workspace);
+  const navigationBlockersBypass = useNavigationBlockersBypass();
 
   const { gitConfig } = useAuthSession(props.workspace.descriptor.gitAuthSessionId);
 
@@ -163,7 +164,12 @@ export function EditorToolbarWithWorkspace(
       })
       .pop();
     if (!nextFile) {
-      history.push({ pathname: routes.home.path({}) });
+      // TODO: This will forcefully return home.
+      // There's no way to undo this deletion because the workspace won't be accesible
+      // anymore without an editable file.
+      navigationBlockersBypass.execute(() => {
+        history.push({ pathname: routes.home.path({}) });
+      });
       return;
     }
 
@@ -177,6 +183,7 @@ export function EditorToolbarWithWorkspace(
   }, [
     editorEnvelopeLocator,
     history,
+    navigationBlockersBypass,
     props.workspace.files,
     props.workspaceFile.relativePath,
     routes.home,
@@ -185,6 +192,7 @@ export function EditorToolbarWithWorkspace(
 
   const deleteWorkspaceFile = useCallback(async () => {
     if (props.workspace.files.length === 1) {
+      // This was the last file, delete the workspace and return home
       await workspaces.deleteWorkspace({ workspaceId: props.workspaceFile.workspaceId });
       history.push({ pathname: routes.home.path({}) });
       return;

--- a/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
@@ -194,7 +194,9 @@ export function EditorToolbarWithWorkspace(
     if (props.workspace.files.length === 1) {
       // This was the last file, delete the workspace and return home
       await workspaces.deleteWorkspace({ workspaceId: props.workspaceFile.workspaceId });
-      history.push({ pathname: routes.home.path({}) });
+      navigationBlockersBypass.execute(() => {
+        history.push({ pathname: routes.home.path({}) });
+      });
       return;
     }
 
@@ -203,7 +205,15 @@ export function EditorToolbarWithWorkspace(
     });
 
     handleDeletedWorkspaceFile();
-  }, [props.workspace.files.length, props.workspaceFile, workspaces, handleDeletedWorkspaceFile, history, routes.home]);
+  }, [
+    props.workspace.files.length,
+    props.workspaceFile,
+    workspaces,
+    handleDeletedWorkspaceFile,
+    navigationBlockersBypass,
+    history,
+    routes.home,
+  ]);
 
   const deleteFileDropdownItem = useMemo(() => {
     return (

--- a/packages/online-editor/src/editor/Toolbar/Workspace/Hooks.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Workspace/Hooks.tsx
@@ -151,6 +151,10 @@ export function useWorkspaceNavigationBlocker(workspace: ActiveWorkspace) {
     } else {
       confirmNavigationAlert.close();
     }
+
+    return () => {
+      confirmNavigationAlert.close();
+    };
   }, [confirmNavigationAlert, navigationStatus]);
 
   return;


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/5c94e7b9-cd43-4d30-ad48-60390e8db8e1

After:

https://github.com/user-attachments/assets/c4aff177-2537-4338-9e0d-ce911c566d19

