### PR TITLE
kie-tools#3438: [sonataflow-deployment-webapp] SonataFlow Deployment Webapp not able to start a workflow

### DIFF
--- a/packages/sonataflow-deployment-webapp/src/pages/Workflows/WorkflowFormPage.tsx
+++ b/packages/sonataflow-deployment-webapp/src/pages/Workflows/WorkflowFormPage.tsx
@@ -172,7 +172,7 @@ export function WorkflowFormPage() {
 
   if (
     openApi.openApiPromise.status === PromiseStateStatus.RESOLVED &&
-    !openApi.openApiData?.tags?.find((t) => t.name === workflowDefinition.workflowName)
+    !openApi.openApiData?.paths[`/${workflowDefinition.workflowName}/schema`]
   ) {
     return (
       <ErrorPage


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3438

**Description:**
SonataFlow Deployment Webapp not able to start a workflow

**Steps to replicate:**
- Start Serverless Logic Webtools
- Start the cors proxy:
```
CORS_PROXY__allowedOrigins="https://localhost:9020" CORS_PROXY__allowedHosts="*" pnpm start
```
- Connect it to OpenShift with the DevMode enabled
- Wait for the deployment to be ready 
- If the Docker image is outdated on there is a new one published on my profile: quay.io/fabrizio_antonangeli/incubator-kie-serverless-logic-web-tools-swf-dev-mode:main
- Open the Deployment URL at the root "/" to show the SonataFlow Deployment Webapp
- Start the "hello_world" WF
- See the message:
`There was an error opening the workflow with name "hello_world".`

**How to test:**
- requirements:
Quay.io profile and the `quay.io/{quay_username}/incubator-kie-serverless-logic-web-tools-swf-dev-mode` repository

- build:
```
pnpm bootstrap
pnpm -F @kie-tools/serverless-logic-web-tools... -F sonataflow-deployment-webapp... -F @kie-tools/serverless-logic-web-tools-swf-deployment-quarkus-app... -F @kie-tools/serverless-logic-web-tools-swf-dev-mode-image... build:dev
```
- build and publish the DevMode image (or simply use mine quay.io/fabrizio_antonangeli/incubator-kie-serverless-logic-web-tools-swf-dev-mode:kie-tools-issue-3438):
```
docker login quay.io
docker tag quay.io/kubesmarts/incubator-kie-serverless-logic-web-tools-swf-dev-mode:main quay.io/{quay_username}/incubator-kie-serverless-logic-web-tools-swf-dev-mode:kie-tools-issue-3438
docker push quay.io/{quay_username}/incubator-kie-serverless-logic-web-tools-swf-dev-mode:kie-tools-issue-3438
```
- start SLWT:
```
export SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageRegistry="quay.io"
export SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageAccount="{quay_username}"
export SERVERLESS_LOGIC_WEB_TOOLS__swfDevModeImageTag="kie-tools-issue-3438"
pnpm -F @kie-tools/serverless-logic-web-tools start
```
- you should see the following in the log:
```
[0] Serverless Logic Web Tools :: Dev Mode Image Registry: quay.io
[0] Serverless Logic Web Tools :: Dev Mode Image Account: {quay_username}
```
- in another terminal:
```
cd packages/cors-proxy
CORS_PROXY__allowedOrigins="https://localhost:9020" CORS_PROXY__allowedHosts="*" pnpm start
```
- do the steps in the **Steps to replicate:** section
- no more errors and you are able to start the workflow

**Preview:**

https://github.com/user-attachments/assets/aa88ed2f-d75c-4b24-b6c6-41173a10b549

