### PR TITLE
kie-issues#2198: DMN Editor: Copy and paste of data type property creates non unique copy

### DIFF
--- a/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
+++ b/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
@@ -205,15 +205,17 @@ export function ItemComponentsTable({
                         return;
                       }
 
+                      const itemDefinitionsCopy = JSON.parse(JSON.stringify(clipboard.itemDefinitions));
+
                       getNewDmnIdRandomizer()
                         .ack({
-                          json: clipboard.itemDefinitions,
+                          json: itemDefinitionsCopy,
                           type: "DMN16__tDefinitions",
                           attr: "itemDefinition",
                         })
-                        .randomize();
+                        .randomize({ skipAlreadyAttributedIds: false });
 
-                      for (const itemDefinition of clipboard.itemDefinitions) {
+                      for (const itemDefinition of itemDefinitionsCopy) {
                         addItemComponent(parent.itemDefinition["@_id"]!, "unshift", itemDefinition);
                       }
                     });
@@ -609,15 +611,19 @@ export function ItemComponentsTable({
                                           return;
                                         }
 
+                                        const itemDefinitionsCopy = JSON.parse(
+                                          JSON.stringify(clipboard.itemDefinitions)
+                                        );
+
                                         getNewDmnIdRandomizer()
                                           .ack({
-                                            json: clipboard.itemDefinitions,
+                                            json: itemDefinitionsCopy,
                                             type: "DMN16__tDefinitions",
                                             attr: "itemDefinition",
                                           })
-                                          .randomize();
+                                          .randomize({ skipAlreadyAttributedIds: false });
 
-                                        for (const itemDefinition of clipboard.itemDefinitions) {
+                                        for (const itemDefinition of itemDefinitionsCopy) {
                                           addItemComponent(dt.itemDefinition["@_id"]!, "unshift", itemDefinition);
                                         }
                                       });

--- a/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
+++ b/packages/dmn-editor/src/dataTypes/ItemComponentsTable.tsx
@@ -205,17 +205,15 @@ export function ItemComponentsTable({
                         return;
                       }
 
-                      const itemDefinitionsCopy = JSON.parse(JSON.stringify(clipboard.itemDefinitions));
-
                       getNewDmnIdRandomizer()
                         .ack({
-                          json: itemDefinitionsCopy,
+                          json: clipboard.itemDefinitions,
                           type: "DMN16__tDefinitions",
                           attr: "itemDefinition",
                         })
                         .randomize({ skipAlreadyAttributedIds: false });
 
-                      for (const itemDefinition of itemDefinitionsCopy) {
+                      for (const itemDefinition of clipboard.itemDefinitions) {
                         addItemComponent(parent.itemDefinition["@_id"]!, "unshift", itemDefinition);
                       }
                     });
@@ -611,19 +609,15 @@ export function ItemComponentsTable({
                                           return;
                                         }
 
-                                        const itemDefinitionsCopy = JSON.parse(
-                                          JSON.stringify(clipboard.itemDefinitions)
-                                        );
-
                                         getNewDmnIdRandomizer()
                                           .ack({
-                                            json: itemDefinitionsCopy,
+                                            json: clipboard.itemDefinitions,
                                             type: "DMN16__tDefinitions",
                                             attr: "itemDefinition",
                                           })
                                           .randomize({ skipAlreadyAttributedIds: false });
 
-                                        for (const itemDefinition of itemDefinitionsCopy) {
+                                        for (const itemDefinition of clipboard.itemDefinitions) {
                                           addItemComponent(dt.itemDefinition["@_id"]!, "unshift", itemDefinition);
                                         }
                                       });


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2198

Before fix:

- Also if i copy and paste the property in same data type and modify the pasted property it is replacing the original property as well but when i modify the original property it is not affecting pasted property.

- If i pasted the property in another data type and modify it , it is asking for rename and replace and just rename, but the expectation is it should be treated as new property.

After fix:

Open the Sample, and then go to DataTypes and try to copy the property "Amount", of type Requested_Product. Then:

- Paste in a new DataType
- Rename the pasted DataType to something else (for example, "Pasted Amount")
- Paste again in another type and confirm that the pasted DataType has the same name (Amount) and not the name that you put in step 2 ("Pasted Amount")
- Go back to Requested_Product and verify if the name of property "Amount" still the same
- Now, try to rename "Amount". The popup confirm the renaming should appear.