### PR TITLE
[NO-ISSUE] Updated ajv dependency from 8.17.1 to 8.18.0

### DIFF
--- a/examples/uniforms-patternfly/package.json
+++ b/examples/uniforms-patternfly/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
     "@types/simpl-schema": "1.12.9",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "react": "^17.0.2",

--- a/packages/dashbuilder-component-uniforms/package.json
+++ b/packages/dashbuilder-component-uniforms/package.json
@@ -26,7 +26,7 @@
     "@kie-tools/uniforms-patternfly": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-table": "^5.4.1",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "lodash": "^4.17.23",

--- a/packages/dmn-runner/package.json
+++ b/packages/dmn-runner/package.json
@@ -29,7 +29,7 @@
     "@kie-tools/uniforms-patternfly": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
     "deep-object-diff": "^1.1.9",

--- a/packages/runtime-tools-components/package.json
+++ b/packages/runtime-tools-components/package.json
@@ -34,7 +34,7 @@
     "@patternfly/react-icons": "^5.4.1",
     "@patternfly/react-styles": "^5.4.0",
     "@patternfly/react-table": "^5.4.1",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "axios": "^1.13.5",
     "copyfiles": "^2.4.1",

--- a/packages/uniforms-patternfly-form-wrapper/package.json
+++ b/packages/uniforms-patternfly-form-wrapper/package.json
@@ -31,7 +31,7 @@
     "@kie-tools/uniforms-patternfly": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-errors": "^1.0.1",
     "ajv-formats": "^3.0.1",

--- a/packages/unitables/package.json
+++ b/packages/unitables/package.json
@@ -37,7 +37,7 @@
     "@patternfly/react-icons": "^5.4.1",
     "@types/lodash": "^4.14.168",
     "@types/react-table": "^7.0.25",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-draft-04": "^1.0.0",
     "ajv-errors": "^1.0.1",
     "ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1066,14 +1066,14 @@ importers:
         specifier: 1.12.9
         version: 1.12.9
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-draft-04:
         specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
+        version: 1.0.0(ajv@8.18.0)
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -3150,14 +3150,14 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-draft-04:
         specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
+        version: 1.0.0(ajv@8.18.0)
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       lodash:
         specifier: ^4.17.23
         version: 4.17.23
@@ -4757,14 +4757,14 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-draft-04:
         specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
+        version: 1.0.0(ajv@8.18.0)
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -8307,11 +8307,11 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       axios:
         specifier: ^1.13.5
         version: 1.13.5
@@ -13087,17 +13087,17 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-draft-04:
         specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
+        version: 1.0.0(ajv@8.18.0)
       ajv-errors:
         specifier: ^1.0.1
-        version: 1.0.1(ajv@8.17.1)
+        version: 1.0.1(ajv@8.18.0)
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -13220,17 +13220,17 @@ importers:
         specifier: ^7.0.25
         version: 7.7.7
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       ajv-draft-04:
         specifier: ^1.0.0
-        version: 1.0.0(ajv@8.17.1)
+        version: 1.0.0(ajv@8.18.0)
       ajv-errors:
         specifier: ^1.0.1
-        version: 1.0.1(ajv@8.17.1)
+        version: 1.0.1(ajv@8.18.0)
       ajv-formats:
         specifier: ^3.0.1
-        version: 3.0.1(ajv@8.17.1)
+        version: 3.0.1(ajv@8.18.0)
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -20546,6 +20546,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   algoliasearch@5.35.0:
     resolution: {integrity: sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==}
@@ -33984,8 +33987,8 @@ snapshots:
 
   '@kubernetes-models/validate@3.0.0':
     dependencies:
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
       tslib: 2.8.1
 
   '@leichtgewicht/ip-codec@2.0.4': {}
@@ -34038,8 +34041,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.25.2(hono@4.11.8)(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.8)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -35795,12 +35798,12 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@readme/better-ajv-errors@1.6.0(ajv@8.17.1)':
+  '@readme/better-ajv-errors@1.6.0(ajv@8.18.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.28.6
       '@humanwhocodes/momoa': 2.0.4
-      ajv: 8.17.1
+      ajv: 8.18.0
       chalk: 4.1.2
       json-to-ast: 2.1.0
       jsonpointer: 5.0.1
@@ -35818,10 +35821,10 @@ snapshots:
       '@apidevtools/openapi-schemas': 2.1.0
       '@apidevtools/swagger-methods': 3.0.2
       '@jsdevtools/ono': 7.1.3
-      '@readme/better-ajv-errors': 1.6.0(ajv@8.17.1)
+      '@readme/better-ajv-errors': 1.6.0(ajv@8.18.0)
       '@readme/json-schema-ref-parser': 1.2.0
-      ajv: 8.17.1
-      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
       call-me-maybe: 1.0.2
       openapi-types: 7.2.3
 
@@ -36010,7 +36013,7 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
-      ajv: 8.17.1
+      ajv: 8.18.0
       debug: 4.4.3
       rc-config-loader: 4.1.3
     transitivePeerDependencies:
@@ -36077,13 +36080,13 @@ snapshots:
 
   '@serverlessworkflow/sdk-typescript@0.8.4':
     dependencies:
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       js-yaml: 4.1.1
 
   '@severlessworkflow/sdk-typescript@3.0.3':
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       js-yaml: 4.1.1
 
   '@sideway/address@4.1.4':
@@ -39140,25 +39143,33 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
-  ajv-errors@1.0.1(ajv@8.17.1):
-    dependencies:
-      ajv: 8.17.1
-
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
+
+  ajv-errors@1.0.1(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -39169,6 +39180,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.1
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.1
@@ -48649,9 +48667,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   scuid@1.1.0: {}
 
@@ -49520,7 +49538,7 @@ snapshots:
 
   table@6.9.0:
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3


### PR DESCRIPTION
 fix the CVE-2025-69873