### PR TITLE
NO-ISSUE: Updagrade Quarkus to 3.27.3 to address security vulnerability + update Kogito version to 20260429

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "869732dc42cfc0b264af267d47792d747664cc90",
+      default: "68caddd2dad3310fe8094583eb84a1ec01eb7d7f",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__optaplannerRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for OptaPlanner",
     },
     DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "45b9a2543eb9bfac9b66168bbb7b2e11b67849e6",
+      default: "e998ba7139a66fb18640a7729c4a9b211f6bacc4",
       description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
@@ -44,7 +44,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Runtimes",
     },
     DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "117dd2bf00cf1eba0081deb6a10f4822051440d8",
+      default: "930e7f79261c6e32d7dd66ea3eed297cdf714ed4",
       description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -52,7 +52,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "6be874df5e33dae20cfdb7ff5ac8eedafc6ba69d",
+      default: "40b1f7be7f2d1373996a433583f6720049bd1a4e",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -124,7 +124,7 @@
     <version.org.kie.kogito>999-20260324-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
-    <version.quarkus>3.27.2</version.quarkus>
+    <version.quarkus>3.27.3</version.quarkus>
 
     <!-- 3rd party dependencies -->
     <version.junit>4.13.2</version.junit>
@@ -135,7 +135,8 @@
     <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.junit.jupiter>5.13.4</version.org.junit.jupiter>
     <version.org.mockito>5.18.0</version.org.mockito>
-    <version.io.netty>4.1.131.Final</version.io.netty>
+    <version.org.kie.j2cl.tools.yaml.mapper>0.4</version.org.kie.j2cl.tools.yaml.mapper>
+    <version.io.netty>4.1.132.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->

--- a/packages/maven-base/pom.xml
+++ b/packages/maven-base/pom.xml
@@ -121,7 +121,7 @@
     <version.maven.surefire.plugin>3.5.0</version.maven.surefire.plugin>
 
     <!-- Apache KIE -->
-    <version.org.kie.kogito>999-20260324-local</version.org.kie.kogito>
+    <version.org.kie.kogito>999-20260429-local</version.org.kie.kogito>
 
     <!-- Quarkus -->
     <version.quarkus>3.27.3</version.quarkus>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,7 +69,7 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.27.2",
+      default: "3.27.3",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260324-local",
+      default: "999-20260429-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */


### PR DESCRIPTION
Updagrading Quarkus to 3.27.3 to address security vulnerability