### PR TITLE
[kie-issues#2212]Update react-router-dom to 6.30.2

### DIFF
--- a/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
@@ -27,7 +27,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
     "webpack": "^5.94.0",

--- a/examples/serverless-workflow-editor-standalone-on-webapp/package.json
+++ b/examples/serverless-workflow-editor-standalone-on-webapp/package.json
@@ -25,7 +25,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "rimraf": "^3.0.2",
     "typescript": "^5.5.3",
     "webpack": "^5.94.0",

--- a/packages/dashbuilder-viewer-deployment-webapp/package.json
+++ b/packages/dashbuilder-viewer-deployment-webapp/package.json
@@ -33,7 +33,7 @@
     "@patternfly/react-icons": "^5.4.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/dev-deployment-dmn-form-webapp/package.json
+++ b/packages/dev-deployment-dmn-form-webapp/package.json
@@ -35,7 +35,7 @@
     "@readme/openapi-parser": "^2.5.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.17.21",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/kie-editors-standalone/package.json
+++ b/packages/kie-editors-standalone/package.json
@@ -78,7 +78,7 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6",
     "start-server-and-test": "^2.0.3",

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -79,7 +79,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.4.2",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.3.1",
     "uuid": "^8.3.2"

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -51,7 +51,7 @@
     "react-cool-onclickoutside": "^1.6.1",
     "react-monaco-editor": "^0.49.0",
     "react-redux": "^7.2.4",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "react-sortable-hoc": "^2.0.0",
     "react-transition-group": "^4.4.1",
     "redux": "^4.1.0",

--- a/packages/runtime-tools-components/package.json
+++ b/packages/runtime-tools-components/package.json
@@ -43,7 +43,7 @@
     "monaco-editor": "^0.39.0",
     "react-datetime-picker": "^3.5.0",
     "react-moment": "0.9.7",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "uniforms": "^3.10.2",
     "uniforms-bridge-json-schema": "^3.10.2",
     "uuid": "^8.3.2"

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -51,7 +51,7 @@
     "react-apollo": "3.1.3",
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -48,7 +48,7 @@
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^17.0.2",
     "react-moment": "0.9.7",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "util": "^0.12.5",
     "uuid": "^8.3.2"
   },

--- a/packages/runtime-tools-shared-webapp-components/package.json
+++ b/packages/runtime-tools-shared-webapp-components/package.json
@@ -26,7 +26,7 @@
     "@kie-tools/runtime-tools-components": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/serverless-logic-web-tools/package.json
+++ b/packages/serverless-logic-web-tools/package.json
@@ -87,7 +87,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.4.2",
     "react-if": "^4.1.4",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "short-unique-id": "^4.4.4",
     "showdown": "^2.1.0",
     "uuid": "^8.3.2",

--- a/packages/serverless-workflow-dev-ui-webapp/package.json
+++ b/packages/serverless-workflow-dev-ui-webapp/package.json
@@ -54,7 +54,7 @@
     "react-apollo": "3.1.3",
     "react-dom": "^17.0.2",
     "react-moment": "0.9.7",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/sonataflow-deployment-webapp/package.json
+++ b/packages/sonataflow-deployment-webapp/package.json
@@ -45,7 +45,7 @@
     "openapi-types": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0",
+    "react-router-dom": "^6.30.2",
     "typescript": "^5.5.3"
   },
   "devDependencies": {

--- a/packages/sonataflow-management-console-webapp/package.json
+++ b/packages/sonataflow-management-console-webapp/package.json
@@ -54,7 +54,7 @@
     "react-apollo": "3.1.3",
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.29.0"
+    "react-router-dom": "^6.30.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,7 +764,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
@@ -1089,7 +1089,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
@@ -3194,7 +3194,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
@@ -3349,7 +3349,7 @@ importers:
         specifier: '>=17.0.2 <19.0.0'
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
@@ -6515,7 +6515,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
@@ -7454,7 +7454,7 @@ importers:
         specifier: ^11.4.2
         version: 11.4.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-virtualized-auto-sizer:
         specifier: ^1.0.7
@@ -7747,7 +7747,7 @@ importers:
         specifier: ^7.2.4
         version: 7.2.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-sortable-hoc:
         specifier: ^2.0.0
@@ -8128,7 +8128,7 @@ importers:
         specifier: 0.9.7
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       uniforms:
         specifier: ^3.10.2
@@ -8271,7 +8271,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
@@ -8530,7 +8530,7 @@ importers:
         specifier: 0.9.7
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       util:
         specifier: ^0.12.5
@@ -9174,7 +9174,7 @@ importers:
         specifier: '>=17.0.2 <19.0.0'
         version: 17.0.2
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
@@ -10048,7 +10048,7 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       short-unique-id:
         specifier: ^4.4.4
@@ -10562,7 +10562,7 @@ importers:
         specifier: 0.9.7
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
@@ -11775,7 +11775,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       typescript:
         specifier: ^5.5.3
@@ -12116,7 +12116,7 @@ importers:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
       react-router-dom:
-        specifier: ^6.29.0
+        specifier: ^6.30.2
         version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
Updated version react-router-dom from 6.29.0 to 6.30.2
Closes https://github.com/apache/incubator-kie-issues/issues/2212