### PR TITLE
[kie-issues#2153] Update testcontainers to 2.0.1.

### DIFF
--- a/packages/sonataflow-builder-image/test-resources/tests/shell/sonataflow-builder/src/RunTests.java
+++ b/packages/sonataflow-builder-image/test-resources/tests/shell/sonataflow-builder/src/RunTests.java
@@ -26,8 +26,8 @@
 //DEPS org.junit.jupiter:junit-jupiter-engine:5.10.1
 
 // testcontainers
-//DEPS org.testcontainers:testcontainers:1.19.3
-//DEPS org.testcontainers:junit-jupiter:1.19.3
+//DEPS org.testcontainers:testcontainers:2.0.1
+//DEPS org.testcontainers:testcontainers-junit-jupiter:2.0.1
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
Updates testcontainers to the latest major stream 2.x. These changes are not dependent on the backend libraries changes, so can be merged without updating the drools and kogito versions. 

Ticket: https://github.com/apache/incubator-kie-issues/issues/2153

Softly related PRs:
drools: https://github.com/apache/incubator-kie-drools/pull/6496
kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4104
kogito-apps: https://github.com/apache/incubator-kie-kogito-apps/pull/2276
kogito-examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2137