### PR TITLE
NO-ISSUE: Fix dev-deployment-dmn-form-webapp dev-webapp and how it parses OpenAPI specs

### DIFF
--- a/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/pom.xml
+++ b/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/pom.xml
@@ -199,7 +199,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${version.maven.surefire.plugin}</version>
+          <version>${version.maven.surefire}</version>
           <dependencies>
             <dependency>
               <groupId>org.iq80.snappy</groupId>
@@ -238,7 +238,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${version.maven.surefire.plugin}</version>
+        <version>${version.maven.surefire}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/packages/dev-deployment-dmn-form-webapp/dev-webapp/start.js
+++ b/packages/dev-deployment-dmn-form-webapp/dev-webapp/start.js
@@ -32,8 +32,8 @@ const mvn = spawn(
     `-Dversion.quarkus=${env.versions.quarkus}`,
     `-Dversion.org.kie.kogito=${env.versions.kogito}`,
     `-Dquarkus.http.port=${env.devDeploymentDmnFormWebapp.dev.quarkusPort}`,
-    `-Dkogito.service.url=http://localhost:${env.devDeploymentDmnFormWebapp.dev.quarkusPort}`,
-    "-Dquarkus.http.root-path=/",
+    `-Dquarkus.http.host=0.0.0.0`,
+    `-Dkogito.service.url=http://0.0.0.0:${env.devDeploymentDmnFormWebapp.dev.quarkusPort}`,
   ],
   { shell: true }
 );

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnDevDeploymentFormWebAppDataApi.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnDevDeploymentFormWebAppDataApi.tsx
@@ -39,11 +39,18 @@ export async function fetchAppData(args: { quarkusAppOrigin: string; quarkusAppP
 
   // Append origin to schema $refs, but only on DMN paths
   //
-  // It's important to skip paths not ending on `/dmnresult` because the application
-  // being deployed may have other paths that we don't control, and not all of them
+  // It's important to skip paths not ending on `/dmnresult` (or paths that don't
+  // have a matching `/dmnresult` path) because the application being
+  // deployed may have other paths that we don't control, and not all of them
   // will have valid JSON Schemas.
+  // Beyond that, we want to delete these paths from the openApiSpec to avoid trying to
+  // dereferencing them.
   Object.keys(openApiSpec.paths).forEach((modelPath) => {
-    if (!modelPath.endsWith("/dmnresult")) {
+    if (
+      !modelPath.endsWith("/dmnresult") &&
+      !Object.keys(openApiSpec.paths).find((path) => path === `${modelPath}/dmnresult`)
+    ) {
+      delete openApiSpec.paths?.[modelPath];
       return;
     }
 

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormErrorPage.tsx
@@ -45,7 +45,7 @@ export function DmnFormErrorPage() {
             <I18nWrapped
               components={{
                 jira: (
-                  <a href={ISSUES_URL} target={"_blank"} rel={"noopener noreferrer"}>
+                  <a href={ISSUES_URL} key="github-issues" target={"_blank"} rel={"noopener noreferrer"}>
                     {ISSUES_URL}
                   </a>
                 ),

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/Sample.dmn
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/Sample.dmn
@@ -24,7 +24,7 @@
   xmlns:kie="https://kie.org/dmn/extensions/1.0"
   xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
   xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
-  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"
+  xmlns:feel="https://www.omg.org/spec/DMN/20230324/FEEL/"
   id="_C6CBECEB-2BBC-4E14-80B0-17F576B2CF92"
   name="loan_pre_qualification"
   expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/"


### PR DESCRIPTION
- Fixed an issue where the "dereferencing" step in the OpenAPI spec parse in the `dev-deployment-dmn-form-webapp` would try to dereference unreachable refs (refs with no origin, like `/MyRef` instead of `http://localhost:9001/MyRef`);
- Fixed the dev-webapp for the `dev-deployment-dmn-form-webapp`. (maven-surefire-plugin version and quarkus.http.host value);
- Fixed the `Sample.dmn` file for the `jbpm-quarkus-devui` dev app.