### PR TITLE
kie-issues#2291: BPMN Editor: Unable to create completion conditions on Milestones - Part 2

### DIFF
--- a/packages/bpmn-editor-envelope/src/customTasks/MilestoneTask.tsx
+++ b/packages/bpmn-editor-envelope/src/customTasks/MilestoneTask.tsx
@@ -35,7 +35,10 @@ import { SlaDueDateInput } from "@kie-tools/bpmn-editor/dist/propertiesPanel/sla
 import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
 import { BpmnEditorEnvelopeI18n, bpmnEditorEnvelopeI18nDefaults, bpmnEditorEnvelopeI18nDictionaries } from "../i18n";
 import { I18n } from "@kie-tools-core/i18n/dist/core";
-import { DEFAULT_DATA_TYPES } from "@kie-tools/bpmn-editor/dist/mutations/addOrGetItemDefinitions";
+import {
+  addOrGetItemDefinitions,
+  DEFAULT_DATA_TYPES,
+} from "@kie-tools/bpmn-editor/dist/mutations/addOrGetItemDefinitions";
 import { DataMapping, setInputAndOutputDataMapping } from "@kie-tools/bpmn-editor/dist/mutations/_dataMapping";
 
 export const MILESTONE_TASK_ICON = (
@@ -101,6 +104,16 @@ export function getMilestoneTask(i18n: BpmnEditorEnvelopeI18n): CustomTask {
       };
     },
     onAdded: (state, task) => {
+      // Make sure String and Object data types are available
+      addOrGetItemDefinitions({
+        definitions: state.bpmn.model.definitions,
+        dataType: DEFAULT_DATA_TYPES.STRING,
+      });
+      addOrGetItemDefinitions({
+        definitions: state.bpmn.model.definitions,
+        dataType: DEFAULT_DATA_TYPES.OBJECT,
+      });
+
       const inputs: DataMapping[] = [
         {
           dtype: DEFAULT_DATA_TYPES.STRING,


### PR DESCRIPTION
Closes : [kie-issues#2291](https://github.com/apache/incubator-kie-issues/issues/2291)

This fix addresses a regression from the previous PR where missing `addOrGetItemDefinitions` calls caused the String data type to appear as `<Undefined>` in the Milestone task's data mapping panel. 

Added calls to `addOrGetItemDefinitions` for both `STRING` and `OBJECT` data types before building the `itemDefinitionIdByDataTypes` map to ensure proper resolution.

<img width="1644" height="634" alt="image" src="https://github.com/user-attachments/assets/8c28a00c-8728-4c28-9bde-51fc1186dedf" />
