### PR TITLE
[incubator-kie-issues#2298] Duplicate datatypes for BPMN files of kie examples

### DIFF
--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -32,20 +32,6 @@ type WithRequiredDeep<T, K extends keyof any> = T extends undefined
         ? { [P in K]-?: NonNullable<WithRequiredDeep<T[P], K>> }
         : T);
 
-// Get the array for `key`, or create an empty one if missing.
-function addOrGetGroup<K, V>(map: Map<K, V[]>, key: K): V[] {
-  let group = map.get(key);
-  if (!group) {
-    group = [];
-    map.set(key, group);
-  }
-  return group;
-}
-
-function getRefToRemap(itemDefinitionIdsToRemap: Map<string, string>, id: string | undefined): string | undefined {
-  return id === undefined ? undefined : itemDefinitionIdsToRemap.get(id) ?? id;
-}
-
 function remapDataItems(
   itemDefinitionIdsToRemap: Map<string, string>,
   items: Array<{ "@_itemSubjectRef"?: string }> | undefined
@@ -55,7 +41,7 @@ function remapDataItems(
   }
   for (const item of items) {
     if (item["@_itemSubjectRef"] !== undefined) {
-      item["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, item["@_itemSubjectRef"]);
+      item["@_itemSubjectRef"] = itemDefinitionIdsToRemap.get(item["@_itemSubjectRef"]) ?? item["@_itemSubjectRef"];
     }
   }
 }
@@ -68,7 +54,9 @@ function remapProperties(
     return;
   }
   for (const p of properties) {
-    p["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, p["@_itemSubjectRef"]);
+    if (p["@_itemSubjectRef"]) {
+      p["@_itemSubjectRef"] = itemDefinitionIdsToRemap.get(p["@_itemSubjectRef"]) ?? p["@_itemSubjectRef"];
+    }
   }
 }
 
@@ -82,10 +70,10 @@ function remapFlowElements(
       el.__$$element === "dataObjectReference" ||
       el.__$$element === "dataStoreReference"
     ) {
-      el["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, el["@_itemSubjectRef"]);
-    }
-
-    if (
+      if (el["@_itemSubjectRef"] !== undefined) {
+        el["@_itemSubjectRef"] = itemDefinitionIdsToRemap.get(el["@_itemSubjectRef"]) ?? el["@_itemSubjectRef"];
+      }
+    } else if (
       el.__$$element === "businessRuleTask" ||
       el.__$$element === "callActivity" ||
       el.__$$element === "serviceTask" ||
@@ -94,29 +82,28 @@ function remapFlowElements(
       remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataInput);
       remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataOutput);
       remapProperties(itemDefinitionIdsToRemap, el.property);
-    }
-
-    if (el.__$$element === "endEvent" || el.__$$element === "intermediateThrowEvent") {
+    } else if (el.__$$element === "endEvent" || el.__$$element === "intermediateThrowEvent") {
       remapDataItems(itemDefinitionIdsToRemap, el.dataInput);
       remapProperties(itemDefinitionIdsToRemap, el.property);
-    }
-
-    if (
+    } else if (
       el.__$$element === "startEvent" ||
       el.__$$element === "intermediateCatchEvent" ||
       el.__$$element === "boundaryEvent"
     ) {
       remapDataItems(itemDefinitionIdsToRemap, el.dataOutput);
       remapProperties(itemDefinitionIdsToRemap, el.property);
-    }
-
-    if (el.__$$element === "subProcess" || el.__$$element === "adHocSubProcess" || el.__$$element === "transaction") {
+    } else if (
+      el.__$$element === "subProcess" ||
+      el.__$$element === "adHocSubProcess" ||
+      el.__$$element === "transaction"
+    ) {
       remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataInput);
       remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataOutput);
       remapProperties(itemDefinitionIdsToRemap, el.property);
       if (el.flowElement) {
         remapFlowElements(itemDefinitionIdsToRemap, el.flowElement);
       }
+    } else {
     }
   }
 }
@@ -179,21 +166,24 @@ export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
     }
   });
 
-  // Merge itemDefinitions that share the same structureRef.
-  deduplicateItemDefinitions(model.definitions);
-
   const normalizedModel = model as Normalized<BpmnLatestModel>;
