### PR TITLE
[CVE][MEDIUM] Override brace-expansion to 1.1.13 for minimatch@^3 to fix CVE-2026-33750

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   d3-color: 3.1.0
   graphql: 14.3.1
   json-refs>js-yaml: ^3.14.2
+  minimatch@^3>brace-expansion: 1.1.13
   minimatch@^5>brace-expansion: ^2.0.2
   openapi-types: 7.2.3
   react-dropzone: ^11.4.2
@@ -1312,7 +1313,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1369,13 +1370,13 @@ importers:
         version: 7.6.13(encoding@0.1.13)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.2)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.2)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+        version: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
         version: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.104.1)
@@ -12646,10 +12647,10 @@ importers:
         version: 7.4.6(@types/react-dom@17.0.8)(@types/react@17.0.21)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.5
-        version: 3.0.5(webpack@5.104.1(esbuild@0.18.20))
+        version: 3.0.5(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: ^7.3.2
         version: 7.6.13(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -12667,7 +12668,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.104.1
-        version: 5.104.1(esbuild@0.18.20)
+        version: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -14505,7 +14506,7 @@ importers:
         version: 7.28.3(@babel/core@7.28.3)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.12.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.2)(typescript@5.9.3))
+        version: 29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3))
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -21018,8 +21019,8 @@ packages:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -34479,6 +34480,25 @@ snapshots:
     dependencies:
       playwright: 1.45.2
 
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))':
+    dependencies:
+      ansi-html-community: 0.0.8
+      common-path-prefix: 3.0.0
+      core-js-pure: 3.33.0
+      error-stack-parser: 2.1.4
+      find-up: 5.0.0
+      html-entities: 2.5.2
+      loader-utils: 2.0.4
+      react-refresh: 0.14.0
+      schema-utils: 3.3.0
+      source-map: 0.7.6
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
+    optionalDependencies:
+      '@types/webpack': 4.41.39
+      type-fest: 4.41.0
+      webpack-dev-server: 4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      webpack-hot-middleware: 2.25.4
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)(webpack@5.104.1)':
     dependencies:
       ansi-html-community: 0.0.8
@@ -34491,29 +34511,11 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
       webpack-dev-server: 4.15.2(webpack-cli@4.10.0)(webpack@5.104.1)
-      webpack-hot-middleware: 2.25.4
-
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.104.1(esbuild@0.18.20))':
-    dependencies:
-      ansi-html-community: 0.0.8
-      common-path-prefix: 3.0.0
-      core-js-pure: 3.33.0
-      error-stack-parser: 2.1.4
-      find-up: 5.0.0
-      html-entities: 2.5.2
-      loader-utils: 2.0.4
-      react-refresh: 0.14.0
-      schema-utils: 3.3.0
-      source-map: 0.7.6
-      webpack: 5.104.1(esbuild@0.18.20)
-    optionalDependencies:
-      '@types/webpack': 4.41.39
-      type-fest: 4.41.0
       webpack-hot-middleware: 2.25.4
 
   '@pnpm/build-modules@9.3.5(@pnpm/logger@4.0.0)(typanion@3.9.0)':
