### PR TITLE
[kie-tools#3526] Set QUARKUS_VERSION in bats tests to avoid environment variable override. 

### DIFF
--- a/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/tests/bats/quarkus-mvn-plugin.bats
+++ b/packages/sonataflow-image-common/resources/modules/sonataflow/common/scripts/tests/bats/quarkus-mvn-plugin.bats
@@ -22,6 +22,7 @@ set -e
 # Set up some environment variables for testing
 setup() {
     export QUARKUS_PLATFORM_VERSION="2.0.0"
+    export QUARKUS_VERSION="2.0.0"
     export KOGITO_VERSION="1.5.0"
     export KOGITO_HOME=$BATS_TMPDIR/maven
     mkdir -p ${KOGITO_HOME}/"launch"


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-tools/issues/3526

Adding QUARKUS_VERSION to the tests setup makes sure the variable set in environment doesn't influence the tests. 