### PR TITLE
kie-issues#2304: BPMN Editor: Usertask On-entry script scriptFormat not persisted

### DIFF
--- a/packages/bpmn-editor/src/propertiesPanel/onEntryAndExitScripts/OnEntryAndExitScriptsFormSection.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/onEntryAndExitScripts/OnEntryAndExitScriptsFormSection.tsx
@@ -23,6 +23,7 @@ import { useState } from "react";
 import { SectionHeader } from "@kie-tools/xyflow-react-kie-diagram/dist/propertiesPanel/SectionHeader";
 import { CodeIcon } from "@patternfly/react-icons/dist/js/icons/code-icon";
 import { CodeInput } from "../codeInput/CodeInput";
+import { getScriptFormat } from "../scriptFormats";
 import { BPMN20__tProcess } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
@@ -86,7 +87,7 @@ export function OnEntryAndExitScriptsFormSection({ element }: { element: WithOnE
                       if (e["@_id"] === element?.["@_id"] && e.__$$element === element.__$$element) {
                         e.extensionElements ??= {};
                         e.extensionElements["drools:onEntry-script"] ??= {
-                          "@_scriptFormat": "",
+                          "@_scriptFormat": getScriptFormat("Java"),
                           "drools:script": { __$$text: "" },
                         };
                         e.extensionElements["drools:onEntry-script"]["drools:script"].__$$text = newValue;
@@ -109,7 +110,7 @@ export function OnEntryAndExitScriptsFormSection({ element }: { element: WithOnE
                       if (e["@_id"] === element?.["@_id"] && e.__$$element === element.__$$element) {
                         e.extensionElements ??= {};
                         e.extensionElements["drools:onExit-script"] ??= {
-                          "@_scriptFormat": "",
+                          "@_scriptFormat": getScriptFormat("Java"),
                           "drools:script": { __$$text: "" },
                         };
                         e.extensionElements["drools:onExit-script"]["drools:script"].__$$text = newValue;

--- a/packages/bpmn-editor/src/propertiesPanel/onEntryAndExitScripts/OnEntryAndExitScriptsFormSection.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/onEntryAndExitScripts/OnEntryAndExitScriptsFormSection.tsx
@@ -23,7 +23,7 @@ import { useState } from "react";
 import { SectionHeader } from "@kie-tools/xyflow-react-kie-diagram/dist/propertiesPanel/SectionHeader";
 import { CodeIcon } from "@patternfly/react-icons/dist/js/icons/code-icon";
 import { CodeInput } from "../codeInput/CodeInput";
-import { getScriptFormat } from "../scriptFormats";
+import { getScriptFormat, ScriptLanguage } from "../scriptFormats";
 import { BPMN20__tProcess } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
@@ -87,7 +87,7 @@ export function OnEntryAndExitScriptsFormSection({ element }: { element: WithOnE
                       if (e["@_id"] === element?.["@_id"] && e.__$$element === element.__$$element) {
                         e.extensionElements ??= {};
                         e.extensionElements["drools:onEntry-script"] ??= {
-                          "@_scriptFormat": getScriptFormat("Java"),
+                          "@_scriptFormat": getScriptFormat(ScriptLanguage.Java),
                           "drools:script": { __$$text: "" },
                         };
                         e.extensionElements["drools:onEntry-script"]["drools:script"].__$$text = newValue;
@@ -110,7 +110,7 @@ export function OnEntryAndExitScriptsFormSection({ element }: { element: WithOnE
                       if (e["@_id"] === element?.["@_id"] && e.__$$element === element.__$$element) {
                         e.extensionElements ??= {};
                         e.extensionElements["drools:onExit-script"] ??= {
-                          "@_scriptFormat": getScriptFormat("Java"),
+                          "@_scriptFormat": getScriptFormat(ScriptLanguage.Java),
                           "drools:script": { __$$text: "" },
                         };
                         e.extensionElements["drools:onExit-script"]["drools:script"].__$$text = newValue;

--- a/packages/bpmn-editor/src/propertiesPanel/scriptFormats.ts
+++ b/packages/bpmn-editor/src/propertiesPanel/scriptFormats.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const SCRIPT_LANGUAGE_FORMATS: Record<string, string> = {
+  Java: "http://www.java.com/java",
+  MVEL: "http://www.mvel.org/2.0",
+  Drools: "http://www.jboss.org/drools/rule",
+  DROOLS: "http://www.jboss.org/drools/rule",
+  drools: "http://www.jboss.org/drools/rule",
+  FEEL: "http://www.omg.org/spec/DMN/20180521/FEEL/",
+};
+
+export function getScriptFormat(language: string | undefined): string {
+  if (!language) {
+    return SCRIPT_LANGUAGE_FORMATS.Java;
+  }
+  return SCRIPT_LANGUAGE_FORMATS[language] ?? SCRIPT_LANGUAGE_FORMATS.Java;
+}

--- a/packages/bpmn-editor/src/propertiesPanel/scriptFormats.ts
+++ b/packages/bpmn-editor/src/propertiesPanel/scriptFormats.ts
@@ -17,18 +17,20 @@
  * under the License.
  */
 
-export const SCRIPT_LANGUAGE_FORMATS: Record<string, string> = {
-  Java: "http://www.java.com/java",
-  MVEL: "http://www.mvel.org/2.0",
-  Drools: "http://www.jboss.org/drools/rule",
-  DROOLS: "http://www.jboss.org/drools/rule",
-  drools: "http://www.jboss.org/drools/rule",
-  FEEL: "http://www.omg.org/spec/DMN/20180521/FEEL/",
+export enum ScriptLanguage {
+  Java = "Java",
+  MVEL = "MVEL",
+  Drools = "Drools",
+  FEEL = "FEEL",
+}
+
+const SCRIPT_LANGUAGE_FORMATS: Record<ScriptLanguage, string> = {
+  [ScriptLanguage.Java]: "http://www.java.com/java",
+  [ScriptLanguage.MVEL]: "http://www.mvel.org/2.0",
+  [ScriptLanguage.Drools]: "http://www.jboss.org/drools/rule",
+  [ScriptLanguage.FEEL]: "http://www.omg.org/spec/DMN/20180521/FEEL/",
 };
 
-export function getScriptFormat(language: string | undefined): string {
-  if (!language) {
-    return SCRIPT_LANGUAGE_FORMATS.Java;
-  }
-  return SCRIPT_LANGUAGE_FORMATS[language] ?? SCRIPT_LANGUAGE_FORMATS.Java;
+export function getScriptFormat(language: ScriptLanguage): string {
+  return SCRIPT_LANGUAGE_FORMATS[language];
 }

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ScriptTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ScriptTaskProperties.tsx
@@ -25,6 +25,7 @@ import { PropertiesPanelHeaderFormSection } from "./_PropertiesPanelHeaderFormSe
 import { TaskIcon } from "../../diagram/nodes/NodeIcons";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 import { CodeInput } from "../codeInput/CodeInput";
+import { getScriptFormat } from "../scriptFormats";
 import { AdhocAutostartCheckbox } from "../adhocAutostartCheckbox/AdhocAutostartCheckbox";
 import { AsyncCheckbox } from "../asyncCheckbox/AsyncCheckbox";
 import { useBpmnEditorStoreApi } from "../../store/StoreContext";
@@ -62,6 +63,7 @@ export function ScriptTaskProperties({
                 if (e["@_id"] === scriptTask["@_id"] && e.__$$element === scriptTask.__$$element) {
                   e.script ??= { __$$text: newScript || "" };
                   e.script.__$$text = newScript;
+                  e["@_scriptFormat"] = getScriptFormat("Java");
                 }
               });
             });

--- a/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ScriptTaskProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/singleNodeProperties/ScriptTaskProperties.tsx
@@ -25,7 +25,7 @@ import { PropertiesPanelHeaderFormSection } from "./_PropertiesPanelHeaderFormSe
 import { TaskIcon } from "../../diagram/nodes/NodeIcons";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
 import { CodeInput } from "../codeInput/CodeInput";
-import { getScriptFormat } from "../scriptFormats";
+import { getScriptFormat, ScriptLanguage } from "../scriptFormats";
 import { AdhocAutostartCheckbox } from "../adhocAutostartCheckbox/AdhocAutostartCheckbox";
 import { AsyncCheckbox } from "../asyncCheckbox/AsyncCheckbox";
 import { useBpmnEditorStoreApi } from "../../store/StoreContext";
@@ -63,7 +63,7 @@ export function ScriptTaskProperties({
                 if (e["@_id"] === scriptTask["@_id"] && e.__$$element === scriptTask.__$$element) {
                   e.script ??= { __$$text: newScript || "" };
                   e.script.__$$text = newScript;
-                  e["@_scriptFormat"] = getScriptFormat("Java");
+                  e["@_scriptFormat"] = getScriptFormat(ScriptLanguage.Java);
                 }
               });
             });


### PR DESCRIPTION
Closes: [kie-issues#2304](https://github.com/apache/incubator-kie-issues/issues/2304)

### Root Cause
When adding on-entry/on-exit scripts to user tasks or editing script tasks, the `scriptFormat` attribute was being initialized with an empty string instead of the proper format URI. This occurred because the code was hardcoding `""` as the default value when creating new script elements.

### Fix
- Created a centralized mapping of script language names to their corresponding format URIs
- Implemented a helper function to retrieve the correct format URI based on the language
- Updated script initialization logic to use the proper format URI (defaulting to Java format) instead of empty strings
- Applied the fix to on-entry scripts, on-exit scripts, and script task properties

This ensures that generated XML contains valid `scriptFormat` attributes, preventing compilation failures.