### PR TITLE
[kie-issues#2204] Quarkus upgrade 3.27 and Spring Boot to 3.5.10

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -162,7 +162,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} build:dev"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} --if-present build:dev"
 
       - name: "PARTIAL → Build changed and downstream"
         shell: bash
@@ -187,7 +187,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} --workspace-concurrency=1 build:prod"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} --if-present --workspace-concurrency=1 build:prod"
 
       - name: "Check tests result (`main` only)"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none'

--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -56,11 +56,11 @@
 
     <!-- 3rd party -->
     <version.junit>4.13.2</version.junit>
-    <version.org.apache.commons.commons-compress>1.27.1</version.org.apache.commons.commons-compress>
+    <version.org.apache.commons.commons-compress>1.28.0</version.org.apache.commons.commons-compress>
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
-    <version.commons-io>2.16.1</version.commons-io>
+    <version.commons-io>2.20.0</version.commons-io>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
-    <version.io.netty>4.1.130.Final</version.io.netty>
+    <version.io.netty>4.1.131.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->

--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -60,13 +60,13 @@
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
     <version.commons-io>2.16.1</version.commons-io>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
-    <version.io.netty>4.1.129.Final</version.io.netty>
+    <version.io.netty>4.1.130.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
     <version.angus.mail>2.0.5</version.angus.mail>
-    <version.nimbus.jose.jwt>9.37.4</version.nimbus.jose.jwt>
-    <version.io.vertx>4.5.22</version.io.vertx>
+    <version.nimbus.jose.jwt>10.4.2</version.nimbus.jose.jwt>
+    <version.io.vertx>4.5.23</version.io.vertx>
     <!-- End of various transitive overrides. -->
   </properties>
 

--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -65,8 +65,6 @@
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
     <version.angus.mail>2.0.5</version.angus.mail>
-    <version.nimbus.jose.jwt>10.4.2</version.nimbus.jose.jwt>
-    <version.io.vertx>4.5.23</version.io.vertx>
     <!-- End of various transitive overrides. -->
   </properties>
 
@@ -78,16 +76,6 @@
         <groupId>org.eclipse.angus</groupId>
         <artifactId>angus-mail</artifactId>
         <version>${version.angus.mail}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>nimbus-jose-jwt</artifactId>
-        <version>${version.nimbus.jose.jwt}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
       </dependency>
       <!-- End of various transitive overrides. -->
 

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "d85a800067cc2704cba133e8cd33d361f26099dd",
+      default: "3a9d1e2721c7fbdc6d9a9dc08053170f6796f39e",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for OptaPlanner",
     },
     DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "dadbe563e01a6ca2cbce0feccc36808946c57120",
+      default: "64098aae2ca6ae8ee1c11bee74969214bfd56601",
       description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "5186404dabc3177e44f476db82776d7da38a2e18",
