### PR TITLE
kie-issues#3318: Enable kie-tools-image-builder to support multi platform builds

### DIFF
--- a/packages/image-builder/README.md
+++ b/packages/image-builder/README.md
@@ -18,7 +18,7 @@ Options:
   -f, --containerfile           Path to the Containerfile/Dockerfile  [string] [default: "Containerfile"]
   -c, --context                 Path to the build context  [string] [default: "./"]
       --build-arg               Build args for the builder in the format '<arg>=<value>', where <value> is a string (Can be used multiple times)  [array] [default: []]
-      --arch                    The target build architecture. If not provided will default to the native architecture  [string] [choices: "amd64", "arm64", "native"] [default: "native"]
+      --arch                    The target build architectures. If not provided will default to the native architecture  [array]
   -h, --help                    Show help  [boolean]
 
 Examples:

--- a/packages/image-builder/README.md
+++ b/packages/image-builder/README.md
@@ -18,7 +18,7 @@ Options:
   -f, --containerfile           Path to the Containerfile/Dockerfile  [string] [default: "Containerfile"]
   -c, --context                 Path to the build context  [string] [default: "./"]
       --build-arg               Build args for the builder in the format '<arg>=<value>', where <value> is a string (Can be used multiple times)  [array] [default: []]
-      --arch                    The target build architectures. If not provided will default to the native architecture  [array]
+      --arch                    The target build architectures, For example: [linux/amd64, linux/arm64]. If not provided will default to the native architecture  [array] [default: ["native"]]
   -h, --help                    Show help  [boolean]
 
 Examples:

--- a/packages/image-builder/src/bin.ts
+++ b/packages/image-builder/src/bin.ts
@@ -391,7 +391,7 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
           }
 
           const imageFullNames = getImageFullNames(args);
-          buildImage({ ...args, arch: ["amd64"] }, imageFullNames);
+          buildImage({ ...args, arch: ["linux/amd64"] }, imageFullNames);
           imageFullNames.forEach((imageName) => {
             execSync(`minikube image load ${imageName}`, { stdio: "inherit" });
           });
@@ -442,7 +442,7 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
           }
 
           const imageFullNames = getImageFullNames(args);
-          buildImage({ ...args, arch: ["amd64"] }, imageFullNames);
+          buildImage({ ...args, arch: ["linux/amd64"] }, imageFullNames);
           imageFullNames.forEach((imageName) => {
             execSync(`kind load docker-image ${imageName} --name ${args.kindClusterName}`, { stdio: "inherit" });
           });

--- a/packages/image-builder/src/bin.ts
+++ b/packages/image-builder/src/bin.ts
@@ -135,7 +135,7 @@ function buildNativeImage(args: ArgsType, imageFullNames: string[]) {
 }
 
 function checkNativeArch(arch: ArgsType["arch"]) {
-  return arch == undefined || (arch?.length == 1 && arch?.includes("native"));
+  return arch?.length == 1 && arch?.includes("native");
 }
 
 function buildImage(args: ArgsType, imageFullNames: string[]) {
@@ -324,12 +324,14 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
         },
         arch: {
           demandOption: false,
-          describe: "The target build architectures. If not provided will default to the native architecture",
+          describe:
+            "The target build architectures, For example: [linux/amd64, linux/arm64]. If not provided will default to the native architecture",
           type: "array",
+          default: ["native"],
           coerce: (arch) => {
             if (arch.length === 1) {
               const evaluedArgs = evalStringArg<string>(arch[0]);
-              return evaluedArgs.split(",").map((a) => (a != "native" ? `linux/${a}` : a)) as string[];
+              return evaluedArgs.split(",") as string[];
             }
             return arch as string[];
           },

--- a/packages/image-builder/src/bin.ts
+++ b/packages/image-builder/src/bin.ts
@@ -34,7 +34,7 @@ type ArgsType = {
   tags: string[];
   push: boolean;
   buildArg: string[];
-  arch: string;
+  arch?: string[];
   allowHostNetworkAccess: boolean;
 };
 
@@ -98,19 +98,14 @@ function checkBuildEngine(args: ArgsType) {
   }
 }
 
