### PR TITLE
[sonataflow-opoerator] NO-ISSUE: Add DbMigrator Env to SonataFlow Operator envs

### DIFF
--- a/packages/sonataflow-operator/Makefile
+++ b/packages/sonataflow-operator/Makefile
@@ -517,7 +517,8 @@ update-config:
 		dataIndexPostgreSQLImageTag=$$(shell build-env sonataFlowOperator.kogitoDataIndexPostgresqlImage) \
 		dataIndexEphemeralImageTag=$$(shell build-env sonataFlowOperator.kogitoDataIndexEphemeralImage) \
 		sonataFlowBaseBuilderImageTag=$$(shell build-env sonataFlowOperator.sonataflowBuilderImage) \
-		sonataFlowDevModeImageTag=$$(shell build-env sonataFlowOperator.sonataflowDevModeImage))
+		sonataFlowDevModeImageTag=$$(shell build-env sonataFlowOperator.sonataflowDevModeImage) \
+		dbMigratorToolImageTag=$$(shell build-env sonataFlowOperator.kogitoDBMigratorToolImage))
 	@if [ -z "$(strip $(PARAMS))" ]; then \
 		echo "⚠️  No variables resolved. Skipping updates to controllers config file."; \
 	else \

--- a/packages/sonataflow-operator/env/index.js
+++ b/packages/sonataflow-operator/env/index.js
@@ -25,6 +25,7 @@ const kogitoJobsServiceEphemeralImageEnv = require("@kie/kogito-jobs-service-eph
 const kogitoJobsServicePostgresqlImageEnv = require("@kie/kogito-jobs-service-postgresql-image/env");
 const kogitoDataIndexEphemeralImageEnv = require("@kie/kogito-data-index-ephemeral-image/env");
 const kogitoDataIndexPostgresqlImageEnv = require("@kie/kogito-data-index-postgresql-image/env");
+const kogitoDBMigratorToolImageEnv = require("@kie-tools/kogito-db-migrator-tool-image/env");
 const rootEnv = require("@kie-tools/root-env/env");
 
 module.exports = composeEnv([rootEnv, sonataflowBuilderImageEnv, sonataflowDevModeImageEnv], {
@@ -69,6 +70,10 @@ module.exports = composeEnv([rootEnv, sonataflowBuilderImageEnv, sonataflowDevMo
       default: `${kogitoDataIndexPostgresqlImageEnv.env.kogitoDataIndexPostgresqlImage.registry}/${kogitoDataIndexPostgresqlImageEnv.env.kogitoDataIndexPostgresqlImage.account}/${kogitoDataIndexPostgresqlImageEnv.env.kogitoDataIndexPostgresqlImage.name}:${kogitoDataIndexPostgresqlImageEnv.env.kogitoDataIndexPostgresqlImage.buildTag}`,
       description: "Kogito Data Index PostgreSQL image",
     },
+    SONATAFLOW_OPERATOR__kogitoDBMigratorToolImage: {
+      default: `${kogitoDBMigratorToolImageEnv.env.kogitoDbMigratorToolImage.registry}/${kogitoDBMigratorToolImageEnv.env.kogitoDbMigratorToolImage.account}/${kogitoDBMigratorToolImageEnv.env.kogitoDbMigratorToolImage.name}:${kogitoDBMigratorToolImageEnv.env.kogitoDbMigratorToolImage.buildTag}`,
+      description: "Kogito DB Migrator image",
+    },
   }),
   get env() {
     return {
@@ -84,6 +89,7 @@ module.exports = composeEnv([rootEnv, sonataflowBuilderImageEnv, sonataflowDevMo
         kogitoJobsServicePostgresqlImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__kogitoJobsServicePostgresqlImage),
         kogitoDataIndexEphemeralImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__kogitoDataIndexEphemeralImage),
         kogitoDataIndexPostgresqlImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__kogitoDataIndexPostgresqlImage),
+        kogitoDBMigratorToolImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__kogitoDBMigratorToolImage),
       },
     };
   },

--- a/packages/sonataflow-operator/hack/bump-version.sh
+++ b/packages/sonataflow-operator/hack/bump-version.sh
@@ -44,6 +44,4 @@ node -p "require('replace-in-file').sync({ from: /\bversion: .*\b/g, to: 'versio
 node -p "require('replace-in-file').sync({ from: /\boperatorVersion = .*/g, to: 'operatorVersion = \"${version}\"', files: ['version/version.go'] });"
 node -p "require('replace-in-file').sync({ from: /\btagVersion = .*/g, to: 'tagVersion = \"${imageTag}\"', files: ['version/version.go'] });"
 
-make manifests
-
 echo "Version bumped to ${version}"

--- a/packages/sonataflow-operator/hack/bump-version.sh
+++ b/packages/sonataflow-operator/hack/bump-version.sh
@@ -44,6 +44,6 @@ node -p "require('replace-in-file').sync({ from: /\bversion: .*\b/g, to: 'versio
 node -p "require('replace-in-file').sync({ from: /\boperatorVersion = .*/g, to: 'operatorVersion = \"${version}\"', files: ['version/version.go'] });"
 node -p "require('replace-in-file').sync({ from: /\btagVersion = .*/g, to: 'tagVersion = \"${imageTag}\"', files: ['version/version.go'] });"
 
-make generate-all
+make manifests
 
 echo "Version bumped to ${version}"

--- a/packages/sonataflow-operator/package.json
+++ b/packages/sonataflow-operator/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@kie-tools/kogito-db-migrator-tool-image": "workspace:*",
     "@kie-tools/python-venv": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/sonataflow-builder-image": "workspace:*",

