### PR TITLE
NO-ISSUE: Rename KOGITO_MANAGEMENT_CONSOLE_IMAGE env var and remove unused properties/build-envs

### DIFF
--- a/examples/process-compact-architecture/README.md
+++ b/examples/process-compact-architecture/README.md
@@ -188,12 +188,12 @@ To help bootstrapping the Infrastructure Services, the example provides a `docke
 
 ```
 PROJECT_VERSION=
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=
+MANAGEMENT_CONSOLE_IMAGE=
 COMPOSE_PROFILES=
 ```
 
 - `PROJECT_VERSION`: Should be set with the current Apache KIE version being used: `PROJECT_VERSION=`
-- `KOGITO_MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Apache KIE Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
+- `MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Apache KIE Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
 - `COMPOSE_PROFILES`: filters which services will run.
 
 ### Development mode
@@ -202,7 +202,7 @@ For development mode, the `.env` must have the `COMPOSE_PROFILES=development`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=development
 ```
 
@@ -212,7 +212,7 @@ For example mode, the `.env` must have the `COMPOSE_PROFILES=example`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=example
 ```
 
@@ -222,7 +222,7 @@ For container mode, the `.env` must have the `COMPOSE_PROFILES=container`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=container
 ```
 

--- a/examples/process-compact-architecture/docker-compose.yml
+++ b/examples/process-compact-architecture/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   management-console:
     container_name: process-compact-architecture-management-console
-    image: ${KOGITO_MANAGEMENT_CONSOLE_IMAGE}
+    image: ${MANAGEMENT_CONSOLE_IMAGE}
     profiles: ["container"]
     ports:
       - 8280:8080

--- a/examples/process-compact-architecture/env/index.js
+++ b/examples/process-compact-architecture/env/index.js
@@ -17,25 +17,13 @@
  * under the License.
  */
 
