### PR TITLE
NO-ISSUE: Remove Python's venv init_hook from Devbox shell configuration

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -22,7 +22,7 @@
     "PATH": "$DEVBOX_PROJECT_ROOT/.devbox/gopkgs/bin:$DEVBOX_PROJECT_ROOT/.devbox/pnpm-store:$PATH"
   },
   "shell": {
-    "init_hook": [". $VENV_DIR/bin/activate"],
+    "init_hook": [],
     "scripts": {
       "versions": ["java --version && mvn -v && node -v && pnpm -v && go version && helm version && make -v"]
     }


### PR DESCRIPTION
Removed Python's venv activation hook from shell init configuration.