### PR TITLE
incubator-kie-tools-3068: Workflow metadata event must use the sonataflow.org/name annotation instead of SonataFlow.Name

### DIFF
--- a/packages/sonataflow-operator/api/v1alpha08/conversion.go
+++ b/packages/sonataflow-operator/api/v1alpha08/conversion.go
@@ -102,9 +102,18 @@ func ToCNCFWorkflow(workflowCR *SonataFlow, context context.Context) (*cncfmodel
 	}
 
 	cncfWorkflow.ID = workflowCR.ObjectMeta.Name
-	cncfWorkflow.Key = workflowCR.ObjectMeta.Annotations[metadata.Key]
-	cncfWorkflow.Description = workflowCR.ObjectMeta.Annotations[metadata.Description]
-	cncfWorkflow.Version = workflowCR.ObjectMeta.Annotations[metadata.Version]
+	if key, ok := workflowCR.ObjectMeta.Annotations[metadata.Key]; ok {
+		cncfWorkflow.Key = key
+	}
+	if name, ok := workflowCR.ObjectMeta.Annotations[metadata.Name]; ok {
+		cncfWorkflow.Name = name
+	}
+	if description, ok := workflowCR.ObjectMeta.Annotations[metadata.Description]; ok {
+		cncfWorkflow.Description = description
+	}
+	if version, ok := workflowCR.ObjectMeta.Annotations[metadata.Version]; ok {
+		cncfWorkflow.Version = version
+	}
 	cncfWorkflow.SpecVersion = extractSpecVersion(workflowCR)
 	cncfWorkflow.ExpressionLang = cncfmodel.ExpressionLangType(extractExpressionLang(workflowCR.ObjectMeta.Annotations))
 

--- a/packages/sonataflow-operator/internal/controller/workflowdef/events.go
+++ b/packages/sonataflow-operator/internal/controller/workflowdef/events.go
@@ -39,7 +39,9 @@ func NewWorkflowDefinitionAvailabilityEvent(workflow *operatorapi.SonataFlow, ev
 	event.SetExtension("partitionkey", workflow.Name)
 	data := make(map[string]interface{})
 	data["id"] = workflow.Name
-	data["name"] = workflow.Name
+	if name, ok := workflow.ObjectMeta.Annotations[metadata.Name]; ok {
+		data["name"] = name
+	}
 	version := workflow.ObjectMeta.Annotations[metadata.Version]
 	data["version"] = version
 	data["type"] = "SW"


### PR DESCRIPTION
closes: #3068 