### PR TITLE
kie-issues#1957: Embed functionality fails due to unescaped apostrophes in the XML

### DIFF
--- a/packages/online-editor/src/editor/Toolbar/Share/EmbedModal.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Share/EmbedModal.tsx
@@ -94,7 +94,10 @@ export function EmbedModal(props: {
   const isGist = useMemo(() => props.workspace.origin.kind === WorkspaceKind.GITHUB_GIST, [props.workspace]);
 
   const getCurrentContentScript = useCallback((content: string, libraryName: string) => {
-    const fileContent = content.replace(/(\r\n|\n|\r)/gm, "").replace(/'/g, "\\'");
+    const fileContent = content
+      .replace(/\\/g, "\\\\")
+      .replace(/'/g, "\\'")
+      .replace(/(\r\n|\n|\r)/gm, "");
     return `
 <script>
   ${libraryName}.open({container: document.body, readOnly: true, initialContent: '${fileContent}', origin: "*" })

--- a/packages/online-editor/src/editor/Toolbar/Share/EmbedModal.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Share/EmbedModal.tsx
@@ -94,7 +94,7 @@ export function EmbedModal(props: {
   const isGist = useMemo(() => props.workspace.origin.kind === WorkspaceKind.GITHUB_GIST, [props.workspace]);
 
   const getCurrentContentScript = useCallback((content: string, libraryName: string) => {
-    const fileContent = content.replace(/(\r\n|\n|\r)/gm, "");
+    const fileContent = content.replace(/(\r\n|\n|\r)/gm, "").replace(/'/g, "\\'");
     return `
 <script>
   ${libraryName}.open({container: document.body, readOnly: true, initialContent: '${fileContent}', origin: "*" })


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1957
Before fix:
1) Click Try Sample under the new Workflow button
2) Click on the Share Dropdown
3) Click embed
4) Copy the embedded code
5) Save the code as an html file
6) Open the html file in the browser and nothing will render. Console will show errors

After fix:
Able to load as html.