+      default: "0a498880e155af60fdee150a0109420874a1db9b",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "226c9bc74eec1550cfc19c8ae19c5bba1ca184a2",
+      default: "23ea984ab5550af666adf371aead494a19a863c2",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "3a9d1e2721c7fbdc6d9a9dc08053170f6796f39e",
+      default: "6977195af01337d7b6e2bac97835e3aabbbec2e0",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -214,7 +214,7 @@ public class DevConsoleProcessor {
         if (propertyConfig == null) {
             propertyConfig = configurationBuildItem
                     .getReadResult()
-                    .getRunTimeDefaultValues()
+                    .getRunTimeValues()
                     .get(propertyKey);
         }
 

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/config/DevConsoleRuntimeConfig.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/config/DevConsoleRuntimeConfig.java
@@ -20,7 +20,6 @@ package org.jbpm.quarkus.devui.runtime.config;
 
 import java.util.Map;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/config/UserConfig.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/src/main/java/org/jbpm/quarkus/devui/runtime/config/UserConfig.java
@@ -21,7 +21,6 @@ package org.jbpm.quarkus.devui.runtime.config;
 import java.util.List;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.smallrye.config.WithName;
 
 @ConfigGroup

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/pom.xml.envsubst
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/pom.xml.envsubst
@@ -74,19 +74,10 @@
     <version.quarkus>$ENVSUBST__VERSION_QUARKUS</version.quarkus>
     <version.kogito>$ENVSUBST__VERSION_KOGITO</version.kogito>
     <version.jbpm-quarkus-devui-bom>$ENVSUBST__VERSION_JBPM_QUARKUS_DEVUI_BOM</version.jbpm-quarkus-devui-bom>
-    <version.io.vertx>4.5.22</version.io.vertx>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities. -->
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
-      </dependency>
-      <!-- End of version overrides. -->
-
       <dependency>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/packages/maven-base/not-reproducible-plugins.properties
+++ b/packages/maven-base/not-reproducible-plugins.properties
@@ -84,7 +84,7 @@ org.eclipse.jetty+jetty-jspc-maven-plugin=fail:https://github.com/eclipse/jetty.
 
 org.jboss.jandex+jandex-maven-plugin=fail:https://github.com/wildfly/jandex-maven-plugin/pull/35
 
-org.springframework.boot+spring-boot-maven-plugin=2.7.1
+org.springframework.boot+spring-boot-maven-plugin=3.5.10
 # https://github.com/spring-projects/spring-boot/issues/21005
 
 org.vafer+jdeb=1.10

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -144,8 +144,6 @@
     <version.tomcat.embed.core>10.1.50</version.tomcat.embed.core>
     <version.apache.commons.lang3>3.18.0</version.apache.commons.lang3>
     <version.angus.mail>2.0.5</version.angus.mail>
-    <version.nimbus.jose.jwt>10.4.2</version.nimbus.jose.jwt>
-    <version.io.vertx>4.5.23</version.io.vertx>
     <version.at.yawk.lz4.java>1.10.1</version.at.yawk.lz4.java>
     <!-- End of various transitive overrides. -->
   </properties>
@@ -158,16 +156,6 @@
         <groupId>org.eclipse.angus</groupId>
         <artifactId>angus-mail</artifactId>
         <version>${version.angus.mail}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>nimbus-jose-jwt</artifactId>
-        <version>${version.nimbus.jose.jwt}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
       </dependency>
       <dependency>
         <groupId>at.yawk.lz4</groupId>

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -129,15 +129,15 @@
 
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>
-    <version.org.apache.commons.commons-compress>1.27.1</version.org.apache.commons.commons-compress>
+    <version.org.apache.commons.commons-compress>1.28.0</version.org.apache.commons.commons-compress>
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
     <version.org.apache.mime4j>0.8.12</version.org.apache.mime4j>
-    <version.org.freemarker>2.3.32</version.org.freemarker>
+    <version.org.freemarker>2.3.34</version.org.freemarker>
     <version.org.assertj>3.27.7</version.org.assertj>
-    <version.org.junit.jupiter>5.12.2</version.org.junit.jupiter>
-    <version.org.mockito>4.11.0</version.org.mockito>
+    <version.org.junit.jupiter>5.13.4</version.org.junit.jupiter>
+    <version.org.mockito>5.18.0</version.org.mockito>
     <version.org.kie.j2cl.tools.yaml.mapper>0.4</version.org.kie.j2cl.tools.yaml.mapper>
-    <version.io.netty>4.1.130.Final</version.io.netty>
+    <version.io.netty>4.1.131.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,31 +122,31 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20260206-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20260220-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
-    <version.quarkus>3.20.3</version.quarkus>
+    <version.quarkus>3.27.2</version.quarkus>
 
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>
     <version.org.apache.commons.commons-compress>1.27.1</version.org.apache.commons.commons-compress>
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
-    <version.org.apache.mime4j>0.8.11</version.org.apache.mime4j>
+    <version.org.apache.mime4j>0.8.12</version.org.apache.mime4j>
     <version.org.freemarker>2.3.32</version.org.freemarker>
     <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.junit.jupiter>5.12.2</version.org.junit.jupiter>
     <version.org.mockito>4.11.0</version.org.mockito>
     <version.org.kie.j2cl.tools.yaml.mapper>0.4</version.org.kie.j2cl.tools.yaml.mapper>
-    <version.io.netty>4.1.129.Final</version.io.netty>
+    <version.io.netty>4.1.130.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
-    <version.tomcat.embed.core>10.1.48</version.tomcat.embed.core>
+    <version.tomcat.embed.core>10.1.50</version.tomcat.embed.core>
     <version.apache.commons.lang3>3.18.0</version.apache.commons.lang3>
     <version.angus.mail>2.0.5</version.angus.mail>
-    <version.nimbus.jose.jwt>9.37.4</version.nimbus.jose.jwt>
-    <version.io.vertx>4.5.22</version.io.vertx>
-    <version.org.lz4.java>1.8.1</version.org.lz4.java>
+    <version.nimbus.jose.jwt>10.4.2</version.nimbus.jose.jwt>
+    <version.io.vertx>4.5.23</version.io.vertx>
+    <version.at.yawk.lz4.java>1.10.1</version.at.yawk.lz4.java>
     <!-- End of various transitive overrides. -->
   </properties>
 
@@ -170,9 +170,9 @@
         <version>${version.io.vertx}</version>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>${version.org.lz4.java}</version>
+        <version>${version.at.yawk.lz4.java}</version>
       </dependency>
       <!-- End of various transitive overrides. -->
 

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -401,7 +401,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito}</version>
         <scope>test</scope>
       </dependency>

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -144,7 +144,6 @@
     <version.tomcat.embed.core>10.1.50</version.tomcat.embed.core>
     <version.apache.commons.lang3>3.18.0</version.apache.commons.lang3>
     <version.angus.mail>2.0.5</version.angus.mail>
