### PR TITLE
NO-ISSUE: Bump drools-and-kogito to 999-20260206-local

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "fc7c5a07e8c2c4de5f4e76ee55e06ddc4ad65d3a",
+      default: "d85a800067cc2704cba133e8cd33d361f26099dd",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for OptaPlanner",
     },
     DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "2f91380f6176f917159f7ceb32cb9ad0a9cb6a72",
+      default: "dadbe563e01a6ca2cbce0feccc36808946c57120",
       description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "52348294fdeb85e4b67dcac39affb14294f1dcae",
+      default: "5186404dabc3177e44f476db82776d7da38a2e18",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "7252d3d337b9cee487b098f3aebd6fe7e8385847",
+      default: "226c9bc74eec1550cfc19c8ae19c5bba1ca184a2",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20260130-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20260206-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.20.3</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260130-local",
+      default: "999-20260206-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */


### PR DESCRIPTION
Drools git ref:https://github.com/apache/incubator-kie-drools/@ ([d85a800](https://github.com/apache/incubator-kie-drools/commit/d85a800067cc2704cba133e8cd33d361f26099dd))
Optaplanner git ref: https://github.com/apache/incubator-kie-optaplanner/@ ([dadbe56](https://github.com/apache/incubator-kie-optaplanner/commit/dadbe563e01a6ca2cbce0feccc36808946c57120))
Kogito Runtimes git ref: https://github.com/apache/incubator-kie-kogito-runtimes/@ ([5186404](https://github.com/apache/incubator-kie-kogito-runtimes/commit/5186404dabc3177e44f476db82776d7da38a2e18))
Kogito Apps git ref: https://github.com/apache/incubator-kie-kogito-apps/@ ([226c9bc](https://github.com/apache/incubator-kie-kogito-apps/commit/226c9bc74eec1550cfc19c8ae19c5bba1ca184a2))