### PR TITLE
kie-issues#1883: New Test Scenario wrongly manages empty cells

### DIFF
--- a/packages/scesim-editor/src/mutations/addColumn.ts
+++ b/packages/scesim-editor/src/mutations/addColumn.ts
@@ -145,7 +145,6 @@ function addColumn({
         name: { __$$text: newFactMapping.factIdentifier.name.__$$text },
         className: { __$$text: newFactMapping.factIdentifier.className.__$$text },
       },
-      rawValue: { __$$text: "", "@_class": "string" },
     });
   });
 }

--- a/packages/scesim-editor/src/mutations/addRow.ts
+++ b/packages/scesim-editor/src/mutations/addRow.ts
@@ -42,7 +42,6 @@ export function addRow({
         name: { __$$text: factMapping.factIdentifier.name!.__$$text },
         className: { __$$text: factMapping.factIdentifier.className!.__$$text },
       },
-      rawValue: { __$$text: "", "@_class": "string" },
     };
   });
 

--- a/packages/scesim-editor/src/mutations/updateCell.ts
+++ b/packages/scesim-editor/src/mutations/updateCell.ts
@@ -48,5 +48,6 @@ export function updateCell({
       factMappingValue.expressionIdentifier.type?.__$$text === factMapping!.expressionIdentifier.type?.__$$text
   );
   const factMappingValueToUpdate = factMappingValues[factMappingValueToUpdateIndex];
-  factMappingValueToUpdate.rawValue = { __$$text: value, "@_class": "string" };
+  factMappingValueToUpdate.rawValue =
+    value !== undefined && value !== "" ? { __$$text: value, "@_class": "string" } : undefined;
 }


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1883

In case of 
- Creation of a new set of cells
- Update a cell to an empty value 

the value of the cell is set to `undefined`