### PR TITLE
kie-issues#2267: KIE Sandbox: DMN Runner form does not support full namespace URIs for same-file references

### DIFF
--- a/packages/dmn-language-service/src/DmnLanguageService.ts
+++ b/packages/dmn-language-service/src/DmnLanguageService.ts
@@ -314,7 +314,7 @@ Error details: ${error}`);
     namespaceToDrgElementsMap.set(model.definitions?.["@_namespace"] ?? "", idToDrgElementsMap);
   }
 
-  //To filter only included inputs for decisions / decisionService
+  // To filter only included inputs for decisions / decisionService
   public filterRequiredDecisionInputDataNodes = (
     namespace: string | undefined,
     namespaceToElementsMap: Map<string, Map<string, DrgElement>>,
@@ -328,16 +328,16 @@ Error details: ${error}`);
       if (drgElement.__$$element === "decision") {
         drgElement.informationRequirement?.forEach((decision) => {
           if (decision.requiredDecision) {
-            const decisionHref = decision.requiredDecision["@_href"];
-            if (decisionIdToInputIdsMap.has(decisionHref)) {
-              requiredDecisionsHref.add(decisionHref);
+            const requiredDecisionHref = decision.requiredDecision["@_href"];
+            if (decisionIdToInputIdsMap.has(requiredDecisionHref)) {
+              requiredDecisionsHref.add(requiredDecisionHref);
             }
 
-            if (decisionHref.includes("#")) {
-              const [namespace] = decisionHref.split("#");
-              if (namespace) {
+            if (requiredDecisionHref.includes("#")) {
+              const [requiredDecisionHrefNamespace] = requiredDecisionHref.split("#");
+              if (requiredDecisionHrefNamespace && requiredDecisionHrefNamespace !== namespace) {
                 this.filterRequiredDecisionInputDataNodes(
-                  namespace,
+                  requiredDecisionHrefNamespace,
                   namespaceToElementsMap,
                   decisionIdToInputIdsMap,
                   requiredDecisionsHref
@@ -350,16 +350,16 @@ Error details: ${error}`);
 
       if (drgElement.__$$element === "decisionService" && drgElement.outputDecision) {
         drgElement.outputDecision.forEach((outputDecision) => {
-          const decisionHref = outputDecision["@_href"];
-          if (decisionIdToInputIdsMap.has(decisionHref)) {
-            requiredDecisionsHref.add(decisionHref);
+          const outputDecisionHref = outputDecision["@_href"];
+          if (decisionIdToInputIdsMap.has(outputDecisionHref)) {
+            requiredDecisionsHref.add(outputDecisionHref);
           }
 
-          if (decisionHref.includes("#")) {
-            const [namespace] = decisionHref.split("#");
-            if (namespace)
+          if (outputDecisionHref.includes("#")) {
+            const [outputDecisionHrefNamespace] = outputDecisionHref.split("#");
+            if (outputDecisionHrefNamespace && outputDecisionHrefNamespace !== namespace)
               this.filterRequiredDecisionInputDataNodes(
-                namespace,
+                outputDecisionHrefNamespace,
                 namespaceToElementsMap,
                 decisionIdToInputIdsMap,
                 requiredDecisionsHref


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2267

Stops the `filterRequiredDecisionInputDataNodes` recursion if the namespace in the href is the same as the current model `definitions` namespace.

---

Reproduction steps for the original bug are in the issue's description.

