### PR TITLE
kie-issues#3257: kie-editors-standalone: ContextManager must only be set once caused by duplicated .cache.js loading

### DIFF
--- a/packages/kie-editors-standalone/src/bpmn/BpmnEditorResources.ts
+++ b/packages/kie-editors-standalone/src/bpmn/BpmnEditorResources.ts
@@ -32,7 +32,9 @@ export class BpmnEditorResources extends BaseEditorResources {
         .filter((r) => r.type === "js")
         .flatMap((r) => r.paths)
         .map((p) => this.createResource({ path: p }, ["\\", "`", "$"])),
-      referencedJsResources: this.getReferencedJSPaths(args.resourcesPathPrefix, bpmnLanguageData.gwtModuleName).map(
+      referencedJsResources: this.getReferencedJSPaths(args.resourcesPathPrefix, bpmnLanguageData.gwtModuleName)
+        .filter(r=>!r.path.includes('.cache.js'))
+        .map(
         (rp) => this.createResource(rp, ["\\", "`", "$"])
       ),
       baseCssResources: bpmnLanguageData.resources


### PR DESCRIPTION
resolve this issue https://github.com/apache/incubator-kie-tools/issues/3257