-const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
-
-const {
-  env: { kogitoManagementConsole: kogitoManagementConsoleImageEnv },
-} = require("@kie-tools/kogito-management-console/env");
+const { varsWithName, composeEnv } = require("@kie-tools-scripts/build-env");
 
 module.exports = composeEnv([require("@kie-tools/root-env/env")], {
-  vars: varsWithName({
-    KIE_TOOLS_EXAMPLE__PROCESS_COMPACT_ARCHITECTURE__managementConsoleImage: {
-      default: `${kogitoManagementConsoleImageEnv.registry}/${kogitoManagementConsoleImageEnv.account}/${kogitoManagementConsoleImageEnv.name}:${kogitoManagementConsoleImageEnv.buildTag}`,
-      description: "The image for the Kogito Management Console.",
-    },
-  }),
+  vars: varsWithName({}),
   get env() {
     return {
       processCompactArchitectureExample: {
-        kogitoManagementConsoleImage: getOrDefault(
-          this.vars.KIE_TOOLS_EXAMPLE__PROCESS_COMPACT_ARCHITECTURE__managementConsoleImage
-        ),
         version: require("../package.json").version,
       },
     };

--- a/examples/process-compact-architecture/install.js
+++ b/examples/process-compact-architecture/install.js
@@ -18,14 +18,9 @@
  */
 
 const { env } = require("./env");
-const { setupMavenConfigFile, setPomProperty, buildTailFromPackageJsonDependencies } = require("@kie-tools/maven-base");
+const { setupMavenConfigFile, buildTailFromPackageJsonDependencies } = require("@kie-tools/maven-base");
 
 setupMavenConfigFile(`
     -Drevision=${env.processCompactArchitectureExample.version}
     -Dmaven.repo.local.tail=${buildTailFromPackageJsonDependencies()}
 `);
-
-setPomProperty({
-  key: "kogito.management-console.image",
-  value: env.processCompactArchitectureExample.kogitoManagementConsoleImage,
-});

--- a/examples/process-security/README.md
+++ b/examples/process-security/README.md
@@ -46,13 +46,13 @@ To help bootstrapping the Infrastructure Services, the example provides a `docke
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=container
 HOST=127.0.0.1
 ```
 
 - `PROJECT_VERSION`: Should be set with the current version being used: `PROJECT_VERSION=0.0.0`
-- `KOGITO_MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Kogito Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
+- `MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Kogito Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
 - `COMPOSE_PROFILES`: filters which services will run.
 - `HOST`: The host used to communicate between the Management Console and the business service. For Windows Subsystem for Linux (WSL) users, use `localhost`.
 
@@ -62,7 +62,7 @@ For development mode, the `.env` must have the `COMPOSE_PROFILES=development`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=development
 HOST=127.0.0.1
 ```
@@ -73,7 +73,7 @@ For JVM mode, the `.env` must have the `COMPOSE_PROFILES=jvm`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=jvm
 HOST=127.0.0.1
 ```
@@ -84,7 +84,7 @@ For container mode, the `.env` must have the `COMPOSE_PROFILES=container`:
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=container
 HOST=127.0.0.1
 ```

--- a/examples/process-security/docker-compose.yml
+++ b/examples/process-security/docker-compose.yml
@@ -173,7 +173,7 @@ services:
 
   managment-console:
     container_name: process-security-management-console
-    image: ${KOGITO_MANAGEMENT_CONSOLE_IMAGE}
+    image: ${MANAGEMENT_CONSOLE_IMAGE}
     profiles: ["container"]
     ports:
       - "8380:8080"

--- a/examples/process-security/env/index.js
+++ b/examples/process-security/env/index.js
@@ -17,25 +17,13 @@
  * under the License.
  */
 
-const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
-
-const {
-  env: { kogitoManagementConsole: kogitoManagementConsoleImageEnv },
-} = require("@kie-tools/kogito-management-console/env");
+const { varsWithName, composeEnv } = require("@kie-tools-scripts/build-env");
 
 module.exports = composeEnv([require("@kie-tools/root-env/env")], {
-  vars: varsWithName({
-    KIE_TOOLS_EXAMPLE__PROCESS_SECURITY__managementConsoleImage: {
-      default: `${kogitoManagementConsoleImageEnv.registry}/${kogitoManagementConsoleImageEnv.account}/${kogitoManagementConsoleImageEnv.name}:${kogitoManagementConsoleImageEnv.buildTag}`,
-      description: "The image for the Kogito Management Console.",
-    },
-  }),
+  vars: varsWithName({}),
   get env() {
     return {
       processSecurityExample: {
-        kogitoManagementConsoleImage: getOrDefault(
-          this.vars.KIE_TOOLS_EXAMPLE__PROCESS_SECURITY__managementConsoleImage
-        ),
         version: require("../package.json").version,
       },
     };

--- a/examples/process-security/install.js
+++ b/examples/process-security/install.js
@@ -18,14 +18,9 @@
  */
 
 const { env } = require("./env");
-const { setupMavenConfigFile, setPomProperty, buildTailFromPackageJsonDependencies } = require("@kie-tools/maven-base");
+const { setupMavenConfigFile, buildTailFromPackageJsonDependencies } = require("@kie-tools/maven-base");
 
 setupMavenConfigFile(`
     -Drevision=${env.processSecurityExample.version}
     -Dmaven.repo.local.tail=${buildTailFromPackageJsonDependencies()}
 `);
-
-setPomProperty({
-  key: "kogito.management-console.image",
-  value: env.processSecurityExample.kogitoManagementConsoleImage,
-});

--- a/examples/process-user-tasks-subsystem/README.md
+++ b/examples/process-user-tasks-subsystem/README.md
@@ -139,17 +139,17 @@ Now, add an `.env` file with the content below:
 
 ```
 PROJECT_VERSION=
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=
+MANAGEMENT_CONSOLE_IMAGE=
 COMPOSE_PROFILES=
 ```
 
 - `PROJECT_VERSION`: Should be set with the current Apache KIE version being used: `PROJECT_VERSION=`
-- `KOGITO_MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Apache KIE Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
+- `MANAGEMENT_CONSOLE_IMAGE`: Should be set with the Apache KIE Management Console image `docker.io/apache/incubator-kie-kogito-management-console:main`
 - `COMPOSE_PROFILES`: filters which services will run.
 
 ```
 PROJECT_VERSION=0.0.0
-KOGITO_MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
+MANAGEMENT_CONSOLE_IMAGE=docker.io/apache/incubator-kie-kogito-management-console:main
 COMPOSE_PROFILES=container
 ```
 

--- a/examples/process-user-tasks-subsystem/docker-compose.yml
+++ b/examples/process-user-tasks-subsystem/docker-compose.yml
@@ -81,7 +81,7 @@ services:
 
   management-console:
     container_name: process-user-tasks-subsystem-management-console
-    image: ${KOGITO_MANAGEMENT_CONSOLE_IMAGE}
+    image: ${MANAGEMENT_CONSOLE_IMAGE}
     ports:
       - 8280:8080
     depends_on:

--- a/examples/process-user-tasks-subsystem/env/index.js
+++ b/examples/process-user-tasks-subsystem/env/index.js
@@ -17,25 +17,13 @@
  * under the License.
  */
 
-const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
-
-const {
-  env: { kogitoManagementConsole: kogitoManagementConsoleImageEnv },
-} = require("@kie-tools/kogito-management-console/env");
+const { varsWithName, composeEnv } = require("@kie-tools-scripts/build-env");
 
 module.exports = composeEnv([require("@kie-tools/root-env/env")], {
-  vars: varsWithName({
-    KIE_TOOLS_EXAMPLE__PROCESS_USER_TASKS_SUBSYSTEM__managementConsoleImage: {
-      default: `${kogitoManagementConsoleImageEnv.registry}/${kogitoManagementConsoleImageEnv.account}/${kogitoManagementConsoleImageEnv.name}:${kogitoManagementConsoleImageEnv.buildTag}`,
-      description: "The image for the Kogito Management Console.",
-    },
-  }),
+  vars: varsWithName({}),
   get env() {
     return {
       processUserTasksSubsystemExample: {
-        kogitoManagementConsoleImage: getOrDefault(
-          this.vars.KIE_TOOLS_EXAMPLE__PROCESS_USER_TASKS_SUBSYSTEM__managementConsoleImage
-        ),
         version: require("../package.json").version,
       },
     };

--- a/examples/process-user-tasks-subsystem/install.js
+++ b/examples/process-user-tasks-subsystem/install.js
@@ -18,14 +18,9 @@
  */
 
 const { env } = require("./env");
-const { setupMavenConfigFile, buildTailFromPackageJsonDependencies, setPomProperty } = require("@kie-tools/maven-base");
+const { setupMavenConfigFile, buildTailFromPackageJsonDependencies } = require("@kie-tools/maven-base");
 
 setupMavenConfigFile(`
     -Drevision=${env.processUserTasksSubsystemExample.version}
     -Dmaven.repo.local.tail=${buildTailFromPackageJsonDependencies()}
 `);
-
-setPomProperty({
-  key: "kogito.management-console.image",
-  value: env.processUserTasksSubsystemExample.kogitoManagementConsoleImage,
-});


### PR DESCRIPTION
- Renamed `KOGITO_MANAGEMENT_CONSOLE_IMAGE` to `MANAGEMENT_CONSOLE_IMAGE`
- Removed `kogitoManagementConsoleImage` build-env
- Removed `kogito.management-console.image` pom property