### PR TITLE
NO-ISSUE: Bump drools-and-kogito to 999-20251006-local

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "59ef10953a50d769a78b188a85dd110a08e7a8e8",
+      default: "2c350fd929325e56e6131cf85b329c1e06ede234",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "4ea84944320ed2284ba61b16012d674a60fe7df4",
+      default: "3fbb4fe5f6f608122ccebeb0cd6651053d2bd490",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "8266e9d1cc6977ad541dc1de2eeabaf1cc3db71e",
+      default: "e35252e391926a6210a4a5a254a97e57a9023267",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20250829-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20251006-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.20.2.2</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20250829-local",
+      default: "999-20251006-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */


### PR DESCRIPTION
Drools git ref: https://github.com/apache/incubator-kie-drools/commit/2c350fd929325e56e6131cf85b329c1e06ede234
Optaplanner git ref: https://github.com/apache/incubator-kie-optaplanner/commit/8833fa4f22a45f38caaff1eca478e4e855cbd024
Kogito Runtimes git ref: https://github.com/apache/incubator-kie-kogito-runtimes/commit/3fbb4fe5f6f608122ccebeb0cd6651053d2bd490
Kogito Apps git ref: https://github.com/apache/incubator-kie-kogito-apps/commit/e35252e391926a6210a4a5a254a97e57a9023267