### PR TITLE
kie-issues#2023: DMN Editor: Support new property "value" for types `date`, `date and time`, `years and months duration`, `days and time duration`

### DIFF
--- a/packages/dmn-feel-antlr4-parser/src/parser/BuiltInTypes.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/BuiltInTypes.ts
@@ -72,7 +72,7 @@ export class BuiltInTypes {
       ["minutes", BuiltInTypes.Number],
       ["seconds", BuiltInTypes.Number],
       ["timezone", BuiltInTypes.String],
-      ["value", BuiltInTypes.String],
+      ["value", BuiltInTypes.Number],
     ]),
 
     source: {
@@ -96,7 +96,7 @@ export class BuiltInTypes {
       ["second", BuiltInTypes.Number],
       ["time offset", BuiltInTypes.DaysAndTimeDuration],
       ["timezone", BuiltInTypes.String],
-      ["value", BuiltInTypes.String],
+      ["value", BuiltInTypes.Number],
     ]),
 
     source: {
@@ -113,7 +113,7 @@ export class BuiltInTypes {
     properties: new Map([
       ["years", BuiltInTypes.Number],
       ["months", BuiltInTypes.Number],
-      ["value", BuiltInTypes.String],
+      ["value", BuiltInTypes.Number],
     ]),
 
     source: {
@@ -133,7 +133,7 @@ export class BuiltInTypes {
       ["second", BuiltInTypes.Number],
       ["time offset", BuiltInTypes.DaysAndTimeDuration],
       ["timezone", BuiltInTypes.String],
-      ["value", BuiltInTypes.String],
+      ["value", BuiltInTypes.Number],
     ]),
     source: {
       expressionsThatUseTheIdentifier: new Map<string, Expression>(),
@@ -151,7 +151,7 @@ export class BuiltInTypes {
       ["month", BuiltInTypes.Number],
       ["day", BuiltInTypes.Number],
       ["weekday", BuiltInTypes.Number],
-      ["value", BuiltInTypes.String],
+      ["value", BuiltInTypes.Number],
     ]),
     source: {
       expressionsThatUseTheIdentifier: new Map<string, Expression>(),

--- a/packages/dmn-feel-antlr4-parser/src/parser/BuiltInTypes.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/BuiltInTypes.ts
@@ -72,6 +72,7 @@ export class BuiltInTypes {
       ["minutes", BuiltInTypes.Number],
       ["seconds", BuiltInTypes.Number],
       ["timezone", BuiltInTypes.String],
+      ["value", BuiltInTypes.String],
     ]),
 
     source: {
@@ -95,6 +96,7 @@ export class BuiltInTypes {
       ["second", BuiltInTypes.Number],
       ["time offset", BuiltInTypes.DaysAndTimeDuration],
       ["timezone", BuiltInTypes.String],
+      ["value", BuiltInTypes.String],
     ]),
 
     source: {
@@ -111,6 +113,7 @@ export class BuiltInTypes {
     properties: new Map([
       ["years", BuiltInTypes.Number],
       ["months", BuiltInTypes.Number],
+      ["value", BuiltInTypes.String],
     ]),
 
     source: {
@@ -130,6 +133,7 @@ export class BuiltInTypes {
       ["second", BuiltInTypes.Number],
       ["time offset", BuiltInTypes.DaysAndTimeDuration],
       ["timezone", BuiltInTypes.String],
+      ["value", BuiltInTypes.String],
     ]),
     source: {
       expressionsThatUseTheIdentifier: new Map<string, Expression>(),
@@ -147,6 +151,7 @@ export class BuiltInTypes {
       ["month", BuiltInTypes.Number],
       ["day", BuiltInTypes.Number],
       ["weekday", BuiltInTypes.Number],
+      ["value", BuiltInTypes.String],
     ]),
     source: {
       expressionsThatUseTheIdentifier: new Map<string, Expression>(),


### PR DESCRIPTION
Part of [kie#2023](https://github.com/apache/incubator-kie-issues/issues/2023)
Value property added for types `date`, `date and time`, `years and months duration`, `days and time duration`