### PR TITLE
kie-issues#2186: DMN Editor: Data Types screen should have independent scroll for each panel

### DIFF
--- a/packages/dmn-editor/src/DmnEditor.css
+++ b/packages/dmn-editor/src/DmnEditor.css
@@ -907,8 +907,16 @@ circle.kie-dmn-editor--diagram-edge-waypoint:hover {
 .kie-dmn-editor--data-types-filter input {
   flex-grow: 1;
 }
+.kie-tools--dmn-editor--data-types-container {
+  overflow: hidden;
+  height: 100%;
+}
 .kie-dmn-editor--data-types-nav {
   padding-left: 16px;
+  overflow-y: auto;
+}
+.kie-dmn-editor--data-types-container .pf-c-drawer__content {
+  overflow-y: auto;
 }
 .kie-dmn-editor--data-types-nav-item:first-child {
   margin-top: 16px;

--- a/packages/dmn-editor/src/DmnEditor.tsx
+++ b/packages/dmn-editor/src/DmnEditor.tsx
@@ -454,7 +454,10 @@ export const DmnEditorInternal = ({
         </Tab>
 
         <Tab eventKey={DmnEditorTab.DATA_TYPES} title={tabTitle.dataTypes}>
-          <div data-testid={"kie-tools--dmn-editor--data-types-container"}>
+          <div
+            data-testid={"kie-tools--dmn-editor--data-types-container"}
+            className="kie-tools--dmn-editor--data-types-container"
+          >
             {navigationTab === DmnEditorTab.DATA_TYPES && <DataTypes />}
           </div>
         </Tab>


### PR DESCRIPTION
Closes [kie#2186](https://github.com/apache/incubator-kie-issues/issues/2186)

Individual scroll added for datatype panels

https://github.com/user-attachments/assets/a8ff4261-72be-4c88-bc40-1fcca77bfda4