-    <version.at.yawk.lz4.java>1.10.1</version.at.yawk.lz4.java>
     <!-- End of various transitive overrides. -->
   </properties>
 
@@ -156,11 +155,6 @@
         <groupId>org.eclipse.angus</groupId>
         <artifactId>angus-mail</artifactId>
         <version>${version.angus.mail}</version>
-      </dependency>
-      <dependency>
-        <groupId>at.yawk.lz4</groupId>
-        <artifactId>lz4-java</artifactId>
-        <version>${version.at.yawk.lz4.java}</version>
       </dependency>
       <!-- End of various transitive overrides. -->
 

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,12 +69,12 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.20.3",
+      default: "3.27.2",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260206-local",
+      default: "999-20260220-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -453,12 +453,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${version.org.mockito}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito2</artifactId>
         <version>${version.powermock.api.mockito2}</version>

--- a/packages/serverless-workflow-diagram-editor/pom.xml
+++ b/packages/serverless-workflow-diagram-editor/pom.xml
@@ -454,7 +454,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
 

--- a/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/pom.xml
+++ b/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/pom.xml
@@ -34,7 +34,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <version.quarkus>3.27.2</version.quarkus>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <surefire-plugin.version>3.5.0</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/pom.xml
+++ b/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/pom.xml
@@ -28,11 +28,11 @@
   <version>1.0</version>
   <properties>
     <compiler-plugin.version>3.13.0</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <version.quarkus>2.13.1.Final</version.quarkus>
+    <version.quarkus>3.27.2</version.quarkus>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>

