### PR TITLE
NO-ISSUE: Add `--load` to `image-builder` when building images without buildx

### DIFF
--- a/packages/image-builder/src/bin.ts
+++ b/packages/image-builder/src/bin.ts
@@ -126,6 +126,7 @@ function buildNativeImage(args: ArgsType, imageFullNames: string[]) {
   console.log(`[image-builder] Building native image`);
   const buildNativeCommand = `${args.engine} build
     --progress=plain
+    --load
     ${args.allowHostNetworkAccess ? "--allow network.host --network host" : ""}
     ${args.push ? "--push" : ""}
     ${imageFullNames.map((fullName) => `-t ${fullName}`).join(" ")}


### PR DESCRIPTION
This makes `colima` setups work on macOS for branch new development setups. I couldn't pinpoint exactly what changed, but I'm guessing configuring Docker locally with `colima` has been updated for fresh installs and it required me to this, otherwise the `canvas-dev-deployment-image-image` couldn't be found when building `canvas-dev-deployment-quarkus-blank-app`.