### PR TITLE
[NO-ISSUE] Update logback to 1.5.19.

### DIFF
--- a/packages/dashbuilder/appformer/pom.xml
+++ b/packages/dashbuilder/appformer/pom.xml
@@ -94,7 +94,7 @@
     <version.org.infinispan.protostream>4.6.2.Final</version.org.infinispan.protostream>
 
     <!-- Newer version in kie-parent causes ServiceLoader error -->
-    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.19</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>
     <version.org.uberfire.latestFinal.release>1.4.0.Final</version.org.uberfire.latestFinal.release>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -186,7 +186,7 @@
     <version.zanata.plugin>2.3.0</version.zanata.plugin>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.19</version.ch.qos.logback>
     <version.com.google.elemental2>1.2.3</version.com.google.elemental2>
     <version.jsinterop.annotations>2.0.0</version.jsinterop.annotations>
     <version.org.gwtproject>2.10.0</version.org.gwtproject>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -214,7 +214,7 @@
     <version.zanata.plugin>2.3.0</version.zanata.plugin>
 
     <!-- Third party Libraries -->
-    <version.ch.qos.logback>1.5.16</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.19</version.ch.qos.logback>
     <version.commons-io>2.19.0</version.commons-io>
     <version.com.google.elemental2>1.1.0</version.com.google.elemental2>
     <version.com.google.guava>33.0.0-jre</version.com.google.guava>


### PR DESCRIPTION
Updates logback to 1.5.19. 

Related PRs:
https://github.com/apache/incubator-kie-drools/pull/6485
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4090