### PR TITLE
kie-issues#3294: i18n generic type is allowing properties that are not part of the type

### DIFF
--- a/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
@@ -54,6 +54,7 @@ export interface BoxedExpressionEditorDictionary {
   };
   editContextEntry: string;
   editParameter: string;
+  editParameters: string;
   editRelation: string;
   enterFunction: string;
   enterText: string;

--- a/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
+export interface BoxedExpressionEditorDictionary {
   addParameter: string;
   builtInAggregator: string;
   builtInAggregatorHelp: {
@@ -153,4 +153,4 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
   };
 }
 
-export interface BoxedExpressionEditorI18n extends BoxedExpressionEditorDictionary, CommonI18n {}
+export interface BoxedExpressionEditorI18n extends BoxedExpressionEditorDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/boxed-expression-component/src/i18n/locales/en.ts
+++ b/packages/boxed-expression-component/src/i18n/locales/en.ts
@@ -56,6 +56,7 @@ export const en: BoxedExpressionEditorI18n = {
   },
   editContextEntry: "Edit Context Entry",
   editParameter: "Edit Parameter",
+  editParameters: "Edit parameters",
   editRelation: "Edit Relation",
   enterFunction: "Function name",
   enterText: "Enter Text",

--- a/packages/boxed-expression-component/src/i18n/locales/en.ts
+++ b/packages/boxed-expression-component/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { BoxedExpressionEditorI18n } from "..";
+import { BoxedExpressionEditorDictionary, BoxedExpressionEditorI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 
 export const en: BoxedExpressionEditorI18n = {
@@ -55,10 +55,7 @@ export const en: BoxedExpressionEditorI18n = {
     output: "Edit Output Clause",
   },
   editContextEntry: "Edit Context Entry",
-  editExpression: "Edit Expression",
-  editHitPolicy: "Edit Hit Policy",
   editParameter: "Edit Parameter",
-  editParameters: "Edit parameters",
   editRelation: "Edit Relation",
   enterFunction: "Function name",
   enterText: "Enter Text",
@@ -110,7 +107,6 @@ export const en: BoxedExpressionEditorI18n = {
   rows: "ROWS",
   ruleAnnotation: "RULE ANNOTATION",
   selectExpression: "Select expression",
-  selectFunctionKind: "Select Function Kind",
   selectLogicType: "Select logic type",
   contextExpression: {
     variable: "variable",
@@ -167,4 +163,4 @@ export const en: BoxedExpressionEditorI18n = {
     in: "in",
     satisfies: "satisfies",
   },
-};
+} as const satisfies BoxedExpressionEditorDictionary;

--- a/packages/chrome-extension/src/app/i18n/ChromeExtensionI18n.ts
+++ b/packages/chrome-extension/src/app/i18n/ChromeExtensionI18n.ts
@@ -19,7 +19,7 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-interface ChromeExtensionDictionary extends ReferenceDictionary {
+export interface ChromeExtensionDictionary {
   openIn: (text: string) => string;
   seeAsDiagram: string;
   fullScreen: string;
@@ -61,4 +61,4 @@ interface ChromeExtensionDictionary extends ReferenceDictionary {
   };
 }
 
-export interface ChromeExtensionI18n extends ChromeExtensionDictionary {}
+export interface ChromeExtensionI18n extends ChromeExtensionDictionary, ReferenceDictionary {}

--- a/packages/chrome-extension/src/app/i18n/locales/en.ts
+++ b/packages/chrome-extension/src/app/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ChromeExtensionI18n } from "..";
+import { ChromeExtensionDictionary, ChromeExtensionI18n } from "..";
 
 export const en: ChromeExtensionI18n = {
   openIn: (name: string) => `Open in ${name}`,
@@ -59,4 +59,4 @@ export const en: ChromeExtensionI18n = {
       },
     },
   },
-};
+} as const satisfies ChromeExtensionDictionary;