--- a/packages/sonataflow-operator/package.json
+++ b/packages/sonataflow-operator/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build:dev": "run-script-if --bool true --then run-script-os --finally \"pnpm format\"",
-    "build:dev:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && make generate-all && make build && pnpm image:build",
+    "build:dev:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && pnpm bump-version && make generate-all && make build && pnpm image:build",
     "build:dev:win32": "echo 'Build not supported on Windows'",
     "build:prod": "run-script-if --bool true --then run-script-os --finally \"pnpm format\"",
     "build:prod:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && make generate-all && make build && pnpm image:build && pnpm test && pnpm test-e2e",
@@ -31,7 +31,7 @@
     "image:bundle:build:darwin:win32": "echo 'Build Operator bundle image not supported on Windows and macOS'",
     "image:bundle:build:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --bool \"$(build-env containerImages.build)\" --then \"make bundle bundle-build\"",
     "install": "run-script-os",
-    "install:darwin:linux": "rimraf bin && go work sync && go mod tidy && pnpm controllers:update:cfg && pnpm format && pnpm bump-version && pnpm format",
+    "install:darwin:linux": "rimraf bin && go work sync && go mod tidy && pnpm controllers:update:cfg && pnpm format",
     "install:win32": "echo 'Install not supported on Windows'",
     "test": "run-script-os",
     "test:darwin:linux": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"make test\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12606,6 +12606,9 @@ importers:
 
   packages/sonataflow-operator:
     devDependencies:
+      '@kie-tools/kogito-db-migrator-tool-image':
+        specifier: workspace:*
+        version: link:../kogito-db-migrator-tool-image
       '@kie-tools/python-venv':
         specifier: workspace:*
         version: link:../python-venv

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -645,6 +645,7 @@ digraph G {
   "@kie-tools/sonataflow-management-console-webapp" -> "@kie-tools/runtime-tools-shared-webapp-components" [ style = "solid", color = "blue" ];
   "@kie-tools/sonataflow-management-console-webapp" -> "@kie-tools/runtime-tools-swf-webapp-components" [ style = "solid", color = "blue" ];
   "@kie-tools/sonataflow-management-console-webapp" -> "@kie-tools/sonataflow-dev-app" [ style = "dashed", color = "blue" ];
+  "@kie-tools/sonataflow-operator" -> "@kie-tools/kogito-db-migrator-tool-image" [ style = "dashed", color = "black" ];
   "@kie-tools/sonataflow-operator" -> "@kie-tools/sonataflow-builder-image" [ style = "dashed", color = "black" ];
   "@kie-tools/sonataflow-operator" -> "@kie-tools/sonataflow-devmode-image" [ style = "dashed", color = "black" ];
   "@kie-tools/sonataflow-operator" -> "@kie/kogito-data-index-ephemeral-image" [ style = "dashed", color = "black" ];

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -189,6 +189,7 @@
       { "id": "@kie-tools/unitables-dmn" },
       { "id": "@kie-tools/kn-plugin-workflow" },
       { "id": "@kie-tools/sonataflow-operator" },
+      { "id": "@kie-tools/kogito-db-migrator-tool-image" },
       { "id": "@kie-tools/sonataflow-builder-image" },
       { "id": "@kie-tools/sonataflow-devmode-image" },
       { "id": "@kie/kogito-data-index-ephemeral-image" },
@@ -199,7 +200,6 @@
       { "id": "@kie-tools/sonataflow-image-common" },
       { "id": "@kie-tools/python-venv" },
       { "id": "@kie-tools/kogito-db-migrator-tool" },
-      { "id": "@kie-tools/kogito-db-migrator-tool-image" },
       { "id": "@kie/kogito-jit-runner-image" },
       { "id": "@kie/kogito-jobs-service-allinone-image" },
       { "id": "@kie-tools/unitables" },
@@ -2050,6 +2050,11 @@
       },
       {
         "source": "@kie-tools/sonataflow-operator",
+        "target": "@kie-tools/kogito-db-migrator-tool-image",
+        "weight": 1
+      },
+      {
+        "source": "@kie-tools/sonataflow-operator",
         "target": "@kie-tools/sonataflow-builder-image",
         "weight": 1
       },
@@ -2076,6 +2081,16 @@
       {
         "source": "@kie-tools/sonataflow-operator",
         "target": "@kie/kogito-jobs-service-postgresql-image",
+        "weight": 1
+      },
+      {
+        "source": "@kie-tools/kogito-db-migrator-tool-image",
+        "target": "@kie-tools/kogito-db-migrator-tool",
+        "weight": 1
+      },
+      {
+        "source": "@kie-tools/kogito-db-migrator-tool-image",
+        "target": "@kie-tools/sonataflow-image-common",
         "weight": 1
       },
       {
@@ -2166,16 +2181,6 @@
       {
         "source": "@kie-tools/kogito-db-migrator-tool",
         "target": "@kie-tools/maven-base",
-        "weight": 1
-      },
-      {
-        "source": "@kie-tools/kogito-db-migrator-tool-image",
-        "target": "@kie-tools/kogito-db-migrator-tool",
-        "weight": 1
-      },
-      {
-        "source": "@kie-tools/kogito-db-migrator-tool-image",
-        "target": "@kie-tools/sonataflow-image-common",
         "weight": 1
       },
       {


### PR DESCRIPTION
In this PR, we add the DBMigrator package as a dependency to the operator and bind them in the configuration env.