### PR TITLE
kie-issues#2172: DMN Editor: Editing Data Type enum constraints moves characters to the last position

### DIFF
--- a/packages/dmn-editor/src/dataTypes/ConstraintsEnum.tsx
+++ b/packages/dmn-editor/src/dataTypes/ConstraintsEnum.tsx
@@ -216,15 +216,22 @@ function EnumElement({
   onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
 }) {
   const { i18n } = useDmnEditorI18n();
-  const value = useMemo<string>(() => initialValue, [initialValue]);
+  const [value, setValue] = useState<string>(initialValue);
   const removeButtonRef = useRef(null);
   const { hovered } = useDraggableItemContext();
+
+  React.useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
 
   return (
     <div style={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}>
       {typeHelper.component({
         autoFocus: true,
-        onChange: (newValue: string) => onChange(newValue),
+        onChange: (newValue: string) => {
+          setValue(newValue);
+          onChange(newValue);
+        },
         id,
         isDisabled,
         style: {


### PR DESCRIPTION
Closes [kie#2172](https://github.com/apache/incubator-kie-issues/issues/2172)

Cursor stays in selected position


https://github.com/user-attachments/assets/c38c216f-e63c-47c7-af6e-655bb4184bc9