--- a/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/src/main/java/org/kie/tools/it/tests/GreetingResource.java
+++ b/packages/serverless-workflow-vscode-extension/e2e-tests/resources/greeting-flow/src/main/java/org/kie/tools/it/tests/GreetingResource.java
@@ -19,10 +19,10 @@
 
 package org.kie.tools.it.tests;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/hello")
 public class GreetingResource {

--- a/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui-deployment/pom.xml
+++ b/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui-deployment/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <path.to.webapp.app>../node_modules/@kie-tools/serverless-workflow-dev-ui-webapp</path.to.webapp.app>
-    <version.apache.mime4j>0.8.11</version.apache.mime4j>
+    <version.apache.mime4j>0.8.12</version.apache.mime4j>
   </properties>
 
   <dependencies>
@@ -127,9 +127,6 @@
               <version>${version.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui-deployment/src/main/java/org/kie/sonataflow/swf/tools/deployment/DevConsoleProcessor.java
+++ b/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui-deployment/src/main/java/org/kie/sonataflow/swf/tools/deployment/DevConsoleProcessor.java
@@ -162,7 +162,7 @@ public class DevConsoleProcessor {
         if (propertyConfig == null) {
             propertyConfig = configurationBuildItem
                     .getReadResult()
-                    .getRunTimeDefaultValues()
+                    .getRunTimeValues()
                     .get(propertyKey);
         }
 

--- a/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui/pom.xml
+++ b/packages/sonataflow-quarkus-devui/sonataflow-quarkus-devui/pom.xml
@@ -158,9 +158,6 @@
               <version>${version.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -635,12 +635,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${version.org.mockito}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito2</artifactId>
         <version>${version.powermock.api.mockito2}</version>

--- a/packages/stunner-editors/pom.xml
+++ b/packages/stunner-editors/pom.xml
@@ -636,7 +636,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
 

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/META-INF/MANIFEST.MF
@@ -12,5 +12,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.lsp4j.jsonrpc
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-ClassPath: lib/freemarker-2.3.32.jar, .
+Bundle-ClassPath: lib/freemarker-2.3.34.jar, .
 Import-Package: com.google.gson, com.google.gson.stream

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/build.properties
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/build.properties
@@ -21,6 +21,6 @@ output..=target/classes/
 bin.includes=plugin.xml,\
              META-INF/,\
              src/main/resources/templates,\
-             lib/freemarker-2.3.32.jar,\
+             lib/freemarker-2.3.34.jar,\
              .
 src.includes=src/main/java

--- a/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/vscode-java-code-completion-extension-plugin-core/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Ticket
https://github.com/apache/incubator-kie-issues/issues/2204

## Summary
Upgrade Quarkus to 3.27.2 and Spring Boot to 3.5.10, update transitive dependencies, remove unused imports, and adapt to breaking API changes.

## Changes
### Quarkus Upgrade

- Upgraded Quarkus from 3.20.3 to 3.27.2
- Java compiler release updated from 11 to 17 (required by Quarkus 3.x) 

### Spring Boot Upgrade

- Upgraded spring-boot-maven-plugin from 2.7.1 to 3.5.10 

### Dependency Version Bumps (Aligned with Quarkus 3.27.2 + Spring Boot 3.5.10 BOMs) 

- io.netty: 4.1.129.Final -> 4.1.130.Final
- nimbus-jose-jwt: 9.37.4 -> 10.4.2
- io.vertx: 4.5.22 -> 4.5.23
- org.apache.mime4j: 0.8.11 -> 0.8.12
- tomcat-embed-core: 10.1.48 -> 10.1.50 (aligned with Spring Boot 3.5.10 BOM) 
- lz4-java: relocated from org.lz4 to at.yawk.lz4, version 1.8.1 -> 1.10.1 

### API Migration

- Replaced getRunTimeDefaultValues() with getRunTimeValues() in DevConsoleProcessor.java 
- Migrated javax.ws.rs imports to jakarta.ws.rs in GreetingResource.java (required for Quarkus 3.x)

### Cleanup

- Removed unused ConfigItem imports from devui config classes (DevConsoleRuntimeConfig.java, UserConfig.java) 
- Removed -AlegacyConfigRoot=true compiler argument (legacy config classes no longer supported since Quarkus 3.25) 

### Affected Packages

- packages/dev-deployment-quarkus-blank-app
- packages/jbpm-quarkus-devui
- packages/maven-base
- packages/root-env
- packages/sonataflow-quarkus-devui