### PR TITLE
NO-ISSUE: Fix jBPM Quarkus DevUI and Management Console after Quarkus 3.27 upgrade

### DIFF
--- a/examples/process-compact-architecture/src/main/resources/application.properties
+++ b/examples/process-compact-architecture/src/main/resources/application.properties
@@ -41,7 +41,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://0
 # Development DS
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-event-driven/hotels/src/main/resources/application.properties
+++ b/examples/process-event-driven/hotels/src/main/resources/application.properties
@@ -25,7 +25,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=hotel-user
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 ############
 # Security #

--- a/examples/process-event-driven/travelers/src/main/resources/application.properties
+++ b/examples/process-event-driven/travelers/src/main/resources/application.properties
@@ -25,7 +25,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=hotel-user
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 ############
 # Security #

--- a/examples/process-security/kie-service-1/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-1/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie1
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-security/kie-service-2/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-2/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie2
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-security/kie-service-3/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-3/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie3
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-user-tasks-subsystem/src/main/resources/application.properties
+++ b/examples/process-user-tasks-subsystem/src/main/resources/application.properties
@@ -45,12 +45,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
-
-# Development DS
-%dev.quarkus.datasource.db-kind=h2
-%dev.quarkus.datasource.username=kie
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
+++ b/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
@@ -58,7 +58,7 @@ kogito.persistence.type=jdbc
 # Default DS
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kie
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/packages/jbpm-quarkus-devui/dev/pom.xml
+++ b/packages/jbpm-quarkus-devui/dev/pom.xml
@@ -79,10 +79,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
     </dependency>
@@ -92,31 +88,22 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-multipart</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-dmn-openapi</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-with-drools-quarkus</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>kogito-ruleunits</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-    <!-- Addons -->
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-addons-quarkus-process-management</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-addons-quarkus-process-svg</artifactId>
@@ -125,29 +112,45 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-addons-quarkus-source-files</artifactId>
     </dependency>
+
+    <!-- Persistence -->
     <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-addons-quarkus-process-management</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-agroal</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kogito-addons-quarkus-jobs-management</artifactId>
+      <artifactId>kie-addons-quarkus-persistence-jdbc</artifactId>
     </dependency>
 
-    <!-- Data-Index -->
+    <!-- Data-Index Addon -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kogito-addons-quarkus-data-index-postgresql</artifactId>
+      <artifactId>kogito-addons-quarkus-data-index-jpa</artifactId>
     </dependency>
 
     <!-- Jobs Service -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>kogito-addons-quarkus-jobs</artifactId>
+      <artifactId>kogito-addons-quarkus-embedded-jobs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>jobs-service-postgresql-common</artifactId>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-embedded-jobs-jpa</artifactId>
+    </dependency>
+
+    <!-- Data Audit -->
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-data-audit-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-data-audit</artifactId>
     </dependency>
 
     <!-- DevUI -->
@@ -155,11 +158,6 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-quarkus-devui</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.quarkiverse.embedded.postgresql</groupId>
-      <artifactId>quarkus-embedded-postgresql</artifactId>
     </dependency>
 
     <dependency>

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -42,15 +42,7 @@ kogito.jobs-service.retryMillis=2000
 
 kogito.jobs-service.exception-details-enabled=true
 
-# Container image
-quarkus.container-image.build=true
-quarkus.container-image.push=false
-quarkus.container-image.group=bamoe
-quarkus.container-image.registry=dev.local
-quarkus.container-image.tag=${revision}
-quarkus.container-image.name=jbpm-quarkus-devui-runtime
-
 # Dev Services
 quarkus.devservices.enabled=false
 
-%dev.jbpm.devui.users.jdoe.groups=admin,HR,IT
+jbpm.devui.users.jdoe.groups=admin,HR,IT

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -17,6 +17,14 @@
 # under the License.
 #
 
+quarkus.http.host=0.0.0.0
+quarkus.http.port=8080
+
+# Kogito-service
+kogito.service.url=http://${quarkus.http.host}:${quarkus.http.port}
+kogito.jobs-service.url=http://${quarkus.http.host}:${quarkus.http.port}
+kogito.data-index.url=http://${quarkus.http.host}:${quarkus.http.port}
+
 # Persistence
 kie.flyway.enabled=true
 kogito.persistence.type=jdbc

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -17,37 +17,40 @@
 # under the License.
 #
 
