### PR TITLE
kie-issues#2067: Java 21 support

### DIFF
--- a/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/packages/serverless-workflow-diagram-editor/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -129,10 +129,12 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
             final EdgeShape edgeShape = (EdgeShape) context.getCanvas().getShape(edge.getUUID());
             final Shape sourceNodeShape = context.getCanvas().getShape(sourceNode.getUUID());
             final Shape targetNodeShape = context.getCanvas().getShape(targetNode.getUUID());
-            edgeShape.applyConnections(edge,
+            if (sourceNodeShape != null && targetNodeShape != null) {
+                edgeShape.applyConnections(edge,
                                        sourceNodeShape.getShapeView(),
                                        targetNodeShape.getShapeView(),
                                        MutationContext.STATIC);
+            }
         }
     }
 

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -145,8 +145,7 @@
 
     <!-- General -->
     <version.checkstyle>8.29</version.checkstyle>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
     <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -201,7 +200,7 @@
     <version.org.codehaus.mojo.extra-enforcer-rules>1.4</version.org.codehaus.mojo.extra-enforcer-rules>
     <version.org.codehaus.selenium.plugin>2.3</version.org.codehaus.selenium.plugin>
     <version.org.commonjava.plugin>1.0</version.org.commonjava.plugin>
-    <version.org.javassist>3.26.0-GA</version.org.javassist>
+    <version.org.javassist>3.30.2-GA</version.org.javassist>
     <version.org.seleniumhq.selenium>4.18.1</version.org.seleniumhq.selenium>
     <version.org.jboss.maven-jdocbook-plugin>2.3.5</version.org.jboss.maven-jdocbook-plugin>
     <version.org.jboss.pressbang>2.0.0</version.org.jboss.pressbang>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -209,7 +209,7 @@
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec
     >1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
     <version.org.jsoup>1.15.3</version.org.jsoup>
-    <version.org.ow2.asm>7.1</version.org.ow2.asm>
+    <version.org.ow2.asm>9.6</version.org.ow2.asm>
     <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
     <version.org.uberfire.patternfly>7.74.1.Final</version.org.uberfire.patternfly>
 

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -145,6 +145,8 @@
 
     <!-- General -->
     <version.checkstyle>8.29</version.checkstyle>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
     <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>

--- a/packages/sonataflow-deployment-webapp/pom.xml
+++ b/packages/sonataflow-deployment-webapp/pom.xml
@@ -44,9 +44,7 @@
 
   <properties>
     <java.module.name />
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/packages/stunner-editors/errai-bom/pom.xml
+++ b/packages/stunner-editors/errai-bom/pom.xml
@@ -82,11 +82,11 @@
   <properties>
     <apache.stanbol.htmlextractor.version>0.10.0</apache.stanbol.htmlextractor.version>
     <appengine.version>1.7.6</appengine.version>
-    <asm.version>7.1</asm.version>
+    <asm.version>9.6</asm.version>
     <gmaven.mojo.version>1.5</gmaven.mojo.version>
     <guice.version>3.0</guice.version>
     <gwt.phonegap.version>3.5.0.1</gwt.phonegap.version>
-    <gwt.version>2.10.0</gwt.version>
+    <gwt.version>2.12.2</gwt.version>
     <javaee.api.version>8.0.1</javaee.api.version>
 
     <!-- ip-bom uses artifact with groupId org.jboss.remoting3 -->
@@ -104,7 +104,7 @@
     <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
     <version.com.google.jsinterop>2.0.0</version.com.google.jsinterop>
     <!-- 3.18+ breaks GWT compilation -->
-    <version.org.eclipse.jdt.ecj>3.17.0</version.org.eclipse.jdt.ecj>
+    <version.org.eclipse.jdt.ecj>3.33.0</version.org.eclipse.jdt.ecj>
     <version.com.google.gwt.gwtmockito>1.1.9</version.com.google.gwt.gwtmockito>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
 
@@ -113,11 +113,11 @@
     <version.javax.persistence-api>2.2</version.javax.persistence-api>
     <!-- we can't use this due GWT hard dependency on api 1.x <version.jakarta.validation>2.0.2</version.jakarta.validation> -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
-    <version.junit>4.13.1</version.junit>
+    <version.junit>4.13.2</version.junit>
 
     <version.org.apache.commons.lang3>3.18.0</version.org.apache.commons.lang3>
     <version.org.apache.deltaspike.core>1.5.1</version.org.apache.deltaspike.core>
-    <version.org.apache.maven>3.3.9</version.org.apache.maven>
+    <version.org.apache.maven>3.9.6</version.org.apache.maven>
     <version.org.dom4j>2.1.3</version.org.dom4j>
     <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
     <version.org.hibernate>5.4.24.Final</version.org.hibernate>

