### PR TITLE
kie-issues#1977: Import types from Java class - replace external data type should not be possible

### DIFF
--- a/packages/dmn-editor/src/dataTypes/DataTypes.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypes.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useEffect } from "react";
 import { DMN15__tItemDefinition } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_5/ts-gen/types";
 import { Normalized } from "@kie-tools/dmn-marshaller/dist/normalization/normalize";
 import { getNewDmnIdRandomizer } from "@kie-tools/dmn-marshaller/dist/idRandomizer/dmnIdRandomizer";
@@ -112,11 +112,23 @@ export function DataTypes() {
   const dataTypesTree = useDmnEditorStore((s) => s.computed(s).getDataTypes(externalModelsByNamespace).dataTypesTree);
 
   const [isOpenImportJavaClassesWizard, setOpenImportJavaClassesWizard] = useState(false);
-  const { conflictsClasses, handleConflictAction, handleImportJavaClasses, isConflictsOccured } =
-    useImportJavaClasses();
+  const {
+    conflictsClasses,
+    handleConflictAction,
+    handleImportJavaClasses,
+    isConflictsOccured,
+    handleCloseConflictsModal,
+  } = useImportJavaClasses();
   const handleImportJavaClassButtonClick = useCallback(() => {
+    setAddDataTypeDropdownOpen(false);
     setOpenImportJavaClassesWizard((prevState) => !prevState);
   }, []);
+
+  useEffect(() => {
+    if (isOpenImportJavaClassesWizard || isConflictsOccured) {
+      setAddDataTypeDropdownOpen(false);
+    }
+  }, [isOpenImportJavaClassesWizard, isConflictsOccured]);
 
   const activeDataType = useMemo(() => {
     return activeItemDefinitionId ? allDataTypesById.get(activeItemDefinitionId) : undefined;
@@ -358,6 +370,7 @@ export function DataTypes() {
                   isOpen={isConflictsOccured}
                   handleConfirm={handleConflictAction}
                   conflictedJavaClasses={conflictsClasses}
+                  onClose={handleCloseConflictsModal}
                 />
               )}
             </DrawerContentBody>

--- a/packages/dmn-editor/src/dataTypes/DataTypes.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypes.tsx
@@ -357,7 +357,7 @@ export function DataTypes() {
                 <ImportJavaClassNameConflictsModal
                   isOpen={isConflictsOccured}
                   handleConfirm={handleConflictAction}
-                  confliectedJavaClasses={conflictsClasses}
+                  conflictedJavaClasses={conflictsClasses}
                 />
               )}
             </DrawerContentBody>

--- a/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
+++ b/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
@@ -152,39 +152,30 @@ const ImportJavaClassNameConflictsModal = ({
       ]}
     >
       <TextContent>
-        {classNames?.length === 1 ? (
-          <Text component={TextVariants.p}>
-            An existing DMN type named{" "}
-            {hasInternalConflicts ? <b>{internalConflicts[0]?.name}</b> : externalConflicts[0]?.name} has been detected.{" "}
-            {hasExternalConflicts
-              ? "This type is an external data type, and no action can be performed on it."
-              : "This type is currently in use within the system. How would you like to proceed?"}
-          </Text>
-        ) : (
-          <Text component={TextVariants.p}>
-            Multiple DMN types have been detected in the list. The following DMN types are currently in use within the
-            system:{" "}
-            {hasInternalConflicts && (
-              <>
-                <b>{internalConflicts.map((c) => c.name).join("  , ")}</b>
-                <span style={{ fontStyle: "italic", color: "gray" }}> (These are internal data types){"."}</span>
-              </>
-            )}
-            {hasExternalConflicts && (
-              <>
-                <span>
-                  {hasInternalConflicts}
-                  {externalConflicts.map((c) => c.name).join(" , ")}
-                  <span style={{ fontStyle: "italic", color: "gray" }}>
-                    {" "}
-                    (These are external data types, and no action can be performed on them.)
-                  </span>
-                </span>
-              </>
-            )}
-            How would you like to proceed?
-          </Text>
+        <Text component={TextVariants.p}>
+          Conflicts have been detected between imported Java classes and existing DMN data types. Please review the
+          details below and choose how to proceed.
+        </Text>
+
+        {hasInternalConflicts && (
+          <>
+            <Text component={TextVariants.h4}>Internal Data Type Conflicts</Text>
+            <Text>
+              <b>{internalConflicts.map((c) => c.name).join(" , ")}</b>- These are editable DMN types. Choose how to
+              resolve them.
+            </Text>
+          </>
         )}
+        {hasExternalConflicts && (
+          <>
+            <Text component={TextVariants.h4}>External Data Type Conflicts</Text>
+            <Text>
+              <b>{externalConflicts.map((c) => c.name).join(", ")}</b>- These types come from external sources and
+              cannot be modified.
+            </Text>
+          </>
+        )}
+
         <Text
           component={TextVariants.blockquote}
           style={{ background: "none", display: "flex", flexDirection: "column", gap: "1rem" }}

--- a/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
+++ b/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
@@ -166,7 +166,8 @@ const ImportJavaClassNameConflictsModal = ({
             system:{" "}
             {hasInternalConflicts && (
               <>
-                <b>{internalConflicts.map((c) => c.name).join("  , ")}</b> {". "}
+                <b>{internalConflicts.map((c) => c.name).join("  , ")}</b>
+                <span style={{ fontStyle: "italic", color: "gray" }}> (These are internal data types.)</span>
               </>
             )}
             {hasExternalConflicts && (

--- a/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
+++ b/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
@@ -176,7 +176,7 @@ const ImportJavaClassNameConflictsModal = ({
           <>
             <Text component={TextVariants.h4}>Internal Data Type Conflicts</Text>
             <Text>
-              <b>{internalConflicts.map((c) => c.name).join(", ")}</b>- These are editable DMN types. Choose how to
+              <b>{internalConflicts.map((c) => c.name).join(", ")}</b>- These are editable DMN Types. Choose how to
               resolve them.
             </Text>
             <Text

--- a/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
+++ b/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
@@ -161,7 +161,7 @@ const ImportJavaClassNameConflictsModal = ({
           <>
             <Text component={TextVariants.h4}>Internal Data Type Conflicts</Text>
             <Text>
-              <b>{internalConflicts.map((c) => c.name).join(" , ")}</b>- These are editable DMN types. Choose how to
+              <b>{internalConflicts.map((c) => c.name).join(", ")}</b>- These are editable DMN types. Choose how to
               resolve them.
             </Text>
           </>

--- a/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
+++ b/packages/dmn-editor/src/dataTypes/ImportJavaClasses.tsx
@@ -167,7 +167,7 @@ const ImportJavaClassNameConflictsModal = ({
             {hasInternalConflicts && (
               <>
                 <b>{internalConflicts.map((c) => c.name).join("  , ")}</b>
-                <span style={{ fontStyle: "italic", color: "gray" }}> (These are internal data types.)</span>
+                <span style={{ fontStyle: "italic", color: "gray" }}> (These are internal data types){"."}</span>
               </>
             )}
             {hasExternalConflicts && (

--- a/packages/import-java-classes-component/src/components/ImportJavaClasses/model/JavaClass.ts
+++ b/packages/import-java-classes-component/src/components/ImportJavaClasses/model/JavaClass.ts
@@ -26,11 +26,14 @@ export class JavaClass {
   public fields: JavaField[];
   /** It indicates if the fields has been loaded, in order to support empty fields Java Classes */
   public fieldsLoaded: boolean;
+  /** It indicates if there is an external conflict */
+  public isExternalConflict: boolean;
 
   constructor(name: string) {
     this.name = name;
     this.fields = [];
     this.fieldsLoaded = false;
+    this.isExternalConflict = false;
   }
 
   setFields(fields: JavaField[]) {

--- a/packages/import-java-classes-component/src/components/ImportJavaClasses/model/JavaClass.ts
+++ b/packages/import-java-classes-component/src/components/ImportJavaClasses/model/JavaClass.ts
@@ -26,14 +26,11 @@ export class JavaClass {
   public fields: JavaField[];
   /** It indicates if the fields has been loaded, in order to support empty fields Java Classes */
   public fieldsLoaded: boolean;
-  /** It indicates if there is an external conflict */
-  public isExternalConflict: boolean;
 
   constructor(name: string) {
     this.name = name;
     this.fields = [];
     this.fieldsLoaded = false;
-    this.isExternalConflict = false;
   }
 
   setFields(fields: JavaField[]) {


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-issues/issues/1977
Before fix:
User can able to see replace option for external data type conflicts also.
After fix:
Replace option is disabled in case of external data type conflicts.

<img width="1094" alt="Screenshot 2025-05-26 at 10 11 54 PM" src="https://github.com/user-attachments/assets/a019c1df-ba16-45ce-bdfd-96a9714bafe6" />



