### PR TITLE
kie-tools-issues#3184- [sonataflow-management-console-webapp] Management console is unable to sort workflow instances by ID

### DIFF
--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
@@ -90,6 +90,38 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
   const [titleType, setTitleType] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedWorkflowInstance, setSelectedWorkflowInstance] = useState<WorkflowInstance | null>(null);
+  const [sortByState, setSortByState] = useState<{ index: number; direction: "asc" | "desc" }>({
+    index: 2,
+    direction: "asc",
+  });
+
+  const getComparableValue = (instance: WorkflowInstance, columnKey: string): any => {
+    switch (columnKey) {
+      case "Id":
+        return instance.id;
+      case "Status":
+        return instance.state;
+      case "Created":
+        return new Date(instance.start);
+      case "Last update":
+        return new Date(instance.lastUpdate);
+      default:
+        return "";
+    }
+  };
+
+  const onSortInternal = (_event: React.SyntheticEvent, index: number, direction: "asc" | "desc") => {
+    const columnKey = columns[index];
+    const sorted = [...workflowInstances].sort((a, b) => {
+      const aVal = getComparableValue(a, columnKey);
+      const bVal = getComparableValue(b, columnKey);
+      if (aVal < bVal) return direction === "asc" ? -1 : 1;
+      if (aVal > bVal) return direction === "asc" ? 1 : -1;
+      return 0;
+    });
+    setSortByState({ index, direction });
+    setWorkflowInstances(sorted);
+  };
 
   const handleModalToggle = (): void => {
     setIsModalOpen(!isModalOpen);
@@ -361,11 +393,14 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
           <Tr ouiaId="workflow-list-table-header">
             {columns.map((column, columnIndex) => {
               let sortParams = {};
-              if (!isLoading && rowPairs.length > 0) {
+              if (!isLoading && rowPairs.length > 0 && columnIndex > 1 && columnIndex !== columns.length - 1) {
                 sortParams = {
                   sort: {
-                    sortBy,
-                    onSort,
+                    sortBy: {
+                      index: sortByState.index,
+                      direction: sortByState.direction,
+                    },
+                    onSort: onSortInternal,
                     columnIndex,
                   },
                 };


### PR DESCRIPTION
✨ **Closes [3184](https://github.com/apache/incubator-kie-tools/issues/3184) – Management console is unable to sort workflow instances by ID**

---
## 🛠️ Fix: Unable to Sort Workflow Instances by ID in Management Console

### Issue
The Management Console was unable to sort the workflow instances list by **ID** on the Workflow Instances page. When selecting the ID option for sorting:
- The sorting did not apply.
- The only way to restore functionality was to refresh the page.
- All other sorting options (e.g., by status) became disabled or unselectable after choosing ID.

This was impacting user experience by blocking expected UI behavior when managing workflow instances.

### What Was Fixed
- Corrected the sorting logic for the **ID** column.
- Ensured that selecting ID as a sort option does not disable or block other sort fields.
- Now, sorting by ID correctly updates the list as expected, without requiring a page refresh.

### ✅ Expected Behavior
- The list of workflow instances should not be empty.
- Sorting by **ID** correctly applies and shows results in the expected order.
- Other sort options remain available and functional after using the ID sort.

---

### 📹 Demo

A video showcasing the updated behavior is attached.

https://github.com/user-attachments/assets/007fccad-3a64-42f6-a02f-7e9699b33c7b