-quarkus.swagger-ui.always-include=true
+# Persistence
+kie.flyway.enabled=true
+kogito.persistence.type=jdbc
+quarkus.datasource.db-kind=h2
+quarkus.datasource.username=kogito
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+
+# Security
+kogito.security.auth.enabled=false
+quarkus.oidc.enabled=false
 quarkus.http.cors=true
-quarkus.http.cors.origins=*
+quarkus.http.cors.origins=/.*/
+
+# Misc.
 quarkus.dev-ui.cors.enabled=false
-
-quarkus.http.host=0.0.0.0
-quarkus.http.port=8080
-quarkus.http.root-path=/kie
-
-dev.quarkus.http.cors.origins=/.*/
-quarkus.smallrye-openapi.path=${quarkus.http.root-path}/docs/openapi.json
-
-quarkus.kogito.devservices.enabled=false
-quarkus.devservices.enabled=false
-
-# Kogito-service
-kogito.service.url=http://${quarkus.http.host}:${quarkus.http.port}${quarkus.http.root-path}
-
-#Job-service
-kogito.jobs-service.url=http://${quarkus.http.host}:${quarkus.http.port}${quarkus.http.root-path}
-kogito.data-index.url=http://${quarkus.http.host}:${quarkus.http.port}${quarkus.http.root-path}
-
+quarkus.smallrye-openapi.path=/docs/openapi.json
+quarkus.swagger-ui.always-include=true
 quarkus.kogito.data-index.graphql.ui.always-include=true
+quarkus.http.test-port=0
 
-quarkus.datasource.db-kind=postgresql
+kogito.jobs-service.maxNumberOfRetries=2
+kogito.jobs-service.retryMillis=2000
 
-# run create tables scripts
-quarkus.flyway.migrate-at-start=true
-quarkus.flyway.baseline-on-migrate=true
-quarkus.flyway.baseline-version=0.0
-quarkus.flyway.locations=classpath:/db/migration,classpath:/db/jobs-service,classpath:/db/data-audit/postgresql
-quarkus.flyway.table=FLYWAY_RUNTIME_SERVICE
+kogito.jobs-service.exception-details-enabled=true
+
+# Container image
+quarkus.container-image.build=true
+quarkus.container-image.push=false
+quarkus.container-image.group=bamoe
+quarkus.container-image.registry=dev.local
+quarkus.container-image.tag=${revision}
+quarkus.container-image.name=jbpm-quarkus-devui-runtime
+
+# Dev Services
+quarkus.devservices.enabled=false
 
 %dev.jbpm.devui.users.jdoe.groups=admin,HR,IT

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -134,12 +134,12 @@ public class DevConsoleProcessor {
                 managementInterfaceBuildTimeConfig, launchModeBuildItem, true);
 
         String devUIUrl = getProperty(configurationBuildItem, systemPropertyBuildItems, "kogito.dev-ui.url");
-        String dataIndexUrl = getProperty(configurationBuildItem, systemPropertyBuildItems,
-                "kogito.data-index.url");
         String quarkusHttpHost = ConfigProvider.getConfig().getOptionalValue("quarkus.http.host", String.class)
                 .orElse("0.0.0.0");
         String quarkusHttpPort = ConfigProvider.getConfig().getOptionalValue("quarkus.http.port", String.class)
                 .orElse("8080");
+        String dataIndexUrl = ConfigProvider.getConfig().getOptionalValue("kogito.data-index.url", String.class)
+                .orElse("http://" + quarkusHttpHost + ":" + quarkusHttpPort + nonApplicationRootPathBuildItem.getNormalizedHttpRootPath());
 
         CardPageBuildItem cardPageBuildItem = new CardPageBuildItem();
 
