### PR TITLE
kie-issues#2166: [TEMPORARY FIX] Disable Chrome Extension tests

### DIFF
--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/BpmnTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/BpmnTest.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const WEB_PAGE =
     "https://github.com/apache/incubator-kie-tools/tree/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples";
   const PROCESS_NAME = "myProcess";

--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnExpressionEditorTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnExpressionEditorTest.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const WEB_PAGE =
     "https://github.com/apache/incubator-kie-tools/tree/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples";
   const FILE_NAME = "test.dmn";

--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnFullScreenTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnFullScreenTest.ts
@@ -32,7 +32,7 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const dmnUrl: string =
     "https://github.com/apache/incubator-kie-tools/" +
     "blob/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples/test.dmn";

--- a/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnTest.ts
+++ b/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/tests/DmnTest.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   tools = await Tools.init(TEST_NAME);
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const WEB_PAGE =
     "https://github.com/apache/incubator-kie-tools/tree/main/packages/chrome-extension-pack-kogito-kie-editors/e2e-tests/samples";
   const DMN_NAME = "myDmn";

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfFullScreenTest.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
   }
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const workflowUrl: string =
     "https://github.com/apache/incubator-kie-tools/blob/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples/chrome_sample.sw.yaml";
   let swfPage: GitHubEditorPage = await tools.openPage(GitHubEditorPage, workflowUrl);

--- a/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
+++ b/packages/chrome-extension-serverless-workflow-editor/e2e-tests/tests/SwfTest.ts
@@ -45,7 +45,7 @@ beforeEach(async () => {
   }
 });
 
-test(TEST_NAME, async () => {
+test.skip(TEST_NAME, async () => {
   const gitHubListPage: GitHubListPage = await tools.openPage(
     GitHubListPage,
     "https://github.com/apache/incubator-kie-tools/tree/main/packages/chrome-extension-serverless-workflow-editor/e2e-tests/samples"


### PR DESCRIPTION
Related to: https://github.com/apache/incubator-kie-tools/issues/3861

Temporary fix by disabling the Chrome Extension tests. We still need to do further investigations to determine what we need to change on the `chrome-extension-test-helper` to accomodate the Chrome update.