### PR TITLE
NO-ISSUE: Remove debugging code from AuthSessionService in `runtime-tools-management-console-webapp`

### DIFF
--- a/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/AuthSessionsService.ts
@@ -296,8 +296,6 @@ export class AuthSessionsService {
       throw new Error("Failed to extract claims from token.");
     }
 
-    console.log({ claims });
-
     const authSession: OpenIDConnectAuthSession = {
       id: uuid(),
       type: AuthSessionType.OPENID_CONNECT,


### PR DESCRIPTION
Probably not a good idea to print the claims in the console :stuck_out_tongue_winking_eye: 

- Removes forgotten `console.log` from https://github.com/apache/incubator-kie-tools/pull/3090