### PR TITLE
[NO-ISSUE] Update vertx-web to 4.5.22 and add version declarations for other version overrides.

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -145,12 +145,49 @@
     <version.apache.commons.lang3>3.18.0</version.apache.commons.lang3>
     <version.angus.mail>2.0.5</version.angus.mail>
     <version.nimbus.jose.jwt>9.37.4</version.nimbus.jose.jwt>
+    <version.io.vertx>4.5.22</version.io.vertx>
     <!-- End of various transitive overrides. -->
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
+           They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
+      <dependency>
+        <groupId>org.eclipse.angus</groupId>
+        <artifactId>angus-mail</artifactId>
+        <version>${version.angus.mail}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>${version.nimbus.jose.jwt}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web</artifactId>
+        <version>${version.io.vertx}</version>
+      </dependency>
+      <!-- End of various transitive overrides. -->
+
+      <!-- Not directly used, but used to override transitive versions from other dependencies to fix vulnerabilities -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat.embed.core}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${version.apache.commons.lang3}</version>
+      </dependency>
+
       <!-- Apache KIE -->
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web</artifactId>
+        <version>${version.io.vertx}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.kie.kogito</groupId>


### PR DESCRIPTION
This PR upgrades vertx to 4.5.22 and adds other version overrides which were forgot to be added in one of my previous PRs (sorry for that). 

Related PRs: 
https://github.com/apache/incubator-kie-drools/pull/6500
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4111