-function buildArchImage(args: ArgsType & { arch: "arm64" | "amd64" }, imageFullNames: string[]) {
-  const platform = {
-    arm64: "linux/arm64",
-    amd64: "linux/amd64",
-  }[args.arch];
-
+function buildArchImage(args: ArgsType & { arch: string[] | undefined }, imageFullNames: string[]) {
   createAndUseDockerBuilder({ allowHostNetworkAccess: args.allowHostNetworkAccess });
   console.log(`[image-builder] Building arch image ${args.arch}`);
   const buildPlatformCommand = `docker buildx build
     ${args.allowHostNetworkAccess ? "--allow network.host --network host" : ""}
     --progress=plain
     --load
-    --platform ${platform}
+    --platform ${args.arch}
     ${args.push ? "--push" : ""}
     ${imageFullNames.map((fullName) => `-t ${fullName}`).join(" ")}
     ${args.buildArg.map((arg) => `--build-arg ${arg}`).join(" ")}
@@ -139,8 +134,8 @@ function buildNativeImage(args: ArgsType, imageFullNames: string[]) {
   execSync(buildNativeCommand, { stdio: "inherit" });
 }
 
-function checkNotNativeArch(arch: ArgsType["arch"]): arch is "arm64" | "amd64" {
-  return arch !== "native";
+function checkNativeArch(arch: ArgsType["arch"]) {
+  return arch == undefined || (arch?.length == 1 && arch?.includes("native"));
 }
 
 function buildImage(args: ArgsType, imageFullNames: string[]) {
@@ -148,10 +143,10 @@ function buildImage(args: ArgsType, imageFullNames: string[]) {
 
   const arch = args.arch;
 
-  if (checkNotNativeArch(arch)) {
-    buildArchImage({ ...args, arch }, imageFullNames);
-  } else {
+  if (checkNativeArch(arch)) {
     buildNativeImage(args, imageFullNames);
+  } else {
+    buildArchImage({ ...args, arch }, imageFullNames);
   }
 }
 
@@ -329,11 +324,15 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
         },
         arch: {
           demandOption: false,
-          describe: "The target build architecture. If not provided will default to the native architecture",
-          type: "string",
-          default: "native",
-          choices: ["amd64", "arm64", "native"] as const,
-          nargs: 1,
+          describe: "The target build architectures. If not provided will default to the native architecture",
+          type: "array",
+          coerce: (arch) => {
+            if (arch.length === 1) {
+              const evaluedArgs = evalStringArg<string>(arch[0]);
+              return evaluedArgs.split(",").map((a) => (a != "native" ? `linux/${a}` : a)) as string[];
+            }
+            return arch as string[];
+          },
         },
       })
       .command(
@@ -353,9 +352,9 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
     - engine: ${args.engine}
     - push: ${args.push}
     - allowHostNetworkAccess: ${args.allowHostNetworkAccess}
-    - arch: linux/${args.arch}
+    - arch: ${args.arch}
         `);
-          if (args.arch !== "native" && args.engine !== "docker") {
+          if (!checkNativeArch(args.arch) && args.engine !== "docker") {
             throw new Error(
               `ERROR! --arch: Targetting non-native architecturies is only supported with the Docker engine.`
             );
@@ -390,7 +389,7 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
           }
 
           const imageFullNames = getImageFullNames(args);
-          buildImage({ ...args, arch: "amd64" }, imageFullNames);
+          buildImage({ ...args, arch: ["amd64"] }, imageFullNames);
           imageFullNames.forEach((imageName) => {
             execSync(`minikube image load ${imageName}`, { stdio: "inherit" });
           });
@@ -441,7 +440,7 @@ Also useful to aid on developing images and pushing them to Kubernetes/OpenShift
           }
 
           const imageFullNames = getImageFullNames(args);
-          buildImage({ ...args, arch: "amd64" }, imageFullNames);
+          buildImage({ ...args, arch: ["amd64"] }, imageFullNames);
           imageFullNames.forEach((imageName) => {
             execSync(`kind load docker-image ${imageName} --name ${args.kindClusterName}`, { stdio: "inherit" });
           });


### PR DESCRIPTION
kie-issue: https://github.com/apache/incubator-kie-tools/issues/3318

The PR enables the kie-tools-image-builder to build multiple platform image. 
- The existing --arch flag is modified to accept array instead of single argument
- Compatible with existing container packages
- It retains the existing behavior for native builds, when no --arch is passed or the value of --arch  is "native", it triggers the native builds.
- Values can be passed to --arch flag like `kie-tools--image-builder build --arch="amd64,arm64"` or  --arch="amd64"