### PR TITLE
NO-ISSUE: Removing duplicated vertx-web dependency declaration

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -184,12 +184,6 @@
 
       <!-- Apache KIE -->
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-bom</artifactId>
         <version>${version.org.kie.kogito}</version>


### PR DESCRIPTION
vertx-web is declared twice

https://github.com/apache/incubator-kie-tools/pull/3338/files#diff-fdeb8acdc189e001b591797ce0d59063d4e857c64b1017b4173421b2562f2065L167

```
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.vertx:vertx-web:jar -> duplicate declaration of version ${version.io.vertx} @ org.kie:kie-tools-maven-base:${revision}, maven-build-parent/node_modules/@kie-tools/maven-base/pom.xml, line 186, column 19
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```