### PR TITLE
修改默认工程名称为"HRL 诊断规则平台"

### DIFF
--- a/packages/online-editor/env/index.js
+++ b/packages/online-editor/env/index.js
@@ -73,7 +73,7 @@ module.exports = composeEnv([rootEnv, extendedServicesJavaEnv, corsProxyEnv, kie
       description: "Service URL to validate commit messages.",
     },
     ONLINE_EDITOR__appName: {
-      default: "Apache KIE™ Sandbox",
+      default: "HRL 诊断规则平台",
       description: "The name used to refer to a particular KIE Sandbox distribution.",
     },
     ONLINE_EDITOR__devDeploymentBaseImageRegistry: {

--- a/packages/runtime-tools-management-console-webapp/env/index.js
+++ b/packages/runtime-tools-management-console-webapp/env/index.js
@@ -34,7 +34,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       description: "Build information to be shown in the 'About' modal.",
     },
     RUNTIME_TOOLS_MANAGEMENT_CONSOLE_WEBAPP__appName: {
-      default: "Apache KIE™ Management Console",
+      default: "HRL 诊断规则平台 管理控制台",
       description: "The name used to refer to a particular KIE Management Console distribution.",
     },
     RUNTIME_TOOLS_MANAGEMENT_CONSOLE_WEBAPP__oidcClientClientId: {


### PR DESCRIPTION
- 将 Online Editor 的默认应用名称从 "Apache KIE™ Sandbox" 改为 "HRL 诊断规则平台"
- 将 Management Console 的默认应用名称从 "Apache KIE™ Management Console" 改为 "HRL 诊断规则平台 管理控制台"

🤖 Generated with [Claude Code](https://claude.com/claude-code)