### PR TITLE
kie-tools#3179: Re-enable Chrome Extensions tests for BPMN, DMN, and SWF extensions

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/package.json
+++ b/packages/chrome-extension-pack-kogito-kie-editors/package.json
@@ -18,9 +18,8 @@
     "install": "node install.js",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "start": "webpack serve --env dev",
-    "test-e2e": "echo 'Tests are skipped for this package as they were flaky. See https://github.com/apache/incubator-kie-tools/pull/3170#issuecomment-2963826517'",
+    "test-e2e": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env chromeExtension.dev.port) test-e2e:run\"",
     "test-e2e:run": "jest --runInBand -c ./jest.e2e.config.js",
-    "test-e2e:skip": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env chromeExtension.dev.port) test-e2e:run\"",
     "test-e2e:start": "pnpm start"
   },
   "dependencies": {

--- a/packages/chrome-extension-serverless-workflow-editor/package.json
+++ b/packages/chrome-extension-serverless-workflow-editor/package.json
@@ -18,9 +18,8 @@
     "install": "node install.js",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
     "start": "webpack serve --env dev",
-    "test-e2e": "echo 'Tests are skipped for this package as they were flaky. See https://github.com/apache/incubator-kie-tools/pull/3170#issuecomment-2963826517'",
+    "test-e2e": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env swfChromeExtension.dev.port) test-e2e:run\"",
     "test-e2e:run": "jest --runInBand -c ./jest.e2e.config.js",
-    "test-e2e:skip": "run-script-if --ignore-errors \"$(build-env endToEndTests.ignoreFailures)\" --bool \"$(build-env endToEndTests.run)\" --then \"pnpm rimraf ./dist-tests-e2e\" \"pnpm start-server-and-test test-e2e:start https-get://localhost:$(build-env swfChromeExtension.dev.port) test-e2e:run\"",
     "test-e2e:start": "pnpm start"
   },
   "devDependencies": {

--- a/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
+++ b/packages/chrome-extension-test-helper/src/utils/tools/Driver.ts
@@ -52,6 +52,8 @@ export default class Driver {
     chromeOptions.addArguments(
       "--user-data-dir=" + CHROME_DIR,
       "--load-extension=" + chromeExtensionPath,
+      // This flag enables --load-extension, required for testing Chrome extensions
+      "--disable-features=DisableLoadExtensionCommandLineSwitch",
       "--enable-features=UnexpireFlagsM118",
       "--allow-insecure-localhost",
       "--disable-web-security",


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3179

**Description:**
e2e tests for our Chrome extensions were failing because the extensions were not starting on Chrome.

**Solution:**
Due to an update on the CLI, Chrome was not able to support the option `--load-extension` by default, to install our extensions in e2e tests.
Adding the option `--disable-features=DisableLoadExtensionCommandLineSwitch` we are able to continue to use it.