### PR TITLE
[kie-issues#2306] Update Spring dependencies to 6.2.18 and Spring Boot to 3.5.14

### DIFF
--- a/packages/maven-base/not-reproducible-plugins.properties
+++ b/packages/maven-base/not-reproducible-plugins.properties
@@ -84,7 +84,7 @@ org.eclipse.jetty+jetty-jspc-maven-plugin=fail:https://github.com/eclipse/jetty.
 
 org.jboss.jandex+jandex-maven-plugin=fail:https://github.com/wildfly/jandex-maven-plugin/pull/35
 
-org.springframework.boot+spring-boot-maven-plugin=3.5.12
+org.springframework.boot+spring-boot-maven-plugin=3.5.14
 # https://github.com/spring-projects/spring-boot/issues/21005
 
 org.vafer+jdeb=1.10


### PR DESCRIPTION
New vulnerabilities have been identified in Spring Boot and the Spring Framework. To address these issues, the following dependency updates are required:
Changes
Spring Boot: 3.5.12 → 3.5.14
These updates include fixes for the latest reported security vulnerabilities.

Related PR:
https://github.com/apache/incubator-kie-optaplanner/pull/3222
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4282
https://github.com/apache/incubator-kie-kogito-examples/pull/2211