### PR TITLE
NO-ISSUE: Fix VS Code ESLint settings after pnpm and Node.js upgrade

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "eslint.options": {
     "overrideConfigFile": "packages/eslint/.eslintrc.js"
   },
+  "eslint.nodePath": "packages/eslint/node_modules",
+  "eslint.workingDirectories": [{ "directory": "packages/eslint", "changeProcessCWD": true }],
   "files.associations": {
     "*.yaml.helm": "helm"
   },


### PR DESCRIPTION
To be honest, I'm not sure why ESLint on VS Code stopped working after the Node.js v4 and pnpm v10 upgrade, but this fixes it.