### PR TITLE
[issue-3482]Fix ci: --if-present flag in ci_build workflow break sonataflow-operator build in PARTIAL branch execution

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -162,7 +162,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} --if-present build:dev"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.upstreamPnpmFilterString }} build:dev"
 
       - name: "PARTIAL → Build changed and downstream"
         shell: bash
@@ -187,7 +187,7 @@ jobs:
           MAVEN_ARGS: "-B -Puse-maven-repo-local-tail"
           MAVEN_OPTS: "-Xmx2g"
         run: |
-          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} --if-present --workspace-concurrency=1 build:prod"
+          eval "pnpm ${{ steps.setup_build_mode.outputs.affectedPnpmFilterString }} --workspace-concurrency=1 build:prod"
 
       - name: "Check tests result (`main` only)"
         if: always() && !cancelled() && steps.setup_build_mode.outputs.mode != 'none'

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "kie-tools--eslint": "eslint.js"
   },
+  "scripts": {
+    "build:dev": "echo \"Nothing to build for this package. Skipping.\"",
+    "build:prod": "echo \"Nothing to build for this package. Skipping.\""
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/packages/image-builder/package.json
+++ b/packages/image-builder/package.json
@@ -23,6 +23,8 @@
     "src"
   ],
   "scripts": {
+    "build:dev": "echo \"Nothing to build for this package. Skipping.\"",
+    "build:prod": "echo \"Nothing to build for this package. Skipping.\"",
     "install": "rimraf dist && tsc && pnpm write-readme",
     "write-readme": "run-script-os",
     "write-readme:darwin:linux": "LC_ALL=en echo '```' > README.md && ./bin.js --help >> README.md && echo '```' >> README.md",

--- a/packages/python-venv/package.json
+++ b/packages/python-venv/package.json
@@ -6,6 +6,8 @@
   "license": "Apache-2.0",
   "keywords": [],
   "scripts": {
+    "build:dev": "echo \"Nothing to build for this package. Skipping.\"",
+    "build:prod": "echo \"Nothing to build for this package. Skipping.\"",
     "install": "python3 -m venv ./venv && run-script-os",
     "install:linux:darwin": ". ./venv/bin/activate && pnpm install:pip",
     "install:pip": "pip3 install -r requirements.txt",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,5 +3,9 @@
   "name": "@kie-tools/tsconfig",
   "version": "0.0.0",
   "keywords": [],
+  "scripts": {
+    "build:dev": "echo \"Nothing to build for this package. Skipping.\"",
+    "build:prod": "echo \"Nothing to build for this package. Skipping.\""
+  },
   "devDependencies": {}
 }

--- a/scripts/build-env/package.json
+++ b/scripts/build-env/package.json
@@ -22,6 +22,8 @@
     "src"
   ],
   "scripts": {
+    "build:dev": "echo \"Nothing to build for this package. Skipping.\"",
+    "build:prod": "echo \"Nothing to build for this package. Skipping.\"",
     "install": "rimraf dist && tsc"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #3482 

Remove the `--if-present` flag.

Adds `build:prod` and `build:dev` to packages reported originally when the flag was added.

Feels like a "band aid" fix, but proposing it anyway :worried: 
