### PR TITLE
Jobs Service - Display version information from jobs service webapp.

### DIFF
--- a/packages/kogito-jobs-service-webapp/env/index.js
+++ b/packages/kogito-jobs-service-webapp/env/index.js
@@ -45,6 +45,10 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "SonataFlow Jobs Service docs",
       description: "Documentation link text",
     },
+    KOGITO_JOBS_SERVICE_WEBAPP_version: {
+      default: require("../package.json").version,
+      description: "Kogito Jobs Service Version",
+    },
   }),
   get env() {
     return {
@@ -62,6 +66,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
           href: getOrDefault(this.vars.SONATAFLOW_JOBS_SERVICE_WEBAPP_docLinkHref),
           text: getOrDefault(this.vars.SONATAFLOW_JOBS_SERVICE_WEBAPP_docLinkText),
         },
+        version: getOrDefault(this.vars.KOGITO_JOBS_SERVICE_WEBAPP_version),
       },
     };
   },

--- a/packages/kogito-jobs-service-webapp/package.json
+++ b/packages/kogito-jobs-service-webapp/package.json
@@ -25,7 +25,6 @@
     "@kie-tools-core/webpack-base": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "copy-webpack-plugin": "^11.0.0",
-    "html-replace-webpack-plugin": "^2.6.0",
     "html-webpack-plugin": "^5.3.2",
     "jest": "^29.7.0",
     "rimraf": "^3.0.2",

--- a/packages/kogito-jobs-service-webapp/src/index.html
+++ b/packages/kogito-jobs-service-webapp/src/index.html
@@ -22,16 +22,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>${KOGITO_JOBS_SERVICE_WEBAPP_TITLE}</title>
+    <title><%= KOGITO_JOBS_SERVICE_WEBAPP_TITLE %></title>
     <link rel="stylesheet" href="styles.css" />
-    <link rel="shortcut icon" type="image/x-icon" href="${KOGITO_JOBS_SERVICE_WEBAPP_LOGO}" />
+    <link rel="shortcut icon" type="image/x-icon" href="<%= KOGITO_JOBS_SERVICE_WEBAPP_LOGO %>" />
   </head>
   <body>
     <div class="maindiv">
       <div class="container">
-        <div class="logo" style="display: flex; justify-content: center">
-          <img src="${KOGITO_JOBS_SERVICE_WEBAPP_LOGO}" alt="KIE Logo" />
-          <h1>${KOGITO_JOBS_SERVICE_WEBAPP_TITLE}</h1>
+        <div class="logo" style="display: flex; justify-content: center; align-items: center">
+          <img src="<%= KOGITO_JOBS_SERVICE_WEBAPP_LOGO %>" alt="KIE Logo" />
+
+          <div style="display: flex; flex-direction: column; gap: 4px">
+            <h1 style="margin: 0"><%= KOGITO_JOBS_SERVICE_WEBAPP_TITLE %></h1>
+            <h6 style="margin: 0; font-weight: normal" class="versionInfo">
+              <%= KOGITO_JOBS_SERVICE_WEBAPP_VERSION %>
+            </h6>
+          </div>
         </div>
         <div>
           <h4>Your Jobs service is up and working!</h4>
@@ -43,13 +49,13 @@
         </p>
         <div class="linkbutton">
           <div>
-            <a href="${SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_HREF}" class="btn" target="_blank"
-              >${SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT}</a
+            <a href="<%= SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_HREF %>" class="btn" target="_blank"
+              ><%= SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT %></a
             >
           </div>
           <div>
-            <a href="${KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_HREF}" class="btn" target="_blank"
-              >${KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT}</a
+            <a href="<%= KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_HREF %>" class="btn" target="_blank"
+              ><%= KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT %></a
             >
           </div>
         </div>

--- a/packages/kogito-jobs-service-webapp/src/styles.css
+++ b/packages/kogito-jobs-service-webapp/src/styles.css
@@ -81,6 +81,10 @@ p {
   justify-content: space-around;
 }
 
+.versionInfo {
+  color: #1f1e1e;
+}
+
 @media (prefers-color-scheme: dark) {
   .maindiv,
   .container {
@@ -90,5 +94,9 @@ p {
   h4,
   p {
     color: #fefefe;
+  }
+
+  .versionInfo {
+    color: #fff;
   }
 }

--- a/packages/kogito-jobs-service-webapp/webpack.config.js
+++ b/packages/kogito-jobs-service-webapp/webpack.config.js
@@ -22,7 +22,6 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { merge } = require("webpack-merge");
 const common = require("@kie-tools-core/webpack-base/webpack.common.config");
 const { env } = require("./env");
-const HtmlReplaceWebpackPlugin = require("html-replace-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = async (webpackEnv) =>
@@ -38,34 +37,16 @@ module.exports = async (webpackEnv) =>
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, "src/index.html"),
         filename: "index.html",
-        chunks: ["app"],
+        templateParameters: {
+          KOGITO_JOBS_SERVICE_WEBAPP_TITLE: env.kogitoJobsServiceWebapp.title,
+          KOGITO_JOBS_SERVICE_WEBAPP_LOGO: env.kogitoJobsServiceWebapp.logo,
+          KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_HREF: env.kogitoJobsServiceWebapp.docLinkKogito.href,
+          KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT: env.kogitoJobsServiceWebapp.docLinkKogito.text,
+          SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_HREF: env.kogitoJobsServiceWebapp.docLinkSonataflow.href,
+          SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT: env.kogitoJobsServiceWebapp.docLinkSonataflow.text,
+          KOGITO_JOBS_SERVICE_WEBAPP_VERSION: env.kogitoJobsServiceWebapp.version,
+        },
       }),