@@ -212,6 +212,8 @@ public class DevConsoleProcessor {
         }
 
         if (propertyConfig == null) {
+            // Quarkus 3.27: getRunTimeDefaultValues() was renamed to getRunTimeValues()
+            // See: https://github.com/quarkusio/quarkus/pull/50745
             propertyConfig = configurationBuildItem
                     .getReadResult()
                     .getRunTimeValues()

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/src/main/java/org/jbpm/quarkus/devui/deployment/DevConsoleProcessor.java
@@ -212,8 +212,6 @@ public class DevConsoleProcessor {
         }
 
         if (propertyConfig == null) {
-            // Quarkus 3.27: getRunTimeDefaultValues() was renamed to getRunTimeValues()
-            // See: https://github.com/quarkusio/quarkus/pull/50745
             propertyConfig = configurationBuildItem
                     .getReadResult()
                     .getRunTimeValues()

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
@@ -40,7 +40,7 @@ kogito.persistence.type=jdbc
 %dev.kie.flyway.enabled=true
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kogito
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 
 

--- a/packages/runtime-tools-components/package.json
+++ b/packages/runtime-tools-components/package.json
@@ -24,6 +24,7 @@
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\""
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^13.0.5",
     "@kie-tools-core/editor": "workspace:*",
     "@kie-tools-core/operating-system": "workspace:*",
     "@kie-tools-core/patternfly-base": "workspace:*",
@@ -52,6 +53,7 @@
     "@kie-tools/eslint": "workspace:*",
     "@kie-tools/root-env": "workspace:*",
     "@kie-tools/tsconfig": "workspace:*",
+    "@types/json-schema": "^7.0.11",
     "@types/lodash": "^4.14.168",
     "@types/react": "^17.0.6",
     "@types/react-datetime-picker": "^3.4.1",

--- a/packages/runtime-tools-components/src/components/FormRenderer/FormRenderer.tsx
+++ b/packages/runtime-tools-components/src/components/FormRenderer/FormRenderer.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import React, { useImperativeHandle, useState } from "react";
+import React, { useCallback, useImperativeHandle, useMemo, useState } from "react";
 import JSONSchemaBridge from "uniforms-bridge-json-schema";
-import { AutoForm, ErrorsField } from "@kie-tools/uniforms-patternfly/dist/esm";
+import { AutoFields, AutoForm, ErrorsField } from "@kie-tools/uniforms-patternfly/dist/esm";
 import { componentOuiaProps, OUIAProps } from "../../ouiaTools";
 import { FormAction, lookupValidator, ModelConversionTool } from "../../utils";
 import { FormFooter } from "../FormFooter";
@@ -51,21 +51,24 @@ export const FormRenderer = React.forwardRef<FormRendererApi, IOwnProps & OUIAPr
       };
     }, [formApiRef]);
 
