### PR TITLE
[CVE][High]CVE-2026-24734-tomcat-embed-core-10.1.50

### DIFF
--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -141,7 +141,7 @@
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
-    <version.tomcat.embed.core>10.1.50</version.tomcat.embed.core>
+    <version.tomcat.embed.core>10.1.52</version.tomcat.embed.core>
     <version.apache.commons.lang3>3.18.0</version.apache.commons.lang3>
     <version.angus.mail>2.0.5</version.angus.mail>
     <!-- End of various transitive overrides. -->


### PR DESCRIPTION
Fix for CVE
[High]https://github.com/advisories/GHSA-mgp5-rv84-w37q
[Medium]https://github.com/advisories/GHSA-qq5r-98hh-rxc9, https://github.com/advisories/GHSA-fpj8-gq4v-p354-tomcat-embed-core-10.1.50

overriding cve version of tomcat-embed-core from 10.1.50 => 10.1.52