### PR TITLE
NO-ISSUE: Automatically refresh custom forms list on every fetch in the jbpm-quarkus-devui

### DIFF
--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/FormsService.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/FormsService.java
@@ -55,6 +55,7 @@ public class FormsService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getFormsList(@QueryParam("names") FormFilter filter) {
         try {
+            storage.refresh();
             return Response.ok(storage.getFormInfoList(filter)).build();
         } catch (Exception e) {
             LOGGER.warn("Error while getting forms list: ", e);

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/FormsStorage.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/FormsStorage.java
@@ -35,4 +35,6 @@ public interface FormsStorage {
     Form getFormContent(String formName) throws IOException;
 
     void updateFormContent(String formName, FormContent formContent) throws IOException;
+
+    void refresh();
 }

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/impl/FormsStorageImpl.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/forms/impl/FormsStorageImpl.java
@@ -115,6 +115,7 @@ public class FormsStorageImpl implements FormsStorage {
         return null;
     }
 
+
     @Override
     public int getFormsCount() {
         return formInfoMap.keySet().size();
@@ -243,6 +244,10 @@ public class FormsStorageImpl implements FormsStorage {
                     formInfoMap.put(FilenameUtils.removeExtension(file.getName()),
                             new FormInfo(FilenameUtils.removeExtension(file.getName()), getFormType(FilenameUtils.getExtension(file.getName())), lastModified));
                 });
+    }
+
+    public void refresh() {
+        this.init();
     }
 
     private Collection<File> readFormResources() {


### PR DESCRIPTION
Fetching the list of custom forms (`/forms`) now will initialize the Storage again, listing all files in the `custom-dev-forms` directory.

This solves the issue when new custom forms are generated using the extension while the jBPM Quarkus DevUI is running, but the forms list is not updated with the new forms.

This solution is not pretty. We should be able to hook into the "hot-reload" API from Quarkus, but I don't know how to do that and couldn't find any documentation online.
This fix should be good enough for development use cases, so I'm not too worried about it.