--- a/packages/stunner-editors/errai-codegen/pom.xml
+++ b/packages/stunner-editors/errai-codegen/pom.xml
@@ -146,53 +146,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <minimizeJar>true</minimizeJar>
-              <createSourcesJar>true</createSourcesJar>
-              <artifactSet>
-                <includes>
-                  <include>org.eclipse.jdt:ecj</include>
-                  <include>org.gwtproject:gwt-dev</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <artifact>org.gwtproject:gwt-dev</artifact>
-                  <excludes>
-                    <exclude>com/google/gwt/**</exclude>
-                    <exclude>org/eclipse/jdt/**</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <relocations>
-                <relocation>
-                  <pattern>org.eclipse.jdt</pattern>
-                  <shadedPattern>org.jboss.errai.codegen.shade.org.eclipse.jdt</shadedPattern>
-                  <excludes>
-                    <exclude>org.eclipse.jdt.core.prefs</exclude>
-                  </excludes>
-                </relocation>
-                <relocation>
-                  <pattern>org.osgi</pattern>
-                  <shadedPattern>org.jboss.errai.codegen.shade.org.osgi</shadedPattern>
-                </relocation>
-              </relocations>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes combine.self="override" />

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/command/MorphCanvasNodeCommand.java
@@ -129,10 +129,12 @@ public class MorphCanvasNodeCommand extends AbstractCanvasCommand {
             final EdgeShape edgeShape = (EdgeShape) context.getCanvas().getShape(edge.getUUID());
             final Shape sourceNodeShape = context.getCanvas().getShape(sourceNode.getUUID());
             final Shape targetNodeShape = context.getCanvas().getShape(targetNode.getUUID());
-            edgeShape.applyConnections(edge,
+            if (sourceNodeShape != null && targetNodeShape != null) {
+                edgeShape.applyConnections(edge,
                                        sourceNodeShape.getShapeView(),
                                        targetNodeShape.getShapeView(),
                                        MutationContext.STATIC);
+            }
         }
     }
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldEditorViewTest.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/src/test/java/org/kie/workbench/common/stunner/bpmn/client/forms/fields/timerEditor/TimerSettingsFieldEditorViewTest.java
@@ -455,11 +455,12 @@ public class TimerSettingsFieldEditorViewTest {
         calendar.set(Calendar.AM_PM, Calendar.AM);
         calendar.set(Calendar.MINUTE, minute);
         calendar.set(Calendar.SECOND, second);
-        int zone = calendar.get(Calendar.ZONE_OFFSET) / 60 / 60 / 1000;
-        int daylightSaving = calendar.get(Calendar.DST_OFFSET) / 60 / 60 / 1000;
-        zone = zone + daylightSaving;
+        int zoneMillisec = calendar.get(Calendar.ZONE_OFFSET)+calendar.get(Calendar.DST_OFFSET);
+        int zone = zoneMillisec / 60 / 60 / 1000;
+        int zoneMinutes = abs((zoneMillisec / (60 * 1000)) % 60);
+
         String currentValue = calendar.get(Calendar.YEAR) + "-" + fullInt(calendar.get(Calendar.MONTH) + 1) + "-" + fullInt(calendar.get(Calendar.DAY_OF_MONTH)) +
-                "T" + fullInt(calendar.get(Calendar.HOUR)) + ":" + fullInt(calendar.get(Calendar.MINUTE)) + ":" + fullInt(calendar.get(Calendar.SECOND)) + (zone >= 0 ? "+" : "-") + fullInt(abs(zone)) + ":00";
+                "T" + fullInt(calendar.get(Calendar.HOUR)) + ":" + fullInt(calendar.get(Calendar.MINUTE)) + ":" + fullInt(calendar.get(Calendar.SECOND)) + (zone >= 0 ? "+" : "-") + fullInt(abs(zone)) +  ":" + fullInt(zoneMinutes);
 
         Date date = view.parseFromISO(currentValue);
         GregorianCalendar result = new GregorianCalendar(TimeZone.getDefault());
@@ -505,12 +506,13 @@ public class TimerSettingsFieldEditorViewTest {
         calendar.set(Calendar.MINUTE, minute);
         calendar.set(Calendar.SECOND, second);
 
-        int zone = calendar.get(Calendar.ZONE_OFFSET) / 60 / 60 / 1000;
-        int daylightSaving = calendar.get(Calendar.DST_OFFSET) / 60 / 60 / 1000;
-        zone = zone + daylightSaving;
+        int zoneMillisec = calendar.get(Calendar.ZONE_OFFSET)+calendar.get(Calendar.DST_OFFSET);
+        int zone = zoneMillisec / 60 / 60 / 1000;
+        int zoneMinutes = abs((zoneMillisec / (60 * 1000)) % 60);
+
         Date date = calendar.getTime();
         String expectedValue = calendar.get(Calendar.YEAR) + "-" + fullInt(calendar.get(Calendar.MONTH) + 1) + "-" + fullInt(calendar.get(Calendar.DAY_OF_MONTH)) +
-                "T" + fullInt(calendar.get(Calendar.HOUR)) + ":" + fullInt(calendar.get(Calendar.MINUTE)) + ":" + fullInt(calendar.get(Calendar.SECOND)) + (zone >= 0 ? "+" : "-") + fullInt(abs(zone)) + ":00";
+                "T" + fullInt(calendar.get(Calendar.HOUR)) + ":" + fullInt(calendar.get(Calendar.MINUTE)) + ":" + fullInt(calendar.get(Calendar.SECOND)) + (zone >= 0 ? "+" : "-") + fullInt(abs(zone)) +  ":" + fullInt(zoneMinutes);
         assertEquals(expectedValue, view.formatToISO(date));
     }
 

--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/main/java/org/eclipse/emf/ecore/xmi/util/XMLString.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-emf/src/main/java/org/eclipse/emf/ecore/xmi/util/XMLString.java
@@ -343,7 +343,7 @@ public class XMLString extends StringSegment {
     }
 
     public void endEmptyElement() {
-        removeLast();
+        removeLastElem();
         add("/>");
         if (!isMixed) {
             addLine();
@@ -355,7 +355,7 @@ public class XMLString extends StringSegment {
         add(">");
         add(content);
         add("</");
-        String name = removeLast();
+        String name = removeLastElem();
         add(name);
         add(">");
         if (!isMixed) {
@@ -369,7 +369,7 @@ public class XMLString extends StringSegment {
             endEmptyElement();
         } else {
             boolean wasMixed = isMixed;
-            String name = removeLast();
+            String name = removeLastElem();
             if (name != null) {
                 if (!wasMixed) {
                     add(getElementIndent(1));
@@ -385,7 +385,7 @@ public class XMLString extends StringSegment {
         }
     }
 
-    protected String removeLast() {
+    protected String removeLastElem() {
         int end = elementNames.size();
         isMixed = mixed.remove(end - 1);
         String result = elementNames.remove(end - 1);

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -194,6 +194,7 @@
     <version.deploy.plugin>3.1.2</version.deploy.plugin>
     <version.enforcer.plugin>3.5.0</version.enforcer.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
+    <version.gwt-maven-plugin>2.10.0</version.gwt-maven-plugin>
     <version.install.plugin>3.1.3</version.install.plugin>
     <version.jacoco.plugin>0.8.11</version.jacoco.plugin>
     <version.jar.plugin>3.1.0</version.jar.plugin>
@@ -216,9 +217,9 @@
     <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
     <version.commons-io>2.19.0</version.commons-io>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
-    <version.com.google.guava>32.1.3-jre</version.com.google.guava>
+    <version.com.google.guava>33.0.0-jre</version.com.google.guava>
     <version.commons.codec>1.13</version.commons.codec>
-    <version.org.gwtproject>2.10.0</version.org.gwtproject>
+    <version.org.gwtproject>2.12.2</version.org.gwtproject>
     <version.com.google.jsinterop.base>1.0.0</version.com.google.jsinterop.base>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.enforce-managed-deps-rule>1.3</version.enforce-managed-deps-rule>
@@ -238,14 +239,14 @@
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <version.org.gwtbootstrap3>1.0.1</version.org.gwtbootstrap3>
     <version.org.gwtbootstrap3-extras>1.0.2</version.org.gwtbootstrap3-extras>
-    <version.org.javassist>3.26.0-GA</version.org.javassist>
+    <version.org.javassist>3.30.2-GA</version.org.javassist>
     <version.org.seleniumhq.selenium>4.18.1</version.org.seleniumhq.selenium>
     <version.org.jboss.maven-jdocbook-plugin>2.3.5</version.org.jboss.maven-jdocbook-plugin>
     <version.org.jboss.pressbang>2.0.0</version.org.jboss.pressbang>
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec
     >1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
     <version.org.jsoup>1.15.3</version.org.jsoup>
-    <version.org.ow2.asm>7.1</version.org.ow2.asm>
+    <version.org.ow2.asm>9.6</version.org.ow2.asm>
     <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
 
     <!-- Test Libraries -->
@@ -1518,7 +1519,19 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>${version.org.gwtproject}</version>
+          <version>${version.gwt-maven-plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.gwtproject</groupId>
+              <artifactId>gwt-dev</artifactId>
+              <version>${version.org.gwtproject}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.gwtproject</groupId>
+              <artifactId>gwt-user</artifactId>
+              <version>${version.org.gwtproject}</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <goals>

--- a/packages/yard-model/pom.xml
+++ b/packages/yard-model/pom.xml
@@ -45,8 +45,7 @@
 
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/packages/yard-validator-worker/pom.xml
+++ b/packages/yard-validator-worker/pom.xml
@@ -46,8 +46,7 @@
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <org.jresearch.gwt.time>2.0.10</org.jresearch.gwt.time>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Closes [kie-issues#2067](https://github.com/apache/incubator-kie-issues/issues/2067)

Changes added for building  Tools using Java 21 and targeting bytecode compatible with Java 17.

Maintained stunner editor for source 8 and upgraded gwt.
Maintained dashbuilder at source 11.