### PR TITLE
kie-tools-issues#3044: [chrome-extension-serverless-workflow-editor] CI e2e-test error activating extension

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/static/scripts/check_url_change.js
+++ b/packages/chrome-extension-pack-kogito-kie-editors/static/scripts/check_url_change.js
@@ -30,4 +30,4 @@ var _wr = function (type) {
     return rv;
   };
 };
-history.replaceState = _wr("replaceState");
+history.pushState = _wr("pushState");

--- a/packages/chrome-extension-serverless-workflow-editor/static/scripts/check_url_change.js
+++ b/packages/chrome-extension-serverless-workflow-editor/static/scripts/check_url_change.js
@@ -30,4 +30,4 @@ var _wr = function (type) {
     return rv;
   };
 };
-history.replaceState = _wr("replaceState");
+history.pushState = _wr("pushState");

--- a/packages/chrome-extension/src/app/utils.ts
+++ b/packages/chrome-extension/src/app/utils.ts
@@ -50,12 +50,12 @@ export function runAfterUriChange(logger: Logger, callback: () => void) {
 
   runScriptOnPage(chrome.runtime.getURL("scripts/check_url_change.js"));
 
-  window.addEventListener("replaceState", () => {
-    logger.log("replaceState event happened");
-    checkUriThenCallback();
-  });
   window.addEventListener("popstate", () => {
     logger.log("popstate event happened");
+    checkUriThenCallback();
+  });
+  window.addEventListener("pushState", () => {
+    logger.log("pushState event happened");
     checkUriThenCallback();
   });
 }


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3044

**Note:**
chrome-extension-pack-kogito-kie-editors is affected as well

**Description:**
Probably due to GitHub Web UI changes the activation of our Chrome Extension is not working when opening a SWF file and we are having CI failures in these PRs:
- https://github.com/apache/incubator-kie-tools/pull/2853
- https://github.com/apache/incubator-kie-tools/pull/3041
- https://github.com/apache/incubator-kie-tools/pull/3040
- https://github.com/apache/incubator-kie-tools/pull/3042

CI run: https://github.com/apache/incubator-kie-tools/actions/runs/14188291057/job/39828630072

**Preview:**
[Screencast From 2025-04-03 11-43-04.webm](https://github.com/user-attachments/assets/f5579ad2-270f-47d0-9b64-f6e839bd5878)
