### PR TITLE
NO-ISSUE: Update `JDT-LS` to 1.43.0

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -107,6 +107,8 @@
 
     <!-- Plugins version -->
     <version.codehaus.flatten.plugin>1.6.0</version.codehaus.flatten.plugin>
+    <version.j2cl.maven.plugin>0.23.0</version.j2cl.maven.plugin>
+    <version.jacoco.maven.plugin>0.8.13</version.jacoco.maven.plugin>
     <version.maven.artifact.plugin>3.5.3</version.maven.artifact.plugin>
     <version.maven.clean.plugin>3.4.0</version.maven.clean.plugin>
     <version.maven.compiler.plugin>3.13.0</version.maven.compiler.plugin>
@@ -137,8 +139,6 @@
     <version.org.junit.jupiter>5.10.2</version.org.junit.jupiter>
     <version.org.mockito>4.11.0</version.org.mockito>
     <version.org.kie.j2cl.tools.yaml.mapper>0.4</version.org.kie.j2cl.tools.yaml.mapper>
-    <version.j2cl.maven.plugin>0.23.0</version.j2cl.maven.plugin>
-    <version.jacoco.maven.plugin>0.8.12</version.jacoco.maven.plugin>
     <version.io.netty>4.1.118.Final</version.io.netty>
   </properties>
 
@@ -363,6 +363,11 @@
         </plugin>
 
         <!-- 3rd party -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${version.jacoco.maven.plugin}</version>
+        </plugin>
         <plugin>
           <groupId>org.kie.j2cl.tools</groupId>
           <artifactId>j2cl-maven-plugin</artifactId>

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -43,10 +43,9 @@
 
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
-    <version.tycho>3.0.5</version.tycho>
+    <version.jdt.ls>1.43.0.20241219145916</version.jdt.ls>
+    <version.tycho>4.0.12</version.tycho>
     <version.tycho.extras>${version.tycho}</version.tycho.extras>
-    <version.jacoco>0.8.12</version.jacoco>
-    <version.jdt.ls>1.30.1.20231207151730</version.jdt.ls>
 
     <!-- Tycho -->
     <tycho.scmUrl>scm:git:https://github.com/apache/incubator-kie-tools.git</tycho.scmUrl>
@@ -65,19 +64,9 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.30.1/repository/</url>
-    </repository>
-    <repository>
-      <id>jdt.ls.maven</id>
-      <url>https://repo.eclipse.org/content/repositories/jdtls-releases/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.43.0/repository</url>
     </repository>
   </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>cbi-release</id>
-      <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <build>
     <plugins>
@@ -92,14 +81,6 @@
         <artifactId>target-platform-configuration</artifactId>
         <version>${version.tycho}</version>
         <configuration>
-          <target>
-            <artifact>
-              <groupId>org.eclipse.jdt.ls</groupId>
-              <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-              <version>${version.jdt.ls}</version>
-            </artifact>
-          </target>
-          <resolver>p2</resolver>
           <pomDependencies>consider</pomDependencies>
         </configuration>
       </plugin>
@@ -219,7 +200,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${version.jacoco}</version>
             <executions>
               <execution>
                 <goals>

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Bundle-Vendor: Apache KIE
 Bundle-ManifestVersion: 2
 Bundle-Name: vscode-java-code-completion-extension-plugin-core
 Bundle-SymbolicName: vscode-java-code-completion-extension-plugin-core;singleton:=true


### PR DESCRIPTION
It seems that the Eclipse repository referred to by the current 1.30.1 version is no longer valid (forbidden is always returned)

Since version 1.41.0, a new repo management was introduced (https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3001) that should (hopefully) improve the current status. 

I updated it to 1.43.0, which is the last version supporting JDK 17 (newer versions require JDK 23).

Updated Jacoco and Tycho versions.