### PR TITLE
[CI] kie-tools-3372: Fix kie-tools-daily-dev-publish job is running out of…

### DIFF
--- a/.ci/jenkins/shared-scripts/buildUtils.groovy
+++ b/.ci/jenkins/shared-scripts/buildUtils.groovy
@@ -51,7 +51,7 @@ def setupPnpm(String mavenSettingsFileId = '') {
     pnpm config set network-timeout 1000000
     pnpm -r exec 'bash' '-c' 'mkdir .mvn'
     pnpm -r exec 'bash' '-c' 'echo -B > .mvn/maven.config'
-    pnpm -r exec 'bash' '-c' 'echo -Xmx2g > .mvn/jvm.config'
+    pnpm -r exec 'bash' '-c' 'echo -Xmx3g > .mvn/jvm.config'
     """.trim()
 
     if (mavenSettingsFileId) {


### PR DESCRIPTION
… heap space

Increase the -Xmx from 2g to 3g

Attempt to fix - https://github.com/apache/incubator-kie-tools/issues/3372

Could be insufficient, but I followed what we [have](https://github.com/apache/incubator-kie-tools/blob/b681281a5bba2cafe6f2a8db69ad2d1c18b7152c/.github/workflows/ci_build.yml#L114C10-L114C31) in Github workflows for `bootstrap` step

If this won't fix it I can try increasing more, or we would need to investigate if this is not a problem related to the apache ci jenkins.