-      new HtmlReplaceWebpackPlugin([
-        {
-          pattern: /\${KOGITO_JOBS_SERVICE_WEBAPP_TITLE}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.title ?? "",
-        },
-        {
-          pattern: /\${KOGITO_JOBS_SERVICE_WEBAPP_LOGO}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.logo ?? "",
-        },
-        {
-          pattern: /\${KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_HREF}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.docLinkKogito.href ?? "",
-        },
-        {
-          pattern: /\${KOGITO_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.docLinkKogito.text ?? "",
-        },
-        {
-          pattern: /\${SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_HREF}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.docLinkSonataflow.href ?? "",
-        },
-        {
-          pattern: /\${SONATAFLOW_JOBS_SERVICE_WEBAPP_DOCLINK_TEXT}/g,
-          replacement: () => env.kogitoJobsServiceWebapp.docLinkSonataflow.text ?? "",
-        },
-      ]),
     ],
     ignoreWarnings: [/Failed to parse source map/],
     devServer: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,7 +765,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1090,7 +1090,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3195,7 +3195,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -3350,7 +3350,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -6516,7 +6516,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -7101,9 +7101,6 @@ importers:
       copy-webpack-plugin:
         specifier: ^11.0.0
         version: 11.0.0(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
-      html-replace-webpack-plugin:
-        specifier: ^2.6.0
-        version: 2.6.0
       html-webpack-plugin:
         specifier: ^5.3.2
         version: 5.3.2(webpack@5.94.0(@swc/core@1.3.92)(webpack-cli@4.10.0))
@@ -7455,7 +7452,7 @@ importers:
         version: 11.4.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-virtualized-auto-sizer:
         specifier: ^1.0.7
         version: 1.0.7(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -7748,7 +7745,7 @@ importers:
         version: 7.2.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-sortable-hoc:
         specifier: ^2.0.0
         version: 2.0.0(prop-types@15.8.1)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -8129,7 +8126,7 @@ importers:
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       uniforms:
         specifier: ^3.10.2
         version: 3.10.2(react@17.0.2)
@@ -8272,7 +8269,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -8531,7 +8528,7 @@ importers:
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       util:
         specifier: ^0.12.5
         version: 0.12.5
@@ -9175,7 +9172,7 @@ importers:
         version: 17.0.2
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -10049,7 +10046,7 @@ importers:
         version: 4.1.4(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       short-unique-id:
         specifier: ^4.4.4
         version: 4.4.4
@@ -10563,7 +10560,7 @@ importers:
         version: 0.9.7(moment@2.29.4)(prop-types@15.8.1)(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -11776,7 +11773,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -12117,7 +12114,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       react-router-dom:
         specifier: ^6.30.2
-        version: 6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -19636,8 +19633,8 @@ packages:
       selenium-webdriver: '>=4.6.1'
       typescript: '>=4.6.2'
 
-  '@remix-run/router@1.23.0':
-    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+  '@remix-run/router@1.23.2':
+    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
 
   '@repeaterjs/repeater@3.0.4':
@@ -28956,15 +28953,15 @@ packages:
       react: 0.14.x || 15.x || 16.x || 17.x
       react-dom: 0.14.x || 15.x || 16.x || 17.x
 
-  react-router-dom@6.30.0:
-    resolution: {integrity: sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==}
+  react-router-dom@6.30.3:
+    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.0:
-    resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
+  react-router@6.30.3:
+    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -42137,7 +42134,7 @@ snapshots:
       type-fest: 4.30.1
       typescript: 5.5.3
 
-  '@remix-run/router@1.23.0': {}
+  '@remix-run/router@1.23.2': {}
 
   '@repeaterjs/repeater@3.0.4': {}
 
@@ -56386,16 +56383,16 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-draggable: 4.4.4(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
 
-  react-router-dom@6.30.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-router-dom@6.30.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.2
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-router: 6.30.0(react@17.0.2)
+      react-router: 6.30.3(react@17.0.2)
 
-  react-router@6.30.0(react@17.0.2):
+  react-router@6.30.3(react@17.0.2):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.2
       react: 17.0.2
 
   react-shallow-renderer@16.15.0(react@17.0.2):


### PR DESCRIPTION
---
Closes https://github.com/apache/incubator-kie-tools/issues/3407
---

## ✨ Enhance Jobs Service Webapp Header with Version 

### 📌 Summary
This PR enhances the **Jobs Service Webapp** by improving visibility and accessibility of key information. It adds **version details** 
- **NOTE** - html-replace-webpack-plugin has been removed because it was breaking the replacement of variables and they are declared in templateParameters

### ✅ What’s New
- **Version Information**
  - Displays the current Data Index version in the webapp UI.



## 🧪 How to Test
Follow these steps to build and run the webapp locally:
```bash
# From the project root
cd incubator-kie-tools/
pnpm -F kogito-jobs-service-webapp... build:dev
cd packages/kogito-jobs-service-webapp
pnpm start
Navigate to - http://localhost:9028
```


### 📷 Screenshots
<img width="1512" height="907" alt="Screenshot 2026-01-27 at 5 59 50 PM" src="https://github.com/user-attachments/assets/0b503c80-f08c-453d-9aab-f117c5d370fb" />