+
+  // Merge itemDefinitions that share the same structureRef.
+  deduplicateItemDefinitions(normalizedModel.definitions);
 
   return normalizedModel;
 }
 
 // Keep one itemDefinition per structureRef and update references to point to it.
-export function deduplicateItemDefinitions(definitions: BpmnLatestModel["definitions"]): void {
-  const itemDefinitionsGroupedStructureRef = new Map<string, Array<{ "@_id"?: string }>>();
+export function deduplicateItemDefinitions(definitions: Normalized<BpmnLatestModel["definitions"]>): void {
+  const itemDefinitionsGroupedStructureRef = new Map<string, Array<string>>();
   for (const rootElement of definitions.rootElement ?? []) {
     if (rootElement.__$$element === "itemDefinition") {
       const itemDefinitionStructureRef = rootElement["@_structureRef"] ?? "";
-      addOrGetGroup(itemDefinitionsGroupedStructureRef, itemDefinitionStructureRef).push(rootElement);
+      itemDefinitionsGroupedStructureRef.set(itemDefinitionStructureRef, [
+        ...(itemDefinitionsGroupedStructureRef.get(itemDefinitionStructureRef) ?? []),
+        rootElement["@_id"],
+      ]);
     }
   }
 
@@ -203,15 +193,9 @@ export function deduplicateItemDefinitions(definitions: BpmnLatestModel["definit
     if (itemDefinitionsGroup.length <= 1) {
       continue;
     }
-    const survivorId = itemDefinitionsGroup[0]["@_id"];
-    if (!survivorId) {
-      continue;
-    }
+    const survivorId = itemDefinitionsGroup[0];
     for (let i = 1; i < itemDefinitionsGroup.length; i++) {
-      const duplicateId = itemDefinitionsGroup[i]["@_id"];
-      if (duplicateId) {
-        itemDefinitionIdsToRemap.set(duplicateId, survivorId);
-      }
+      itemDefinitionIdsToRemap.set(itemDefinitionsGroup[i], survivorId);
     }
   }
 
@@ -219,23 +203,33 @@ export function deduplicateItemDefinitions(definitions: BpmnLatestModel["definit
     return;
   }
 
-  // Remove the duplicate itemDefinitions and update every itemSubjectRef.
-  const itemDefinitionIdsToRemove = new Set(itemDefinitionIdsToRemap.keys());
+  // Remove the duplicate itemDefinitions and update every reference to them.
   definitions.rootElement = definitions.rootElement?.filter(
-    (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && itemDefinitionIdsToRemove.has(e["@_id"]))
+    (e) => !(e.__$$element === "itemDefinition" && itemDefinitionIdsToRemap.has(e["@_id"]))
   );
 
   for (const rootElement of definitions.rootElement ?? []) {
     if (rootElement.__$$element === "dataStore") {
-      rootElement["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, rootElement["@_itemSubjectRef"]);
-    }
-    if (rootElement.__$$element === "process") {
+      if (rootElement["@_itemSubjectRef"] !== undefined) {
+        rootElement["@_itemSubjectRef"] =
+          itemDefinitionIdsToRemap.get(rootElement["@_itemSubjectRef"]) ?? rootElement["@_itemSubjectRef"];
+      }
+    } else if (rootElement.__$$element === "message") {
+      if (rootElement["@_itemRef"] !== undefined) {
+        rootElement["@_itemRef"] = itemDefinitionIdsToRemap.get(rootElement["@_itemRef"]) ?? rootElement["@_itemRef"];
+      }
+    } else if (rootElement.__$$element === "correlationProperty") {
+      if (rootElement["@_type"] !== undefined) {
+        rootElement["@_type"] = itemDefinitionIdsToRemap.get(rootElement["@_type"]) ?? rootElement["@_type"];
+      }
+    } else if (rootElement.__$$element === "process") {
       remapDataItems(itemDefinitionIdsToRemap, rootElement.ioSpecification?.dataInput);
       remapDataItems(itemDefinitionIdsToRemap, rootElement.ioSpecification?.dataOutput);
       remapProperties(itemDefinitionIdsToRemap, rootElement.property);
       if (rootElement.flowElement) {
         remapFlowElements(itemDefinitionIdsToRemap, rootElement.flowElement);
       }
+    } else {
     }
   }
 }

--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -42,38 +42,50 @@ function addOrGetGroup<K, V>(map: Map<K, V[]>, key: K): V[] {
   return group;
 }
 
-function remapRef(remap: Map<string, string>, id: string | undefined): string | undefined {
-  return id === undefined ? undefined : remap.get(id) ?? id;
+function getRefToRemap(
+  itemDefinitionIdsToRemap: Map<string, string>,
+  id: string | undefined
+): string | undefined {
+  return id === undefined ? undefined : itemDefinitionIdsToRemap.get(id) ?? id;
 }
 
-function remapDataItems(remap: Map<string, string>, items: Array<{ "@_itemSubjectRef"?: string }> | undefined) {
+function remapDataItems(
+  itemDefinitionIdsToRemap: Map<string, string>,
+  items: Array<{ "@_itemSubjectRef"?: string }> | undefined
+) {
   if (!items) {
     return;
   }
   for (const item of items) {
     if (item["@_itemSubjectRef"] !== undefined) {
-      item["@_itemSubjectRef"] = remapRef(remap, item["@_itemSubjectRef"]);
+      item["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, item["@_itemSubjectRef"]);
     }
   }
 }
 
-function remapProperties(remap: Map<string, string>, properties: Array<{ "@_itemSubjectRef"?: string }> | undefined) {
+function remapProperties(
+  itemDefinitionIdsToRemap: Map<string, string>,
+  properties: Array<{ "@_itemSubjectRef"?: string }> | undefined
+) {
   if (!properties) {
     return;
   }
   for (const p of properties) {
-    p["@_itemSubjectRef"] = remapRef(remap, p["@_itemSubjectRef"]);
+    p["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, p["@_itemSubjectRef"]);
   }
 }
 
-function remapFlowElements(remap: Map<string, string>, flowElements: NonNullable<BPMN20__tProcess["flowElement"]>) {
+function remapFlowElements(
+  itemDefinitionIdsToRemap: Map<string, string>,
+  flowElements: NonNullable<BPMN20__tProcess["flowElement"]>
+) {
   for (const el of flowElements) {
     if (
       el.__$$element === "dataObject" ||
       el.__$$element === "dataObjectReference" ||
       el.__$$element === "dataStoreReference"
     ) {
-      el["@_itemSubjectRef"] = remapRef(remap, el["@_itemSubjectRef"]);
+      el["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, el["@_itemSubjectRef"]);
     }
 
     if (
@@ -82,14 +94,14 @@ function remapFlowElements(remap: Map<string, string>, flowElements: NonNullable
       el.__$$element === "serviceTask" ||
       el.__$$element === "userTask"
     ) {
-      remapDataItems(remap, el.ioSpecification?.dataInput);
-      remapDataItems(remap, el.ioSpecification?.dataOutput);
-      remapProperties(remap, el.property);
+      remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataInput);
+      remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataOutput);
+      remapProperties(itemDefinitionIdsToRemap, el.property);
     }
 
     if (el.__$$element === "endEvent" || el.__$$element === "intermediateThrowEvent") {
-      remapDataItems(remap, el.dataInput);
-      remapProperties(remap, el.property);
+      remapDataItems(itemDefinitionIdsToRemap, el.dataInput);
+      remapProperties(itemDefinitionIdsToRemap, el.property);
     }
 
     if (
@@ -97,16 +109,16 @@ function remapFlowElements(remap: Map<string, string>, flowElements: NonNullable
       el.__$$element === "intermediateCatchEvent" ||
       el.__$$element === "boundaryEvent"
     ) {
-      remapDataItems(remap, el.dataOutput);
-      remapProperties(remap, el.property);
+      remapDataItems(itemDefinitionIdsToRemap, el.dataOutput);
+      remapProperties(itemDefinitionIdsToRemap, el.property);
     }
 
     if (el.__$$element === "subProcess" || el.__$$element === "adHocSubProcess" || el.__$$element === "transaction") {
-      remapDataItems(remap, el.ioSpecification?.dataInput);
-      remapDataItems(remap, el.ioSpecification?.dataOutput);
-      remapProperties(remap, el.property);
+      remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataInput);
+      remapDataItems(itemDefinitionIdsToRemap, el.ioSpecification?.dataOutput);
+      remapProperties(itemDefinitionIdsToRemap, el.property);
       if (el.flowElement) {
-        remapFlowElements(remap, el.flowElement);
+        remapFlowElements(itemDefinitionIdsToRemap, el.flowElement);
       }
     }
   }
@@ -180,52 +192,52 @@ export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
 
 // Keep one itemDefinition per structureRef and update references to point to it.
 export function deduplicateItemDefinitions(definitions: BpmnLatestModel["definitions"]): void {
-  const itemDefGroups = new Map<string, Array<{ "@_id"?: string }>>();
+  const itemDefinitionsGroupedStructureRef = new Map<string, Array<{ "@_id"?: string }>>();
   for (const rootElement of definitions.rootElement ?? []) {
     if (rootElement.__$$element === "itemDefinition") {
-      const key = rootElement["@_structureRef"] ?? "";
-      addOrGetGroup(itemDefGroups, key).push(rootElement);
+      const itemDefinitionStructureRef = rootElement["@_structureRef"] ?? "";
+      addOrGetGroup(itemDefinitionsGroupedStructureRef, itemDefinitionStructureRef).push(rootElement);
     }
   }
 
   // Map each duplicate id to the id of the first occurrence we keep.
-  const itemDefIdRemap = new Map<string, string>();
-  for (const group of itemDefGroups.values()) {
-    if (group.length <= 1) {
+  const itemDefinitionIdsToRemap = new Map<string, string>();
+  for (const itemDefinitionsGroup of itemDefinitionsGroupedStructureRef.values()) {
+    if (itemDefinitionsGroup.length <= 1) {
       continue;
     }
-    const survivorId = group[0]["@_id"];
+    const survivorId = itemDefinitionsGroup[0]["@_id"];
     if (!survivorId) {
       continue;
     }
-    for (let i = 1; i < group.length; i++) {
-      const duplicateId = group[i]["@_id"];
+    for (let i = 1; i < itemDefinitionsGroup.length; i++) {
+      const duplicateId = itemDefinitionsGroup[i]["@_id"];
       if (duplicateId) {
-        itemDefIdRemap.set(duplicateId, survivorId);
+        itemDefinitionIdsToRemap.set(duplicateId, survivorId);
       }
     }
   }
 
-  if (itemDefIdRemap.size === 0) {
+  if (itemDefinitionIdsToRemap.size === 0) {
     return;
   }
 
   // Remove the duplicate itemDefinitions and update every itemSubjectRef.
-  const idsToRemove = new Set(itemDefIdRemap.keys());
+  const itemDefinitionIdsToRemove = new Set(itemDefinitionIdsToRemap.keys());
   definitions.rootElement = definitions.rootElement?.filter(
-    (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && idsToRemove.has(e["@_id"]))
+    (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && itemDefinitionIdsToRemove.has(e["@_id"]))
   );
 
   for (const rootElement of definitions.rootElement ?? []) {
     if (rootElement.__$$element === "dataStore") {
-      rootElement["@_itemSubjectRef"] = remapRef(itemDefIdRemap, rootElement["@_itemSubjectRef"]);
+      rootElement["@_itemSubjectRef"] = getRefToRemap(itemDefinitionIdsToRemap, rootElement["@_itemSubjectRef"]);
     }
     if (rootElement.__$$element === "process") {
-      remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataInput);
-      remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataOutput);
-      remapProperties(itemDefIdRemap, rootElement.property);
+      remapDataItems(itemDefinitionIdsToRemap, rootElement.ioSpecification?.dataInput);
+      remapDataItems(itemDefinitionIdsToRemap, rootElement.ioSpecification?.dataOutput);
+      remapProperties(itemDefinitionIdsToRemap, rootElement.property);
       if (rootElement.flowElement) {
-        remapFlowElements(itemDefIdRemap, rootElement.flowElement);
+        remapFlowElements(itemDefinitionIdsToRemap, rootElement.flowElement);
       }
     }
   }

--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -42,10 +42,7 @@ function addOrGetGroup<K, V>(map: Map<K, V[]>, key: K): V[] {
   return group;
 }
 
-function getRefToRemap(
-  itemDefinitionIdsToRemap: Map<string, string>,
-  id: string | undefined
-): string | undefined {
+function getRefToRemap(itemDefinitionIdsToRemap: Map<string, string>, id: string | undefined): string | undefined {
   return id === undefined ? undefined : itemDefinitionIdsToRemap.get(id) ?? id;
 }
 

--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -104,6 +104,7 @@ function remapFlowElements(
         remapFlowElements(itemDefinitionIdsToRemap, el.flowElement);
       }
     } else {
+      // Other flow elements do not reference itemDefinitions.
     }
   }
 }
@@ -230,6 +231,7 @@ export function deduplicateItemDefinitions(definitions: Normalized<BpmnLatestMod
         remapFlowElements(itemDefinitionIdsToRemap, rootElement.flowElement);
       }
     } else {
+      // Other rootElement types do not reference itemDefinitions.
     }
   }
 }

--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -32,7 +32,7 @@ type WithRequiredDeep<T, K extends keyof any> = T extends undefined
         ? { [P in K]-?: NonNullable<WithRequiredDeep<T[P], K>> }
         : T);
 
-// Returns the existing array for `key`, creating and storing a new empty one if absent.
+// Get the array for `key`, or create an empty one if missing.
 function addOrGetGroup<K, V>(map: Map<K, V[]>, key: K): V[] {
   let group = map.get(key);
   if (!group) {
@@ -170,16 +170,25 @@ export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
     }
   });
 
-  // Deduplicate itemDefinitions that share the same structureRef
+  // Merge itemDefinitions that share the same structureRef.
+  deduplicateItemDefinitions(model.definitions);
+
+  const normalizedModel = model as Normalized<BpmnLatestModel>;
+
+  return normalizedModel;
+}
+
+// Keep one itemDefinition per structureRef and update references to point to it.
+export function deduplicateItemDefinitions(definitions: BpmnLatestModel["definitions"]): void {
   const itemDefGroups = new Map<string, Array<{ "@_id"?: string }>>();
-  for (const rootElement of model.definitions.rootElement ?? []) {
+  for (const rootElement of definitions.rootElement ?? []) {
     if (rootElement.__$$element === "itemDefinition") {
       const key = rootElement["@_structureRef"] ?? "";
       addOrGetGroup(itemDefGroups, key).push(rootElement);
     }
   }
 
-  // Map duplicate ids to the first occurrence
+  // Map each duplicate id to the id of the first occurrence we keep.
   const itemDefIdRemap = new Map<string, string>();
   for (const group of itemDefGroups.values()) {
     if (group.length <= 1) {
@@ -197,29 +206,27 @@ export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
     }
   }
 
-  if (itemDefIdRemap.size > 0) {
-    // Drop the duplicates and remap all itemSubjectRef references
-    const idsToRemove = new Set(itemDefIdRemap.keys());
-    model.definitions.rootElement = model.definitions.rootElement?.filter(
-      (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && idsToRemove.has(e["@_id"]))
-    );
+  if (itemDefIdRemap.size === 0) {
+    return;
+  }
 
-    for (const rootElement of model.definitions.rootElement ?? []) {
-      if (rootElement.__$$element === "dataStore") {
-        rootElement["@_itemSubjectRef"] = remapRef(itemDefIdRemap, rootElement["@_itemSubjectRef"]);
-      }
-      if (rootElement.__$$element === "process") {
-        remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataInput);
-        remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataOutput);
-        remapProperties(itemDefIdRemap, rootElement.property);
-        if (rootElement.flowElement) {
-          remapFlowElements(itemDefIdRemap, rootElement.flowElement);
-        }
+  // Remove the duplicate itemDefinitions and update every itemSubjectRef.
+  const idsToRemove = new Set(itemDefIdRemap.keys());
+  definitions.rootElement = definitions.rootElement?.filter(
+    (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && idsToRemove.has(e["@_id"]))
+  );
+
+  for (const rootElement of definitions.rootElement ?? []) {
+    if (rootElement.__$$element === "dataStore") {
+      rootElement["@_itemSubjectRef"] = remapRef(itemDefIdRemap, rootElement["@_itemSubjectRef"]);
+    }
+    if (rootElement.__$$element === "process") {
+      remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataInput);
+      remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataOutput);
+      remapProperties(itemDefIdRemap, rootElement.property);
+      if (rootElement.flowElement) {
+        remapFlowElements(itemDefIdRemap, rootElement.flowElement);
       }
     }
   }
-
-  const normalizedModel = model as Normalized<BpmnLatestModel>;
-
-  return normalizedModel;
 }

--- a/packages/bpmn-editor/src/normalization/normalize.ts
+++ b/packages/bpmn-editor/src/normalization/normalize.ts
@@ -18,6 +18,7 @@
  */
 
 import { BpmnLatestModel } from "@kie-tools/bpmn-marshaller";
+import { BPMN20__tProcess } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { getNewBpmnIdRandomizer } from "../idRandomizer/bpmnIdRandomizer";
 import { State } from "../store/Store";
 
@@ -30,6 +31,86 @@ type WithRequiredDeep<T, K extends keyof any> = T extends undefined
     : { [P in keyof T]: WithRequiredDeep<T[P], K> } & (K extends keyof T
         ? { [P in K]-?: NonNullable<WithRequiredDeep<T[P], K>> }
         : T);
+
+// Returns the existing array for `key`, creating and storing a new empty one if absent.
+function addOrGetGroup<K, V>(map: Map<K, V[]>, key: K): V[] {
+  let group = map.get(key);
+  if (!group) {
+    group = [];
+    map.set(key, group);
+  }
+  return group;
+}
+
+function remapRef(remap: Map<string, string>, id: string | undefined): string | undefined {
+  return id === undefined ? undefined : remap.get(id) ?? id;
+}
+
+function remapDataItems(remap: Map<string, string>, items: Array<{ "@_itemSubjectRef"?: string }> | undefined) {
+  if (!items) {
+    return;
+  }
+  for (const item of items) {
+    if (item["@_itemSubjectRef"] !== undefined) {
+      item["@_itemSubjectRef"] = remapRef(remap, item["@_itemSubjectRef"]);
+    }
+  }
+}
+
+function remapProperties(remap: Map<string, string>, properties: Array<{ "@_itemSubjectRef"?: string }> | undefined) {
+  if (!properties) {
+    return;
+  }
+  for (const p of properties) {
+    p["@_itemSubjectRef"] = remapRef(remap, p["@_itemSubjectRef"]);
+  }
+}
+
+function remapFlowElements(remap: Map<string, string>, flowElements: NonNullable<BPMN20__tProcess["flowElement"]>) {
+  for (const el of flowElements) {
+    if (
+      el.__$$element === "dataObject" ||
+      el.__$$element === "dataObjectReference" ||
+      el.__$$element === "dataStoreReference"
+    ) {
+      el["@_itemSubjectRef"] = remapRef(remap, el["@_itemSubjectRef"]);
+    }
+
+    if (
+      el.__$$element === "businessRuleTask" ||
+      el.__$$element === "callActivity" ||
+      el.__$$element === "serviceTask" ||
+      el.__$$element === "userTask"
+    ) {
+      remapDataItems(remap, el.ioSpecification?.dataInput);
+      remapDataItems(remap, el.ioSpecification?.dataOutput);
+      remapProperties(remap, el.property);
+    }
+
+    if (el.__$$element === "endEvent" || el.__$$element === "intermediateThrowEvent") {
+      remapDataItems(remap, el.dataInput);
+      remapProperties(remap, el.property);
+    }
+
+    if (
+      el.__$$element === "startEvent" ||
+      el.__$$element === "intermediateCatchEvent" ||
+      el.__$$element === "boundaryEvent"
+    ) {
+      remapDataItems(remap, el.dataOutput);
+      remapProperties(remap, el.property);
+    }
+
+    if (el.__$$element === "subProcess" || el.__$$element === "adHocSubProcess" || el.__$$element === "transaction") {
+      remapDataItems(remap, el.ioSpecification?.dataInput);
+      remapDataItems(remap, el.ioSpecification?.dataOutput);
+      remapProperties(remap, el.property);
+      if (el.flowElement) {
+        remapFlowElements(remap, el.flowElement);
+      }
+    }
+  }
+}
 
 export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
   getNewBpmnIdRandomizer()
@@ -88,6 +169,55 @@ export function normalize(model: BpmnLatestModel): State["bpmn"]["model"] {
       }
     }
   });
+
+  // Deduplicate itemDefinitions that share the same structureRef
+  const itemDefGroups = new Map<string, Array<{ "@_id"?: string }>>();
+  for (const rootElement of model.definitions.rootElement ?? []) {
+    if (rootElement.__$$element === "itemDefinition") {
+      const key = rootElement["@_structureRef"] ?? "";
+      addOrGetGroup(itemDefGroups, key).push(rootElement);
+    }
+  }
+
+  // Map duplicate ids to the first occurrence
+  const itemDefIdRemap = new Map<string, string>();
+  for (const group of itemDefGroups.values()) {
+    if (group.length <= 1) {
+      continue;
+    }
+    const survivorId = group[0]["@_id"];
+    if (!survivorId) {
+      continue;
+    }
+    for (let i = 1; i < group.length; i++) {
+      const duplicateId = group[i]["@_id"];
+      if (duplicateId) {
+        itemDefIdRemap.set(duplicateId, survivorId);
+      }
+    }
+  }
+
+  if (itemDefIdRemap.size > 0) {
+    // Drop the duplicates and remap all itemSubjectRef references
+    const idsToRemove = new Set(itemDefIdRemap.keys());
+    model.definitions.rootElement = model.definitions.rootElement?.filter(
+      (e) => !(e.__$$element === "itemDefinition" && e["@_id"] && idsToRemove.has(e["@_id"]))
+    );
+
+    for (const rootElement of model.definitions.rootElement ?? []) {
+      if (rootElement.__$$element === "dataStore") {
+        rootElement["@_itemSubjectRef"] = remapRef(itemDefIdRemap, rootElement["@_itemSubjectRef"]);
+      }
+      if (rootElement.__$$element === "process") {
+        remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataInput);
+        remapDataItems(itemDefIdRemap, rootElement.ioSpecification?.dataOutput);
+        remapProperties(itemDefIdRemap, rootElement.property);
+        if (rootElement.flowElement) {
+          remapFlowElements(itemDefIdRemap, rootElement.flowElement);
+        }
+      }
+    }
+  }
 
   const normalizedModel = model as Normalized<BpmnLatestModel>;
 

--- a/packages/bpmn-editor/src/propertiesPanel/propertiesManager/PropertiesManager.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/propertiesManager/PropertiesManager.tsx
@@ -49,6 +49,7 @@ import {
 import { addOrGetItemDefinitions, DEFAULT_DATA_TYPES } from "../../mutations/addOrGetItemDefinitions";
 import { deleteItemDefinition } from "../../mutations/deleteItemDefinition";
 import { renameItemDefinition } from "../../mutations/renameItemDefinition";
+import { deduplicateItemDefinitions } from "../../normalization/normalize";
 import { addOrGetMessages } from "../../mutations/addOrGetMessages";
 import { renameMessage } from "../../mutations/renameMessage";
 import { deleteMessage } from "../../mutations/deleteMessage";
@@ -172,6 +173,14 @@ export function PropertiesManager({ p }: { p: undefined | WithVariables }) {
                               id: entry["@_id"],
                               newItemDefinitionName: e.target.value,
                             });
+                          });
+                        }}
+                        onBlur={() => {
+                          if (!entry["@_structureRef"]) {
+                            return;
+                          }
+                          bpmnEditorStoreApi.setState((s) => {
+                            deduplicateItemDefinitions(s.bpmn.model.definitions);
                           });
                         }}
                       />


### PR DESCRIPTION
Issue
When a BPMN file was loaded, multiple elements (Data Types) sharing the same structureRef were kept as duplicates. This caused the same Data Type to show up multiple times in the editor.

Fix
In normalize.ts, on load we now condense duplicate elements into a single one:

Group all itemDefinition elements by their @_structureRef.
Keep the first one as the "survivor" and drop the rest.
Update every itemSubjectRef across the model (process properties, dataObjects, task ioSpecification, inputs/outputs, event data inputs/outputs, and nested subProcess/adHocSubProcess /transaction elements) to point at the survivor's id.



Closes: https://github.com/apache/incubator-kie-issues/issues/2298