### PR TITLE
kie-issues#2220: BPMN Editor: Interface tags configured in a service task are missing from the generated XML

### DIFF
--- a/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
@@ -34,6 +34,7 @@ import { useCustomTasks } from "../../../customTasks/BpmnEditorCustomTasksContex
 import { CustomTask } from "../../../BpmnEditor";
 import { WritableDraft } from "immer";
 import { State } from "../../../store/Store";
+import { deleteInterfaceAndOperation } from "../../../mutations/deleteInterfaceAndOperation";
 
 export function useTaskNodeMorphingActions(task: Task) {
   const bpmnEditorStoreApi = useBpmnEditorStoreApi();
@@ -110,9 +111,15 @@ export function useTaskNodeMorphingActions(task: Task) {
       // 6 - Call activity
       bpmnEditorStoreApi.setState((s) => {
         _morphTo(s, newTaskElement, [], []);
+        if (task.__$$element === "serviceTask" && newTaskElement !== "serviceTask") {
+          deleteInterfaceAndOperation({
+            definitions: s.bpmn.model.definitions,
+            serviceTaskId: task["@_id"],
+          });
+        }
       });
     },
-    [bpmnEditorStoreApi, _morphTo]
+    [bpmnEditorStoreApi, _morphTo, task]
   );
 
   const morphToCustom = useCallback(

--- a/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
@@ -97,6 +97,13 @@ export function useTaskNodeMorphingActions(task: Task) {
           return false; // Will stop visiting.
         }
       });
+
+      if (task.__$$element === "serviceTask" && newTaskElement !== "serviceTask") {
+        deleteInterfaceAndOperation({
+          definitions: s.bpmn.model.definitions,
+          serviceTaskId: task["@_id"],
+        });
+      }
     },
     [task]
   );
@@ -111,15 +118,9 @@ export function useTaskNodeMorphingActions(task: Task) {
       // 6 - Call activity
       bpmnEditorStoreApi.setState((s) => {
         _morphTo(s, newTaskElement, [], []);
-        if (task.__$$element === "serviceTask" && newTaskElement !== "serviceTask") {
-          deleteInterfaceAndOperation({
-            definitions: s.bpmn.model.definitions,
-            serviceTaskId: task["@_id"],
-          });
-        }
       });
     },
-    [bpmnEditorStoreApi, _morphTo, task]
+    [bpmnEditorStoreApi, _morphTo]
   );
 
   const morphToCustom = useCallback(

--- a/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/morphing/useTaskNodeMorphingActions.tsx
@@ -98,10 +98,10 @@ export function useTaskNodeMorphingActions(task: Task) {
         }
       });
 
-      if (task.__$$element === "serviceTask" && newTaskElement !== "serviceTask") {
+      if (task.__$$element === "serviceTask" && newTaskElement !== "serviceTask" && task["@_operationRef"]) {
         deleteInterfaceAndOperation({
           definitions: s.bpmn.model.definitions,
-          serviceTaskId: task["@_id"],
+          operationRef: task["@_operationRef"],
         });
       }
     },

--- a/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
+import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
+import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
+import { Normalized } from "../normalization/normalize";
+
+export function addOrGetInterfaces({
+  definitions,
+  interfaceName,
+  id,
+}: {
+  definitions: Normalized<BPMN20__tDefinitions>;
+  interfaceName: string;
+  id: string;
+}): {
+  interface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">;
+} {
+  definitions.rootElement ??= [];
+  const interfaces = definitions.rootElement.filter((s) => s.__$$element === "interface");
+
+  const existingInterface = interfaces.find((s) => s["@_id"] === id);
+  if (existingInterface) {
+    if (existingInterface["@_name"] !== interfaceName) {
+      existingInterface["@_name"] = interfaceName;
+    }
+    return { interface: existingInterface };
+  }
+
+  const newInterface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface"> = {
+    __$$element: "interface",
+    "@_id": id,
+    "@_name": interfaceName,
+    operation: [],
+  };
+
+  definitions.rootElement.push(newInterface);
+  return { interface: newInterface };
+}

