### PR TITLE
NO-ISSUE: [CI] upgrade macos runner

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         partition: [0, 1, 2]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
         partition: [0, 1, 2]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15, windows-latest]
+        os: [macos-14, windows-latest]
     steps:
       - name: "Support longpaths (Windows only)"
         if: runner.os == 'Windows'

--- a/.github/workflows/release_build_extended_services.yml
+++ b/.github/workflows/release_build_extended_services.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, windows-latest]
+        os: [macos-15, windows-latest]
     steps:
       - name: "Support longpaths (Windows only)"
         if: runner.os == 'Windows'


### PR DESCRIPTION
MacOS GHAs are not running [here](https://github.com/apache/incubator-kie-tools/actions/runs/20066334405):
```
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.
```
This PR is to test the upgrade from `macos-13` :crossed_fingers: 