### PR TITLE
kie-issues#1754: Remove Google Tag Manager analytics from webapps

### DIFF
--- a/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.kie-sandbox
@@ -62,7 +62,6 @@ pipeline {
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageAccount = 'apache'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageName = 'incubator-kie-sandbox-dev-deployment-dmn-form-webapp'
         ONLINE_EDITOR__devDeploymentDmnFormWebappImageTag = "${params.RELEASE_VERSION}"
-        ONLINE_EDITOR__gtmId = 'GTM-PQGMKNW'
 
         RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"
 

--- a/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
+++ b/.ci/jenkins/release-jobs/Jenkinsfile.online-editor
@@ -56,7 +56,6 @@ pipeline {
         ONLINE_EDITOR__devDeploymentKogitoQuarkusBlankAppImageAccount = 'apache'
         ONLINE_EDITOR__devDeploymentKogitoQuarkusBlankAppImageName = 'incubator-kie-sandbox-dev-deployment-quarkus-blank-app'
         ONLINE_EDITOR__devDeploymentKogitoQuarkusBlankAppImageTag = "${params.RELEASE_VERSION}"
-        ONLINE_EDITOR__gtmId = 'GTM-PQGMKNW'
         ONLINE_EDITOR__corsProxyUrl = 'https://cors-proxy-kie-sandbox.rhba-0ad6762cc85bcef5745bb684498c2436-0000.us-south.containers.appdomain.cloud'
 
         RELEASE_ARTIFACTS_DIR = "${WORKSPACE}/release-artifacts"

--- a/packages/dashbuilder-viewer-deployment-webapp/static/index.html
+++ b/packages/dashbuilder-viewer-deployment-webapp/static/index.html
@@ -20,7 +20,6 @@
 <!doctype html>
 <html lang="en" class="pf-m-redhat-font">
   <head>
-    <!-- gtm:header -->
     <title>Dashbuilder Deployment</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -28,7 +27,6 @@
     <link rel="shortcut icon" type="image/x-icon" href="favicon.svg" />
   </head>
   <body>
-    <!-- gtm:body -->
     <div id="app" style="height: 100vh"></div>
     <script src="index.js"></script>
   </body>

--- a/packages/online-editor/env/index.js
+++ b/packages/online-editor/env/index.js
@@ -48,10 +48,6 @@ module.exports = composeEnv([rootEnv, extendedServicesJavaEnv, corsProxyEnv, kie
       description:
         "Version Extended Services compatile with KIE Sandbox. Exact match only. No version ranges are supported.",
     },
-    ONLINE_EDITOR__gtmId: {
-      default: undefined,
-      description: "Google Tag Manager ID. Used for analytics.",
-    },
     ONLINE_EDITOR__corsProxyUrl: {
       default: `http://localhost:${corsProxyEnv.env.corsProxy.dev.port}`,
       description: "CORS Proxy URL.",
@@ -163,7 +159,6 @@ module.exports = composeEnv([rootEnv, extendedServicesJavaEnv, corsProxyEnv, kie
         test: {
           skipForArm64: getOrDefault(this.vars.ONLINE_EDITOR__skipPlaywrightTestsForArm64),
         },
-        gtmId: getOrDefault(this.vars.ONLINE_EDITOR__gtmId),
         buildInfo: getOrDefault(this.vars.ONLINE_EDITOR__buildInfo),
         extendedServices: {
           compatibleVersion: getOrDefault(this.vars.ONLINE_EDITOR__extendedServicesCompatibleVersion),

--- a/packages/online-editor/static/index.html
+++ b/packages/online-editor/static/index.html
@@ -20,7 +20,6 @@
 <!doctype html>
 <html lang="en" class="pf-m-redhat-font">
   <head>
-    <!-- gtm:header -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -32,7 +31,6 @@
     <link rel="shortcut icon" type="image/x-icon" href="favicon.svg" />
   </head>
   <body>
-    <!-- gtm:body -->
     <div id="app" style="height: 100vh"></div>
     <script src="index.js"></script>
   </body>

--- a/packages/online-editor/webpack.config.ts
+++ b/packages/online-editor/webpack.config.ts
@@ -30,10 +30,6 @@ import childProcess from "child_process";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import HtmlReplaceWebpackPlugin from "html-replace-webpack-plugin";
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { env } from "./env";
 const buildEnv: any = env; // build-env is not typed
 
@@ -45,7 +41,6 @@ export default async (webpackEnv: any, webpackArgv: any) => {
     extendedServices_windowsDownloadUrl,
     extendedServices_compatibleVersion,
   ] = getExtendedServicesArgs();
-  const gtmResource = getGtmResource();
 
   let lastCommitHash = "";
   try {
@@ -91,12 +86,6 @@ export default async (webpackEnv: any, webpackArgv: any) => {
             inject: false,
             minify: false,
           }),
-          new HtmlReplaceWebpackPlugin([
-            {
-              pattern: /(<!-- gtm):([\w-/]+)(\s*-->)?/g,
-              replacement: (match: any, gtm: any, type: keyof typeof gtmResource) => gtmResource?.[type] ?? `${match}`,
-            },
-          ]),
           new EnvironmentPlugin({
             WEBPACK_REPLACE__commitHash: lastCommitHash,
             WEBPACK_REPLACE__buildInfo: buildInfo,
@@ -176,39 +165,6 @@ export default async (webpackEnv: any, webpackArgv: any) => {
     },
   ];
 };
-
-function getGtmResource() {
-  const gtmId = buildEnv.onlineEditor.gtmId;
-  console.info(`Google Tag Manager :: ID: ${gtmId}`);
-
-  if (!gtmId) {
-    return undefined;
-  }
-
-  return {
-    id: gtmId,
-    header: `<!-- Google Tag Manager -->
-    <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${gtmId}');
-    </script>
-    <!-- End Google Tag Manager -->`,
-    body: `<!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe
-        src="https://www.googletagmanager.com/ns.html?id=${gtmId}"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"
-      >
-      </iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->`,
-  };
-}
 
 function getBuildInfo() {
   const buildInfo = buildEnv.onlineEditor.buildInfo;

--- a/packages/serverless-logic-web-tools/env/index.js
+++ b/packages/serverless-logic-web-tools/env/index.js
@@ -53,10 +53,6 @@ module.exports = composeEnv(
         default: "main",
         description: "Tag/branch to fetch samples from `kiegroup/kie-samples` repository",
       },
-      SERVERLESS_LOGIC_WEB_TOOLS__gtmId: {
-        default: undefined,
-        description: "Google Tag Manager ID for Analytics",
-      },
       SERVERLESS_LOGIC_WEB_TOOLS__swfBuilderImageTag: {
         default: rootEnv.env.root.streamName,
         description:
@@ -89,7 +85,6 @@ module.exports = composeEnv(
         serverlessLogicWebTools: {
           version: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__version),
           buildInfo: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__buildInfo),
-          gtmId: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__gtmId),
           dev: {
             cypressUrl: getOrDefault(this.vars.SERVERLESS_LOGIC_WEB_TOOLS__cypressUrl),
             port: 9020,

--- a/packages/serverless-logic-web-tools/static/index.html
+++ b/packages/serverless-logic-web-tools/static/index.html
@@ -20,7 +20,6 @@
 <!doctype html>
 <html lang="en" class="pf-m-redhat-font">
   <head>
-    <!-- gtm:header -->
     <title>Serverless Logic Web Tools</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -28,7 +27,6 @@
     <link rel="shortcut icon" type="image/x-icon" href="favicon.svg" />
   </head>
   <body>
-    <!-- gtm:body -->
     <div id="app" style="height: 100vh"></div>
     <script src="index.js"></script>
   </body>

--- a/packages/serverless-logic-web-tools/webpack.config.ts
+++ b/packages/serverless-logic-web-tools/webpack.config.ts
@@ -31,16 +31,11 @@ import { defaultEnvJson } from "./build/defaultEnvJson";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import HtmlReplaceWebpackPlugin from "html-replace-webpack-plugin";
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { env } from "./env";
 const buildEnv: any = env; // build-env is not typed
 
 export default async (webpackEnv: any, webpackArgv: any) => {
   const buildInfo = getBuildInfo();
-  const gtmResource = getGtmResource();
   const [swfBuilderImageRegistry, swfBuilderImageAccount, swfBuilderImageName, swfBuilderImageTag] =
     getSwfBuilderImageArgs();
   const [baseBuilderImageRegistry, baseBuilderImageAccount, baseBuilderImageName, baseBuilderImageTag] =
@@ -96,12 +91,6 @@ export default async (webpackEnv: any, webpackArgv: any) => {
             inject: false,
             minify: false,
           }),
-          new HtmlReplaceWebpackPlugin([
-            {
-              pattern: /(<!-- gtm):([\w-/]+)(\s*-->)?/g,
-              replacement: (match: any, gtm: any, type: keyof typeof gtmResource) => gtmResource?.[type] ?? `${match}`,
-            },
-          ]),
           new EnvironmentPlugin({
             WEBPACK_REPLACE__version: buildEnv.serverlessLogicWebTools.version,
             WEBPACK_REPLACE__buildInfo: buildInfo,
@@ -279,39 +268,6 @@ function getDashbuilderViewerImageArgs() {
     dashbuilderViewerImageName,
     dashbuilderViewerImageTag,
   ];
-}
-
-function getGtmResource() {
-  const gtmId = buildEnv.serverlessLogicWebTools.gtmId;
-  console.info(`Google Tag Manager :: ID: ${gtmId}`);
-
-  if (!gtmId) {
-    return undefined;
-  }
-
-  return {
-    id: gtmId,
-    header: `<!-- Google Tag Manager -->
-    <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${gtmId}');
-    </script>
-    <!-- End Google Tag Manager -->`,
-    body: `<!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe
-        src="https://www.googletagmanager.com/ns.html?id=${gtmId}"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"
-      >
-      </iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->`,
-  };
 }
 
 function getBuildInfo() {


### PR DESCRIPTION
Closes [incubator-kie-issues#1754](https://github.com/apache/incubator-kie-issues/issues/1754)

I didn't switch to Apache Matomo because I'm not sure we are even using the info. 

Also, the `HtmlReplaceWebpackPlugin` wasn't working 🤔 