--- a/packages/dashbuilder-viewer-deployment-webapp/src/i18n/AppI18n.ts
+++ b/packages/dashbuilder-viewer-deployment-webapp/src/i18n/AppI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface AppDictionary extends ReferenceDictionary {
+export interface AppDictionary {
   masthead: {
     disclaimer: {
       title: string;
@@ -36,4 +36,4 @@ interface AppDictionary extends ReferenceDictionary {
   };
 }
 
-export interface AppI18n extends AppDictionary, CommonI18n {}
+export interface AppI18n extends AppDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/dashbuilder-viewer-deployment-webapp/src/i18n/locales/en.ts
+++ b/packages/dashbuilder-viewer-deployment-webapp/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@
 
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { AppI18n } from "..";
+import { AppDictionary, AppI18n } from "..";
 
 export const en: AppI18n = {
   ...en_common,
@@ -37,4 +37,4 @@ export const en: AppI18n = {
       referToJira: ["Please refer to ", wrapped("jira"), " and report an issue."],
     },
   },
-};
+} as const satisfies AppDictionary;

--- a/packages/dev-deployment-dmn-form-webapp/src/i18n/DmnFormI18n.ts
+++ b/packages/dev-deployment-dmn-form-webapp/src/i18n/DmnFormI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface DmnFormDictionary extends ReferenceDictionary {
+export interface DmnFormDictionary {
   formToolbar: {
     disclaimer: {
       title: string;
@@ -42,4 +42,4 @@ interface DmnFormDictionary extends ReferenceDictionary {
   };
 }
 
-export interface DmnFormI18n extends DmnFormDictionary, CommonI18n {}
+export interface DmnFormI18n extends DmnFormDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/dev-deployment-dmn-form-webapp/src/i18n/locales/en.ts
+++ b/packages/dev-deployment-dmn-form-webapp/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@
 
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { DmnFormI18n } from "..";
+import { DmnFormDictionary, DmnFormI18n } from "..";
 
 export const en: DmnFormI18n = {
   ...en_common,
@@ -43,4 +43,4 @@ export const en: DmnFormI18n = {
     title: "An unexpected error happened while trying to fetch your file",
     notFound: "A required file could be not be found",
   },
-};
+} as const satisfies DmnFormDictionary;

--- a/packages/dmn-editor-envelope/src/i18n/DmnEditorEnvelopeI18n.ts
+++ b/packages/dmn-editor-envelope/src/i18n/DmnEditorEnvelopeI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface DmnEditorEnvelopeDictionary extends ReferenceDictionary {
+export interface DmnEditorEnvelopeDictionary {
   edit: string;
   misc: string;
   move: string;
@@ -51,4 +51,4 @@ interface DmnEditorEnvelopeDictionary extends ReferenceDictionary {
   holdAndScrollToNavigateHorizontally: string;
 }
 
-export interface DmnEditorEnvelopeI18n extends DmnEditorEnvelopeDictionary, CommonI18n {}
+export interface DmnEditorEnvelopeI18n extends DmnEditorEnvelopeDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/dmn-editor-envelope/src/i18n/locales/en.ts
+++ b/packages/dmn-editor-envelope/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnEditorEnvelopeI18n } from "..";
+import { DmnEditorEnvelopeDictionary, DmnEditorEnvelopeI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 
 export const en: DmnEditorEnvelopeI18n = {
@@ -50,4 +50,4 @@ export const en: DmnEditorEnvelopeI18n = {
   holdAndDragtoPan: "Hold and drag to Pan",
   holdAndScrollToZoomInOut: "Hold and scroll to zoom in/out",
   holdAndScrollToNavigateHorizontally: "Hold and scroll to navigate horizontally",
-};
+} as const satisfies DmnEditorEnvelopeDictionary;

--- a/packages/dmn-editor/src/i18n/DmnEditorI18n.ts
+++ b/packages/dmn-editor/src/i18n/DmnEditorI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface DmnEditorDictionary extends ReferenceDictionary {
+export interface DmnEditorDictionary {
   autoLayout: string;
   backToDiagram: string;
   yourAnnotationsHere: string;
@@ -362,4 +362,4 @@ interface DmnEditorDictionary extends ReferenceDictionary {
   };
 }
 
-export interface DmnEditorI18n extends DmnEditorDictionary, CommonI18n {}
+export interface DmnEditorI18n extends DmnEditorDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/dmn-editor/src/i18n/locales/en.ts
+++ b/packages/dmn-editor/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@
  */
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { DmnEditorI18n } from "../DmnEditorI18n";
+import { DmnEditorDictionary, DmnEditorI18n } from "../DmnEditorI18n";
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
 
 export const en: DmnEditorI18n = {
@@ -406,4 +406,4 @@ export const en: DmnEditorI18n = {
     tryUndoingLastAction: "Try undoing last action",
     fileAnIssue: "File an issue...",
   },
-};
+} as const satisfies DmnEditorDictionary;

--- a/packages/editor/src/envelope/i18n/EditorEnvelopeI18n.ts
+++ b/packages/editor/src/envelope/i18n/EditorEnvelopeI18n.ts
@@ -19,7 +19,7 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-export interface EditorEnvelopeDictionary extends ReferenceDictionary {
+export interface EditorEnvelopeDictionary {
   keyBindingsHelpOverlay: {
     title: string;
     categories: {
@@ -39,4 +39,4 @@ export interface EditorEnvelopeDictionary extends ReferenceDictionary {
   kogitoEditor: string;
 }
 
-export interface EditorEnvelopeI18n extends EditorEnvelopeDictionary {}
+export interface EditorEnvelopeI18n extends EditorEnvelopeDictionary, ReferenceDictionary {}

--- a/packages/editor/src/envelope/i18n/locales/en.ts
+++ b/packages/editor/src/envelope/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { EditorEnvelopeI18n } from "../EditorEnvelopeI18n";
+import { EditorEnvelopeDictionary, EditorEnvelopeI18n } from "../EditorEnvelopeI18n";
 
 export const en: EditorEnvelopeI18n = {
   keyBindingsHelpOverlay: {
@@ -37,4 +37,4 @@ export const en: EditorEnvelopeI18n = {
   },
   editorNotAvailable: (extension: string): string => `No Editor available for '${extension}' extension`,
   kogitoEditor: "Kogito editor",
-};
+} as const satisfies EditorEnvelopeDictionary;

--- a/packages/feel-input-component/src/i18n/FeelInputComponentI18n.ts
+++ b/packages/feel-input-component/src/i18n/FeelInputComponentI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface FeelInputComponentDictionary extends ReferenceDictionary {
+export interface FeelInputComponentDictionary {
   functionDescription: {
     absDescription: (value: string) => string;
     afterPoint: (result: string, point1: string, point2: string) => string;
@@ -171,4 +171,4 @@ interface FeelInputComponentDictionary extends ReferenceDictionary {
   };
 }
 
-export interface FeelInputComponentI18n extends FeelInputComponentDictionary, CommonI18n {}
+export interface FeelInputComponentI18n extends FeelInputComponentDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/feel-input-component/src/i18n/locales/en.ts
+++ b/packages/feel-input-component/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@
  */
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { FeelInputComponentI18n } from "../FeelInputComponentI18n";
+import { FeelInputComponentDictionary, FeelInputComponentI18n } from "../FeelInputComponentI18n";
 
 export const en: FeelInputComponentI18n = {
   ...en_common,
@@ -251,4 +251,4 @@ export const en: FeelInputComponentI18n = {
     weekOfYear: "Returns the Gregorian week of the year as defined by ISO 8601",
     yearsAndMonthsDuration: "Calculates the years and months duration between the two specified parameters.",
   },
-};
+} as const satisfies FeelInputComponentDictionary;

--- a/packages/form-code-generator-vscode-command/src/i18n/FormCodeGeneratorI18n.ts
+++ b/packages/form-code-generator-vscode-command/src/i18n/FormCodeGeneratorI18n.ts
@@ -19,7 +19,7 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-interface FormCodeGeneratorDictionary extends ReferenceDictionary {
+export interface FormCodeGeneratorDictionary {
   generateFormCode: {
     selectProjectFolder: string;
     notFoundProjectsTarget: string;
@@ -37,4 +37,4 @@ interface FormCodeGeneratorDictionary extends ReferenceDictionary {
   };
 }
 
-export interface FormCodeGeneratorI18n extends FormCodeGeneratorDictionary {}
+export interface FormCodeGeneratorI18n extends FormCodeGeneratorDictionary, ReferenceDictionary {}

--- a/packages/form-code-generator-vscode-command/src/i18n/locales/en.ts
+++ b/packages/form-code-generator-vscode-command/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { FormCodeGeneratorI18n } from "../FormCodeGeneratorI18n";
+import { FormCodeGeneratorDictionary, FormCodeGeneratorI18n } from "../FormCodeGeneratorI18n";
 
 export const en: FormCodeGeneratorI18n = {
   generateFormCode: {
@@ -35,4 +35,4 @@ export const en: FormCodeGeneratorI18n = {
     successFormGeneration: (files: string): string => `Success generating form code for the following files: ${files}`,
     errorFormGeneration: (files: string): string => `Error generating form code for the following files: ${files}`,
   },
-};
+} as const satisfies FormCodeGeneratorDictionary;

--- a/packages/form-dmn/src/i18n/FormDmnI18n.ts
+++ b/packages/form-dmn/src/i18n/FormDmnI18n.ts
@@ -19,6 +19,7 @@
 
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { FormDictionary } from "@kie-tools/form/dist/i18n/FormI18n";
+import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
 export interface FormDmnI18nDictionary extends FormDictionary {
   validation: {
@@ -52,4 +53,4 @@ export interface FormDmnI18nDictionary extends FormDictionary {
   };
 }
 
-export interface FormDmnI18n extends FormDmnI18nDictionary, ReferenceDictionary {}
+export interface FormDmnI18n extends FormDmnI18nDictionary, ReferenceDictionary, CommonI18n {}

--- a/packages/form-dmn/src/i18n/FormDmnI18n.ts
+++ b/packages/form-dmn/src/i18n/FormDmnI18n.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { Wrapped } from "@kie-tools-core/i18n/dist/core";
-import { FormI18n } from "@kie-tools/form/dist/i18n/FormI18n";
+import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
+import { FormDictionary } from "@kie-tools/form/dist/i18n/FormI18n";
 
-export interface FormDmnI18n extends FormI18n {
+export interface FormDmnI18nDictionary extends FormDictionary {
   validation: {
     xDmnAllowedValues: string;
     xDmnTypeConstraint: string;
@@ -51,3 +51,5 @@ export interface FormDmnI18n extends FormI18n {
     openExpression: (name: string) => string;
   };
 }
+
+export interface FormDmnI18n extends FormDmnI18nDictionary, ReferenceDictionary {}

--- a/packages/form-dmn/src/i18n/locales/en.ts
+++ b/packages/form-dmn/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@
  */
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { FormDmnI18n } from "../FormDmnI18n";
+import { FormDmnI18n, FormDmnI18nDictionary } from "../FormDmnI18n";
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
 
 export const en: FormDmnI18n = {
@@ -80,4 +80,4 @@ export const en: FormDmnI18n = {
     recursiveStructureNotSupported: ["Recursive structures ", wrapped("linebreak"), "are not supported yet"],
     openExpression: (name: string) => `Open '${name}' expression`,
   },
-};
+} as const satisfies FormDmnI18nDictionary;

--- a/packages/form/src/i18n/FormI18n.ts
+++ b/packages/form/src/i18n/FormI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface FormDictionary extends ReferenceDictionary {
+export interface FormDictionary {
   form: {
     status: {
       autoGenerationError: {
@@ -43,4 +43,4 @@ interface FormDictionary extends ReferenceDictionary {
   };
 }
 
-export interface FormI18n extends FormDictionary, CommonI18n {}
+export interface FormI18n extends FormDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/form/src/i18n/locales/en.ts
+++ b/packages/form/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
-import { FormI18n } from "../FormI18n";
+import { FormDictionary, FormI18n } from "../FormI18n";
 
 export const en: FormI18n = {
   ...en_common,
@@ -47,4 +47,4 @@ export const en: FormI18n = {
   schema: {
     selectPlaceholder: "Select...",
   },
-};
+} as const satisfies FormDictionary;

--- a/packages/i18n-common-dictionary/src/CommonI18n.ts
+++ b/packages/i18n-common-dictionary/src/CommonI18n.ts
@@ -109,7 +109,9 @@ export type CommonDictionary = {
   };
 };
 
-export interface CommonI18n extends ReferenceDictionary {
+export interface CommonI18nDictionary {
   names: typeof names;
   terms: CommonDictionary;
 }
+
+export interface CommonI18n extends CommonI18nDictionary, ReferenceDictionary {}

--- a/packages/i18n-common-dictionary/src/locales/en.ts
+++ b/packages/i18n-common-dictionary/src/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { CommonI18n } from "../CommonI18n";
+import { CommonI18n, CommonI18nDictionary } from "../CommonI18n";
 import { names } from "../names";
 
 export const en: CommonI18n = {
@@ -110,4 +110,4 @@ export const en: CommonI18n = {
       shift: "Shift",
     },
   },
-};
+} as const satisfies CommonI18nDictionary;

--- a/packages/import-java-classes-component/src/i18n/ImportJavaClassesWizardI18n.ts
+++ b/packages/import-java-classes-component/src/i18n/ImportJavaClassesWizardI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface ImportJavaClassesWizardDictionary extends ReferenceDictionary {
+export interface ImportJavaClassesWizardDictionary {
   modalButton: {
     text: string;
     disabledMessage: string;
@@ -54,4 +54,7 @@ interface ImportJavaClassesWizardDictionary extends ReferenceDictionary {
   };
 }
 
-export interface ImportJavaClassesWizardI18n extends ImportJavaClassesWizardDictionary, CommonI18n {}
+export interface ImportJavaClassesWizardI18n
+  extends ImportJavaClassesWizardDictionary,
+    CommonI18n,
+    ReferenceDictionary {}

--- a/packages/import-java-classes-component/src/i18n/locales/en.ts
+++ b/packages/import-java-classes-component/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ImportJavaClassesWizardI18n } from "..";
+import { ImportJavaClassesWizardDictionary, ImportJavaClassesWizardI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 
 export const en: ImportJavaClassesWizardI18n = {
@@ -55,4 +55,4 @@ export const en: ImportJavaClassesWizardI18n = {
       fetchButtonLabel: "Fetch",
     },
   },
-};
+} as const satisfies ImportJavaClassesWizardDictionary;

--- a/packages/kie-bc-editors/src/common/i18n/KieBcEditorsI18n.ts
+++ b/packages/kie-bc-editors/src/common/i18n/KieBcEditorsI18n.ts
@@ -19,6 +19,8 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-export interface KieBcEditorsI18n extends ReferenceDictionary {
+export interface KieBcEditorsI18nDictionary {
   unsupportedFile: string;
 }
+
+export interface KieBcEditorsI18n extends ReferenceDictionary {}

--- a/packages/kie-bc-editors/src/common/i18n/locales/en.ts
+++ b/packages/kie-bc-editors/src/common/i18n/locales/en.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { KieBcEditorsI18n } from "../KieBcEditorsI18n";
+import { KieBcEditorsI18n, KieBcEditorsI18nDictionary } from "../KieBcEditorsI18n";
 
 const ISSUES_URL = "https://github.com/apache/incubator-kie-issues/issues";
 
 export const en: KieBcEditorsI18n = {
   unsupportedFile: `This file contains a construct that is not yet supported. Please refer to ${ISSUES_URL} and report an issue. Don't forget to upload the current file.`,
-};
+} as const satisfies KieBcEditorsI18nDictionary;

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -23,7 +23,7 @@ import { DmnUnitablesI18n } from "@kie-tools/unitables-dmn/dist/i18n";
 import { GistEnabledAuthProviderType, SupportedGitAuthProviders } from "../authProviders/AuthProvidersApi";
 import { SupportedActions } from "../workspace/components/GitStatusIndicatorActions";
 
-interface OnlineDictionary extends ReferenceDictionary {
+export interface OnlineDictionary {
   editorPage: {
     textEditorModal: {
       title: (fileName: string) => string;
@@ -594,4 +594,4 @@ interface OnlineDictionary extends ReferenceDictionary {
   };
 }
 
-export interface OnlineI18n extends OnlineDictionary, CommonI18n {}
+export interface OnlineI18n extends OnlineDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { OnlineI18n } from "..";
+import { OnlineDictionary, OnlineI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 import { en as en_unitables } from "@kie-tools/unitables/dist/i18n/locales/en";
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
@@ -781,4 +781,4 @@ export const en: OnlineI18n = {
       confirmButtonText: "Yes, revert permanently",
     },
   },
-};
+} as const satisfies OnlineDictionary;

--- a/packages/scesim-editor-envelope/src/i18n/ScesimEditorEnvelopeI18n.ts
+++ b/packages/scesim-editor-envelope/src/i18n/ScesimEditorEnvelopeI18n.ts
@@ -20,11 +20,11 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface ScesimEditorEnvelopeDictionary extends ReferenceDictionary {
+export interface ScesimEditorEnvelopeDictionary {
   testScenarioEditor: string;
   i: string;
   misc: string;
   openCloseDockPanel: string;
 }
 
-export interface ScesimEditorEnvelopeI18n extends ScesimEditorEnvelopeDictionary, CommonI18n {}
+export interface ScesimEditorEnvelopeI18n extends ScesimEditorEnvelopeDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/scesim-editor-envelope/src/i18n/locales/en.ts
+++ b/packages/scesim-editor-envelope/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@
  */
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { ScesimEditorEnvelopeI18n } from "../ScesimEditorEnvelopeI18n";
+import { ScesimEditorEnvelopeDictionary, ScesimEditorEnvelopeI18n } from "../ScesimEditorEnvelopeI18n";
 
 export const en: ScesimEditorEnvelopeI18n = {
   ...en_common,
@@ -26,4 +26,4 @@ export const en: ScesimEditorEnvelopeI18n = {
   i: "I",
   misc: "Misc",
   openCloseDockPanel: "Open/Close dock panel",
-};
+} as const satisfies ScesimEditorEnvelopeDictionary;

--- a/packages/scesim-editor/src/i18n/TestScenarioEditorI18n.ts
+++ b/packages/scesim-editor/src/i18n/TestScenarioEditorI18n.ts
@@ -20,7 +20,7 @@
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-interface TestScenarioEditorDictionary extends ReferenceDictionary {
+export interface TestScenarioEditorDictionary {
   alerts: {
     ruleDataNotAvailable: string;
     dmnDataRetrievedFromScesim: string;
@@ -170,4 +170,4 @@ interface TestScenarioEditorDictionary extends ReferenceDictionary {
   unsupportedMessage: (version: string) => string;
 }
 
-export default interface TestScenarioEditorI18n extends TestScenarioEditorDictionary, CommonI18n {}
+export default interface TestScenarioEditorI18n extends TestScenarioEditorDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/scesim-editor/src/i18n/locales/en.ts
+++ b/packages/scesim-editor/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@
  */
 
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import TestScenarioEditorI18n from "../TestScenarioEditorI18n";
+import TestScenarioEditorI18n, { TestScenarioEditorDictionary } from "../TestScenarioEditorI18n";
 
 export const en: TestScenarioEditorI18n = {
   ...en_common,
@@ -195,4 +195,4 @@ export const en: TestScenarioEditorI18n = {
   unsupportedTitle: (version: string) => `This file holds a Test Scenario asset version ( ${version} ) not supported`,
   unsupportedMessage: (version: string) =>
     `Most likely, this file has been generated with a very old Business Central version (< 7.30.0.Final). Please update your Business Central instance and download again this scesim file, it will be automatically updated to the supported version ( ${version} ).`,
-};
+} as const satisfies TestScenarioEditorDictionary;

--- a/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/AppI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary, Wrapped } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface AppDictionary extends ReferenceDictionary {
+export interface AppDictionary {
   editorPage: {
     textEditorModal: {
       title: (fileName: string) => string;
@@ -113,4 +113,4 @@ interface AppDictionary extends ReferenceDictionary {
   };
 }
 
-export interface AppI18n extends AppDictionary, CommonI18n {}
+export interface AppI18n extends AppDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
+++ b/packages/serverless-logic-web-tools/src/i18n/locales/en.ts
@@ -19,7 +19,7 @@
 
 import { wrapped } from "@kie-tools-core/i18n/dist/core";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
-import { AppI18n } from "..";
+import { AppI18n, AppDictionary } from "..";
 
 export const en: AppI18n = {
   ...en_common,
@@ -114,4 +114,4 @@ export const en: AppI18n = {
       dataIndexConnectionError: "Connection refused. Please check the information provided.",
     },
   },
-};
+} as const satisfies AppDictionary;

--- a/packages/unitables-dmn/src/i18n/DmnUnitablesI18n.ts
+++ b/packages/unitables-dmn/src/i18n/DmnUnitablesI18n.ts
@@ -21,10 +21,10 @@ import { UnitablesI18n } from "@kie-tools/unitables/dist/i18n";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-interface DmnUniablesDictionary extends ReferenceDictionary {
+export interface DmnUniablesDictionary {
   schema: {
     selectPlaceholder: string;
   };
 }
 
-export interface DmnUnitablesI18n extends DmnUniablesDictionary, CommonI18n, UnitablesI18n {}
+export interface DmnUnitablesI18n extends DmnUniablesDictionary, CommonI18n, UnitablesI18n, ReferenceDictionary {}

--- a/packages/unitables-dmn/src/i18n/locales/en.ts
+++ b/packages/unitables-dmn/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DmnUnitablesI18n } from "..";
+import { DmnUniablesDictionary, DmnUnitablesI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 import { en as en_unitables } from "@kie-tools/unitables/dist/i18n/locales/en";
 
@@ -27,4 +27,4 @@ export const en: DmnUnitablesI18n = {
   schema: {
     selectPlaceholder: "Select...",
   },
-};
+} as const satisfies DmnUniablesDictionary;

--- a/packages/unitables/src/i18n/UnitablesI18n.ts
+++ b/packages/unitables/src/i18n/UnitablesI18n.ts
@@ -21,7 +21,7 @@ import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 import { BoxedExpressionEditorI18n } from "@kie-tools/boxed-expression-component/dist/i18n";
 
-interface UnitablesDictionary extends ReferenceDictionary {
+export interface UnitablesDictionary {
   schema: {
     selectPlaceholder: string;
   };
@@ -35,4 +35,8 @@ interface UnitablesDictionary extends ReferenceDictionary {
   addInputDecisionNodes: string;
 }
 
-export interface UnitablesI18n extends UnitablesDictionary, CommonI18n, BoxedExpressionEditorI18n {}
+export interface UnitablesI18n
+  extends UnitablesDictionary,
+    CommonI18n,
+    BoxedExpressionEditorI18n,
+    ReferenceDictionary {}

--- a/packages/unitables/src/i18n/locales/en.ts
+++ b/packages/unitables/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { UnitablesI18n } from "../UnitablesI18n";
+import { UnitablesDictionary, UnitablesI18n } from "../UnitablesI18n";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 import { en as en_boxed_expression } from "@kie-tools/boxed-expression-component/dist/i18n/locales/en";
 
@@ -36,4 +36,4 @@ export const en: UnitablesI18n = {
   noDecisionResults: "No Decision results yet...",
   addInputDecisionNodes:
     "Add input and decision nodes, provide values to the inputs at the left and see the Decisions results here.",
-};
+} as const satisfies UnitablesDictionary;

--- a/packages/vscode-extension/src/i18n/VsCodeI18n.ts
+++ b/packages/vscode-extension/src/i18n/VsCodeI18n.ts
@@ -19,7 +19,7 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-interface VsCodeDictionary extends ReferenceDictionary {
+export interface VsCodeDictionary {
   savedSvg: (fileName: string) => string;
   openSvg: string;
   savedSuccessfully: string;
@@ -29,4 +29,4 @@ interface VsCodeDictionary extends ReferenceDictionary {
   reopenAsDiagramButton: string;
 }
 
-export interface VsCodeI18n extends VsCodeDictionary {}
+export interface VsCodeI18n extends VsCodeDictionary, ReferenceDictionary {}

--- a/packages/vscode-extension/src/i18n/locales/en.ts
+++ b/packages/vscode-extension/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { VsCodeI18n } from "..";
+import { VsCodeDictionary, VsCodeI18n } from "..";
 
 export const en: VsCodeI18n = {
   savedSvg: (fileName) => `SVG saved at ${fileName}.`,
@@ -27,4 +27,4 @@ export const en: VsCodeI18n = {
   openAsTextButton: "Open as text",
   reopenAsDiagramText: "After you're finished fixing it, you can reopen it as diagram.",
   reopenAsDiagramButton: "Reopen as diagram",
-};
+} as const satisfies VsCodeDictionary;

--- a/packages/vscode-extension/src/notifications/PopupMessagesNotificationHandler.ts
+++ b/packages/vscode-extension/src/notifications/PopupMessagesNotificationHandler.ts
@@ -21,12 +21,12 @@ import { I18n } from "@kie-tools-core/i18n/dist/core";
 import { Notification, NotificationSeverity } from "@kie-tools-core/notifications/dist/api";
 import * as vscode from "vscode";
 import { VsCodeWorkspaceChannelApiImpl } from "../workspace/VsCodeWorkspaceChannelApiImpl";
-import { NotificationsApiVsCodeI18nDictionary } from "./i18n";
+import { NotificationsApiVsCodeI18n } from "./i18n";
 
 export class PopupMessagesNotificationHandler {
   constructor(
     private readonly vscodeWorkspace: VsCodeWorkspaceChannelApiImpl,
-    private readonly i18n: I18n<NotificationsApiVsCodeI18nDictionary>
+    private readonly i18n: I18n<NotificationsApiVsCodeI18n>
   ) {}
 
   public createNotification(notification: Notification): void {

--- a/packages/vscode-extension/src/notifications/i18n/NotificationsApiVsCodeI18nDictionary.ts
+++ b/packages/vscode-extension/src/notifications/i18n/NotificationsApiVsCodeI18nDictionary.ts
@@ -19,6 +19,8 @@
 
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 
-export interface NotificationsApiVsCodeI18nDictionary extends ReferenceDictionary {
+export interface NotificationsApiVsCodeI18nDictionary {
   open: string;
 }
+
+export interface NotificationsApiVsCodeI18n extends NotificationsApiVsCodeI18nDictionary, ReferenceDictionary {}

--- a/packages/vscode-extension/src/notifications/i18n/locales/de.ts
+++ b/packages/vscode-extension/src/notifications/i18n/locales/de.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { NotificationsApiVsCodeI18nDictionary } from "..";
+import { NotificationsApiVsCodeI18n } from "..";
 
-export const de: NotificationsApiVsCodeI18nDictionary = {
+export const de: NotificationsApiVsCodeI18n = {
   open: `Öffnen`,
 };

--- a/packages/vscode-extension/src/notifications/i18n/locales/en.ts
+++ b/packages/vscode-extension/src/notifications/i18n/locales/en.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { NotificationsApiVsCodeI18nDictionary } from "..";
+import { NotificationsApiVsCodeI18n, NotificationsApiVsCodeI18nDictionary } from "..";
 
-export const en: NotificationsApiVsCodeI18nDictionary = {
+export const en: NotificationsApiVsCodeI18n = {
   open: `Open`,
-};
+} as const satisfies NotificationsApiVsCodeI18nDictionary;

--- a/packages/vscode-extension/src/notifications/i18n/setup.ts
+++ b/packages/vscode-extension/src/notifications/i18n/setup.ts
@@ -20,14 +20,14 @@
 import { en } from "./locales";
 import { de } from "./locales";
 import { I18nDefaults, I18nDictionaries } from "@kie-tools-core/i18n/dist/core";
-import { NotificationsApiVsCodeI18nDictionary } from "./NotificationsApiVsCodeI18nDictionary";
+import { NotificationsApiVsCodeI18n } from "./NotificationsApiVsCodeI18nDictionary";
 
-export const notificationsApiVsCodeI18nDefaults: I18nDefaults<NotificationsApiVsCodeI18nDictionary> = {
+export const notificationsApiVsCodeI18nDefaults: I18nDefaults<NotificationsApiVsCodeI18n> = {
   locale: "en",
   dictionary: en,
 };
 
-export const notificationsApiVsCodeI18nDictionaries: I18nDictionaries<NotificationsApiVsCodeI18nDictionary> = new Map([
+export const notificationsApiVsCodeI18nDictionaries: I18nDictionaries<NotificationsApiVsCodeI18n> = new Map([
   ["en", en],
   ["de", de],
 ]);

--- a/packages/yard-editor/src/i18n/YardEditorI18n.ts
+++ b/packages/yard-editor/src/i18n/YardEditorI18n.ts
@@ -20,7 +20,7 @@
 import { ReferenceDictionary } from "@kie-tools-core/i18n/dist/core";
 import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 
-interface YardEditorDictionary extends ReferenceDictionary {
+export interface YardEditorDictionary {
   decisionElementsTab: {
     emptyStateTitle: string;
     emptyStateBody: string;
@@ -42,4 +42,4 @@ interface YardEditorDictionary extends ReferenceDictionary {
   };
 }
 
-export interface YardEditorI18n extends YardEditorDictionary, CommonI18n {}
+export interface YardEditorI18n extends YardEditorDictionary, CommonI18n, ReferenceDictionary {}

--- a/packages/yard-editor/src/i18n/locales/en.ts
+++ b/packages/yard-editor/src/i18n/locales/en.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { YardEditorI18n } from "..";
+import { YardEditorDictionary, YardEditorI18n } from "..";
 import { en as en_common } from "@kie-tools/i18n-common-dictionary";
 
 export const en: YardEditorI18n = {
@@ -41,4 +41,4 @@ export const en: YardEditorI18n = {
     specVersion: "Specification version",
     tabTitle: "General",
   },
-};
+} as const satisfies YardEditorDictionary;


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-tools/issues/3294,

Before fix:
When we add any unknown property in en.ts file , it is not throwing any error

After fix:
Adding unknown key will throw an error
<img width="695" height="501" alt="Screenshot 2025-10-06 at 9 40 05 PM" src="https://github.com/user-attachments/assets/12ffca84-796e-483a-8f74-9b15d6f5c66d" />
