### PR TITLE
NO-ISSUE: Bump drools-and-kogito to 999-20260324-local

### DIFF
--- a/packages/dmn-marshaller-backend-compatibility-tester/package.json
+++ b/packages/dmn-marshaller-backend-compatibility-tester/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build:dev": "rimraf dist dist-m2 && tsc -p tsconfig.json && pnpm prefetch",
     "build:prod": "pnpm build:dev",
+    "powershell": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command",
     "prefetch": "run-script-os",
     "prefetch:darwin:linux": "cross-env JBANG_REPO=$(node -p \"require('path').resolve('dist-m2')\") node dist/dependenciesFetch.js",
     "prefetch:win32": "pnpm powershell \"cross-env JBANG_REPO=$(Resolve-Path . | Write-Host)\\dist-m2 node dist/dependenciesFetch.js\""

--- a/packages/dmn-marshaller-backend-compatibility-tester/package.json
+++ b/packages/dmn-marshaller-backend-compatibility-tester/package.json
@@ -28,7 +28,7 @@
     "prefetch:win32": "pnpm powershell \"cross-env JBANG_REPO=$(Resolve-Path . | Write-Host)\\dist-m2 node dist/dependenciesFetch.js\""
   },
   "dependencies": {
-    "@jbangdev/jbang": "0.2.3"
+    "@jbangdev/jbang": "0.7.1"
   },
   "devDependencies": {
     "@kie-tools-core/drools-and-kogito": "workspace:*",

--- a/packages/dmn-marshaller/package.json
+++ b/packages/dmn-marshaller/package.json
@@ -31,7 +31,7 @@
     "build:dev": "rimraf dist && pnpm build:codegen && tsc -p tsconfig.json",
     "build:prod": "pnpm lint && rimraf dist && pnpm build:codegen && tsc -p tsconfig.json && pnpm test",
     "lint": "run-script-if --bool \"$(build-env linters.run)\" --then \"kie-tools--eslint ./src\"",
-    "test": "rimraf dist-tests && run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --verbose --passWithNoTests\""
+    "test": "rimraf dist-tests && run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --runInBand --verbose --passWithNoTests\""
   },
   "dependencies": {
     "@kie-tools/xml-parser-ts": "workspace:*",

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "6977195af01337d7b6e2bac97835e3aabbbec2e0",
+      default: "869732dc42cfc0b264af267d47792d747664cc90",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for OptaPlanner",
     },
     DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "64098aae2ca6ae8ee1c11bee74969214bfd56601",
+      default: "45b9a2543eb9bfac9b66168bbb7b2e11b67849e6",
       description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "0a498880e155af60fdee150a0109420874a1db9b",
+      default: "117dd2bf00cf1eba0081deb6a10f4822051440d8",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "23ea984ab5550af666adf371aead494a19a863c2",
+      default: "6be874df5e33dae20cfdb7ff5ac8eedafc6ba69d",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -122,7 +122,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20260220-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20260324-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.27.2</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260220-local",
+      default: "999-20260324-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4714,8 +4714,8 @@ importers:
   packages/dmn-marshaller-backend-compatibility-tester:
     dependencies:
       '@jbangdev/jbang':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.7.1
+        version: 0.7.1
     devDependencies:
       '@kie-tools-core/drools-and-kogito':
         specifier: workspace:*
@@ -16629,8 +16629,9 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jbangdev/jbang@0.2.3':
-    resolution: {integrity: sha512-fGkNarIf9HmxlbWNFLlNLYgahwz5SKwQ8NEstB7tnLEkoZqLCyjt+Z0Hr/WntWSFGSzJeezgQKJJg4so6OA6YA==}
+  '@jbangdev/jbang@0.7.1':
+    resolution: {integrity: sha512-Bvs3DVqzSTA3GP/B6EqZ3bmxIiftE/hVK0+CpOzQmEJlGDTkuoAAi9o44hz3VeAnGC7Nt/IYW8ZTEczamUV89A==}
+    hasBin: true
 
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -28241,9 +28242,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
+  shelljs@0.9.2:
+    resolution: {integrity: sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   shellwords@0.1.1:
@@ -33411,9 +33412,12 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jbangdev/jbang@0.2.3':
+  '@jbangdev/jbang@0.7.1':
     dependencies:
-      shelljs: 0.8.5
+      debug: 4.4.3
+      shelljs: 0.9.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/console@29.7.0':
     dependencies:
@@ -48678,9 +48682,10 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  shelljs@0.8.5:
+  shelljs@0.9.2:
     dependencies:
-      glob: 7.2.3
+      execa: 1.0.0
+      fast-glob: 3.3.3
       interpret: 1.4.0
       rechoir: 0.6.2
 


### PR DESCRIPTION
Drools git ref:https://github.com/apache/incubator-kie-drools/@ ([869732d](https://github.com/apache/incubator-kie-drools/commit/869732dc42cfc0b264af267d47792d747664cc90))
Optaplanner git ref: https://github.com/apache/incubator-kie-optaplanner/@ ([45b9a25](https://github.com/apache/incubator-kie-optaplanner/commit/45b9a2543eb9bfac9b66168bbb7b2e11b67849e6))
Kogito Runtimes git ref: https://github.com/apache/incubator-kie-kogito-runtimes/@ ([117dd2b](https://github.com/apache/incubator-kie-kogito-runtimes/commit/117dd2bf00cf1eba0081deb6a10f4822051440d8))
Kogito Apps git ref: https://github.com/apache/incubator-kie-kogito-apps/@ ([6be874d](https://github.com/apache/incubator-kie-kogito-apps/commit/6be874df5e33dae20cfdb7ff5ac8eedafc6ba69d))

Also updated @jbangdev/jbang to 0.7.1 and made the `dmn-marshaller` tests run sequentially to fix the JBang fetch issues.