### PR TITLE
kie-issues#2067: Java 21 support

### DIFF
--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -36,8 +36,7 @@
   <name>KIE Tools :: KIE Sandbox :: Dev deployment Quarkus blank app</name>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/pom.xml.envsubst
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/pom.xml.envsubst
@@ -66,8 +66,7 @@
   </repositories>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -96,8 +96,7 @@
   </mailingLists>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -89,6 +89,8 @@
         <artifactId>tycho-compiler-plugin</artifactId>
         <version>${version.tycho}</version>
         <configuration>
+          <source>17</source>
+          <target>17</target>
           <compilerArgument>-err:-forbidden</compilerArgument>
           <useProjectSettings>false</useProjectSettings>
         </configuration>


### PR DESCRIPTION
Part of [kie#2067](https://github.com/apache/incubator-kie-issues/issues/2067)

Changes added for building Tools using Java 21 and targeting bytecode compatible with Java 17 for maven-base and dev-deployments-quarkus-blank-app

