### PR TITLE
NO-ISSUE: On Devbox environment, only load glibc-locales on Linux

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -9,7 +9,10 @@
     "go": "1.23.8",
     "python": "3.12.2",
     "libxml2": "2.13.3",
-    "glibcLocales": "2.40-66"
+    "glibcLocales": {
+      "version": "2.40-66",
+      "platforms": ["x86_64-linux", "aarch64-linux"]
+    }
   },
   "env": {
     "PLAYWRIGHT_BROWSERS_PATH": "0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,10 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-06-22T15:15:55Z",
+      "resolved": "github:NixOS/nixpkgs/3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6?lastModified=1750605355&narHash=sha256-xT8cPLTxlktxI9vSdoBlAVK7dXgd8IK59j7ZwzkkhnI%3D"
+    },
     "glibcLocales@2.40-66": {
       "last_modified": "2025-05-16T20:19:48Z",
       "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#glibcLocales",


### PR DESCRIPTION
glibc-locales is needed to build the upstream repos (drools, optaplanner,  runtimes, apps) while using the Devbox shell on Linux.

This PR ensures that Devbox only installs this lib on Linux systems.