-    const bridge = new JSONSchemaBridge(formSchema, (formModel) => {
-      // Converting back all the JS Dates into String before validating the model
-      const newModel = ModelConversionTool.convertDateToString(formModel, formSchema);
-      return validator.validate(newModel);
-    });
-
-    // Converting Dates that are in string format into JS Dates so they can be correctly bound to the uniforms DateField
-    const formData = ModelConversionTool.applySchemaDefaults(
-      ModelConversionTool.convertStringToDate(model, formSchema),
-      formSchema
+    const bridge = useMemo(
+      () =>
+        new JSONSchemaBridge(formSchema, (formModel) => {
+          // Converting back al the JS Dates into String before validating the model
+          const newModel = ModelConversionTool.convertDateToString(formModel, formSchema);
+          return validator.validate(newModel);
+        }),
+      [formSchema, validator]
     );
 
-    const submitFormData = (): void => {
-      formApiRef!.submit();
-    };
+    // Converting Dates that are in string format into JS Dates so they can be correctly bound to the uniforms DateField
+    const formData = useMemo(() => ModelConversionTool.convertStringToDate(model, formSchema), [formSchema, model]);
+
+    const submitFormData = useCallback((): void => {
+      if (formApiRef) {
+        formApiRef.submit();
+      }
+    }, [formApiRef]);
 
     return (
       <React.Fragment>
@@ -80,7 +83,7 @@ export const FormRenderer = React.forwardRef<FormRendererApi, IOwnProps & OUIAPr
           {...componentOuiaProps(ouiaId, "form-renderer", ouiaSafe)}
         >
           <ErrorsField />
-          {children}
+          <AutoFields />
         </AutoForm>
         <FormFooter actions={formActions} enabled={!readOnly} onSubmitForm={submitFormData} />
       </React.Fragment>

--- a/packages/runtime-tools-components/src/components/FormRenderer/utils.ts
+++ b/packages/runtime-tools-components/src/components/FormRenderer/utils.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { JSONSchema4 } from "json-schema";
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+
+type Field = {
+  type?: string;
+  properties?: Record<string, Field>;
+};
+
+function getFieldDefaultValue(field: Field): string | boolean | [] | object | undefined {
+  if (field.type === "string") {
+    return "";
+  }
+  if (field.type === "number") {
+    return undefined;
+  }
+  if (field.type === "boolean") {
+    return false;
+  }
+  if (field.type === "array") {
+    return [];
+  }
+  if (field.type === "object") {
+    if (field.properties) {
+      return Object.keys(field.properties).reduce((objectValues: Record<string, any>, key: string) => {
+        if (field.properties?.[key]) {
+          objectValues[key] = getFieldDefaultValue(field.properties[key]);
+        } else {
+          objectValues[key] = undefined;
+        }
+        return objectValues;
+      }, {});
+    } else {
+      return {};
+    }
+  }
+  return undefined;
+}
+
+/**
+ * get default values based on the jsonSchema
+ */
+export async function getDefaultValues(jsonSchema: JSONSchema4, skipDereference = false) {
+  // Dereference schema (replace $refs with their values)
+  if (!skipDereference) {
+    await $RefParser.dereference(jsonSchema, { continueOnError: true, resolve: { external: false } });
+  }
+
+  return Object.entries(jsonSchema.properties ?? {})?.reduce(
+    (acc, [key, field]: [string, Record<string, string>]) => {
+      acc[key] = getFieldDefaultValue(field);
+      return acc;
+    },
+    {} as Record<string, any>
+  );
+}

--- a/packages/runtime-tools-management-console-webapp/README.md
+++ b/packages/runtime-tools-management-console-webapp/README.md
@@ -42,7 +42,7 @@ Add the `quarkus-oidc-proxy` extension to your `pom.xml` to proxy the Identity P
 <dependency>
   <groupId>io.quarkiverse.oidc-proxy</groupId>
   <artifactId>quarkus-oidc-proxy</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.2</version>
 </dependency>
 ```
 

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>io.quarkiverse.oidc-proxy</groupId>
       <artifactId>quarkus-oidc-proxy</artifactId>
-      <version>0.2.2</version>
+      <version>0.3.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
@@ -32,7 +32,7 @@ kie.flyway.enabled=true
 kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kogito
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Security
 kogito.security.auth.enabled=true

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
@@ -27,7 +27,7 @@ kie.flyway.enabled=true
 kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kogito
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
 
 # Security
 kogito.security.auth.enabled=false

--- a/packages/runtime-tools-management-console-webapp/webpack.config.js
+++ b/packages/runtime-tools-management-console-webapp/webpack.config.js
@@ -19,7 +19,7 @@
 
 const path = require("path");
 const { merge } = require("webpack-merge");
-const { EnvironmentPlugin } = require("webpack");
+const { EnvironmentPlugin, ProvidePlugin } = require("webpack");
 const common = require("@kie-tools-core/webpack-base/webpack.common.config");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
@@ -69,12 +69,24 @@ module.exports = async (webpackEnv) => {
           },
         ],
       }),
+      new ProvidePlugin({
+        Buffer: ["buffer", "Buffer"],
+      }),
     ],
     module: {
       rules: [
         {
           test: /\.(css|sass|scss)$/,
-          use: [require.resolve("style-loader"), require.resolve("css-loader"), require.resolve("sass-loader")],
+          use: [
+            require.resolve("style-loader"),
+            require.resolve("css-loader"),
+            {
+              loader: require.resolve("sass-loader"),
+              options: {
+                api: "modern",
+              },
+            },
+          ],
         },
         {
           test: /\.(svg|ttf|eot|woff|woff2)$/,

--- a/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
+++ b/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
@@ -106,6 +106,9 @@ module.exports = async (webpackEnv) => {
           replacement: () => env.runtimeToolsProcessDevUIWebapp.port ?? "",
         },
       ]),
+      new webpack.ProvidePlugin({
+        Buffer: ["buffer", "Buffer"],
+      }),
     ],
     module: {
       rules: [
@@ -158,7 +161,16 @@ module.exports = async (webpackEnv) => {
         },
         {
           test: /\.(css|sass|scss)$/,
-          use: [require.resolve("style-loader"), require.resolve("css-loader"), require.resolve("sass-loader")],
+          use: [
+            require.resolve("style-loader"),
+            require.resolve("css-loader"),
+            {
+              loader: require.resolve("sass-loader"),
+              options: {
+                api: "modern",
+              },
+            },
+          ],
         },
         {
           test: /\.css$/,

--- a/packages/runtime-tools-process-enveloped-components/src/processForm/envelope/components/ProcessForm.tsx
+++ b/packages/runtime-tools-process-enveloped-components/src/processForm/envelope/components/ProcessForm.tsx
@@ -25,6 +25,7 @@ import { Form } from "@kie-tools/runtime-tools-shared-gateway-api/dist/types";
 import { FormAction } from "@kie-tools/runtime-tools-components/dist/utils";
 import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
 import { ServerErrors } from "@kie-tools/runtime-tools-components/dist/components/ServerErrors";
+import { getDefaultValues } from "@kie-tools/runtime-tools-components/dist/components/FormRenderer/utils";
 import { ProcessDefinition } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 import { Card, CardBody } from "@patternfly/react-core/dist/js/components/Card";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
@@ -56,6 +57,7 @@ const ProcessForm: React.FC<ProcessFormProps> = ({
   const formRendererApi = React.useRef<FormRendererApi>(null);
   const [processFormSchema, setProcessFormSchema] = useState<any>({});
   const [processCustomForm, setProcessCustomForm] = useState<Form>();
+  const [processFormModel, setProcessFormModel] = useState<any>({});
   const [svg, setSvg] = useState<JSX.Element>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>();
@@ -64,32 +66,32 @@ const ProcessForm: React.FC<ProcessFormProps> = ({
     if (!isEnvelopeConnectedToChannel) {
       return;
     }
-    const customFormPromise: Promise<void> = new Promise<void>((resolve) => {
-      if (!shouldLoadCustomForms) {
-        resolve();
-        return;
-      }
-      channelApi.requests
-        .processForm__getCustomForm(processDefinition)
-        .then((customForm) => {
-          setProcessCustomForm(customForm);
-          resolve();
-        })
-        .catch((error) => resolve());
-    });
+    const customFormPromise = !shouldLoadCustomForms
+      ? Promise.resolve()
+      : channelApi.requests
+          .processForm__getCustomForm(processDefinition)
+          .then((customForm) => {
+            setProcessCustomForm(customForm);
+            return;
+          })
+          .catch((error) => {
+            // no-op
+            return;
+          });
 
-    const schemaPromise: Promise<void> = new Promise<void>((resolve, reject) => {
-      channelApi.requests
-        .processForm__getProcessFormSchema(processDefinition)
-        .then((schema) => {
-          setProcessFormSchema(schema);
-          resolve();
-        })
-        .catch((error) => {
-          setError(error);
-          reject(error);
-        });
-    });
+    const schemaPromise: Promise<void> = channelApi.requests
+      .processForm__getProcessFormSchema(processDefinition)
+      .then((schema) => {
+        setProcessFormSchema(schema);
+        return getDefaultValues(schema, shouldLoadCustomForms ? true : false);
+      })
+      .then((defaultValues) => {
+        setProcessFormModel(defaultValues);
+      })
+      .catch((error) => {
+        setError(error);
+        throw error;
+      });
 
     Promise.all([customFormPromise, schemaPromise]).finally(() => {
       setIsLoading(false);
@@ -163,7 +165,7 @@ const ProcessForm: React.FC<ProcessFormProps> = ({
             <CardBody>
               <FormRenderer
                 formSchema={processFormSchema}
-                model={{}}
+                model={processFormModel}
                 readOnly={false}
                 onSubmit={onSubmit}
                 formActions={formAction}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8192,6 +8192,9 @@ importers:
 
   packages/runtime-tools-components:
     dependencies:
+      '@apidevtools/json-schema-ref-parser':
+        specifier: ^13.0.5
+        version: 13.0.5
       '@kie-tools-core/editor':
         specifier: workspace:*
         version: link:../editor
@@ -8277,6 +8280,9 @@ importers:
       '@kie-tools/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/json-schema':
+        specifier: ^7.0.11
+        version: 7.0.15
       '@types/lodash':
         specifier: ^4.14.168
         version: 4.14.202
@@ -14776,6 +14782,10 @@ packages:
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
+
+  '@apidevtools/json-schema-ref-parser@13.0.5':
+    resolution: {integrity: sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==}
+    engines: {node: '>= 16'}
 
   '@apidevtools/json-schema-ref-parser@9.0.6':
     resolution: {integrity: sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==}
@@ -30675,6 +30685,11 @@ snapshots:
       '@angular/common': 20.3.16(@angular/core@20.3.16(@angular/compiler@20.3.16)(rxjs@7.8.2)(zone.js@0.14.8))(rxjs@7.8.2)
       '@angular/core': 20.3.16(@angular/compiler@20.3.16)(rxjs@7.8.2)(zone.js@0.14.8)
       tslib: 2.8.1
+
+  '@apidevtools/json-schema-ref-parser@13.0.5':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 3.14.2
 
   '@apidevtools/json-schema-ref-parser@9.0.6':
     dependencies:


### PR DESCRIPTION
- Updates the dependencies in the pom.xml to use in-memory DB and removes unavailable dependencies.
- Fixes Task and Process forms that were not loading correctly.
- Fixes jBPM Quarkus DevUI not reaching the GraphQL endpoint.