### PR TITLE
NO-ISSUE: Process security example not working after Quarkus Upgrade

### DIFF
--- a/examples/process-security/kie-service-1/pom.xml
+++ b/examples/process-security/kie-service-1/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>io.quarkiverse.oidc-proxy</groupId>
       <artifactId>quarkus-oidc-proxy</artifactId>
-      <version>0.2.2</version>
+      <version>0.3.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/examples/process-security/kie-service-2/pom.xml
+++ b/examples/process-security/kie-service-2/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>io.quarkiverse.oidc-proxy</groupId>
       <artifactId>quarkus-oidc-proxy</artifactId>
-      <version>0.2.2</version>
+      <version>0.3.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
`quarkus-oidc-proxy` was upgraded from  0.2.2 → 0.3.2