### PR TITLE
kie-tools#3422: m2-repo-via-http not resolving local maven metadata files

### DIFF
--- a/packages/maven-m2-repo-via-http-image/Containerfile
+++ b/packages/maven-m2-repo-via-http-image/Containerfile
@@ -32,7 +32,8 @@ RUN echo "Mutex posixsem" >> /etc/httpd/conf/httpd.conf \
  && sed -i "s/Options Indexes FollowSymLinks/Options +Indexes +FollowSymLinks/" /etc/httpd/conf/httpd.conf \
  && sed -i "$ a ServerTokens Prod" /etc/httpd/conf/httpd.conf \
  && sed -i "$ a ServerSignature Off" /etc/httpd/conf/httpd.conf \
- && sed -i "\$ a <Directory \"/var/www/html\">\n    Options +Indexes +FollowSymLinks\n    AllowOverride None\n    Require all granted\n    IndexOptions FancyIndexing SuppressDescription SuppressHTMLPreamble SuppressLastModified SuppressSize NameWidth=* SuppressColumnSorting SuppressIcon SuppressRules\n    HeaderName /header.html\n    ReadmeName /readme.html\n</Directory>" /etc/httpd/conf/httpd.conf
+ && sed -i "\$ a <Directory \"/var/www/html\">\n    Options +Indexes +FollowSymLinks\n    AllowOverride None\n    Require all granted\n    IndexOptions FancyIndexing SuppressDescription SuppressHTMLPreamble SuppressLastModified SuppressSize NameWidth=* SuppressColumnSorting SuppressIcon SuppressRules\n    HeaderName /header.html\n    ReadmeName /readme.html\n</Directory>" /etc/httpd/conf/httpd.conf \
+ && sed -i "\$ a # Fallback: serve maven-metadata-local.xml when maven-metadata.xml is requested but not found\nLoadModule rewrite_module modules/mod_rewrite.so\nRewriteEngine On\nRewriteCond %{REQUEST_FILENAME} !-f\nRewriteCond %{REQUEST_URI} maven-metadata\\\\.xml\$\nRewriteRule ^(.*)maven-metadata\\\\.xml\$ \$1maven-metadata-local.xml [L]" /etc/httpd/conf/httpd.conf 
 
 VOLUME /var/www/html/
 


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3422

In downstream builds, we encountered an error building `@kie-tools/serverless-logic-web-tools-swf-dev-mode-image`:
```
The following artifacts could not be resolved: org.kie.kogito:kogito-bom:pom:999-20250829-local
```

**My understanding of the `999-20250829` version:**
- `@kie-tools/serverless-logic-web-tools-swf-dev-mode-image` tries to download:
http://172.17.0.2/org/apache/kie/sonataflow/sonataflow-quarkus-devui-bom/999-SNAPSHOT/maven-metadata.xml :green_circle: 
- not found and fallback to:
https://repository.apache.org/snapshots/org/apache/kie/sonataflow/sonataflow-quarkus-devui-bom/999-SNAPSHOT/maven-metadata.xml :red_circle: 
- the Apache metadata has: :red_circle: 
```
<lastUpdated>20250831025730</lastUpdated>
```
- this can also affect other images :red_circle: 
<br />

**Why `maven-metadata.xml` is missing:**
- `mvn install` (or `mvn deploy -Dmaven.deploy.skip=true`) creates only `maven-metadata-local.xml`
- `prepareHardLinkedM2ForPackage` copies this to the HTTP repositoryof the m2-repo-via-http container
- Maven in Docker treats m2-repo-via-http repo as remote, looks for `maven-metadata.xml`, *not* `maven-metadata-local.xml`

**How to replicate the issue:**
```
$pnpm bootstrap 
...
$pnpm -F @kie-tools/serverless-logic-web-tools-swf-dev-mode-image... build:dev
...
$pnpm -F @kie-tools/serverless-logic-web-tools-swf-dev-mode-image m2-repo-via-http:container:run
...
# maven-metadata.xml not found (404)
$curl http://172.17.0.2/org/apache/kie/sonataflow/sonataflow-quarkus-devui-bom/maven-metadata.xml
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
# Only maven-metadata-local.xml exists, but it's not used by maven
$curl http://172.17.0.2/org/apache/kie/sonataflow/sonataflow-quarkus-devui-bom/maven-metadata-local.xml
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>org.apache.kie.sonataflow</groupId>
  <artifactId>sonataflow-quarkus-devui-bom</artifactId>
  <versioning>
    <release>0.0.0</release>
    <versions>
      <version>999-SNAPSHOT</version>
      <version>0.0.0</version>
    </versions>
    <lastUpdated>20260204085317</lastUpdated>
  </versioning>
</metadata>
```

**After the fix:**
Redo the steps in the previous section.
```
$ curl http://172.17.0.2/org/apache/kie/sonataflow/sonataflow-quarkus-devui-bom/maven-metadata.xml
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>org.apache.kie.sonataflow</groupId>
  <artifactId>sonataflow-quarkus-devui-bom</artifactId>
  <versioning>
    <release>0.0.0</release>
    <versions>
      <version>999-SNAPSHOT</version>
      <version>0.0.0</version>
    </versions>
    <lastUpdated>20260204085317</lastUpdated>
  </versioning>
</metadata>
```