### PR TITLE
kie-tools-issues#3034: [serverless-workflow-editor-standalone-on-webapp] Text editor syntax highlight is not loaded

### DIFF
--- a/packages/serverless-workflow-standalone-editor/src/swf/resources/SwfTextEditorResources.ts
+++ b/packages/serverless-workflow-standalone-editor/src/swf/resources/SwfTextEditorResources.ts
@@ -33,6 +33,7 @@ interface ServerlessWorkflowResources extends EditorResources {
 export class ServerlessWorkflowTextEditorResources extends BaseEditorResources {
   private readonly JS_RESOURCES_EXPR = "(\\wmonaco-editor.*)(\\wjso|\\wyaml)";
   private readonly JS_WORKER_EXPR = ".worker.js";
+  private readonly JS_BUNDLES_EXPR = ".bundle.js";
 
   public get(args: { resourcesPathPrefix: string }) {
     const swfTextEditorResources: ServerlessWorkflowResources = {
@@ -48,7 +49,10 @@ export class ServerlessWorkflowTextEditorResources extends BaseEditorResources {
   }
 
   public getReferencedJSPaths(resourcesPathPrefix: string) {
-    return this.getJSResources(resourcesPathPrefix, this.JS_RESOURCES_EXPR);
+    return [
+      ...this.getJSResources(resourcesPathPrefix, this.JS_RESOURCES_EXPR),
+      ...this.getJSResources(resourcesPathPrefix, this.JS_BUNDLES_EXPR),
+    ];
   }
 
   public getWorkersJSResources(resourcesPathPrefix: string) {

--- a/packages/serverless-workflow-standalone-editor/webpack.editor-resources.config.js
+++ b/packages/serverless-workflow-standalone-editor/webpack.editor-resources.config.js
@@ -56,6 +56,7 @@ module.exports = (webpackEnv) => [
             copy: [
               { source: "./dist/*monaco-editor*.js", destination: "./dist/resources/swf/js/" },
               { source: "./dist/*worker*.js", destination: "./dist/resources/swf/js/" },
+              { source: "./dist/*.bundle.js", destination: "./dist/resources/swf/js/" },
             ],
             delete: ["./dist/*monaco-editor*.js", "./dist/*worker*.js"],
           },


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3034

This PR also bring the validations to the Standalone Editor.

**Description:**
The example webapp examples/serverless-workflow-editor-standalone-on-webapp doesn't load the monaco syntax highlight.

**Preview:**
Before:
![Screenshot From 2025-03-27 18-42-23](https://github.com/user-attachments/assets/9356da74-3070-42c7-9926-3eb256828849)
After:
![Screenshot From 2025-03-27 19-07-20](https://github.com/user-attachments/assets/497179ed-3510-42fc-86ca-c8c2323d1541)