@@ -36485,10 +36487,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.104.1(esbuild@0.18.20))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))':
     dependencies:
       '@babel/core': 7.28.3
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1(esbuild@0.18.20))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -36603,81 +36605,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1(esbuild@0.18.20))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.104.1(esbuild@0.18.20))
+      css-loader: 6.7.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       es-module-lexer: 1.7.0
       express: 4.22.1
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.18.20))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.104.1(esbuild@0.18.20))
+      html-webpack-plugin: 5.6.4(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.7.4
-      style-loader: 3.3.3(webpack@5.104.1(esbuild@0.18.20))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.104.1(esbuild@0.18.20))
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(esbuild@0.18.20))
+      style-loader: 3.3.3(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.1(webpack@5.104.1(esbuild@0.18.20))
-      webpack-hot-middleware: 2.25.4
-      webpack-virtual-modules: 0.5.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/helpers'
-      - encoding
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@4.10.0)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@storybook/channels': 7.6.13
-      '@storybook/client-logger': 7.6.13
-      '@storybook/core-common': 7.6.13(encoding@0.1.13)
-      '@storybook/core-events': 7.6.13
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/preview': 7.6.13
-      '@storybook/preview-api': 7.6.13
-      '@swc/core': 1.3.92
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.104.1)
-      browser-assert: 1.2.1
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.2.3
-      constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.104.1)
-      es-module-lexer: 1.7.0
-      express: 4.22.1
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.104.1)
-      fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.104.1)
-      magic-string: 0.30.17
-      path-browserify: 1.0.1
-      process: 0.11.10
-      semver: 7.7.4
-      style-loader: 3.3.3(webpack@5.104.1)
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.104.1)
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1)
-      ts-dedent: 2.2.0
-      url: 0.11.3
-      util: 0.12.5
-      util-deprecate: 1.0.2
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
-      webpack-dev-middleware: 6.1.1(webpack@5.104.1)
+      webpack-dev-middleware: 6.1.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -37120,16 +37071,16 @@ snapshots:
 
   '@storybook/postinstall@7.4.6': {}
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)(webpack@5.104.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -37140,7 +37091,7 @@ snapshots:
       react-dom: 17.0.2(react@17.0.2)
       react-refresh: 0.14.0
       semver: 7.7.4
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -37179,44 +37130,6 @@ snapshots:
       react-refresh: 0.14.0
       semver: 7.7.4
       webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/webpack'
-      - encoding
-      - esbuild
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.104.1(esbuild@0.18.20))
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.18.20))
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-plugin-add-react-displayname: 0.0.5
-      fs-extra: 11.2.0
-      magic-string: 0.30.17
-      react: 17.0.2
-      react-docgen: 7.0.3
-      react-dom: 17.0.2(react@17.0.2)
-      react-refresh: 0.14.0
-      semver: 7.7.4
-      webpack: 5.104.1(esbuild@0.18.20)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -37308,7 +37221,7 @@ snapshots:
 
   '@storybook/preview@7.6.13': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.18.20))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -37318,7 +37231,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
     transitivePeerDependencies:
       - supports-color
 
@@ -37332,7 +37245,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -37346,10 +37259,10 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)(webpack-cli@4.10.0)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)))(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 17.0.2
@@ -37377,33 +37290,6 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(typescript@5.9.3)(webpack-cli@4.10.0)
       '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)(webpack-hot-middleware@2.25.4)
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
-      '@types/node': 18.19.130
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/helpers'
-      - '@types/webpack'
-      - encoding
-      - esbuild
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 17.0.2
@@ -39728,19 +39614,19 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.104.1(@swc/core@1.3.92)
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.104.1(esbuild@0.18.20)):
+  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.104.1):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -40086,7 +39972,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.51
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -40929,7 +40815,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   copy-webpack-plugin@13.0.1(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -41158,7 +41044,7 @@ snapshots:
       semver: 7.7.4
       webpack: 5.104.1(webpack-cli@4.10.0)
 
-  css-loader@6.7.1(webpack@5.104.1(esbuild@0.18.20)):
+  css-loader@6.7.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -41168,7 +41054,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   css-loader@6.7.1(webpack@5.104.1):
     dependencies:
@@ -41180,7 +41066,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   css-loader@7.1.2(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -42964,7 +42850,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@4.10.0)
 
   file-selector@0.4.0:
     dependencies:
@@ -43140,7 +43026,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1(esbuild@0.18.20)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -43155,7 +43041,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
@@ -43172,7 +43058,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   form-data-encoder@4.0.2: {}
 
@@ -43753,6 +43639,16 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-webpack-plugin@5.6.4(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.23
+      pretty-error: 4.0.0
+      tapable: 2.3.0
+    optionalDependencies:
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
+
   html-webpack-plugin@5.6.4(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -43764,16 +43660,6 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.3.92)
     optional: true
 
-  html-webpack-plugin@5.6.4(webpack@5.104.1(esbuild@0.18.20)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.23
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.104.1(esbuild@0.18.20)
-
   html-webpack-plugin@5.6.4(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -43782,7 +43668,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -46081,7 +45967,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@5.1.9:
     dependencies:
@@ -46231,7 +46117,7 @@ snapshots:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
+      webpack: 5.104.1(webpack-cli@4.10.0)
 
   monaco-editor@0.39.0: {}
 
@@ -47757,7 +47643,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -49552,13 +49438,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.104.1(webpack-cli@4.10.0)
 
-  style-loader@3.3.3(webpack@5.104.1(esbuild@0.18.20)):
+  style-loader@3.3.3(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   style-loader@3.3.3(webpack@5.104.1):
     dependencies:
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -49637,15 +49523,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.104.1(esbuild@0.18.20)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.104.1):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   symbol-observable@1.2.0: {}
 
@@ -49792,26 +49678,14 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(esbuild@0.18.20)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.18.20)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-      esbuild: 0.18.20
-
-  terser-webpack-plugin@5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.46.0
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
     optionalDependencies:
       '@swc/core': 1.3.92
       esbuild: 0.18.20
@@ -49850,17 +49724,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.92
 
-  terser-webpack-plugin@5.3.16(esbuild@0.18.20)(webpack@5.104.1(esbuild@0.18.20)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.46.0
-      webpack: 5.104.1(esbuild@0.18.20)
-    optionalDependencies:
-      esbuild: 0.18.20
-
   terser-webpack-plugin@5.3.16(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -49868,7 +49731,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.104.1(webpack-cli@4.10.0)
+      webpack: 5.104.1
 
   terser@5.43.1:
     dependencies:
@@ -50093,25 +49956,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.3)
       esbuild: 0.15.13
-
-  ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.2)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.12.2)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.2)(typescript@5.9.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      esbuild: 0.18.20
 
   ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.10.11)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.10.11)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -51079,6 +50923,16 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
       webpack-merge: 5.10.0
 
