### PR TITLE
NO-ISSUE: Add flags to allow for local overrides of the Quarkus and Kogito versions

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,10 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-04-09T19:38:50Z",
+      "resolved": "github:NixOS/nixpkgs/b0188973b4b2a5b6bdba8b65381d6cd09a533da0?lastModified=1775763530&narHash=sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc%3D"
+    },
     "glibcLocales@2.40-66": {
       "last_modified": "2025-05-16T20:19:48Z",
       "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#glibcLocales",

--- a/packages/maven-base/env/index.js
+++ b/packages/maven-base/env/index.js
@@ -25,6 +25,15 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "true",
       description: "Determines if a Maven build skips a deploy. Can be `true` or `false`.",
     },
+    KIE_TOOLS_BUILD__kogitoVersionSetPropertySkip: {
+      default: "false",
+      description:
+        "Determines if the `version.org.kie.kogito` property in the pom.xml should NOT be updated during install.",
+    },
+    KIE_TOOLS_BUILD__quarkusVersionSetPropertySkip: {
+      default: "false",
+      description: "Determines if the `version.quarkus` property in the pom.xml should NOT be updated during install.",
+    },
   }),
   get env() {
     return {
@@ -37,6 +46,14 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       maven: {
         deploy: {
           skip: getOrDefault(this.vars.KIE_TOOLS_BUILD__mavenDeploySkip),
+        },
+      },
+      properties: {
+        setKogitoVersion: {
+          skip: getOrDefault(this.vars.KIE_TOOLS_BUILD__kogitoVersionSetPropertySkip),
+        },
+        setQuarkusVersion: {
+          skip: getOrDefault(this.vars.KIE_TOOLS_BUILD__quarkusVersionSetPropertySkip),
         },
       },
     };

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -30,8 +30,12 @@ const MVN_CONFIG_FILE_PATH = path.join(".mvn", "maven.config");
 const EMPTY_POM_XML_PATH = path.join(__dirname, "empty-pom.xml");
 const SETTINGS_XML_PATH = path.join(__dirname, "settings.xml");
 
+// The `version.org.kie.kogito` and `version.quarkus` properties are set with
+// the respective env var values here to allow for local and/or downstream overrides.
 const DEFAULT_MAVEN_CONFIG = `
 -Dstyle.color=always
+-Dversion.org.kie.kogito=${env.versions.kogito}
+-Dversion.quarkus=${env.versions.quarkus}
 --batch-mode
 --settings=${SETTINGS_XML_PATH}
 `.trim();

--- a/packages/maven-base/install.js
+++ b/packages/maven-base/install.js
@@ -27,12 +27,16 @@ setupMavenConfigFile(
 `
 );
 
-setPomProperty({
-  key: "version.org.kie.kogito",
-  value: env.versions.kogito,
-});
+if (!env.properties.setKogitoVersion.skip) {
+  setPomProperty({
+    key: "version.org.kie.kogito",
+    value: env.versions.kogito,
+  });
+}
 
-setPomProperty({
-  key: "version.quarkus",
-  value: env.versions.quarkus,
-});
+if (!env.properties.setQuarkusVersion.skip) {
+  setPomProperty({
+    key: "version.quarkus",
+    value: env.versions.quarkus,
+  });
+}


### PR DESCRIPTION
Added two new env vars:
- `KIE_TOOLS_BUILD__kogitoVersionSetPropertySkip`
- `KIE_TOOLS_BUILD__quarkusVersionSetPropertySkip`

Setting them to `true` allows developers to override the `KOGITO_RUNTIME_version` and `QUARKUS_PLATFORM_version` env vars values without changing the `packages/maven-base/pom.xml` file.

This is important for quick (and ephemeral) tests of different Kogito or Quarkus versions, without generating unwanted changes.

### Usage example:

```sh
export KIE_TOOLS_BUILD__kogitoVersionSetPropertySkip=true
export KIE_TOOLS_BUILD__quarkusVersionSetPropertySkip=true
# Using a `999-<date>-local` version here will trigger a new build of `drools-and-kogito`.
export KOGITO_RUNTIME_version=10.2.0
export QUARKUS_PLATFORM_version=3.27.3

pnpm bootstrap
pnpm -F @kie-tools/jbpm-quarkus-devui... build:dev
```

In this scenario, `@kie-tools/jbpm-quarkus-devui` will be built against a new Quarkus version and the published `10.2.0` version of Apache KIE Kogito Runtime, without changing the `packages/maven-base/pom.xml` file.

---

The default behavior remains the same as before.