### PR TITLE
kie-issues#1879: New Test Scenario Editor crashes after changing the DMN model which is referenced

### DIFF
--- a/packages/scesim-editor/src/drawer/TestScenarioDrawerDataSelectorPanel.tsx
+++ b/packages/scesim-editor/src/drawer/TestScenarioDrawerDataSelectorPanel.tsx
@@ -344,36 +344,40 @@ function TestScenarioDataSelectorPanel() {
   const treeViewEmptyStatus = useMemo(() => {
     const isReferencedFileLoaded =
       testScenarioType === "RULE" || externalModelsByNamespace?.has(referencedDmnNamespace!);
-    const isTreeViewNotEmpty = dataObjects.length > 0;
+    const isTreeViewNotEmpty = filteredItems.length > 0;
+    const activeItem = treeViewStatus.activeItems[0];
     const treeViewVisibleStatus = isReferencedFileLoaded ? (isTreeViewNotEmpty ? "visible" : "hidden") : "loading";
-    const treeViewEmptyIcon = filteredItems.length === 0 ? WarningTriangleIcon : WarningTriangleIcon;
     const title =
       dataObjects.length === 0
         ? testScenarioType === "DMN"
           ? i18n.drawer.dataSelector.emptyDataObjectsTitleDMN
           : i18n.drawer.dataSelector.emptyDataObjectsTitleRule
-        : i18n.drawer.dataSelector.emptyDataObjectsTitle;
+        : activeItem !== undefined
+          ? i18n.drawer.dataSelector.emptyDataObjectsTitle
+          : i18n.drawer.dataSelector.emptyDataObjectsMissingTitle;
     const description =
       dataObjects.length === 0
         ? testScenarioType === "DMN"
           ? i18n.drawer.dataSelector.emptyDataObjectsDescriptionDMN
           : i18n.drawer.dataSelector.emptyDataObjectsDescriptionRule
-        : i18n.drawer.dataSelector.emptyDataObjectsDescription;
-
+        : activeItem !== undefined
+          ? i18n.drawer.dataSelector.emptyDataObjectsDescription
+          : i18n.drawer.dataSelector.emptyDataObjectsMissingDescription;
     {
       testScenarioType === "DMN"
         ? i18n.drawer.dataSelector.emptyDataObjectsTitleDMN
         : i18n.drawer.dataSelector.emptyDataObjectsTitleRule;
     }
 
-    return { description: description, icon: treeViewEmptyIcon, title: title, visibility: treeViewVisibleStatus };
+    return { description: description, icon: WarningTriangleIcon, title: title, visibility: treeViewVisibleStatus };
   }, [
-    externalModelsByNamespace,
-    referencedDmnNamespace,
-    filteredItems.length,
     dataObjects.length,
-    testScenarioType,
+    externalModelsByNamespace,
+    filteredItems.length,
     i18n.drawer.dataSelector,
+    referencedDmnNamespace,
+    testScenarioType,
+    treeViewStatus,
   ]);
 
   const insertDataObjectButtonStatus = useMemo(() => {
@@ -397,6 +401,7 @@ function TestScenarioDataSelectorPanel() {
     );
 
     const isAssignable =
+      activeItem !== undefined &&
       (activeItem.children !== undefined &&
         activeItem.children.length > 0 &&
         activeItem.expressionElements.length > 1) === false &&

--- a/packages/scesim-editor/src/i18n/TestScenarioEditorI18n.ts
+++ b/packages/scesim-editor/src/i18n/TestScenarioEditorI18n.ts
@@ -84,9 +84,11 @@ interface TestScenarioEditorDictionary extends ReferenceDictionary {
       descriptionDMN: string;
       descriptionRule: string;
       emptyDataObjectsTitle: string;
+      emptyDataObjectsMissingTitle: string;
       emptyDataObjectsTitleDMN: string;
       emptyDataObjectsTitleRule: string;
       emptyDataObjectsDescription: string;
+      emptyDataObjectsMissingDescription: string;
       emptyDataObjectsDescriptionDMN: string;
       emptyDataObjectsDescriptionRule: string;
       expandAll: string;

--- a/packages/scesim-editor/src/i18n/locales/en.ts
+++ b/packages/scesim-editor/src/i18n/locales/en.ts
@@ -106,7 +106,7 @@ export const en: TestScenarioEditorI18n = {
       emptyDataObjectsTitleRule: "No Java Classes",
       emptyDataObjectsDescription: "All the Data Objects have been already assigned",
       emptyDataObjectsMissingDescription:
-        "The selected column's Data Object is missing. Most likely, this scesim file is no longer synchronized with the referenced DMN file. Please manually remove this and update your file accordingly with the DMN file.",
+        "The selected column's Data Object is missing. Most likely, this scesim file is no longer synchronized with the referenced DMN file. Please manually remove it and update your table accordingly with the DMN file.",
       emptyDataObjectsDescriptionDMN: "Impossible to retrieve the DMN Nodes data from the linked DMN file.",
       emptyDataObjectsDescriptionRule: "Impossible to retrieve the Java Classes from the project.",
       expandAll: "Expand all",

--- a/packages/scesim-editor/src/i18n/locales/en.ts
+++ b/packages/scesim-editor/src/i18n/locales/en.ts
@@ -100,10 +100,13 @@ export const en: TestScenarioEditorI18n = {
         "To edit a test scenario definition, select a grid's column and assign it a DMN Node attribute using the below selector",
       descriptionRule:
         "To edit a test scenario definition, select a grid's column and assign it a Java Class field using the below selector",
-      emptyDataObjectsTitle: "No more properties",
+      emptyDataObjectsTitle: "No Data Objects",
+      emptyDataObjectsMissingTitle: "Missing Data Object",
       emptyDataObjectsTitleDMN: "No DMN Nodes",
       emptyDataObjectsTitleRule: "No Java Classes",
-      emptyDataObjectsDescription: "All the properties have been already assigned",
+      emptyDataObjectsDescription: "All the Data Objects have been already assigned",
+      emptyDataObjectsMissingDescription:
+        "The selected column's Data Object is missing. Most likely, this scesim file is no longer synchronized with the referenced DMN file. Please manually remove this and update your file accordingly with the DMN file.",
       emptyDataObjectsDescriptionDMN: "Impossible to retrieve the DMN Nodes data from the linked DMN file.",
       emptyDataObjectsDescriptionRule: "Impossible to retrieve the Java Classes from the project.",
       expandAll: "Expand all",


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1879

In case the user selects a column with a Data Object removed on the DMN file side, now the editor doesn't crash, offering a description to support the user.


https://github.com/user-attachments/assets/bcc4e3c6-6ede-40b1-8c51-79274b6c37dd

