### PR TITLE
kie-tools-issues#3184- [sonataflow-management-console-webapp] Management console is unable to sort workflow instances by ID 

### DIFF
--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowList/WorkflowList.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowList/WorkflowList.tsx
@@ -172,7 +172,11 @@ const WorkflowList: React.FC<WorkflowListProps & OUIAProps> = ({
     setSortBy({ index, direction });
     let sortingColumn: string = event.target.innerText;
     sortingColumn = _.camelCase(sortingColumn);
-    let sortByObj = _.set({}, sortingColumn, direction.toUpperCase());
+    const sortFieldMap: Record<string, string> = {
+      id: "processName",
+    };
+    const graphqlSortField = sortFieldMap[sortingColumn] || sortingColumn;
+    let sortByObj = _.set({}, graphqlSortField, direction.toUpperCase());
     sortByObj = alterOrderByObj(sortByObj);
     await driver.applySorting(sortByObj);
     doQuery(0, defaultPageSize, true, true);

--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowList/WorkflowList.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowList/WorkflowList.tsx
@@ -172,11 +172,7 @@ const WorkflowList: React.FC<WorkflowListProps & OUIAProps> = ({
     setSortBy({ index, direction });
     let sortingColumn: string = event.target.innerText;
     sortingColumn = _.camelCase(sortingColumn);
-    const sortFieldMap: Record<string, string> = {
-      id: "processName",
-    };
-    const graphqlSortField = sortFieldMap[sortingColumn] || sortingColumn;
-    let sortByObj = _.set({}, graphqlSortField, direction.toUpperCase());
+    let sortByObj = _.set({}, sortingColumn, direction.toUpperCase());
     sortByObj = alterOrderByObj(sortByObj);
     await driver.applySorting(sortByObj);
     doQuery(0, defaultPageSize, true, true);

--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
@@ -91,41 +91,6 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
   const [titleType, setTitleType] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedWorkflowInstance, setSelectedWorkflowInstance] = useState<WorkflowInstance | null>(null);
-  const [sortByState, setSortByState] = useState<{ index: number; direction: "asc" | "desc" }>({
-    index: 2,
-    direction: "asc",
-  });
-
-  const getComparableValue = useCallback((instance: WorkflowInstance, columnKey: string): any => {
-    switch (columnKey) {
-      case "Id":
-        return instance.processName?.toLowerCase?.() || "";
-      case "Status":
-        return instance.state;
-      case "Created":
-        return new Date(instance.start);
-      case "Last update":
-        return new Date(instance.lastUpdate);
-      default:
-        return "";
-    }
-  }, []);
-
-  const onSortInternal = useCallback(
-    (_event: React.SyntheticEvent, index: number, direction: "asc" | "desc") => {
-      const columnKey = columns[index];
-      const sorted = [...workflowInstances].sort((a, b) => {
-        const aVal = getComparableValue(a, columnKey);
-        const bVal = getComparableValue(b, columnKey);
-        if (aVal < bVal) return direction === "asc" ? -1 : 1;
-        if (aVal > bVal) return direction === "asc" ? 1 : -1;
-        return 0;
-      });
-      setSortByState({ index, direction });
-      setWorkflowInstances(sorted);
-    },
-    [columns, workflowInstances, setSortByState, setWorkflowInstances]
-  );
 
   const handleModalToggle = (): void => {
     setIsModalOpen(!isModalOpen);
@@ -397,14 +362,11 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
           <Tr ouiaId="workflow-list-table-header">
             {columns.map((column, columnIndex) => {
               let sortParams = {};
-              if (!isLoading && rowPairs.length > 0 && columnIndex > 1 && columnIndex !== columns.length - 1) {
+              if (!isLoading && rowPairs.length > 0) {
                 sortParams = {
                   sort: {
-                    sortBy: {
-                      index: sortByState.index,
-                      direction: sortByState.direction,
-                    },
-                    onSort: onSortInternal,
+                    sortBy,
+                    onSort,
                     columnIndex,
                   },
                 };

--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
@@ -91,6 +91,41 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
   const [titleType, setTitleType] = useState<string>("");
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedWorkflowInstance, setSelectedWorkflowInstance] = useState<WorkflowInstance | null>(null);
+  const [sortByState, setSortByState] = useState<{ index: number; direction: "asc" | "desc" }>({
+    index: 2,
+    direction: "asc",
+  });
+
+  const getComparableValue = useCallback((instance: WorkflowInstance, columnKey: string): any => {
+    switch (columnKey) {
+      case "Id":
+        return instance.processName?.toLowerCase?.() || "";
+      case "Status":
+        return instance.state;
+      case "Created":
+        return new Date(instance.start);
+      case "Last update":
+        return new Date(instance.lastUpdate);
+      default:
+        return "";
+    }
+  }, []);
+
+  const onSortInternal = useCallback(
+    (_event: React.SyntheticEvent, index: number, direction: "asc" | "desc") => {
+      const columnKey = columns[index];
+      const sorted = [...workflowInstances].sort((a, b) => {
+        const aVal = getComparableValue(a, columnKey);
+        const bVal = getComparableValue(b, columnKey);
+        if (aVal < bVal) return direction === "asc" ? -1 : 1;
+        if (aVal > bVal) return direction === "asc" ? 1 : -1;
+        return 0;
+      });
+      setSortByState({ index, direction });
+      setWorkflowInstances(sorted);
+    },
+    [columns, workflowInstances, setSortByState, setWorkflowInstances]
+  );
 
   const handleModalToggle = (): void => {
     setIsModalOpen(!isModalOpen);
@@ -362,11 +397,14 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
           <Tr ouiaId="workflow-list-table-header">
             {columns.map((column, columnIndex) => {
               let sortParams = {};
-              if (!isLoading && rowPairs.length > 0) {
+              if (!isLoading && rowPairs.length > 0 && columnIndex > 1 && columnIndex !== columns.length - 1) {
                 sortParams = {
                   sort: {
-                    sortBy,
-                    onSort,
+                    sortBy: {
+                      index: sortByState.index,
+                      direction: sortByState.direction,
+                    },
+                    onSort: onSortInternal,
                     columnIndex,
                   },
                 };
@@ -388,7 +426,7 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
               }
               return (
                 <Th style={styleParams} key={`${column}_header`} {...sortParams}>
-                  {column.startsWith("__") ? "" : column}
+                  {columnIndex === 2 ? "Process Name" : column.startsWith("__") ? "" : column}
                 </Th>
               );
             })}

--- a/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
+++ b/packages/runtime-tools-swf-enveloped-components/src/workflowList/envelope/components/WorkflowListTable/WorkflowListTable.tsx
@@ -85,7 +85,7 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
   ouiaSafe,
 }) => {
   const [rowPairs, setRowPairs] = useState<any>([]);
-  const columns: string[] = ["__Toggle", "__Select", "Id", "Status", "Created", "Last update", "__Actions"];
+  const columns: string[] = ["__Toggle", "__Select", "Process name", "Status", "Created", "Last update", "__Actions"];
   const [modalTitle, setModalTitle] = useState<string>("");
   const [modalContent, setModalContent] = useState<string>("");
   const [titleType, setTitleType] = useState<string>("");
@@ -388,7 +388,7 @@ const WorkflowListTable: React.FC<WorkflowListTableProps & OUIAProps> = ({
               }
               return (
                 <Th style={styleParams} key={`${column}_header`} {...sortParams}>
-                  {columnIndex === 2 ? "Process Name" : column.startsWith("__") ? "" : column}
+                  {column.startsWith("__") ? "" : column}
                 </Th>
               );
             })}


### PR DESCRIPTION
✨ **Closes [3184](https://github.com/apache/incubator-kie-tools/issues/3184) – Management console is unable to sort workflow instances by ID**

---
## 🛠️ Fix: Unable to Sort Workflow Instances by ID in Management Console

### Issue
The Management Console was unable to sort the workflow instances list by **ID** on the Workflow Instances page. When selecting the ID option for sorting:
- The sorting did not apply.
- The only way to restore functionality was to refresh the page.
- All other sorting options (e.g., by status) became disabled or unselectable after choosing ID.

This was impacting user experience by blocking expected UI behavior when managing workflow instances.

### What Was Fixed
- Renamed Id column to Process Name
- Corrected the sorting logic for the **ID** column as now the sorting is done alphabetically on Process Name
- Ensured that selecting Process Name as a sort option does not disable or block other sort fields.
- Now, sorting by Process Name correctly updates the list as expected, without requiring a page refresh.

### ✅ Expected Behavior
- The list of workflow instances should not be empty.
- Sorting by **Process Name** correctly applies and shows results in the expected order.
- Other sort options remain available and functional after using the Process Name sort.

---

### 📹 Demo

A video showcasing the updated behavior is attached.


Uploading Screen Recording 2025-06-26 at 4.22.40 PM.mov…





