### PR TITLE
kie-tools#3060: sonataflow-operator: Upgrade CSV catalog to stable channel

### DIFF
--- a/packages/sonataflow-operator/bundle/metadata/annotations.yaml
+++ b/packages/sonataflow-operator/bundle/metadata/annotations.yaml
@@ -21,8 +21,10 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: sonataflow-operator
-  operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.0
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.35.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   com.redhat.openshift.versions: v4.11

--- a/packages/sonataflow-operator/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
+++ b/packages/sonataflow-operator/config/manifests/bases/sonataflow-operator.clusterserviceversion.yaml
@@ -299,7 +299,7 @@ spec:
   maintainers:
     - email: dev@kie.apache.org
       name: Apache KIE
-  maturity: alpha
+  maturity: stable
   minKubeVersion: 1.23.0
   provider:
     name: Apache KIE

--- a/packages/sonataflow-operator/images/bundle.yaml
+++ b/packages/sonataflow-operator/images/bundle.yaml
@@ -43,9 +43,9 @@ labels:
   - name: operators.operatorframework.io.bundle.package.v1
     value: sonataflow-operator
   - name: operators.operatorframework.io.bundle.channels.v1
-    value: "alpha"
+    value: "stable"
   - name: operators.operatorframework.io.bundle.channel.default.v1
-    value: alpha
+    value: stable
   - name: operators.operatorframework.io.metrics.mediatype.v1
     value: metrics+v1
   - name: operators.operatorframework.io.metrics.builder
@@ -59,7 +59,7 @@ labels:
   - name: com.redhat.delivery.operator.bundle
     value: "true"
   - name: com.redhat.openshift.versions
-    value: v4.10
+    value: v4.11
 
 modules:
   repositories:


### PR DESCRIPTION
Fix #3060 

Upgrades the operator to the `stable` release, targeting the next release.