--- a/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
@@ -36,7 +36,8 @@ export function addOrGetInterfaces({
   definitions.rootElement ??= [];
   const interfaces = definitions.rootElement.filter((s) => s.__$$element === "interface");
 
-  const existingInterface = interfaces.find((s) => s["@_id"] === id);
+  const interfaceId = `${id}_ServiceInterface`;
+  const existingInterface = interfaces.find((s) => s["@_id"] === interfaceId);
   if (existingInterface) {
     if (existingInterface["@_name"] !== interfaceName) {
       existingInterface["@_name"] = interfaceName;
@@ -46,7 +47,7 @@ export function addOrGetInterfaces({
 
   const newInterface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface"> = {
     __$$element: "interface",
-    "@_id": id,
+    "@_id": interfaceId,
     "@_name": interfaceName,
     operation: [],
   };

--- a/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetInterfaces.ts
@@ -21,33 +21,28 @@ import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bp
 import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
 import { Normalized } from "../normalization/normalize";
+import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
 
 export function addOrGetInterfaces({
   definitions,
   interfaceName,
-  id,
 }: {
   definitions: Normalized<BPMN20__tDefinitions>;
   interfaceName: string;
-  id: string;
 }): {
   interface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">;
 } {
   definitions.rootElement ??= [];
   const interfaces = definitions.rootElement.filter((s) => s.__$$element === "interface");
 
-  const interfaceId = `${id}_ServiceInterface`;
-  const existingInterface = interfaces.find((s) => s["@_id"] === interfaceId);
+  const existingInterface = interfaces.find((s) => s["@_name"] === interfaceName);
   if (existingInterface) {
-    if (existingInterface["@_name"] !== interfaceName) {
-      existingInterface["@_name"] = interfaceName;
-    }
     return { interface: existingInterface };
   }
 
   const newInterface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface"> = {
     __$$element: "interface",
-    "@_id": interfaceId,
+    "@_id": generateUuid(),
     "@_name": interfaceName,
     operation: [],
   };

--- a/packages/bpmn-editor/src/mutations/addOrGetMessages.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetMessages.ts
@@ -26,9 +26,11 @@ import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid
 export function addOrGetMessages({
   definitions,
   messageName,
+  id,
 }: {
   definitions: Normalized<BPMN20__tDefinitions>;
-  messageName: string;
+  messageName?: string;
+  id?: string;
 }): {
   messageRef: string;
 } {
@@ -42,7 +44,7 @@ export function addOrGetMessages({
 
   const newMessage: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "message"> = {
     __$$element: "message",
-    "@_id": generateUuid(),
+    "@_id": id ?? generateUuid(),
     "@_itemRef": `${messageName}Type`,
     "@_name": messageName,
   };

--- a/packages/bpmn-editor/src/mutations/addOrGetMessages.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetMessages.ts
@@ -26,11 +26,9 @@ import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid
 export function addOrGetMessages({
   definitions,
   messageName,
-  id,
 }: {
   definitions: Normalized<BPMN20__tDefinitions>;
-  messageName?: string;
-  id?: string;
+  messageName: string;
 }): {
   messageRef: string;
 } {
@@ -44,8 +42,8 @@ export function addOrGetMessages({
 
   const newMessage: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "message"> = {
     __$$element: "message",
-    "@_id": id ?? generateUuid(),
-    "@_itemRef": `${messageName}Type`,
+    "@_id": generateUuid(),
+    "@_itemRef": `${messageName}Type`, // broken reference to a placeholder type that has no meaning to the jBPM Workflow Engine
     "@_name": messageName,
   };
 

--- a/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
+import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
+import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
+import { Normalized } from "../normalization/normalize";
+import { addOrGetInterfaces } from "./addOrGetInterfaces";
+
+export function addOrGetOperations({
+  definitions,
+  interfaceName,
+  operationName,
+  id,
+}: {
+  definitions: Normalized<BPMN20__tDefinitions>;
+  interfaceName: string;
+  operationName: string;
+  id: string;
+}): {
+  interface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">;
+  operation: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">["operation"][number];
+} {
+  const { interface: serviceTaskInterface } = addOrGetInterfaces({
+    definitions,
+    interfaceName,
+    id: id,
+  });
+
+  serviceTaskInterface.operation ??= [];
+
+  let operation = serviceTaskInterface.operation.find((s) => s["@_id"] === id);
+
+  if (!operation) {
+    operation = {
+      "@_id": id,
+      "@_name": operationName,
+      inMessageRef: { __$$text: id },
+    };
+    serviceTaskInterface.operation.push(operation);
+  } else if (operation["@_name"] !== operationName) {
+    operation["@_name"] = operationName;
+  }
+
+  return { interface: serviceTaskInterface, operation: operation };
+}

--- a/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
@@ -52,6 +52,7 @@ export function addOrGetOperations({
       "@_id": id,
       "@_name": operationName,
       inMessageRef: { __$$text: id },
+      outMessageRef: { __$$text: id },
     };
     serviceTaskInterface.operation.push(operation);
   } else if (operation["@_name"] !== operationName) {

--- a/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
@@ -22,6 +22,7 @@ import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
 import { Normalized } from "../normalization/normalize";
 import { addOrGetInterfaces } from "./addOrGetInterfaces";
+import { addOrGetMessages } from "./addOrGetMessages";
 
 export function addOrGetOperations({
   definitions,
@@ -45,16 +46,28 @@ export function addOrGetOperations({
 
   serviceTaskInterface.operation ??= [];
 
-  let operation = serviceTaskInterface.operation.find((s) => s["@_id"] === id);
+  const operationId = `${id}_ServiceOperation`;
+  let operation = serviceTaskInterface.operation.find((s) => s["@_id"] === operationId);
 
   if (!operation) {
+    const inMessageId = `${id}_InMessage`;
+    const outMessageId = `${id}_OutMessage`;
+
     operation = {
-      "@_id": id,
+      "@_id": operationId,
       "@_name": operationName,
-      inMessageRef: { __$$text: id },
-      outMessageRef: { __$$text: id },
+      inMessageRef: { __$$text: inMessageId },
+      outMessageRef: { __$$text: outMessageId },
     };
     serviceTaskInterface.operation.push(operation);
+    addOrGetMessages({
+      definitions,
+      id: inMessageId,
+    });
+    addOrGetMessages({
+      definitions,
+      id: outMessageId,
+    });
   } else if (operation["@_name"] !== operationName) {
     operation["@_name"] = operationName;
   }

--- a/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetOperations.ts
@@ -23,17 +23,18 @@ import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
 import { Normalized } from "../normalization/normalize";
 import { addOrGetInterfaces } from "./addOrGetInterfaces";
 import { addOrGetMessages } from "./addOrGetMessages";
+import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
 
 export function addOrGetOperations({
   definitions,
   interfaceName,
+  operationRef,
   operationName,
-  id,
 }: {
   definitions: Normalized<BPMN20__tDefinitions>;
   interfaceName: string;
+  operationRef?: string;
   operationName: string;
-  id: string;
 }): {
   interface: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">;
   operation: ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">["operation"][number];
@@ -41,33 +42,61 @@ export function addOrGetOperations({
   const { interface: serviceTaskInterface } = addOrGetInterfaces({
     definitions,
     interfaceName,
-    id: id,
   });
 
   serviceTaskInterface.operation ??= [];
 
-  const operationId = `${id}_ServiceOperation`;
-  let operation = serviceTaskInterface.operation.find((s) => s["@_id"] === operationId);
+  let operation:
+    | ElementFilter<Unpacked<Normalized<BPMN20__tDefinitions["rootElement"]>>, "interface">["operation"][number]
+    | undefined;
+
+  if (operationRef) {
+    const interfaces = definitions.rootElement?.filter((s) => s.__$$element === "interface") ?? [];
+
+    for (const iface of interfaces) {
+      if (iface.__$$element === "interface") {
+        iface.operation ??= [];
+        const operationIndex = iface.operation.findIndex((op) => op["@_id"] === operationRef);
+
+        if (operationIndex >= 0) {
+          operation = iface.operation[operationIndex];
+
+          if (iface["@_id"] !== serviceTaskInterface["@_id"]) {
+            iface.operation.splice(operationIndex, 1);
+            serviceTaskInterface.operation.push(operation);
+
+            if (iface.operation.length === 0) {
+              const interfaceIndex = definitions.rootElement?.findIndex(
+                (s) => s.__$$element === "interface" && s["@_id"] === iface["@_id"]
+              );
+              if (interfaceIndex !== undefined && interfaceIndex >= 0) {
+                definitions.rootElement?.splice(interfaceIndex, 1);
+              }
+            }
+          }
+          break;
+        }
+      }
+    }
+  }
 
   if (!operation) {
-    const inMessageId = `${id}_InMessage`;
-    const outMessageId = `${id}_OutMessage`;
+    const { messageRef: inMessageId } = addOrGetMessages({
+      definitions,
+      messageName: "",
+    });
+    const { messageRef: outMessageId } = addOrGetMessages({
+      definitions,
+      messageName: "",
+    });
 
     operation = {
-      "@_id": operationId,
+      "@_id": generateUuid(),
       "@_name": operationName,
       inMessageRef: { __$$text: inMessageId },
       outMessageRef: { __$$text: outMessageId },
     };
     serviceTaskInterface.operation.push(operation);
-    addOrGetMessages({
-      definitions,
-      id: inMessageId,
-    });
-    addOrGetMessages({
-      definitions,
-      id: outMessageId,
-    });
   } else if (operation["@_name"] !== operationName) {
     operation["@_name"] = operationName;
   }

--- a/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
+++ b/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
+import { Normalized } from "../normalization/normalize";
+import { addOrGetProcessAndDiagramElements } from "./addOrGetProcessAndDiagramElements";
+import { visitFlowElementsAndArtifacts } from "./_elementVisitor";
+
+export function deleteInterfaceAndOperation({
+  definitions,
+  serviceTaskId,
+}: {
+  definitions: Normalized<BPMN20__tDefinitions>;
+  serviceTaskId: string;
+}) {
+  const existingInterfaceIndex = definitions.rootElement?.findIndex(
+    (s) => s.__$$element === "interface" && s["@_id"] === serviceTaskId
+  );
+
+  if (existingInterfaceIndex === undefined || existingInterfaceIndex < 0) {
+    return;
+  }
+
+  const { process } = addOrGetProcessAndDiagramElements({ definitions });
+  let hasCorrespondingServiceTask = false;
+
+  visitFlowElementsAndArtifacts(process, ({ element }) => {
+    if (element["@_id"] === serviceTaskId && element.__$$element === "serviceTask") {
+      hasCorrespondingServiceTask = true;
+      return false; // Will stop visiting.
+    }
+  });
+
+  if (!hasCorrespondingServiceTask) {
+    definitions.rootElement?.splice(existingInterfaceIndex, 1);
+  }
+}

--- a/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
+++ b/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
@@ -29,10 +29,19 @@ export function deleteInterfaceAndOperation({
   definitions: Normalized<BPMN20__tDefinitions>;
   serviceTaskId: string;
 }) {
-  const existingInterfaceIndex = definitions.rootElement?.findIndex(
-    (s) => s.__$$element === "interface" && s["@_id"] === serviceTaskId
-  );
+  const interfaceId = `${serviceTaskId}_ServiceInterface`;
+  const inMessageId = `${serviceTaskId}_InMessage`;
+  const outMessageId = `${serviceTaskId}_OutMessage`;
 
+  const existingInterfaceIndex = definitions.rootElement?.findIndex(
+    (s) => s.__$$element === "interface" && s["@_id"] === interfaceId
+  );
+  const existingInMessageIndex = definitions.rootElement?.findIndex(
+    (s) => s.__$$element === "message" && s["@_id"] === inMessageId
+  );
+  const existingOutMessageIndex = definitions.rootElement?.findIndex(
+    (s) => s.__$$element === "message" && s["@_id"] === outMessageId
+  );
   if (existingInterfaceIndex === undefined || existingInterfaceIndex < 0) {
     return;
   }
@@ -48,6 +57,11 @@ export function deleteInterfaceAndOperation({
   });
 
   if (!hasCorrespondingServiceTask) {
-    definitions.rootElement?.splice(existingInterfaceIndex, 1);
+    const indicesToDelete = [existingInterfaceIndex, existingInMessageIndex, existingOutMessageIndex]
+      .filter((index): index is number => index !== undefined && index >= 0)
+      .sort((a, b) => b - a);
+    for (const index of indicesToDelete) {
+      definitions.rootElement?.splice(index, 1);
+    }
   }
 }

--- a/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
+++ b/packages/bpmn-editor/src/mutations/deleteInterfaceAndOperation.ts
@@ -19,49 +19,60 @@
 
 import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { Normalized } from "../normalization/normalize";
-import { addOrGetProcessAndDiagramElements } from "./addOrGetProcessAndDiagramElements";
-import { visitFlowElementsAndArtifacts } from "./_elementVisitor";
 
 export function deleteInterfaceAndOperation({
   definitions,
-  serviceTaskId,
+  operationRef,
 }: {
   definitions: Normalized<BPMN20__tDefinitions>;
-  serviceTaskId: string;
+  operationRef: string;
 }) {
-  const interfaceId = `${serviceTaskId}_ServiceInterface`;
-  const inMessageId = `${serviceTaskId}_InMessage`;
-  const outMessageId = `${serviceTaskId}_OutMessage`;
-
-  const existingInterfaceIndex = definitions.rootElement?.findIndex(
-    (s) => s.__$$element === "interface" && s["@_id"] === interfaceId
-  );
-  const existingInMessageIndex = definitions.rootElement?.findIndex(
-    (s) => s.__$$element === "message" && s["@_id"] === inMessageId
-  );
-  const existingOutMessageIndex = definitions.rootElement?.findIndex(
-    (s) => s.__$$element === "message" && s["@_id"] === outMessageId
-  );
-  if (existingInterfaceIndex === undefined || existingInterfaceIndex < 0) {
+  if (!definitions.rootElement) {
     return;
   }
 
-  const { process } = addOrGetProcessAndDiagramElements({ definitions });
-  let hasCorrespondingServiceTask = false;
+  const serviceTaskInterface = definitions.rootElement.find(
+    (s) => s.__$$element === "interface" && s.operation?.some((op) => op["@_id"] === operationRef)
+  );
 
-  visitFlowElementsAndArtifacts(process, ({ element }) => {
-    if (element["@_id"] === serviceTaskId && element.__$$element === "serviceTask") {
-      hasCorrespondingServiceTask = true;
-      return false; // Will stop visiting.
-    }
-  });
+  if (!serviceTaskInterface || serviceTaskInterface.__$$element !== "interface") {
+    return;
+  }
 
-  if (!hasCorrespondingServiceTask) {
-    const indicesToDelete = [existingInterfaceIndex, existingInMessageIndex, existingOutMessageIndex]
-      .filter((index): index is number => index !== undefined && index >= 0)
-      .sort((a, b) => b - a);
-    for (const index of indicesToDelete) {
+  serviceTaskInterface.operation ??= [];
+
+  const operationIndex = serviceTaskInterface.operation.findIndex((op) => op["@_id"] === operationRef);
+  if (operationIndex < 0) {
+    return;
+  }
+
+  const operation = serviceTaskInterface.operation[operationIndex];
+
+  const inMessageId = operation.inMessageRef.__$$text;
+  const outMessageId = operation.outMessageRef?.__$$text;
+
+  const existingInMessageIndex = definitions.rootElement.findIndex(
+    (s) => s.__$$element === "message" && s["@_id"] === inMessageId
+  );
+  const existingOutMessageIndex = outMessageId
+    ? definitions.rootElement.findIndex((s) => s.__$$element === "message" && s["@_id"] === outMessageId)
+    : -1;
+
+  [existingInMessageIndex, existingOutMessageIndex]
+    .filter((index): index is number => index >= 0)
+    .sort((a, b) => b - a)
+    .forEach((index) => {
       definitions.rootElement?.splice(index, 1);
+    });
+
+  serviceTaskInterface.operation.splice(operationIndex, 1);
+
+  if (serviceTaskInterface.operation.length === 0) {
+    const interfaceIndex = definitions.rootElement.findIndex(
+      (s) => s.__$$element === "interface" && s["@_id"] === serviceTaskInterface["@_id"]
+    );
+    if (interfaceIndex >= 0) {
+      definitions.rootElement.splice(interfaceIndex, 1);
     }
   }
 }

--- a/packages/bpmn-editor/src/mutations/deleteNode.ts
+++ b/packages/bpmn-editor/src/mutations/deleteNode.ts
@@ -29,6 +29,7 @@ import { deleteEdge } from "./deleteEdge";
 import { FoundElement, visitFlowElementsAndArtifacts } from "./_elementVisitor";
 import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
 import { ElementExclusion } from "@kie-tools/xml-parser-ts/dist/elementFilter";
+import { deleteInterfaceAndOperation } from "./deleteInterfaceAndOperation";
 
 export function deleteNode({
   definitions,
@@ -82,6 +83,14 @@ export function deleteNode({
   // if flowElement or artifact
   if (foundElement) {
     deletedBpmnElement = foundElement.array.splice(foundElement.index, 1)?.[0] as BpmnNodeElement | undefined;
+  }
+
+  // if Service Task
+  if (deletedBpmnElement?.__$$element === "serviceTask") {
+    deleteInterfaceAndOperation({
+      definitions,
+      serviceTaskId: deletedBpmnElement["@_id"],
+    });
   }
 
   // if lane

--- a/packages/bpmn-editor/src/mutations/deleteNode.ts
+++ b/packages/bpmn-editor/src/mutations/deleteNode.ts
@@ -86,10 +86,10 @@ export function deleteNode({
   }
 
   // if Service Task
-  if (deletedBpmnElement?.__$$element === "serviceTask") {
+  if (deletedBpmnElement?.__$$element === "serviceTask" && deletedBpmnElement["@_operationRef"]) {
     deleteInterfaceAndOperation({
       definitions,
-      serviceTaskId: deletedBpmnElement["@_id"],
+      operationRef: deletedBpmnElement["@_operationRef"],
     });
   }
 

--- a/packages/bpmn-editor/src/propertiesPanel/messageSelector/MessageSelector.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/messageSelector/MessageSelector.tsx
@@ -31,6 +31,7 @@ import { useCallback, useMemo } from "react";
 import { addOrGetMessages } from "../../mutations/addOrGetMessages";
 import "./MessageSelector.css";
 import { useBpmnEditorI18n } from "../../i18n";
+import { getServiceTaskMessageIds } from "../../store/getServiceTaskMessageIds";
 
 export type EventWithMessage =
   | undefined
@@ -57,14 +58,14 @@ export function MessageSelector({
 
   const bpmnEditorStoreApi = useBpmnEditorStoreApi();
 
-  const messagesById = useBpmnEditorStore(
-    (s) =>
-      new Map(
-        s.bpmn.model.definitions.rootElement
-          ?.filter((e) => e.__$$element === "message")
-          .map((m) => [m["@_id"], m] as [string, BPMN20__tMessage])
-      )
-  );
+  const messagesById = useBpmnEditorStore((s) => {
+    const allMessages = s.bpmn.model.definitions.rootElement?.filter((e) => e.__$$element === "message") ?? [];
+    const serviceTaskMessageIds = getServiceTaskMessageIds(s.bpmn.model.definitions);
+
+    const filteredMessages = allMessages.filter((msg) => !serviceTaskMessageIds.has(msg["@_id"]));
+
+    return new Map(filteredMessages.map((m) => [m["@_id"], m] as [string, BPMN20__tMessage]));
+  });
 
   const disableIdsSet = useMemo(() => new Set<string | undefined>(disableValues), [disableValues]);
 

--- a/packages/bpmn-editor/src/propertiesPanel/propertiesManager/PropertiesManager.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/propertiesManager/PropertiesManager.tsx
@@ -62,6 +62,7 @@ import { renameEscalation } from "../../mutations/renameEscalation";
 import { deleteError } from "../../mutations/deleteError";
 import { renameError } from "../../mutations/renameError";
 import { useBpmnEditorI18n } from "../../i18n";
+import { getServiceTaskMessageIds } from "../../store/getServiceTaskMessageIds";
 
 export type WithVariables = Normalized<
   | ElementFilter<Unpacked<NonNullable<BPMN20__tDefinitions["rootElement"]>>, "process">
@@ -87,9 +88,12 @@ export function PropertiesManager({ p }: { p: undefined | WithVariables }) {
   )?.filter(
     (s) => Object.values(DEFAULT_DATA_TYPES).findIndex((defaultDataType) => defaultDataType === s["@_structureRef"]) < 0
   );
-  const messages = useBpmnEditorStore((s) =>
-    s.bpmn.model.definitions.rootElement?.filter((s) => s.__$$element === "message")
-  );
+  const messages = useBpmnEditorStore((s) => {
+    const allMessages = s.bpmn.model.definitions.rootElement?.filter((s) => s.__$$element === "message") ?? [];
+    const serviceTaskMessageIds = getServiceTaskMessageIds(s.bpmn.model.definitions);
+
+    return allMessages.filter((msg) => !serviceTaskMessageIds.has(msg["@_id"]));
+  });
   const signals = useBpmnEditorStore((s) =>
     s.bpmn.model.definitions.rootElement?.filter((s) => s.__$$element === "signal")
   );

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
@@ -42,6 +42,8 @@ import { addOrGetProcessAndDiagramElements } from "../../mutations/addOrGetProce
 import { useBpmnEditorStore, useBpmnEditorStoreApi } from "../../store/StoreContext";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { useBpmnEditorI18n } from "../../i18n";
+import { addOrGetInterfaces } from "../../mutations/addOrGetInterfaces";
+import { addOrGetOperations } from "../../mutations/addOrGetOperations";
 
 export function ServiceTaskProperties({
   serviceTask,
@@ -128,6 +130,11 @@ export function ServiceTaskProperties({
                 });
                 visitFlowElementsAndArtifacts(process, ({ element: e }) => {
                   if (e["@_id"] === serviceTask["@_id"] && e.__$$element === serviceTask.__$$element) {
+                    addOrGetInterfaces({
+                      definitions: s.bpmn.model.definitions,
+                      interfaceName: newInterface,
+                      id: e["@_id"],
+                    });
                     e["@_drools:serviceinterface"] = newInterface;
                   }
                 });
@@ -150,6 +157,12 @@ export function ServiceTaskProperties({
                 });
                 visitFlowElementsAndArtifacts(process, ({ element: e }) => {
                   if (e["@_id"] === serviceTask["@_id"] && e.__$$element === serviceTask.__$$element) {
+                    addOrGetOperations({
+                      definitions: s.bpmn.model.definitions,
+                      interfaceName: e["@_drools:serviceinterface"] || "",
+                      operationName: newOperation,
+                      id: e["@_id"],
+                    });
                     e["@_drools:serviceoperation"] = newOperation;
                   }
                 });

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
@@ -44,6 +44,7 @@ import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { useBpmnEditorI18n } from "../../i18n";
 import { addOrGetInterfaces } from "../../mutations/addOrGetInterfaces";
 import { addOrGetOperations } from "../../mutations/addOrGetOperations";
+import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
 
 export function ServiceTaskProperties({
   serviceTask,
@@ -164,6 +165,7 @@ export function ServiceTaskProperties({
                       id: e["@_id"],
                     });
                     e["@_drools:serviceoperation"] = newOperation;
+                    e["@_operationRef"] ??= generateUuid();
                   }
                 });
               })

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
@@ -44,7 +44,6 @@ import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { useBpmnEditorI18n } from "../../i18n";
 import { addOrGetInterfaces } from "../../mutations/addOrGetInterfaces";
 import { addOrGetOperations } from "../../mutations/addOrGetOperations";
-import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
 
 export function ServiceTaskProperties({
   serviceTask,
@@ -165,7 +164,7 @@ export function ServiceTaskProperties({
                       id: e["@_id"],
                     });
                     e["@_drools:serviceoperation"] = newOperation;
-                    e["@_operationRef"] ??= generateUuid();
+                    e["@_operationRef"] ??= e["@_id"];
                   }
                 });
               })

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
@@ -164,7 +164,7 @@ export function ServiceTaskProperties({
                       id: e["@_id"],
                     });
                     e["@_drools:serviceoperation"] = newOperation;
-                    e["@_operationRef"] ??= e["@_id"];
+                    e["@_operationRef"] ??= `${e["@_id"]}_ServiceOperation`;
                   }
                 });
               })

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ServiceTaskProperties.tsx
@@ -42,7 +42,6 @@ import { addOrGetProcessAndDiagramElements } from "../../mutations/addOrGetProce
 import { useBpmnEditorStore, useBpmnEditorStoreApi } from "../../store/StoreContext";
 import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import { useBpmnEditorI18n } from "../../i18n";
-import { addOrGetInterfaces } from "../../mutations/addOrGetInterfaces";
 import { addOrGetOperations } from "../../mutations/addOrGetOperations";
 
 export function ServiceTaskProperties({
@@ -130,12 +129,14 @@ export function ServiceTaskProperties({
                 });
                 visitFlowElementsAndArtifacts(process, ({ element: e }) => {
                   if (e["@_id"] === serviceTask["@_id"] && e.__$$element === serviceTask.__$$element) {
-                    addOrGetInterfaces({
+                    const { operation } = addOrGetOperations({
                       definitions: s.bpmn.model.definitions,
                       interfaceName: newInterface,
-                      id: e["@_id"],
+                      operationRef: e["@_operationRef"],
+                      operationName: e["@_drools:serviceoperation"] || "",
                     });
                     e["@_drools:serviceinterface"] = newInterface;
+                    e["@_operationRef"] = operation["@_id"];
                   }
                 });
               })
@@ -157,14 +158,14 @@ export function ServiceTaskProperties({
                 });
                 visitFlowElementsAndArtifacts(process, ({ element: e }) => {
                   if (e["@_id"] === serviceTask["@_id"] && e.__$$element === serviceTask.__$$element) {
-                    addOrGetOperations({
+                    const { operation } = addOrGetOperations({
                       definitions: s.bpmn.model.definitions,
                       interfaceName: e["@_drools:serviceinterface"] || "",
+                      operationRef: e["@_operationRef"],
                       operationName: newOperation,
-                      id: e["@_id"],
                     });
                     e["@_drools:serviceoperation"] = newOperation;
-                    e["@_operationRef"] ??= `${e["@_id"]}_ServiceOperation`;
+                    e["@_operationRef"] = operation["@_id"];
                   }
                 });
               })

--- a/packages/bpmn-editor/src/store/getServiceTaskMessageIds.ts
+++ b/packages/bpmn-editor/src/store/getServiceTaskMessageIds.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
+import { Normalized } from "../normalization/normalize";
+
+export function getServiceTaskMessageIds(definitions: Normalized<BPMN20__tDefinitions>): Set<string> {
+  const interfaces = definitions.rootElement?.filter((e) => e.__$$element === "interface") ?? [];
+  const operationMessageIds = new Set<string>();
+
+  interfaces.forEach((iface) => {
+    if (iface.__$$element === "interface") {
+      iface.operation?.forEach((op) => {
+        if (op.inMessageRef?.__$$text) {
+          operationMessageIds.add(op.inMessageRef.__$$text);
+        }
+        if (op.outMessageRef?.__$$text) {
+          operationMessageIds.add(op.outMessageRef.__$$text);
+        }
+      });
+    }
+  });
+
+  return operationMessageIds;
+}


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2220
Added logic to create interfaces and operations when defined in the property panel of a service task.
Interfaces/Operations will be removed when the service task is deleted, or when the service task is morphed to a different task type.

Updated the BPMN XML by defining `<interface>`, `<operation>`, `<inMessageRef>`, and `<outMessageRef>` tags when a Service Task interface/operation is specified, and added the `operationRef` property within the `<serviceTask>` when an operation is added.

Sample new XML:

```xml
<interface id="_CD21A0AD-04F5-49F3-9B70-B8C910C361AC" name="TestInterface">
    <operation id="_CD21A0AD-04F5-49F3-9B70-B8C910C361AC" name="TestOperation">
      <inMessageRef>_CD21A0AD-04F5-49F3-9B70-B8C910C361AC</inMessageRef>
      <outMessageRef>_CD21A0AD-04F5-49F3-9B70-B8C910C361AC</outMessageRef>
    </operation>
  </interface>

  <process id="_EE0EB4FF-D8B7-4032-AF52-79A9AFA9B27B">
    <serviceTask id="_CD21A0AD-04F5-49F3-9B70-B8C910C361AC" name="New Task" implementation="Java" drools:serviceinterface="TestInterface" drools:serviceoperation="TestOperation" operationRef="_CD21A0AD-04F5-49F3-9B70-B8C910C361AC" drools:serviceimplementation="Java">
```