### PR TITLE
kie-issues#2268: DMN Editor: Import Java Classes button missing in Data Types panel due to missing channelType pro

### DIFF
--- a/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
+++ b/packages/dmn-editor-envelope/src/NewDmnEditorFactory.tsx
@@ -74,6 +74,7 @@ export class NewDmnEditorInterface extends DmnEditorInterface {
             this.initArgs.channel === ChannelType.ONLINE || this.initArgs.channel === ChannelType.ONLINE_MULTI_FILE
           }
           isReadOnly={this.initArgs.isReadOnly}
+          channelType={this.initArgs.channel}
           locale={this.initArgs.initialLocale}
           onOpenedBoxedExpressionEditorNodeChange={(newOpenedNodeId) => {
             (


### PR DESCRIPTION
Closes [kie-issues#2268](https://github.com/apache/incubator-kie-issues/issues/2268)

Added missing channelType prop to the DmnEditorRootWrapper component in the New DMN editor envelope factory. This prop is required for the "Import Java Classes" button to appear correctly in the DMN data types panel.