### PR TITLE
KIE Sandbox: Allow choosing between `lenient` and `strict` error modes on DMN Runner

### DIFF
--- a/packages/extended-services-api/src/payload.ts
+++ b/packages/extended-services-api/src/payload.ts
@@ -26,4 +26,5 @@ export interface ExtendedServicesModelPayload {
   mainURI: string;
   resources: ExtendedServicesModelResource[];
   context?: any;
+  isStrictMode?: boolean;
 }

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
@@ -41,6 +41,7 @@ export interface DmnRunnerContextType {
   results: Array<DecisionResult[] | undefined>;
   resultsDifference: Array<Array<object>>;
   status: DmnRunnerStatus;
+  isStrictMode: boolean;
 }
 
 export interface DmnRunnerCallbacksContextType {
@@ -51,6 +52,7 @@ export interface DmnRunnerCallbacksContextType {
   onRowDeleted: (args: { rowIndex: number }) => void;
   setDmnRunnerInputs: (newInputsRow: (previousInputs: Array<InputRow>) => Array<InputRow> | Array<InputRow>) => void;
   setDmnRunnerMode: (newMode: DmnRunnerMode) => void;
+  setIsStrictMode: (newMode: boolean) => void;
   setDmnRunnerConfigInputs: (
     newConfigInputs: (previousConfigInputs: UnitablesInputsConfigs) => UnitablesInputsConfigs | UnitablesInputsConfigs
   ) => void;

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -263,6 +263,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   const dmnRunnerAjv = useMemo(() => new DmnRunnerAjv().getAjv(), []);
   const [currentResponseMessages, setCurrentResponseMessages] = useState<DmnEvaluationMessages[]>([]);
   const [invalidElementPaths, setInvalidElementPaths] = useState<string[][]>([]);
+  const [isStrictMode, setIsStrictMode] = useState(false);
 
   const { envelopeServer } = useEditorDockContext();
 
@@ -330,9 +331,16 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
             URI: normalizedPosixPathRelativeToTheWorkspaceRoot,
           })
         ),
+        isStrictMode: isStrictMode,
       };
     },
-    [props.dmnLanguageService, props.workspaceFile.relativePath, props.workspaceFile.workspaceId, workspaces]
+    [
+      isStrictMode,
+      props.dmnLanguageService,
+      props.workspaceFile.relativePath,
+      props.workspaceFile.workspaceId,
+      workspaces,
+    ]
   );
 
   const findDecisionIdBySourceId = useCallback(
@@ -842,6 +850,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       setDmnRunnerInputs,
       setDmnRunnerMode,
       setDmnRunnerPersistenceJson,
+      setIsStrictMode,
     }),
     [
       onRowAdded,
@@ -852,6 +861,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       setDmnRunnerInputs,
       setDmnRunnerMode,
       setDmnRunnerPersistenceJson,
+      setIsStrictMode,
     ]
   );
 
@@ -870,6 +880,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       results,
       resultsDifference,
       status,
+      isStrictMode,
     }),
     [
       canBeVisualized,
@@ -885,6 +896,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       results,
       resultsDifference,
       status,
+      isStrictMode,
     ]
   );
 

--- a/packages/online-editor/src/editor/ExtendedServices/ExtendedServicesButtons.tsx
+++ b/packages/online-editor/src/editor/ExtendedServices/ExtendedServicesButtons.tsx
@@ -45,6 +45,7 @@ import { DeleteDropdownWithConfirmation } from "../DeleteDropdownWithConfirmatio
 import { useDmnRunnerPersistenceDispatch } from "../../dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext";
 import { DmnRunnerProviderActionType } from "../../dmnRunner/DmnRunnerTypes";
 import { PanelId, useEditorDockContext } from "../EditorPageDockContextProvider";
+import { Switch } from "@patternfly/react-core/dist/js/components/Switch";
 
 interface Props {
   workspace: ActiveWorkspace | undefined;
@@ -56,8 +57,8 @@ export function ExtendedServicesButtons(props: Props) {
   const extendedServices = useExtendedServices();
   const devDeployments = useDevDeployments();
   const { onTogglePanel, onOpenPanel } = useEditorDockContext();
-  const { isExpanded, mode } = useDmnRunnerState();
-  const { setDmnRunnerMode, setDmnRunnerContextProviderState } = useDmnRunnerDispatch();
+  const { isExpanded, mode, isStrictMode } = useDmnRunnerState();
+  const { setDmnRunnerMode, setDmnRunnerContextProviderState, setIsStrictMode } = useDmnRunnerDispatch();
   const devDeploymentsDropdownItems = useDevDeploymentsDeployDropdownItems(props.workspace);
   const { onDeleteDmnRunnerPersistenceJson, onDownloadDmnRunnerPersistenceJson, onUploadDmnRunnerPersistenceJson } =
     useDmnRunnerPersistenceDispatch();
@@ -185,6 +186,24 @@ export function ExtendedServicesButtons(props: Props) {
                 >
                   As Table
                 </DropdownItem>,
+                <React.Fragment key={"dmn-runner-mode"}>
+                  <Divider />
+                  <DropdownItem key={"strict-mode"} component={"button"} className={"strict-mode-check"}>
+                    <div onClick={(e) => e.stopPropagation()}>
+                      <Switch
+                        id="validation-mode"
+                        label={"Strict"}
+                        isChecked={isStrictMode}
+                        isDisabled={false}
+                        onChange={(e, val) => {
+                          if (extendedServices.status === ExtendedServicesStatus.RUNNING) {
+                            setIsStrictMode(val);
+                          }
+                        }}
+                      />
+                    </div>
+                  </DropdownItem>
+                </React.Fragment>,
                 <React.Fragment key={"dmn-runner-inputs"}>
                   <Divider />
                   <DropdownItem


### PR DESCRIPTION
Part of [kie#2062](https://github.com/apache/incubator-kie-issues/issues/2062)

This PR includes the changes added in dmn editor to handle the option to choose error handling mode.
As per the selection of mode new payload is added.

<img width="306" height="416" alt="image" src="https://github.com/user-attachments/assets/c70ed7b0-0787-4c1d-af62-5479e3a461a8" />
<img width="257" height="391" alt="image" src="https://github.com/user-attachments/assets/4c069b16-9ef1-4176-8cc2-9f1d0b134fda" />
