### PR TITLE
kie-issues#1933: Preparing `bpmn-marshaller` for Custom Tasks on the upcoming BPMN Editor

### DIFF
--- a/packages/bpmn-marshaller/src/drools-extension.ts
+++ b/packages/bpmn-marshaller/src/drools-extension.ts
@@ -155,6 +155,11 @@ declare module "./schemas/bpmn-2_0/ts-gen/types" {
   export interface BPMN20__tGroup__extensionElements extends WithEntryAndExitScripts, WithMetaData {}
   export interface BPMN20__tTextAnnotation__extensionElements extends WithEntryAndExitScripts, WithMetaData {}
 
+  // Custom Tasks
+  export interface BPMN20__tTask {
+    "@_drools:taskName"?: Namespaced<DROOLS, string>;
+  }
+
   // Other
   export interface BPMN20__tProperty__extensionElements extends WithMetaData {}
   export interface BPMN20__tLane__extensionElements extends WithMetaData {}


### PR DESCRIPTION
The attribute `drools:taskName` is understood by the Workflow engine as the pointer to custom WIHs. This is compatible with BPMN Editor (classic) too.