### PR TITLE
kie-tools#3216: Failed to resolve Maven artifact from `m2-repo-via-http` container during the build

### DIFF
--- a/packages/dev-deployment-quarkus-blank-app-image/package.json
+++ b/packages/dev-deployment-quarkus-blank-app-image/package.json
@@ -30,7 +30,7 @@
     "image:docker:build": "kie-tools--image-builder build --allowHostNetworkAccess -r \"$(build-env devDeploymentQuarkusBlankAppImage.registry)\" -a \"$(build-env devDeploymentQuarkusBlankAppImage.account)\" -n \"$(build-env devDeploymentQuarkusBlankAppImage.name)\" -t \"$(build-env devDeploymentQuarkusBlankAppImage.buildTag)\" --build-arg BUILDER_IMAGE_ARG=\"$(build-env devDeploymentQuarkusBlankAppImage.builderImage)\"",
     "m2-repo-via-http:container:kill": "(docker container kill m2-repo-via-http || true) && (docker container rm m2-repo-via-http || true)",
     "m2-repo-via-http:container:prepare-m2-repo-volume": "node -e 'require(`@kie-tools/maven-base`).prepareHardLinkedM2ForPackage(`./dist/tmp-m2/repository`, `./node_modules/@kie-tools/dev-deployment-quarkus-blank-app`)'",
