### PR TITLE
NO-ISSUE: Remove unexpected 'T' from Scenario Simulation cheatsheet

### DIFF
--- a/packages/scesim-editor/src/drawer/TestScenarioDrawerCheatSheetPanel.tsx
+++ b/packages/scesim-editor/src/drawer/TestScenarioDrawerCheatSheetPanel.tsx
@@ -59,7 +59,6 @@ function TestScenarioDrawerCheatSheetPanel() {
         <TextListItem>
           {testScenarioType === "DMN" ? i18n.drawer.cheatSheet.expression5DMN : i18n.drawer.cheatSheet.expression5Rule}
         </TextListItem>
-        T
         <TextListItem>
           {testScenarioType === "DMN" ? i18n.drawer.cheatSheet.expression6DMN : i18n.drawer.cheatSheet.expression6Rule}
         </TextListItem>


### PR DESCRIPTION
<img width="472" height="897" alt="Screenshot 2025-09-15 103907" src="https://github.com/user-attachments/assets/56621cce-96ba-495c-b597-c1b70731b3bb" />
