### PR TITLE
[sonataflow-operator] - NO-ISSUE: replace operator tag version with platform version

### DIFF
--- a/packages/sonataflow-operator/env/index.js
+++ b/packages/sonataflow-operator/env/index.js
@@ -46,6 +46,11 @@ module.exports = composeEnv([rootEnv, sonataflowBuilderImageEnv, sonataflowDevMo
       default: rootEnv.env.root.streamName,
       description: "Tag version of this image. E.g., `main` or `10.0.x` or `10.0.0",
     },
+    SONATAFLOW_OPERATOR__platformTag: {
+      default: rootEnv.env.root.streamName,
+      description:
+        "Tag version the platform Tag - The default tag used for all the images managed by the operator. It changes the version.go file. E.g., `main` or `10.0.x` or `10.0.0",
+    },
     SONATAFLOW_OPERATOR__sonataflowBuilderImage: {
       default: `${sonataflowBuilderImageEnv.env.sonataflowBuilderImage.registry}/${sonataflowBuilderImageEnv.env.sonataflowBuilderImage.account}/${sonataflowBuilderImageEnv.env.sonataflowBuilderImage.name}:${sonataflowBuilderImageEnv.env.sonataflowBuilderImage.buildTag}`,
       description: "Sonataflow Builder image",
@@ -82,6 +87,7 @@ module.exports = composeEnv([rootEnv, sonataflowBuilderImageEnv, sonataflowDevMo
         account: getOrDefault(this.vars.SONATAFLOW_OPERATOR__account),
         name: getOrDefault(this.vars.SONATAFLOW_OPERATOR__name),
         buildTag: getOrDefault(this.vars.SONATAFLOW_OPERATOR__buildTag),
+        platformTag: getOrDefault(this.vars.SONATAFLOW_OPERATOR__platformTag),
         version: require("../package.json").version,
         sonataflowBuilderImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__sonataflowBuilderImage),
         sonataflowDevModeImage: getOrDefault(this.vars.SONATAFLOW_OPERATOR__sonataflowDevModeImage),

--- a/packages/sonataflow-operator/hack/bump-version.sh
+++ b/packages/sonataflow-operator/hack/bump-version.sh
@@ -22,6 +22,7 @@ set -e
 
 imageName=$(pnpm build-env sonataFlowOperator.registry)/$(pnpm build-env sonataFlowOperator.account)/$(pnpm build-env sonataFlowOperator.name)
 imageTag=$(pnpm build-env sonataFlowOperator.buildTag)
+platformTag=$(pnpm build-env sonataFlowOperator.platformTag)
 version=$(pnpm build-env sonataFlowOperator.version)
 
 if [ -z "${version}" ]; then
@@ -42,6 +43,6 @@ node -p "require('replace-in-file').sync({ from: /\bversion: .*\b/g, to: 'versio
 node -p "require('replace-in-file').sync({ from: /\bversion: .*\b/g, to: 'version: ${version}', files: ['./images/manager.yaml'] });"
 
 node -p "require('replace-in-file').sync({ from: /\boperatorVersion = .*/g, to: 'operatorVersion = \"${version}\"', files: ['version/version.go'] });"
-node -p "require('replace-in-file').sync({ from: /\btagVersion = .*/g, to: 'tagVersion = \"${imageTag}\"', files: ['version/version.go'] });"
+node -p "require('replace-in-file').sync({ from: /\bplatformTagVersion = .*/g, to: 'platformTagVersion = \"${platformTag}\"', files: ['version/version.go'] });"
 
 echo "Version bumped to ${version}"

--- a/packages/sonataflow-operator/version/version.go
+++ b/packages/sonataflow-operator/version/version.go
@@ -20,7 +20,8 @@ package version
 // Don't change it manually, use the make bump-version <version>
 const operatorVersion = "0.0.0"
 
-const tagVersion = "main"
+// Don't change it manually, it depends on the bump-version recipe
+const platformTagVersion = "main"
 
 // GetOperatorVersion gets the current operator version
 func GetOperatorVersion() string {
@@ -29,5 +30,5 @@ func GetOperatorVersion() string {
 
 // GetImageTagVersion gets the current tag version for the published images
 func GetImageTagVersion() string {
-	return tagVersion
+	return platformTagVersion
 }


### PR DESCRIPTION
In this short PR, we changed the variable used to set the default image version if none is passed in the configuration channels.