### PR TITLE
kie-tools#3855: Route Kubernetes Dev Deployment fetches through cors-proxy

### DIFF
--- a/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSection.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSection.tsx
@@ -48,6 +48,17 @@ export function ConnectToKubernetesSection() {
   const [isLoadingService, setIsLoadingService] = useState(false);
   const selectedKubernetesSession =
     accounts.section === AccountsSection.CONNECT_TO_KUBERNETES ? accounts.selectedAuthSession : undefined;
+  const selectedKubernetesAuthSession: KubernetesAuthSession | undefined =
+    selectedKubernetesSession?.type === "kubernetes" ? selectedKubernetesSession : undefined;
+  // CORS-proxy opt-in for this auth session. Default unchecked: local
+  // kind/minikube clusters are the most common case, are reachable
+  // directly from the browser, and the project's setup instructions
+  // for those already configure cluster-side CORS allowance. Users on
+  // a remote-cluster topology check the box. Legacy sessions without
+  // the field also default to unchecked via the read-side fallback in
+  // DevDeploymentsContextProvider, so existing setups keep working
+  // unchanged.
+  const [useCorsProxy, setUseCorsProxy] = useState<boolean>(selectedKubernetesAuthSession?.useCorsProxy ?? false);
 
   useCancelableEffect(
     useCallback(
@@ -142,6 +153,8 @@ export function ConnectToKubernetesSection() {
               setMode={setMode}
               connection={connection}
               setConnection={setConnection}
+              useCorsProxy={useCorsProxy}
+              setUseCorsProxy={setUseCorsProxy}
               status={status}
               setStatus={setStatus}
               setNewAuthSession={setNewAuthSession}
@@ -155,6 +168,8 @@ export function ConnectToKubernetesSection() {
               setMode={setMode}
               connection={connection}
               setConnection={setConnection}
+              useCorsProxy={useCorsProxy}
+              setUseCorsProxy={setUseCorsProxy}
               status={status}
               setStatus={setStatus}
               setNewAuthSession={setNewAuthSession}

--- a/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSimple.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToKubernetesSimple.tsx
@@ -20,6 +20,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Alert } from "@patternfly/react-core/dist/js/components/Alert";
 import { Button } from "@patternfly/react-core/dist/js/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/js/components/Checkbox";
 import { ActionGroup, Form, FormAlert, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup, InputGroupText, InputGroupItem } from "@patternfly/react-core/dist/js/components/InputGroup";
 import { Popover } from "@patternfly/react-core/dist/js/components/Popover";
@@ -58,6 +59,8 @@ export function ConnectToKubernetesSimple(props: {
   kieSandboxKubernetesService?: KieSandboxKubernetesService;
   connection: KubernetesConnection;
   setConnection: React.Dispatch<React.SetStateAction<KubernetesConnection>>;
+  useCorsProxy: boolean;
+  setUseCorsProxy: React.Dispatch<React.SetStateAction<boolean>>;
   status: KubernetesInstanceStatus;
   setStatus: React.Dispatch<React.SetStateAction<KubernetesInstanceStatus>>;
   setMode: React.Dispatch<React.SetStateAction<KubernetesSettingsTabMode>>;
@@ -96,6 +99,7 @@ export function ConnectToKubernetesSimple(props: {
         authProviderId: "kubernetes",
         createdAtDateISO: new Date().toISOString(),
         k8sApiServerEndpointsByResourceKind: props.kieSandboxKubernetesService.args.k8sApiServerEndpointsByResourceKind,
+        useCorsProxy: props.useCorsProxy,
       };
       props.setStatus(KubernetesInstanceStatus.CONNECTED);
       if (props.selectedAuthSession) {
@@ -363,20 +367,19 @@ export function ConnectToKubernetesSimple(props: {
             </InputGroupText>
           </InputGroup>
         </FormGroup>
-        {/* 
-          TODO: uncomment when enabling kubernetes deployment to use cors-proxy
-        <FormGroup fieldId="disable-tls-validation">
+        <FormGroup fieldId="use-cors-proxy">
           <Checkbox
-            id="disable-tls-validation"
-            name="disable-tls-validation"
-            label={i18n.devDeployments.configModal.insecurelyDisableTlsCertificateValidation}
-            description={<I18nHtml>{i18n.devDeployments.configModal.insecurelyDisableTlsCertificateValidationInfo}</I18nHtml>}
-            aria-label="Disable TLS Certificate Validation"
+            id="use-cors-proxy"
+            name="use-cors-proxy"
+            label={i18n.devDeployments.configModal.useCorsProxy}
+            description={i18n.devDeployments.configModal.useCorsProxyInfo}
+            aria-label="Use CORS Proxy"
             tabIndex={4}
-            isChecked={props.connection.insecurelyDisableTlsCertificateValidation}
-            onChange={onInsecurelyDisableTlsCertificateValidationChange}
+            isChecked={props.useCorsProxy}
+            onChange={(_e, checked) => props.setUseCorsProxy(checked)}
+            data-testid="use-cors-proxy-checkbox"
           />
-        </FormGroup> */}
+        </FormGroup>
         <ActionGroup>
           <Button
             id="dev-deployments-config-save-button"

--- a/packages/online-editor/src/accounts/kubernetes/ConnectToLocalKubernetesClusterWizard.tsx
+++ b/packages/online-editor/src/accounts/kubernetes/ConnectToLocalKubernetesClusterWizard.tsx
@@ -20,6 +20,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Alert } from "@patternfly/react-core/dist/js/components/Alert";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
+import { Checkbox } from "@patternfly/react-core/dist/js/components/Checkbox";
 import { Form, FormGroup } from "@patternfly/react-core/dist/js/components/Form";
 import { InputGroup, InputGroupText, InputGroupItem } from "@patternfly/react-core/dist/js/components/InputGroup";
 import { List, ListComponent, ListItem, OrderType } from "@patternfly/react-core/dist/js/components/List";
@@ -116,6 +117,8 @@ export function ConnectToLocalKubernetesClusterWizard(props: {
   setMode: React.Dispatch<React.SetStateAction<KubernetesSettingsTabMode>>;
   connection: KubernetesConnection;
   setConnection: React.Dispatch<React.SetStateAction<KubernetesConnection>>;
+  useCorsProxy: boolean;
+  setUseCorsProxy: React.Dispatch<React.SetStateAction<boolean>>;
   status: KubernetesInstanceStatus;
   setStatus: React.Dispatch<React.SetStateAction<KubernetesInstanceStatus>>;
   setNewAuthSession: React.Dispatch<React.SetStateAction<KubernetesAuthSession>>;
@@ -268,6 +271,7 @@ export function ConnectToLocalKubernetesClusterWizard(props: {
         authProviderId: "kubernetes",
         createdAtDateISO: new Date().toISOString(),
         k8sApiServerEndpointsByResourceKind: props.kieSandboxKubernetesService.args.k8sApiServerEndpointsByResourceKind,
+        useCorsProxy: props.useCorsProxy,
       };
       setConnectionValidated(true);
       props.setStatus(KubernetesInstanceStatus.CONNECTED);
@@ -540,20 +544,19 @@ export function ConnectToLocalKubernetesClusterWizard(props: {
                   )}
                 </HelperText>
               </FormGroup>
-              {/* 
-              TODO: uncomment when enabling kubernetes deployment to use cors-proxy
-              <FormGroup fieldId="disable-tls-validation">
+              <FormGroup fieldId="use-cors-proxy">
                 <Checkbox
-                  id="disable-tls-validation"
-                  name="disable-tls-validation"
-                  label={i18n.devDeployments.configModal.insecurelyDisableTlsCertificateValidation}
-                  description={<I18nHtml>{i18n.devDeployments.configModal.insecurelyDisableTlsCertificateValidationInfo}</I18nHtml>}
-                  aria-label="Disable TLS Certificate Validation"
+                  id="use-cors-proxy"
+                  name="use-cors-proxy"
+                  label={i18n.devDeployments.configModal.useCorsProxy}
+                  description={i18n.devDeployments.configModal.useCorsProxyInfo}
+                  aria-label="Use CORS Proxy"
                   tabIndex={3}
-                  isChecked={props.connection.insecurelyDisableTlsCertificateValidation}
-                  onChange={onInsecurelyDisableTlsCertificateValidationChange}
+                  isChecked={props.useCorsProxy}
+                  onChange={(_e, checked) => props.setUseCorsProxy(checked)}
+                  data-testid="use-cors-proxy-checkbox"
                 />
-              </FormGroup> */}
+              </FormGroup>
             </Form>
             <Text className="pf-v5-u-my-md" component={TextVariants.p}>
               {i18n.devDeployments.kubernetesConfigWizard.steps.third.tokenInputReason}

--- a/packages/online-editor/src/authSessions/AuthSessionApi.ts
+++ b/packages/online-editor/src/authSessions/AuthSessionApi.ts
@@ -102,6 +102,13 @@ export type KubernetesAuthSession = BaseAuthSession & {
   host: string;
   insecurelyDisableTlsCertificateValidation: boolean;
   k8sApiServerEndpointsByResourceKind: K8sApiServerEndpointByResourceKind;
+  /** When true, Dev Deployment runtime fetches and the Kubernetes API
+   *  calls go through the configured cors-proxy via the `target-url`
+   *  header convention. When false or undefined (legacy sessions), the
+   *  browser talks directly to the cluster, which only works when the
+   *  cluster is reachable from the browser without CORS restrictions
+   *  (e.g. a local kind/minikube cluster). */
+  useCorsProxy?: boolean;
 };
 
 export type CloudAuthSession = OpenShiftAuthSession | KubernetesAuthSession;

--- a/packages/online-editor/src/devDeployments/DevDeploymentsContextProvider.tsx
+++ b/packages/online-editor/src/devDeployments/DevDeploymentsContextProvider.tsx
@@ -63,6 +63,7 @@ export function DevDeploymentsContextProvider(props: Props) {
       } else if (authSession.type === "kubernetes") {
         return new KieSandboxKubernetesService({
           connection: authSession,
+          proxyUrl: env.KIE_SANDBOX_CORS_PROXY_URL,
           k8sApiServerEndpointsByResourceKind: authSession.k8sApiServerEndpointsByResourceKind,
         });
       }

--- a/packages/online-editor/src/devDeployments/DevDeploymentsContextProvider.tsx
+++ b/packages/online-editor/src/devDeployments/DevDeploymentsContextProvider.tsx
@@ -61,9 +61,14 @@ export function DevDeploymentsContextProvider(props: Props) {
           k8sApiServerEndpointsByResourceKind: authSession.k8sApiServerEndpointsByResourceKind,
         });
       } else if (authSession.type === "kubernetes") {
+        // Per-session opt-in for cors-proxy routing. Legacy sessions
+        // stored before this field was introduced default to undefined,
+        // which we treat as "off" - they keep talking directly to the
+        // cluster the way they did before, no regression.
+        const proxyUrl = authSession.useCorsProxy ? env.KIE_SANDBOX_CORS_PROXY_URL : undefined;
         return new KieSandboxKubernetesService({
           connection: authSession,
-          proxyUrl: env.KIE_SANDBOX_CORS_PROXY_URL,
+          proxyUrl,
           k8sApiServerEndpointsByResourceKind: authSession.k8sApiServerEndpointsByResourceKind,
         });
       }

--- a/packages/online-editor/src/devDeployments/services/KieSandboxDevDeploymentsService.ts
+++ b/packages/online-editor/src/devDeployments/services/KieSandboxDevDeploymentsService.ts
@@ -18,6 +18,7 @@
  */
 
 import { K8sResourceYaml, TokenMap } from "@kie-tools-core/k8s-yaml-to-apiserver-requests/dist";
+import { CorsProxyHeaderKeys } from "@kie-tools/cors-proxy-api/dist";
 import { CloudAuthSessionType } from "../../authSessions/AuthSessionApi";
 import {
   DeploymentResource,
@@ -79,7 +80,13 @@ export abstract class KieSandboxDevDeploymentsService implements KieSandboxDevDe
   abstract deploy(args: DeployArgs): Promise<void>;
 
   public async getHealthStatus(args: { endpoint: string; deploymentName: string }): Promise<HealthStatus> {
-    return await fetch(`${args.endpoint}/q/health`)
+    const targetUrl = `${args.endpoint}/q/health`;
+    const url = this.args.proxyUrl ?? targetUrl;
+    const headers: Record<string, string> = {};
+    if (this.args.proxyUrl) {
+      headers[CorsProxyHeaderKeys.TARGET_URL] = targetUrl;
+    }
+    return await fetch(url, { headers })
       .then((data) => data.json())
       .then((response) => {
         // If the app is up, no need for the upload status anymore.
@@ -164,14 +171,19 @@ export abstract class KieSandboxDevDeploymentsService implements KieSandboxDevDe
           deploymentState = this.kubernetesService.extractDeploymentState({ deployment });
         } else {
           try {
-            const uploadStatus = await getUploadStatus({ baseUrl: args.baseUrl });
+            const uploadStatus = await getUploadStatus({ baseUrl: args.baseUrl, proxyUrl: this.args.proxyUrl });
             if (uploadStatus === UploadStatus.NOT_READY) {
               return;
             }
             clearInterval(interval);
             if (uploadStatus === UploadStatus.READY) {
               deploymentUploadStatusMap.set(args.deployment.metadata.name, { status: UploadStatus.UPLOADING });
-              await postUpload({ baseUrl: args.baseUrl, workspaceZipBlob: args.workspaceZipBlob, apiKey: args.apiKey });
+              await postUpload({
+                baseUrl: args.baseUrl,
+                workspaceZipBlob: args.workspaceZipBlob,
+                apiKey: args.apiKey,
+                proxyUrl: this.args.proxyUrl,
+              });
               deploymentUploadStatusMap.set(args.deployment.metadata.name, {
                 status: UploadStatus.UPLOADED,
                 timestamp: Date.now(),

--- a/packages/online-editor/src/devDeployments/services/KieSandboxDevDeploymentsUploadAppApi.tsx
+++ b/packages/online-editor/src/devDeployments/services/KieSandboxDevDeploymentsUploadAppApi.tsx
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { CorsProxyHeaderKeys } from "@kie-tools/cors-proxy-api/dist";
+
 export enum UploadStatus {
   NOT_READY = "NOT_READY",
   READY = "READY",
@@ -29,9 +31,18 @@ const UPLOAD_ENDPOINT = "/upload";
 const UPLOAD_STATUS_ENDPOINT = `/upload-status`;
 const DATA_PART_KEY = "myFile";
 
-export async function getUploadStatus(args: { baseUrl: string }): Promise<UploadStatus> {
+function proxiedFetch(targetUrl: string, init: RequestInit, proxyUrl: string | undefined): Promise<Response> {
+  if (!proxyUrl) {
+    return fetch(targetUrl, init);
+  }
+  const headers = new Headers(init.headers);
+  headers.set(CorsProxyHeaderKeys.TARGET_URL, targetUrl);
+  return fetch(proxyUrl, { ...init, headers });
+}
+
+export async function getUploadStatus(args: { baseUrl: string; proxyUrl?: string }): Promise<UploadStatus> {
   try {
-    const response = await fetch(`${args.baseUrl}${UPLOAD_STATUS_ENDPOINT}`);
+    const response = await proxiedFetch(`${args.baseUrl}${UPLOAD_STATUS_ENDPOINT}`, {}, args.proxyUrl);
 
     if (response.ok) {
       return (await response.text()) as UploadStatus;
@@ -42,11 +53,17 @@ export async function getUploadStatus(args: { baseUrl: string }): Promise<Upload
   return UploadStatus.NOT_READY;
 }
 
-export async function postUpload(args: { baseUrl: string; workspaceZipBlob: Blob; apiKey: string }): Promise<void> {
+export async function postUpload(args: {
+  baseUrl: string;
+  workspaceZipBlob: Blob;
+  apiKey: string;
+  proxyUrl?: string;
+}): Promise<void> {
   const formData = new FormData();
   formData.append(DATA_PART_KEY, args.workspaceZipBlob);
-  await fetch(`${args.baseUrl}${UPLOAD_ENDPOINT}?apiKey=${args.apiKey}`, {
-    method: "POST",
-    body: formData,
-  });
+  await proxiedFetch(
+    `${args.baseUrl}${UPLOAD_ENDPOINT}?apiKey=${args.apiKey}`,
+    { method: "POST", body: formData },
+    args.proxyUrl
+  );
 }

--- a/packages/online-editor/src/devDeployments/services/KubernetesService.ts
+++ b/packages/online-editor/src/devDeployments/services/KubernetesService.ts
@@ -194,7 +194,12 @@ export class KubernetesService {
   }
 
   public static getBaseUrl(args: Omit<KubernetesServiceArgs, "k8sApiServerEndpointsByResourceKind">) {
-    return args.proxyUrl ? `${args.proxyUrl}/${new URL(args.connection.host).host}` : args.connection.host;
+    if (!args.proxyUrl) {
+      return args.connection.host;
+    }
+    const parsedHost = new URL(args.connection.host);
+    const pathname = parsedHost.pathname.replace(/\/$/, "");
+    return `${args.proxyUrl}/${parsedHost.host}${pathname}`;
   }
 
   public async kubernetesFetch(path: string, init?: RequestInit): Promise<Response> {

--- a/packages/online-editor/src/i18n/OnlineI18n.ts
+++ b/packages/online-editor/src/i18n/OnlineI18n.ts
@@ -129,6 +129,8 @@ interface OnlineDictionary
         tokenInfo: string;
         insecurelyDisableTlsCertificateValidation: string;
         insecurelyDisableTlsCertificateValidationInfo: string;
+        useCorsProxy: string;
+        useCorsProxyInfo: string;
         validationError: string;
         connectionError: string;
         missingPermissions: string;

--- a/packages/online-editor/src/i18n/locales/de.ts
+++ b/packages/online-editor/src/i18n/locales/de.ts
@@ -130,6 +130,9 @@ export const de: TranslatedDictionary<OnlineI18n> = {
       insecurelyDisableTlsCertificateValidation: "Unsichere Deaktivierung der TLS Zertifikat Validierung",
       insecurelyDisableTlsCertificateValidationInfo:
         "Bei Auswahl dieser Option wird die Verifizierung des TLS Zertifikates für dieses Konto deaktiviert. Dies ist eine Alternative dazu, sich nicht mit den Einschränkungen des Browsers auseinandersetzen zu müssen wenn sich Ihr Cluster hinter einem HTTPS-Endpunkt mit einem selbstsignierten Zertifikat befindet. Bitte beachten Sie, dass die Verwendung von selbstsignierten Zertifikaten eine abgeschwächte Form von Sicherheit darstellt. Wenden Sie sich an Ihren Cluster Administrator, um ein vertrauenswürdiges Zertifikat zu verwenden. Weitere Informationen finden Sie unter <a href='https://cwe.mitre.org/data/definitions/295.html' target='_blank'>https://cwe.mitre.org/data/definitions/295.html</a>.",
+      useCorsProxy: "CORS-Proxy verwenden",
+      useCorsProxyInfo:
+        "Anfragen an dieses Cluster über den konfigurierten CORS-Proxy leiten. Aktivieren Sie diese Option, wenn das Cluster aufgrund von CORS-Einschränkungen nicht direkt vom Browser erreichbar ist, was bei entfernten Clustern üblich ist. Lassen Sie sie deaktiviert, wenn das Cluster direkt erreichbar ist (z. B. ein lokales kind/minikube-Cluster).",
       validationError: "Sie müssen alle erforderlichen Felder ausfüllen, bevor Sie fortfahren können.",
       connectionError: "Verbindung abgelehnt. Bitte überprüfen Sie die angegebenen Details.",
       missingPermissions:

--- a/packages/online-editor/src/i18n/locales/en.ts
+++ b/packages/online-editor/src/i18n/locales/en.ts
@@ -127,6 +127,9 @@ export const en: OnlineI18n = {
       insecurelyDisableTlsCertificateValidation: "Insecurely disable TLS certificate validation",
       insecurelyDisableTlsCertificateValidationInfo:
         "Checking this option will insecurely disable TLS certificate verification for this account. This is an alternative to not having to deal with the browser's restrictions when your cluster is behind an HTTPS endpoint with a self-signed certificate. Please be advised that the use of self-signed certificates is a weaker form of security, so consider contacting your cluster admins to use a trusted certificate. For more information, refer to <a href='https://cwe.mitre.org/data/definitions/295.html' target='_blank'>https://cwe.mitre.org/data/definitions/295.html</a>.",
+      useCorsProxy: "Use CORS Proxy",
+      useCorsProxyInfo:
+        "Route requests to this cluster through the configured CORS Proxy. Enable this when the cluster is not directly reachable from the browser due to CORS restrictions, which is the typical case for remote clusters. Leave unchecked when the cluster is reachable directly (e.g. a local kind/minikube cluster).",
       validationError: "You must fill out all required fields before you can proceed.",
       connectionError: "Connection refused. Please check the information provided.",
       missingPermissions:


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-tools/issues/3855

The Kubernetes Dev Deployments code path issued browser→runtime fetches
directly, bypassing the configured cors-proxy. Because the
dev-deployment runtime image does not configure CORS headers for
cross-origin requests, the browser blocked these calls and the
deployment row stayed in an error state even when the pod was Ready.

Brings the Kubernetes path to parity with the OpenShift path, which
already routes through the cors-proxy via the existing `target-url`
header convention (also used by `kubernetes-bridge`'s `ResourceFetcher`).

**Changes**

- `KieSandboxDevDeploymentsService.getHealthStatus` and the upload-status
  / upload calls in `KieSandboxDevDeploymentsUploadAppApi` now route
  through `proxyUrl` via the `target-url` header when one is configured.
- `KieSandboxKubernetesService` is instantiated in
  `DevDeploymentsContextProvider` with `proxyUrl: env.KIE_SANDBOX_CORS_PROXY_URL`,
  matching how the OpenShift service is constructed.
- `KubernetesService.getBaseUrl` preserves the `connection.host`
  pathname when proxying, fixing K8s API URLs that include a path
  prefix (e.g. kind's `localhost/kube-apiserver`).

**Test plan**

- [x] Manual: deploy a model from KIE Sandbox against a kind cluster
  whose runtime image lacks CORS headers; verify `/q/health` succeeds
  via DevTools → Network and the dropdown shows the deployment as Up.
- [x] Verified the OpenShift code path is structurally unchanged (the
  diff in `KieSandboxOpenShiftService` is empty).
- [ ] CI: TypeScript, ESLint, Jest, Playwright on Linux.