### PR TITLE
NO-ISSUE: Quarkus Dev UI: Blank screen when trying to open any page after quarkus upgrade

### DIFF
--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -58,7 +58,7 @@ import io.quarkus.vertx.http.runtime.management.ManagementInterfaceBuildTimeConf
 
 public class DevConsoleProcessor {
     private static final String STATIC_RESOURCES_PATH = "dev-static/";
-    private static final String BASE_RELATIVE_URL = "dev-ui/org.jbpm.jbpm-quarkus-devui";
+    private static final String BASE_RELATIVE_URL = "dev-ui/jbpm-quarkus-devui";
     private static final String NON_APPLICATION_BASE_RELATIVE_URL = "/q/" + BASE_RELATIVE_URL;
     private static final String DATA_INDEX_CAPABILITY = "org.kie.kogito.data-index";
     private static final GACT DEVCONSOLE_WEBJAR_ARTIFACT_KEY = new GACT("org.jbpm", "jbpm-quarkus-devui-deployment", null, "jar");


### PR DESCRIPTION

The Quarkus 3.20.3 → 3.27.2 upgrade included a Vaadin Router 1.7.5 → 2.0.0 change that shortened Dev UI page URLs:

- **Old:** `/q/dev-ui/org.jbpm.jbpm-quarkus-devui`
- **New:** `/q/dev-ui/jbpm-quarkus-devui`

Static resources were still being served at the full namespace path, while the iframe resolved relative URLs against the new short-name page URL — causing `envelope.js` to be fetched from the wrong path and Quarkus's Dev UI catch-all returning HTML instead of JS.

### Changes
1. **`DevConsoleProcessor.java` ( jBPM):** Updated `BASE_RELATIVE_URL` to use the short artifact name matching Quarkus's new page routing, and registered static resource routes with explicit priority so they are evaluated before Quarkus's Dev UI catch-all
   - jBPM: `dev-ui/jbpm-quarkus-devui`

### Test plan
On a Kogito application with the jbpm-quarkus-devui module:
- `mvn clean quarkus:dev` → Dev UI pages (Process Instances, Tasks, Jobs, Forms) load without blank screen
