### PR TITLE
NO-ISSUE: Fix setPromProperty when maven-base pom.xml is invalid

### DIFF
--- a/packages/maven-base/README.md
+++ b/packages/maven-base/README.md
@@ -23,7 +23,7 @@ Foundational files for Maven-based packages.
 - `settings.xml`: Moslty repositories configuration.
 - `index.js`: Essential scripts for configuring properties such as `-Drevision` and `-Dmaven.repo.local.tail`.
 
-For more information, refer to the [KIE Tools :: Manual](../../repo/docs/MANUAL.md#specifics--maven)
+For more information, refer to the [KIE Tools :: Manual](../../repo/MANUAL.md#specifics--maven)
 
 ---
 

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -142,10 +142,15 @@ module.exports = {
     console.info(`[maven-base] Setting property '${key}' with value '${value}'...`);
     console.time(`[maven-base] Setting property '${key}' with value '${value}'...`);
 
-    const cmd = `mvn versions:set-property -Dproperty=${key} -DnewVersion=${value} -DgenerateBackupPoms=false ${BOOTSTRAP_CLI_ARGS}`;
+    // Using "sed" instead of "mvn versions:set-property" because Maven fails if the pom.xml is invalid before setting the property.
+    // This may happen if you're bootstraping the repo with a new Kogito version before building the previous one.
+    const cmd = `sed -i 's|<${key}>.*</${key}>|<${key}>${value}</${key}>|g' pom.xml`;
 
     if (process.platform === "win32") {
       cp.execSync(cmd.replaceAll(" -", " `-"), { stdio: "inherit", shell: "powershell.exe" });
+    } else if (process.platform === "darwin") {
+      // Account for macOS BSD sed implementation
+      cp.execSync(cmd.replace("-i", "-i ''"), { stdio: "inherit" });
     } else {
       cp.execSync(cmd, { stdio: "inherit" });
     }

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -143,7 +143,7 @@ module.exports = {
     console.time(`[maven-base] Setting property '${key}' with value '${value}'...`);
 
     // Using "sed" instead of "mvn versions:set-property" because Maven fails if the pom.xml is invalid before setting the property.
-    // This may happen if you're bootstraping the repo with a new Kogito version before building the previous one.
+    // This may happen if you're bootstraping the repo with a new "KOGITO_RUNTIME_version" value before building "packages/drools-and-kogito" with the previous one, for example.
     const cmd = `sed -i 's|<${key}>.*</${key}>|<${key}>${value}</${key}>|g' pom.xml`;
 
     if (process.platform === "win32") {


### PR DESCRIPTION
This PR fixes the `setPomProperty` function in `packages/maven-base/index.js` to allow for setting new pom.xml properties without having valid dependencies. This is useful in the scenario where we are changing the `KOGITO_RUNTIME_version` value before having built `packages/drools-and-kogito` with the previous one.