### PR TITLE
NO-ISSUE: Bump drools-and-kogito to 999-20260120-local

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "94ad1abaa44e874967b6ee1233f135403b056d73",
+      default: "fe6decc777e02e22a40e822dd56738c553396f5a",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for OptaPlanner",
     },
     DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "446fc6abb09f419459a8fc2bbed0888cf293cddb",
+      default: "2ee3fb2897cf5e658fc27742e791e488a4476bc4",
       description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "f47d7bd97b2677ef8530b88dfe73bd92b619d6f6",
+      default: "3fb6a68047838f5caf97a507c9a54567069a8c1f",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "c185f57fcfc098ba5b3de10e0061beb093d380e2",
+      default: "7252d3d337b9cee487b098f3aebd6fe7e8385847",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20251107-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20260120-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.20.3</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20251107-local",
+      default: "999-20260120-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */


### PR DESCRIPTION
Drools git ref:https://github.com/apache/incubator-kie-drools/@ [fe6decc](https://github.com/apache/incubator-kie-drools/commit/fe6decc777e02e22a40e822dd56738c553396f5a)
Optaplanner git ref: https://github.com/apache/incubator-kie-optaplanner/@ [2ee3fb2](https://github.com/apache/incubator-kie-optaplanner/commit/2ee3fb2897cf5e658fc27742e791e488a4476bc4)
Kogito Runtimes git ref: https://github.com/apache/incubator-kie-kogito-runtimes/@  [3fb6a68](https://github.com/apache/incubator-kie-kogito-runtimes/commit/3fb6a68047838f5caf97a507c9a54567069a8c1f)
Kogito Apps git ref: https://github.com/apache/incubator-kie-kogito-apps/@ [7252d3d](https://github.com/apache/incubator-kie-kogito-apps/commit/7252d3d337b9cee487b098f3aebd6fe7e8385847)