### PR TITLE
kie-issues#3098: Fix for handle latest firefox to build incubator-kie-tools-ci-build image

### DIFF
--- a/.ci/incubator-kie-tools-ci-build.Dockerfile
+++ b/.ci/incubator-kie-tools-ci-build.Dockerfile
@@ -50,9 +50,9 @@ apt-get clean autoclean && apt-get autoremove --yes && \
 rm -rf /var/lib/{apt,cache,log}/
 
 # Install firefox
-RUN wget -O /tmp/firefox-latest.tar.bz2 "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" && \
-    tar xjf /tmp/firefox-latest.tar.bz2 -C /tmp && mv /tmp/firefox /opt/firefox-latest && \
-    rm /tmp/firefox-latest.tar.bz2 && \
+RUN wget -O /tmp/firefox-latest.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" && \
+    tar xf /tmp/firefox-latest.tar.xz -C /tmp && mv /tmp/firefox /opt/firefox-latest && \
+    rm /tmp/firefox-latest.tar.xz && \
     ln -s /opt/firefox-latest/firefox /usr/bin/firefox
 
 # Install chromedriver


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-tools/issues/3098