### PR TITLE
DMN Editor: Erasing an expression language of a boxed expression leaves an empty string

### DIFF
--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
@@ -145,8 +145,12 @@ export function DecisionTableInputHeaderCell(props: {
               expressionPath={selectedObjectInfos?.expressionPath ?? []}
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
-                  dmnObject.inputExpression ??= { "@_id": generateUuid() };
-                  dmnObject.inputExpression["@_expressionLanguage"] = newExpressionLanguage;
+                  if (newExpressionLanguage === "") {
+                    delete dmnObject.inputExpression["@_expressionLanguage"];
+                  } else {
+                    dmnObject.inputExpression ??= { "@_id": generateUuid() };
+                    dmnObject.inputExpression["@_expressionLanguage"] = newExpressionLanguage;
+                  }
                 })
               }
             />
@@ -181,8 +185,12 @@ export function DecisionTableInputHeaderCell(props: {
               expressionPath={selectedObjectInfos?.expressionPath ?? []}
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
-                  dmnObject.inputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
-                  dmnObject.inputValues["@_expressionLanguage"] = newExpressionLanguage;
+                  if (newExpressionLanguage === "") {
+                    delete dmnObject.inputValues?.["@_expressionLanguage"];
+                  } else {
+                    dmnObject.inputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
+                    dmnObject.inputValues["@_expressionLanguage"] = newExpressionLanguage;
+                  }
                 })
               }
             />

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputHeaderCell.tsx
@@ -186,7 +186,7 @@ export function DecisionTableInputHeaderCell(props: {
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
                   if (newExpressionLanguage === "") {
-                    delete dmnObject.inputValues?.["@_expressionLanguage"];
+                    dmnObject.inputValues && delete dmnObject.inputValues["@_expressionLanguage"];
                   } else {
                     dmnObject.inputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
                     dmnObject.inputValues["@_expressionLanguage"] = newExpressionLanguage;

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputRuleCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableInputRuleCell.tsx
@@ -113,7 +113,11 @@ export function DecisionTableInputRule(props: { boxedExpressionIndex?: BoxedExpr
         expressionPath={selectedObjectInfos?.expressionPath ?? []}
         onChange={(newExpressionLanguage: string) =>
           updater((dmnObject) => {
-            dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            if (newExpressionLanguage === "") {
+              delete dmnObject["@_expressionLanguage"];
+            } else {
+              dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            }
           })
         }
       />

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
@@ -245,7 +245,7 @@ export function DecisionTableOutputHeaderCell(props: {
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
                   if (newExpressionLanguage === "") {
-                    delete dmnObject.defaultOutputEntry?.["@_expressionLanguage"];
+                    dmnObject.defaultOutputEntry && delete dmnObject.defaultOutputEntry["@_expressionLanguage"];
                   } else {
                     dmnObject.defaultOutputEntry ??= { "@_id": generateUuid() };
                     dmnObject.defaultOutputEntry["@_expressionLanguage"] = newExpressionLanguage;
@@ -297,7 +297,7 @@ export function DecisionTableOutputHeaderCell(props: {
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
                   if (newExpressionLanguage === "") {
-                    delete dmnObject.outputValues?.["@_expressionLanguage"];
+                    dmnObject.outputValues && delete dmnObject.outputValues["@_expressionLanguage"];
                   } else {
                     dmnObject.outputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
                     dmnObject.outputValues["@_expressionLanguage"] = newExpressionLanguage;

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputHeaderCell.tsx
@@ -244,8 +244,12 @@ export function DecisionTableOutputHeaderCell(props: {
               expressionPath={selectedObjectInfos?.expressionPath ?? []}
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
-                  dmnObject.defaultOutputEntry ??= { "@_id": generateUuid() };
-                  dmnObject.defaultOutputEntry["@_expressionLanguage"] = newExpressionLanguage;
+                  if (newExpressionLanguage === "") {
+                    delete dmnObject.defaultOutputEntry?.["@_expressionLanguage"];
+                  } else {
+                    dmnObject.defaultOutputEntry ??= { "@_id": generateUuid() };
+                    dmnObject.defaultOutputEntry["@_expressionLanguage"] = newExpressionLanguage;
+                  }
                 })
               }
             />
@@ -292,8 +296,12 @@ export function DecisionTableOutputHeaderCell(props: {
               expressionPath={selectedObjectInfos?.expressionPath ?? []}
               onChange={(newExpressionLanguage) =>
                 updater((dmnObject) => {
-                  dmnObject.outputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
-                  dmnObject.outputValues["@_expressionLanguage"] = newExpressionLanguage;
+                  if (newExpressionLanguage === "") {
+                    delete dmnObject.outputValues?.["@_expressionLanguage"];
+                  } else {
+                    dmnObject.outputValues ??= { "@_id": generateUuid(), text: { __$$text: "" } };
+                    dmnObject.outputValues["@_expressionLanguage"] = newExpressionLanguage;
+                  }
                 })
               }
             />

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputRuleCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/DecisionTableOutputRuleCell.tsx
@@ -145,7 +145,11 @@ export function DecisionTableOutputRuleCell(props: {
         expressionPath={selectedObjectInfos?.expressionPath ?? []}
         onChange={(newExpressionLanguage: string) =>
           updater((dmnObject) => {
-            dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            if (newExpressionLanguage === "") {
+              delete dmnObject["@_expressionLanguage"];
+            } else {
+              dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            }
           })
         }
       />

--- a/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/LiteralExpressionContentCell.tsx
+++ b/packages/dmn-editor/src/propertiesPanel/BoxedExpressionPropertiesPanelComponents/LiteralExpressionContentCell.tsx
@@ -62,7 +62,11 @@ export function LiteralExpressionContentCell(props: {
         expressionPath={selectedObjectInfos?.expressionPath ?? []}
         onChange={(newExpressionLanguage: string) =>
           updater((dmnObject) => {
-            dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            if (newExpressionLanguage === "") {
+              delete dmnObject["@_expressionLanguage"];
+            } else {
+              dmnObject["@_expressionLanguage"] = newExpressionLanguage;
+            }
           })
         }
       />


### PR DESCRIPTION
Closes [kie#2136](https://github.com/apache/incubator-kie-issues/issues/2136)

On erasing expression language,  expression langauge property is removed  so that top level DMN Expression Language will be used for evaluation.