### PR TITLE
kie-issues#2196: DMN Editor: Syntax highlight for sub-properties of parameters with struct Data Types not working

### DIFF
--- a/packages/dmn-feel-antlr4-parser/src/parser/IdentifiersRepository.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/IdentifiersRepository.ts
@@ -284,6 +284,7 @@ export class IdentifiersRepository {
             identifierDefinedByTheContext: parameter["@_name"] ?? "<parameter>",
             kind: FeelSyntacticSymbolNature.Parameter,
             parentContext: parentElement,
+            typeRef: parameter["@_typeRef"],
             applyValueToSource: (value) => {
               parameter["@_name"] = value;
             },


### PR DESCRIPTION
Closes [kie#2196](https://github.com/apache/incubator-kie-issues/issues/2196)

For struct datatypes, properties are highlighted for bkm nodes.
 
<img width="691" height="342" alt="image" src="https://github.com/user-attachments/assets/629493d8-1537-4e6e-8472-c2546722be85" />