-    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run -p 8888:80 --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html\" -dit $(build-env devDeploymentQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImage)",
+    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run -p 8888:80 --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html:z\" -dit $(build-env devDeploymentQuarkusBlankAppImage.dev.mavenM2RepoViaHttpImage)",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command"
   },
   "dependencies": {

--- a/packages/serverless-logic-web-tools-swf-dev-mode-image/package.json
+++ b/packages/serverless-logic-web-tools-swf-dev-mode-image/package.json
@@ -31,7 +31,7 @@
     "install": "node install.js",
     "m2-repo-via-http:container:kill": "(docker container kill m2-repo-via-http || true) && (docker container rm m2-repo-via-http || true)",
     "m2-repo-via-http:container:prepare-m2-repo-volume": "node -e 'require(`@kie-tools/maven-base`).prepareHardLinkedM2ForPackage(`./dist/tmp-m2/repository`, `./node_modules/@kie-tools/serverless-logic-web-tools-swf-deployment-quarkus-app`)'",
-    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html\" -dit $(build-env slwtDevModeImage.dev.mavenM2RepoViaHttpImage)",
+    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html:z\" -dit $(build-env slwtDevModeImage.dev.mavenM2RepoViaHttpImage)",
     "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command"
   },
   "devDependencies": {

--- a/packages/sonataflow-builder-image/package.json
+++ b/packages/sonataflow-builder-image/package.json
@@ -33,7 +33,7 @@
     "install": "node install.js && pnpm format",
     "m2-repo-via-http:container:kill": "(docker container kill m2-repo-via-http || true) && (docker container rm m2-repo-via-http || true)",
     "m2-repo-via-http:container:prepare-m2-repo-volume": "node -e 'require(`@kie-tools/maven-base`).prepareHardLinkedM2ForPackage(`./dist/tmp-m2/repository`, `.`)'",
-    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run -p 8888:80 --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html\" -dit $(build-env sonataflowBuilderImage.dev.mavenM2RepoViaHttpImage)",
+    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run -p 8888:80 --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html:z\" -dit $(build-env sonataflowBuilderImage.dev.mavenM2RepoViaHttpImage)",
     "setup:env": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && cross-env KOGITO_IMAGE_REGISTRY=$(build-env sonataflowBuilderImage.registry) KOGITO_IMAGE_REGISTRY_ACCOUNT=$(build-env sonataflowBuilderImage.account) KOGITO_IMAGE_NAME=$(build-env sonataflowBuilderImage.name) KOGITO_IMAGE_TAG=$(build-env sonataflowBuilderImage.buildTag) QUARKUS_PLATFORM_GROUPID=$(build-env kogitoImagesCekitModules.quarkusGroupId) QUARKUS_PLATFORM_VERSION=$(build-env versions.quarkus) KOGITO_VERSION=$(build-env versions.kogito)",
     "test": "run-script-os",
     "test:cleanup": "mv dist-tests/report.xml dist-tests/junit-report.xml || true",

--- a/packages/sonataflow-devmode-image/package.json
+++ b/packages/sonataflow-devmode-image/package.json
@@ -33,7 +33,7 @@
     "install": "node install.js && pnpm format",
     "m2-repo-via-http:container:kill": "(docker container kill m2-repo-via-http || true) && (docker container rm m2-repo-via-http || true)",
     "m2-repo-via-http:container:prepare-m2-repo-volume": "node -e 'require(`@kie-tools/maven-base`).prepareHardLinkedM2ForPackage(`./dist/tmp-m2/repository`, `./node_modules/@kie-tools/sonataflow-quarkus-devui`)'",
-    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html\" -dit $(build-env sonataflowDevModeImage.dev.mavenM2RepoViaHttpImage)",
+    "m2-repo-via-http:container:run": "(pnpm m2-repo-via-http:container:kill || true) && pnpm m2-repo-via-http:container:prepare-m2-repo-volume && docker run --name m2-repo-via-http -v \"./dist/tmp-m2/repository:/var/www/html:z\" -dit $(build-env sonataflowDevModeImage.dev.mavenM2RepoViaHttpImage)",
     "setup:env": ". ./node_modules/@kie-tools/python-venv/venv/bin/activate && cross-env KOGITO_IMAGE_REGISTRY=$(build-env sonataflowDevModeImage.registry) KOGITO_IMAGE_REGISTRY_ACCOUNT=$(build-env sonataflowDevModeImage.account) KOGITO_IMAGE_NAME=$(build-env sonataflowDevModeImage.name) KOGITO_IMAGE_TAG=$(build-env sonataflowDevModeImage.buildTag) QUARKUS_PLATFORM_GROUPID=$(build-env kogitoImagesCekitModules.quarkusGroupId) QUARKUS_PLATFORM_VERSION=$(build-env versions.quarkus) KOGITO_VERSION=$(build-env versions.kogito) SONATAFLOW_QUARKUS_DEVUI_VERSION=$(build-env sonataflowDevModeImage.sonataflowQuarkusDevUiVersion)"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-tools/issues/3216

Please let me know if this bug is confirmed by others.

**Description:**
When building some images like `sonataflow-builder-image` I had this error: 
```
2025-07-24 11:55:21,795 docker_builder.py:107 INFO Docker: [ERROR] Failed to execute goal
io.quarkus.platform:quarkus-maven-plugin:3.20.1:create (default-cli) on project standalone-pom: Failed to generate 
Quarkus project: Failed to resolve extension org.kie:kie-addons-quarkus-process-management::jar:999-20250622-local: 
Failed to resolve artifact org.kie:kie-addons-quarkus-process-management:jar:999-20250622-local: The following artifacts 
could not be resolved: org.kie:kie-addons-quarkus-process-management:jar:999-20250622-local (absent): Could not 
transfer artifact org.kie:kie-addons-quarkus-process-management:jar:999-20250622-local from/to kie-tools--maven-m2-repo-via-http-allowed (http://172.17.0.2/): 
status code: 403, reason phrase: Forbidden (403) -> [Help 1]
```
Entering the image `m2-repo-via-http`, the permissions where:
```
[root@d97b27f979a3 /]# ls -la /var/www
total 0
drwxr-xr-x. 1 root root   8 Jun 27 08:28 .
drwxr-xr-x. 1 root root   6 Jun 27 08:28 ..
drwxr-xr-x. 1 root root   0 Jan 29 17:56 cgi-bin
drwxr-xr-x. 1 1000 1001 986 Jul 16 12:54 HTML
```
Causing httpd in the image to answer with a `403 Forbidden`, but it was not possible to fix this with chown/chmod.
This is due to SELinux preventing httpd from accessing the mounted directory, even when file permissions are set to 777, in the host.

**Solution:**
The `:z` option in the volume tells SELinux to grant access to the volume.