### PR TITLE
[NO-ISSUE] Skip `test-e2e` on `chrome-extension-pack-kogito-kie-editors` due to flaky tests

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/package.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/package.json
@@ -18,8 +18,9 @@
     "install": "node install.js",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "start": "webpack serve --env dev",
-    "test-e2e": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env chromeExtension.dev.port) test-e2e:run\"",
+    "test-e2e": "echo 'Tests are skipped for this package as they were flaky. See https://github.com/apache/incubator-kie-tools/pull/3170#issuecomment-2963826517'",
     "test-e2e:run": "jest --runInBand -c ./jest.e2e.config.js",
+    "test-e2e:skip": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env chromeExtension.dev.port) test-e2e:run\"",
     "test-e2e:start": "pnpm start"
   },
   "dependencies": {


### PR DESCRIPTION
See https://github.com/apache/incubator-kie-tools/issues/3179 for bringing them back.