### PR TITLE
DMN Editor: Copy of a Decision Service causes trouble to edges where target or source node is in the Decision Service

### DIFF
--- a/packages/dmn-editor/src/clipboard/Clipboard.ts
+++ b/packages/dmn-editor/src/clipboard/Clipboard.ts
@@ -165,7 +165,9 @@ export function buildClipboardFromDiagram(rfState: RF.ReactFlowState, dmnEditorS
             continue;
           }
 
-          accNode(decisionNode);
+          if (!selectedNodesById.has(decisionNode.id)) {
+            accNode(decisionNode);
+          }
         }
       }
 


### PR DESCRIPTION
Closes [kie#2107](https://github.com/apache/incubator-kie-issues/issues/2107)

Duplicate edge issue caused when copy pasting decision services resolved.