### PR TITLE
kie-tools-issues#3271: Use graphql GET requests for Sonataflow Management Console -> Data Index communication

### DIFF
--- a/packages/sonataflow-management-console-webapp/src/index.tsx
+++ b/packages/sonataflow-management-console-webapp/src/index.tsx
@@ -51,7 +51,7 @@ const onLoadFailure = (): void => {
 const appRender = async (ctx: UserContext) => {
   const httpLink = new HttpLink({
     uri: (window as any)["DATA_INDEX_ENDPOINT"],
-    useGETForQueries: true
+    useGETForQueries: true,
   });
   const fallbackUI = onError(({ networkError }: any) => {
     if (networkError && networkError.stack === "TypeError: Failed to fetch") {

--- a/packages/sonataflow-management-console-webapp/src/index.tsx
+++ b/packages/sonataflow-management-console-webapp/src/index.tsx
@@ -51,6 +51,7 @@ const onLoadFailure = (): void => {
 const appRender = async (ctx: UserContext) => {
   const httpLink = new HttpLink({
     uri: (window as any)["DATA_INDEX_ENDPOINT"],
+    useGETForQueries: true
   });
   const fallbackUI = onError(({ networkError }: any) => {
     if (networkError && networkError.stack === "TypeError: Failed to fetch") {


### PR DESCRIPTION
Closes [apache/incubator-kie-tools#3271](https://github.com/apache/incubator-kie-tools/issues/3271)