### PR TITLE
kie-tools-issues#3051: [sonataflow-management-console-image] SIGWINCH on terminal resize

### DIFF
--- a/packages/sonataflow-management-console-image/README.md
+++ b/packages/sonataflow-management-console-image/README.md
@@ -88,7 +88,7 @@ This package contains the `Containerfile/Dockerfile` and scripts to build a cont
    1. Using a different Data Index Service.
 
       ```bash
-      docker run -t -p 8080:8080 -e SONATAFLOW_MANAGEMENT_CONSOLE_DATA_INDEX_ENDPOINT=<my_value> -i --rm docker.io/apache/incubator-kie-sonataflow-management-console:main
+      docker run -p 8080:8080 -e SONATAFLOW_MANAGEMENT_CONSOLE_DATA_INDEX_ENDPOINT=<my_value> -i --rm docker.io/apache/incubator-kie-sonataflow-management-console:main
       ```
 
       _NOTE: Replace `docker` with `podman` if necessary._
@@ -115,7 +115,7 @@ When building, set the `SONATAFLOW_MANAGEMENT_CONSOLE__port` environment variabl
    Replace `<HOST_IP_ADDRESS>` with the IP address of your host machine.
 
    ```bash
-   docker run --rm -it -p 8080:8080 \
+   docker run --rm -p 8080:8080 \
      -e SONATAFLOW_MANAGEMENT_CONSOLE_KOGITO_ENV_MODE='DEV' \
      -e SONATAFLOW_MANAGEMENT_CONSOLE_DATA_INDEX_ENDPOINT='http://<HOST_IP_ADDRESS>:4000/graphql' \
      docker.io/apache/incubator-kie-sonataflow-management-console:main
@@ -127,6 +127,8 @@ When building, set the `SONATAFLOW_MANAGEMENT_CONSOLE__port` environment variabl
     cd ../sonataflow-dev-app
     pnpm start
    ```
+
+   **Important Note:** Avoid using the `-it` option (interactive and TTY) with the docker run command, as it may cause the internal Apache HTTPD server to terminate with SIGWINCH during terminal resizing. For more details, refer to https://bz.apache.org/bugzilla/show_bug.cgi?id=50669
 
 ---
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3051

**Description:**
When running the SonataFlow Management Console Docker container, using the `-it` option (interactive) with the docker run command can cause the internal Apache HTTPD server to terminate with a `SIGWINCH` signal being sent during terminal resizing.

**Steps to Reproduce:**
- `cd sonataflow-management-console-image; pnpm build:dev` 
- `docker run -it -p 8080:8080 docker.io/apache/incubator-kie-sonataflow-management-console:main`
- Resize the terminal window.
- Apache HTTPD server terminates with a SIGWINCH signal and the image shut down
