### PR TITLE
NO-ISSUE: Upgrade isomorphic-git from 1.11.1 to 1.30.1, improving performance

### DIFF
--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -77,7 +77,7 @@
     "cross-env": "^7.0.3",
     "deep-object-diff": "^1.1.9",
     "history": "^4.9.0",
-    "isomorphic-git": "^1.11.1",
+    "isomorphic-git": "^1.30.1",
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.17.21",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -34,7 +34,7 @@
     "@kie-tools-core/vscode-java-code-completion": "workspace:*",
     "@kie-tools-core/workspace": "workspace:*",
     "@types/vscode": "1.67.0",
-    "isomorphic-git": "^1.11.1",
+    "isomorphic-git": "^1.30.1",
     "minimatch": "^3.0.5"
   },
   "devDependencies": {

--- a/packages/workspaces-git-fs/package.json
+++ b/packages/workspaces-git-fs/package.json
@@ -30,7 +30,7 @@
     "@kie-tools/emscripten-fs": "^0.0.2",
     "@kie-tools/kie-sandbox-fs": "workspace:*",
     "client-zip": "^2.3.1",
-    "isomorphic-git": "^1.11.1",
+    "isomorphic-git": "^1.30.1",
     "minimatch": "^3.0.5",
     "react-router": "^5.3.4",
     "uuid": "^8.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7805,8 +7805,8 @@ importers:
         specifier: ^4.9.0
         version: 4.10.1
       isomorphic-git:
-        specifier: ^1.11.1
-        version: 1.11.1(patch_hash=j7cg2tlxujycdt53drg3qdvfbi)
+        specifier: ^1.30.1
+        version: 1.30.1
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -13284,8 +13284,8 @@ importers:
         specifier: 1.67.0
         version: 1.67.0
       isomorphic-git:
-        specifier: ^1.11.1
-        version: 1.11.1(patch_hash=j7cg2tlxujycdt53drg3qdvfbi)
+        specifier: ^1.30.1
+        version: 1.30.1
       minimatch:
         specifier: ^3.0.5
         version: 3.0.5
@@ -13724,8 +13724,8 @@ importers:
         specifier: ^2.3.1
         version: 2.4.3
       isomorphic-git:
-        specifier: ^1.11.1
-        version: 1.11.1(patch_hash=j7cg2tlxujycdt53drg3qdvfbi)
+        specifier: ^1.30.1
+        version: 1.30.1
       minimatch:
         specifier: ^3.0.5
         version: 3.0.5
@@ -21482,8 +21482,8 @@ packages:
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
-  async-lock@1.3.0:
-    resolution: {integrity: sha512-8A7SkiisnEgME2zEedtDYPxUPzdv3x//E7n5IFktPAtMYSEAV7eNJF0rMwrVyUFj6d/8rgajLantbjcNRQYXIg==}
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
@@ -25528,9 +25528,9 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  isomorphic-git@1.11.1:
-    resolution: {integrity: sha512-SUjsx//K0HPk7wnUOOkp13/PjyfY9XsLJq6KG2OVqimykdzC2OtTM9IFlXIPuU1vQa0NjzmmJLlygCx8narvUg==}
-    engines: {node: '>=10'}
+  isomorphic-git@1.30.1:
+    resolution: {integrity: sha512-eWBlPIPDOctGY/bTUc/whs6EZ8YvnG1H2kOjTCJ/AkvBWUzODXcfulhpiA8Y4Px9e+bRYYkifE5fSE8FcRk8Ew==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   isomorphic-textencoder@1.0.1:
@@ -45301,7 +45301,7 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
-  async-lock@1.3.0: {}
+  async-lock@1.4.1: {}
 
   async-retry@1.3.3:
     dependencies:
@@ -51068,15 +51068,16 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-git@1.11.1(patch_hash=j7cg2tlxujycdt53drg3qdvfbi):
+  isomorphic-git@1.30.1:
     dependencies:
-      async-lock: 1.3.0
+      async-lock: 1.4.1
       clean-git-ref: 2.0.1
       crc-32: 1.2.0
       diff3: 0.0.3
-      ignore: 5.2.0
+      ignore: 5.3.1
       minimisted: 2.0.1
       pako: 1.0.11
+      path-browserify: 1.0.1
       pify: 4.0.1
       readable-stream: 3.6.0
       sha.js: 2.4.11
@@ -57542,7 +57543,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 22.10.7
-      acorn: 8.12.1
+      acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.0
       create-require: 1.1.1
@@ -59006,7 +59007,7 @@ snapshots:
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack@5.94.0)
+      webpack-cli: 4.10.0(webpack-dev-server@4.15.1)(webpack@5.94.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
Here's a simple benchmark of cloning the `kie-tools` repository inside KIE Sandbox and the follow up `git status` a.k.a. `hasLocalChanges` function calls.

--------------------------------------------

isomorphic-git 1.11.1 - kie-tools repo

GitService#clone: 34262.06396484375 ms
Initial hasLocalChanges: 7644.275146484375 ms
hasLocalChanges: 3522.132080078125 ms
hasLocalChanges: 3572.39404296875 ms
hasLocalChanges: 4417.22802734375 ms
hasLocalChanges: 4208.256103515625 ms
hasLocalChanges: 3810.68115234375 ms

--------------------------------------------
isomorphic-git 1.30.1 - kie-tools repo

GitService#clone: 24659.52392578125 ms
Initial hasLocalChanges: 2881.740966796875 ms
hasLocalChanges: 1848.5419921875 ms
hasLocalChanges: 1971.06494140625 ms
hasLocalChanges: 1981.93896484375 ms
hasLocalChanges: 2032.190185546875 ms
hasLocalChanges: 2040.037109375 ms

--------------------------------------------


These performance gains are most likely related to these changes to `isomorphic-git`:
- https://github.com/isomorphic-git/isomorphic-git/pull/2023
- https://github.com/isomorphic-git/isomorphic-git/pull/2063