### PR TITLE
kie-tools#3166: [serverless-logic-web-tools-swf-dev-mode-image] Fix mvn version

### DIFF
--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/Containerfile
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/Containerfile
@@ -31,7 +31,7 @@ WORKDIR /home/kogito/serverless-logic-web-tools-swf-deployment-quarkus-app/
 
 RUN chown kogito /home/kogito/.m2 && \
   rm -rf src/test/ && \
-  mvn clean package \
+  "${MAVEN_CMD}" clean package \
   quarkus:go-offline \
   -B \
   -s /home/kogito/.m2/settings.xml \

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
@@ -46,4 +46,3 @@ mkdir "${KOGITO_HOME}"/.m2
 chown -R kogito:kogito "${KOGITO_HOME}"/.m2
 cp -v "${SCRIPT_DIR}"/maven/* "${KOGITO_HOME}"/.m2
 cp -v "${SCRIPT_DIR}"/added/* "${KOGITO_HOME}"/launch/
-echo "alias mvn='${MAVEN_HOME}/bin/mvnw'" >>"${KOGITO_HOME}"/.bashrc

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/configure
@@ -43,5 +43,7 @@ else
 fi
 
 mkdir "${KOGITO_HOME}"/.m2
+chown -R kogito:kogito "${KOGITO_HOME}"/.m2
 cp -v "${SCRIPT_DIR}"/maven/* "${KOGITO_HOME}"/.m2
 cp -v "${SCRIPT_DIR}"/added/* "${KOGITO_HOME}"/launch/
+echo "alias mvn='${MAVEN_HOME}/bin/mvnw'" >>"${KOGITO_HOME}"/.bashrc

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/module.yaml
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/module.yaml
@@ -23,7 +23,6 @@ version: "main"
 envs:
   - name: "MAVEN_VERSION"
     description: "The Maven version to setup with this module"
-    value: "3.8.6"
   - name: "MAVEN_HOME"
     value: "/usr/share/maven"
   - name: "MAVEN_CMD"

--- a/packages/sonataflow-image-common/resources/modules/kogito-maven/common/module.yaml
+++ b/packages/sonataflow-image-common/resources/modules/kogito-maven/common/module.yaml
@@ -23,6 +23,7 @@ version: "main"
 envs:
   - name: "MAVEN_VERSION"
     description: "The Maven version to setup with this module"
+    value: "3.8.6"
   - name: "MAVEN_HOME"
     value: "/usr/share/maven"
   - name: "MAVEN_CMD"


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-tools/issues/3166

Running `incubator-kie-serverless-logic-web-tools-swf-dev-mode` image there is this error:
```
[fantonan@fantonan-thinkpadp1gen3 serverless-logic-web-tools-swf-dev-mode-image]$ docker run --rm -it --name tmp -p 8080:8080 quay.io/kubesmarts/incubator-kie-serverless-logic-web-tools-swf-dev-mode:main 
[INFO] Scanning for projects...
[INFO] 
[INFO] --< org.kie.kogito:serverless-logic-web-tools-swf-deployment-quarkus-app >--
[INFO] Building KIE Tools :: Serverless Logic Web Tools :: Deployment Quarkus app 0.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- quarkus-maven-plugin:3.15.3.1:dev (default-cli) @ serverless-logic-web-tools-swf-deployment-quarkus-app ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.838 s
[INFO] Finished at: 2025-05-30T14:22:26Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:3.15.3.1:dev (default-cli) on project serverless-logic-web-tools-swf-deployment-quarkus-app: Detected Maven Version (3.8.5)  is not supported, it must be in [3.8.6,). -> [Help 1]
```

This PR changes the MVN version to 3.8.6 but only if you are inside bash:
```
[fantonan@fantonan-thinkpadp1gen3 kogito-base-builder-image]$ docker run --rm -it --name tmp -p 8080:8080  docker.io/apache/incubator-kie-kogito-base-builder:main mvn -v
Apache Maven 3.8.5 (Red Hat 3.8.5-6)
Maven home: /usr/share/maven
Java version: 17.0.13, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el8.x86_64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "6.14.6-300.fc42.x86_64", arch: "amd64", family: "unix"
[fantonan@fantonan-thinkpadp1gen3 kogito-base-builder-image]$ docker run --rm -it --name tmp -p 8080:8080  docker.io/apache/incubator-kie-kogito-base-builder:main bash
[kogito@b8bd367b8608 ~]$ mvn -v
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /home/kogito/.m2/wrapper/dists/apache-maven-3.8.6-bin/67568434/apache-maven-3.8.6
Java version: 17.0.13, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el8.x86_64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "6.14.6-300.fc42.x86_64", arch: "amd64", family: "unix"
```

