### PR TITLE
NO-ISSUE: Enable Test Scenario Editor Classic compatibility with the new Test Scenario Editor

### DIFF
--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -382,7 +382,7 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
 
     protected void unmarshallContent(String toUnmarshal) {
         /* Removing the default namespace introduced in the new Test Scenario editor, that is incompatible with this unmarshaller implementation. */
-        toUnmarshal = toUnmarshal.replace("xmlns=\"https://kie.org/scesim/1.8\" ", "");
+        toUnmarshal = toUnmarshal.replace("xmlns=\"https://kie.org/scesim/1.8\"", "");
         SCESIMMainJs.unmarshall(toUnmarshal, SCESIM, getJSInteropUnmarshallCallback());
     }
 

--- a/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/packages/stunner-editors/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -381,6 +381,8 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
     }
 
     protected void unmarshallContent(String toUnmarshal) {
+        /* Removing the default namespace introduced in the new Test Scenario editor, that is incompatible with this unmarshaller implementation. */
+        toUnmarshal = toUnmarshal.replace("xmlns=\"https://kie.org/scesim/1.8\" ", "");
         SCESIMMainJs.unmarshall(toUnmarshal, SCESIM, getJSInteropUnmarshallCallback());
     }
 


### PR DESCRIPTION
File generated / edited with the new Test Scenario Editor are not compatible with the Classic Editor.

The reason relies on the namespace introduced in the new Editor `xmlns="https://kie.org/scesim/1.8"`: that is mandatory for the new Editor. Unfortunately, the classic editor's unmarshaller is not able to parse a scesim file with that namespace. 
I made a tentative to add the namespace in the unmarshalling process, but with that change, the namespace would be mandatory for the old editor too, breaking the compatibility with the old scesim files.


https://github.com/user-attachments/assets/16fdfb7c-df33-4b90-9a20-f17b8fa84f50


As a workaround, the old editor now removes the namespace from the scesim file string representation before getting unmarshalled. Not a nice solution, but I guess it's reasonable based on the future deprecation and removal plans of the old editors.