+  webpack-dev-middleware@5.3.4(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.1
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.3.3
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
+    optional: true
+
   webpack-dev-middleware@5.3.4(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
       colorette: 2.0.20
@@ -51097,7 +50951,7 @@ snapshots:
       schema-utils: 4.3.3
       webpack: 5.104.1(webpack-cli@4.10.0)
 
-  webpack-dev-middleware@6.1.1(webpack@5.104.1(esbuild@0.18.20)):
+  webpack-dev-middleware@6.1.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -51105,7 +50959,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.18.20)
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
 
   webpack-dev-middleware@6.1.1(webpack@5.104.1):
     dependencies:
@@ -51115,7 +50969,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0)
+      webpack: 5.104.1(@swc/core@1.3.92)(webpack-cli@4.10.0)
 
   webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -51170,6 +51024,47 @@ snapshots:
       - debug
       - supports-color
       - utf-8-validate
+
+  webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.25
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.10
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.3.0
+      chokidar: 3.6.0
+      colorette: 2.0.20
+      compression: 1.8.1
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.22.1
+      graceful-fs: 4.2.11
+      html-entities: 2.5.2
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      ipaddr.js: 2.3.0
+      launch-editor: 2.12.0
+      open: 8.4.2
+      p-retry: 4.6.1
+      rimraf: 3.0.2
+      schema-utils: 4.3.3
+      selfsigned: 2.4.1
+      serve-index: 1.9.2
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 5.3.4(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
+      ws: 8.19.0
+    optionalDependencies:
+      webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   webpack-dev-server@4.15.2(webpack@5.104.1(@swc/core@1.3.92)):
     dependencies:
@@ -51373,43 +51268,9 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.18.20)(webpack-cli@4.10.0):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.3.92)(esbuild@0.18.20)(webpack@5.104.1)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -51475,39 +51336,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.104.1)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.1(esbuild@0.18.20):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.18.20)(webpack@5.104.1(esbuild@0.18.20))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
+      webpack-cli: 4.10.0(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   "d3-color": "3.1.0"
   "graphql": "14.3.1"
   "json-refs>js-yaml": "^3.14.2"
+  "minimatch@^3>brace-expansion": "1.1.13"
   "minimatch@^5>brace-expansion": "^2.0.2"
   "openapi-types": "7.2.3"
   "react-dropzone": "^11.4.2"


### PR DESCRIPTION
Override brace-expansion to 1.1.13 for minimatch@^3 to fix CVE-2026-33750