### PR TITLE
kie-issues#2297: BPMN Editor: Creating new edges on existing edges from and to gateway nodes causes issues

### DIFF
--- a/packages/bpmn-editor/src/mutations/addEdge.ts
+++ b/packages/bpmn-editor/src/mutations/addEdge.ts
@@ -80,7 +80,7 @@ export function addEdge({
     );
   }
 
-  const newEdgeId = generateUuid();
+  let newEdgeId = generateUuid();
 
   const { process, diagramElements } = addOrGetProcessAndDiagramElements({ definitions });
 
@@ -130,12 +130,13 @@ export function addEdge({
       (a) => a.__$$element === "sequenceFlow" && areEdgesEquivalent(a, newSequenceFlow)
     );
     existingEdgeId = removed?.["@_id"];
+    newEdgeId = tryKeepingEdgeId(existingEdgeId, newEdgeId);
 
     // Replace with the new one.
     process.flowElement?.push({
       __$$element: "sequenceFlow",
       ...newSequenceFlow,
-      "@_id": tryKeepingEdgeId(existingEdgeId, newEdgeId),
+      "@_id": newEdgeId,
     });
   }
 
@@ -151,6 +152,15 @@ export function addEdge({
       element.__$$element !== "dataObjectReference"
     ) {
       if (__readonly_edge.type === EDGE_TYPES.sequenceFlow) {
+        // Clean up old edge references from all nodes when replacing an edge
+        if (existingEdgeId) {
+          if (element.outgoing) {
+            element.outgoing = element.outgoing.filter((o) => o.__$$text !== existingEdgeId);
+          }
+          if (element.incoming) {
+            element.incoming = element.incoming.filter((o) => o.__$$text !== existingEdgeId);
+          }
+        }
         // outgoing
         if (element["@_id"] === __readonly_sourceNode.href) {
           element.outgoing ??= [];


### PR DESCRIPTION
Closes [kie#2297](https://github.com/apache/incubator-kie-issues/issues/2297)

In BPMN editor, creating a new edge between two nodes which already have an edge create duplicate entry in the xml incoming and outgoing tag. As a result gateway node creates two issues:

1. An entry in route dropdown when a new edge is created on top of an existing edge from gateway node to a task node.

<img width="1727" height="745" alt="Screenshot 2026-05-12 at 9 33 16 AM" src="https://github.com/user-attachments/assets/d4c138d0-a892-4b47-b36f-aadb2bcf2a30" />

2. If an edge is created from a node to a gateway node, where there is already a connection, unspecified error is displayed.
<img width="1728" height="746" alt="Screenshot 2026-05-12 at 9 33 36 AM" src="https://github.com/user-attachments/assets/4dbca96b-2c0b-49a4-83dc-65e3d6c4efb3" />

Fix:
Duplicate entries are not allowed in incoming and outgoing tag for all nodes.