### PR TITLE
[NO-ISSUE] Update Drools and Kogito version to 999-20251014-local

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "2c350fd929325e56e6131cf85b329c1e06ede234",
+      default: "3c372b0d424047f9d0e26da5fd43ca84047659a5",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "3fbb4fe5f6f608122ccebeb0cd6651053d2bd490",
+      default: "cfc1489ac9a70de93d7db3bd6e0c1deb0bacbd2b",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "3c372b0d424047f9d0e26da5fd43ca84047659a5",
+      default: "7dee28ce41fd5acade93491d628f14f23a94ca4b",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20251014-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20251015-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.20.2.2</version.quarkus>

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20251006-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20251014-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.20.2.2</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20251006-local",
+      default: "999-20251014-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20251014-local",
+      default: "999-20251015-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */


### PR DESCRIPTION
PR for updating Drools and Kogito version. I have build errors locally when doing pnpm bootstrap. It doesn't install some dependencies into the custom m2 repository used in the build. @tiagobento @thiagoelg could you please try? I cannot find the problem from the logs. 