### PR TITLE
[kn-plugin-workflow] quarkus convert moves the hidden folders

### DIFF
--- a/packages/kn-plugin-workflow/go.mod
+++ b/packages/kn-plugin-workflow/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/afero v1.12.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sys v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.6
@@ -115,7 +116,6 @@ require (
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.8.0 // indirect

--- a/packages/kn-plugin-workflow/pkg/command/quarkus/convert.go
+++ b/packages/kn-plugin-workflow/pkg/command/quarkus/convert.go
@@ -21,6 +21,7 @@ package quarkus
 
 import (
 	"fmt"
+	fsutils "github.com/apache/incubator-kie-tools/packages/kn-plugin-workflow/pkg/common/fs"
 	"io"
 	"os"
 	"path/filepath"
@@ -167,6 +168,14 @@ func moveSWFFilesToQuarkusProject(cfg CreateQuarkusProjectConfig, rootFolder str
 			continue
 		}
 
+		info, err := item.Info()
+		if err != nil {
+			return err
+		}
+		if fsutils.IsHidden(info, item.Name()) && info.IsDir() {
+			continue
+		}
+
 		srcPath := filepath.Join(rootFolder, item.Name())
 		dstPath := filepath.Join(targetFolder, item.Name())
 
@@ -203,6 +212,10 @@ func copyDir(src, dst string) error {
 	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if fsutils.IsHidden(info, path) && info.IsDir() {
+			return nil
 		}
 
 		dstPath := filepath.Join(dst, path[len(src):])

--- a/packages/kn-plugin-workflow/pkg/common/fs/is_hidden_unix.go
+++ b/packages/kn-plugin-workflow/pkg/common/fs/is_hidden_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+// +build !windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fsutils
+
+import (
+	"os"
+	"strings"
+)
+
+func IsHidden(info os.FileInfo, path string) bool {
+	return strings.HasPrefix(info.Name(), ".")
+}

--- a/packages/kn-plugin-workflow/pkg/common/fs/is_hidden_windows.go
+++ b/packages/kn-plugin-workflow/pkg/common/fs/is_hidden_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+// +build windows
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fsutils
+
+import (
+	"golang.org/x/sys/windows"
+	"os"
+)
+
+func IsHidden(info os.FileInfo, path string) bool {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false
+	}
+	attrs, err := windows.GetFileAttributes(p)
+	if err != nil {
+		return false
+	}
+	return attrs&windows.FILE_ATTRIBUTE_HIDDEN != 0
+}


### PR DESCRIPTION
issue: https://github.com/apache/incubator-kie-tools/issues/3120

I’d like to add that hidden folders are also used to store settings for IDEA, VSCode, and so on, so moving them into `src/main/resources` isn't nice

