### PR TITLE
Fix #3059 - Remove quarkus-kubernetes extension from SonataFlow builder image

### DIFF
--- a/packages/sonataflow-builder-image/resources/incubator-kie-sonataflow-builder-image.yaml
+++ b/packages/sonataflow-builder-image/resources/incubator-kie-sonataflow-builder-image.yaml
@@ -36,7 +36,7 @@
 - name: "docker.io/apache/incubator-kie-sonataflow-builder"
   from: "registry.access.redhat.com/ubi8/openjdk-17:1.21"
   version: "main"
-  description: "Kogito Serverless Workflow base builder with Quarkus extensions libraries preinstalled"
+  description: "Apache KIE SonataFlow base builder with Quarkus extensions libraries preinstalled"
 
   labels:
     - name: "io.openshift.s2i.scripts-url"
@@ -50,11 +50,11 @@
     - name: "maintainer"
       value: "Apache KIE <dev@kie.apache.org>"
     - name: "io.k8s.description"
-      value: "Sonataflow base builder with Quarkus extensions libraries preinstalled."
+      value: "Apache KIE SonataFlow base builder with Quarkus extensions libraries preinstalled."
     - name: "io.k8s.display-name"
-      value: "Sonataflow Builder"
+      value: "Apache KIE SonataFlow Builder"
     - name: "io.openshift.tags"
-      value: "kogito,builder,serverless,workflow"
+      value: "sonataflow,kogito,kie,builder,serverless,workflow"
 
   modules:
     repositories:

--- a/packages/sonataflow-builder-image/resources/modules/sonataflow/builder/build-config/module.yaml
+++ b/packages/sonataflow-builder-image/resources/modules/sonataflow/builder/build-config/module.yaml
@@ -19,11 +19,11 @@
 schema_version: 1
 name: org.kie.sonataflow.builder.build-config
 version: "main"
-description: "Sonataflow builder image build configuration"
+description: "Apache KIE SonataFlow builder image build configuration"
 
 envs:
   - name: "SCRIPT_DEBUG"
     value: "false"
   - name: QUARKUS_EXTENSIONS
     # Follow up issue to remove KOGITO_VERSION: https://issues.redhat.com/browse/KOGITO-9270
-    value: quarkus-kubernetes,smallrye-health,org.apache.kie.sonataflow:sonataflow-quarkus:${KOGITO_VERSION},org.kie:kie-addons-quarkus-knative-eventing:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-microprofile-config-service-catalog:${KOGITO_VERSION},org.kie:kie-addons-quarkus-kubernetes:${KOGITO_VERSION},org.kie:kie-addons-quarkus-events-process:${KOGITO_VERSION},org.kie:kie-addons-quarkus-process-management:${KOGITO_VERSION},org.kie:kie-addons-quarkus-source-files:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-knative-serving:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-jobs-knative-eventing:${KOGITO_VERSION},org.kie:kie-addons-quarkus-monitoring-prometheus:${KOGITO_VERSION},org.kie:kie-addons-quarkus-monitoring-sonataflow:${KOGITO_VERSION}
+    value: smallrye-health,org.apache.kie.sonataflow:sonataflow-quarkus:${KOGITO_VERSION},org.kie:kie-addons-quarkus-knative-eventing:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-microprofile-config-service-catalog:${KOGITO_VERSION},org.kie:kie-addons-quarkus-kubernetes:${KOGITO_VERSION},org.kie:kie-addons-quarkus-events-process:${KOGITO_VERSION},org.kie:kie-addons-quarkus-process-management:${KOGITO_VERSION},org.kie:kie-addons-quarkus-source-files:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-knative-serving:${KOGITO_VERSION},org.kie:kogito-addons-quarkus-jobs-knative-eventing:${KOGITO_VERSION},org.kie:kie-addons-quarkus-monitoring-prometheus:${KOGITO_VERSION},org.kie:kie-addons-quarkus-monitoring-sonataflow:${KOGITO_VERSION}

--- a/packages/sonataflow-builder-image/resources/modules/sonataflow/builder/runtime/community/module.yaml
+++ b/packages/sonataflow-builder-image/resources/modules/sonataflow/builder/runtime/community/module.yaml
@@ -19,7 +19,7 @@
 schema_version: 1
 name: org.kie.sonataflow.builder.runtime.community
 version: "main"
-description: "Sonataflow builder runtime module"
+description: "Apache KIE SonataFlow builder runtime module"
 
 artifacts:
   - image: builder


### PR DESCRIPTION
Fix #3059 

Related https://github.com/apache/incubator-kie-kogito-runtimes/pull/3892, but can be merged any time.