### PR TITLE
kie-issues#1512: DMN Editor: Context result row change causes expression data type to be reverted

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
@@ -66,8 +66,6 @@ export function ContextResultExpressionCell(props: {
           const ret: Normalized<BoxedContext> = {
             ...prev,
             contextEntry: newContextEntries,
-            "@_label": newExpression?.["@_label"] ?? prev["@_label"],
-            "@_typeRef": newExpression?.["@_typeRef"] ?? prev["@_typeRef"],
           };
 
           return ret;

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
@@ -61,7 +61,6 @@ export function ContextResultExpressionCell(props: {
           } else {
             newContextEntries.splice(resultIndex, 1);
           }
-
           // Do not inline this variable for type safety. See https://github.com/microsoft/TypeScript/issues/241
           const ret: Normalized<BoxedContext> = {
             ...prev,

--- a/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/populate.spec.ts
+++ b/packages/boxed-expression-component/tests-e2e/boxedExpressions/context/populate.spec.ts
@@ -98,4 +98,30 @@ test.describe("Populate Boxed Context", () => {
 
     await expect(bee.getContainer()).toHaveScreenshot("boxed-context-pre-bureau-risk-category.png");
   });
+
+  test("should not revert context header when '<result>' cell is edited", async ({ stories, bee }) => {
+    test.info().annotations.push({
+      type: TestAnnotations.REGRESSION,
+      description: "https://github.com/apache/incubator-kie-issues/issues/1512",
+    });
+
+    await stories.openBoxedContext();
+
+    // edit '<result>' cell for the fist time
+    await bee.expression.asContext().result.selectExpressionMenu.selectLiteral();
+    await bee.expression.asContext().result.expression.asLiteral().fill("1");
+
+    // change the context header
+    await bee.expression.asContext().expressionHeaderCell.open();
+    await bee.expression.asContext().expressionHeaderCell.setName({ name: "New Expression Name", close: false });
+    await bee.expression.asContext().expressionHeaderCell.setDataType({ dataType: "number", close: true });
+
+    // edit '<result>' cell for the second time
+    await bee.expression.asContext().result.expression.asLiteral().fill("2");
+
+    // check the context header is not changed since last edit
+    expect(await bee.expression.asContext().expressionHeaderCell.getName()).toBe("New Expression Name");
+    expect(await bee.expression.asContext().expressionHeaderCell.getDataType()).toBe("(number)");
+    await expect(bee.expression.asContext().result.expression.asLiteral().cell.content).toContainText("2");
+  });
 });


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1512
Before fix:
Data type/label is getting changed to the initially selected value.
After fix:
Data type/label is with the updated values irrespective of changing values.