### PR TITLE
kie-issues#3387: DMN Runner missing validation information about the number range 

### DIFF
--- a/packages/form-dmn/tests/__snapshots__/FormDmn.test.tsx.snap
+++ b/packages/form-dmn/tests/__snapshots__/FormDmn.test.tsx.snap
@@ -756,11 +756,13 @@ exports[`FormDmn tests should validate the formInputs - invalid 1`] = `
               class="pf-v5-c-helper-text"
             >
               <div
-                class="pf-v5-c-helper-text__item"
+                class="pf-v5-c-helper-text__item pf-m-error"
               >
                 <span
                   class="pf-v5-c-helper-text__item-text"
-                />
+                >
+                  should match format P1D(ays)T2H(ours)3M(inutes)1S(econds)
+                </span>
               </div>
             </div>
           </div>
@@ -1255,11 +1257,13 @@ exports[`FormDmn tests shouldn't submit the formInputs 1`] = `
               class="pf-v5-c-helper-text"
             >
               <div
-                class="pf-v5-c-helper-text__item"
+                class="pf-v5-c-helper-text__item pf-m-error"
               >
                 <span
                   class="pf-v5-c-helper-text__item-text"
-                />
+                >
+                  should match format P1D(ays)T2H(ours)3M(inutes)1S(econds)
+                </span>
               </div>
             </div>
           </div>

--- a/packages/uniforms-patternfly/src/wrapField.tsx
+++ b/packages/uniforms-patternfly/src/wrapField.tsx
@@ -48,9 +48,18 @@ filterDOMProps.register(
   "menuAppendTo"
 );
 
+interface ValidationError {
+  instancePath: string;
+  message: string;
+  keyword: string;
+  params: Record<string, any>;
+  schemaPath?: string;
+  data?: any;
+}
+
 type WrapperProps = {
   id: string;
-  error?: boolean | object;
+  error?: boolean | ValidationError;
   errorMessage?: string;
   help?: string;
   showInlineError?: boolean;
@@ -99,7 +108,7 @@ export default function wrapField(
       {...filterDOMProps(props)}
     >
       {children}
-      {error === true || (error && typeof error === "object") ? (
+      {error ? (
         <FormHelperText>
           <HelperText>
             <HelperTextItem variant="error">{errorMessage}</HelperTextItem>

--- a/packages/uniforms-patternfly/src/wrapField.tsx
+++ b/packages/uniforms-patternfly/src/wrapField.tsx
@@ -50,7 +50,7 @@ filterDOMProps.register(
 
 type WrapperProps = {
   id: string;
-  error?: boolean;
+  error?: boolean | object;
   errorMessage?: string;
   help?: string;
   showInlineError?: boolean;
@@ -99,7 +99,7 @@ export default function wrapField(
       {...filterDOMProps(props)}
     >
       {children}
-      {error === true ? (
+      {error === true || (error && typeof error === "object") ? (
         <FormHelperText>
           <HelperText>
             <HelperTextItem variant="error">{errorMessage}</HelperTextItem>


### PR DESCRIPTION
Closes : [kie-issues#3387](https://github.com/apache/incubator-kie-tools/issues/3387)


Fix for DMN Runner missing validation information about the number range

<img width="3456" height="2046" alt="image (4)" src="https://github.com/user-attachments/assets/cb442c67-f803-481e-9c5f-7920221d086c" />


<img width="3456" height="2042" alt="image (5)" src="https://github.com/user-attachments/assets/8792e76e-e091-4193-b0dc-2a95e6bf42ca" />
