### PR TITLE
NO-ISSUE: Fix kogito-management-console build command

### DIFF
--- a/packages/kogito-management-console/README.md
+++ b/packages/kogito-management-console/README.md
@@ -45,7 +45,7 @@ This package contains the `Containerfile/Dockerfile` and scripts to build a cont
 - After optionally setting up the environment variables, run the following in the root folder of the repository to build the package:
 
   ```bash
-  pnpm -F @kie-tools/runtime-tools-management-console-webapp-image... build:prod
+  pnpm -F @kie-tools/runtime-tools-management-console-webapp... build:prod
   ```
 
 - Then check if the image is correctly stored:


### PR DESCRIPTION
The command in the readme doesn't work as it's referring to a non-existant package:
runtime-tools-management-console-webapp-image
as opposed to:
runtime-tools-management-console-webapp