### PR TITLE
NO-ISSUE: Override brace-expansion to 2.0.3 for minimatch@^5 to address securiy vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   graphql: 14.3.1
   json-refs>js-yaml: ^3.14.2
   minimatch@^3>brace-expansion: 1.1.13
-  minimatch@^5>brace-expansion: ^2.0.2
+  minimatch@^5>brace-expansion: ^2.0.3
   openapi-types: 7.2.3
   path-to-regexp@^0: 0.1.13
   react-dropzone: ^11.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ overrides:
   "graphql": "14.3.1"
   "json-refs>js-yaml": "^3.14.2"
   "minimatch@^3>brace-expansion": "1.1.13"
-  "minimatch@^5>brace-expansion": "^2.0.2"
+  "minimatch@^5>brace-expansion": "^2.0.3"
   "openapi-types": "7.2.3"
   "path-to-regexp@^0": "0.1.13"
   "react-dropzone": "^11.4.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ overrides:
   "d3-color": "3.1.0"
   "graphql": "14.3.1"
   "json-refs>js-yaml": "^3.14.2"
+  # CVE-2026-33750: Fix security vulnerability in brace-expansion
+  # Overriding transitive dependency until minimatch updates to patched brace-expansion version
   "minimatch@^3>brace-expansion": "1.1.13"
   "minimatch@^5>brace-expansion": "^2.0.3"
   "openapi-types": "7.2.3"


### PR DESCRIPTION
Override brace-expansion to 2.0.3 for minimatch@^5 to address securiy vulnerabilities