### PR TITLE
[DO NOT MERGE] NO_ISSUE: Run containerized E2E in downstream of partial CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -173,6 +173,7 @@ jobs:
           KIE_TOOLS_BUILD__runTests: "true"
           KIE_TOOLS_BUILD__runEndToEndTests: ${{ runner.os == 'Linux' }}
           KIE_TOOLS_BUILD__buildContainerImages: ${{ runner.os == 'Linux' }}
+          KIE_TOOLS_BUILD__containerizedEndToEndTests: ${{ runner.os == 'Linux' }}
           KIE_TOOLS_BUILD__buildExamples: "true"
           PLAYWRIGHT_BASE__enableChromiumProject: "true"
           PLAYWRIGHT_BASE__enableGoogleChromeProject: "true"

--- a/packages/sonataflow-operator/cmd/main.go
+++ b/packages/sonataflow-operator/cmd/main.go
@@ -78,6 +78,7 @@ func init() {
 }
 
 func main() {
+	fmt.Printf("Ignore this change")
 	var metricsAddr string
 	var enableLeaderElection bool
 	var leaseDuration *time.Duration


### PR DESCRIPTION
This PR is to explore the issue highlighted on [#tooling-dev > Query on kie-tools build checks on PRs - maybe an issue?](https://kie.zulipchat.com/#narrow/channel/382045-tooling-dev/topic/Query.20on.20kie-tools.20build.20checks.20on.20PRs.20-.20maybe.20an.20issue.3F/with/576915880)

I am enabling the `KIE_TOOLS_BUILD__containerizedEndToEndTests: ${{ runner.os == 'Linux' }}` for the Partial branch and forcing the CI to run it using fe242c234a40dafbc5d7e8eb8643cdecc3c256e5 commit

Also this is one of the differences between FULL and PARTIAL branches so just trying to get some data and see how this compares to https://github.com/apache/incubator-kie-tools/pull/3476