### PR TITLE
kie-tools#3037: include High Contrast Light possibility for Themes

### DIFF
--- a/packages/editor/src/api/EditorTheme.ts
+++ b/packages/editor/src/api/EditorTheme.ts
@@ -21,4 +21,5 @@ export enum EditorTheme {
   DARK,
   LIGHT,
   HIGH_CONTRAST,
+  HIGH_CONTRAST_LIGHT,
 }

--- a/packages/vscode-extension/src/VsCodeKieEditorController.ts
+++ b/packages/vscode-extension/src/VsCodeKieEditorController.ts
@@ -105,6 +105,8 @@ export class VsCodeKieEditorController implements EditorApi {
         return EditorTheme.DARK;
       case ColorThemeKind.HighContrast:
         return EditorTheme.HIGH_CONTRAST;
+      case ColorThemeKind.HighContrastLight:
+        return EditorTheme.HIGH_CONTRAST_LIGHT;
       default:
         return EditorTheme.LIGHT;
     }


### PR DESCRIPTION
* added to the constant
* configured for VS Code
* not configured for Monaco clients, it seems Monaco editor doesn't support it out of the box (
https://github.com/microsoft/monaco-editor/blob/e03e965994f72b2e27f0153afdccf13e7cd22d8c/website/static/monarch-static.html#L76 , https://github.com/microsoft/monaco-editor/blob/e03e965994f72b2e27f0153afdccf13e7cd22d8c/website/src/website/components/monaco/MonacoEditor.tsx#L211 ) despite an issue closed as if it is supported
https://github.com/microsoft/monaco-editor/issues/3085 (but changes are only in VS Code)

Closes: #3037