### PR TITLE
NO-ISSUE: BPMN Editor: Auto-generated namespace has an extra "/"

### DIFF
--- a/packages/bpmn-editor/src/mutations/setTargetNamespace.ts
+++ b/packages/bpmn-editor/src/mutations/setTargetNamespace.ts
@@ -21,7 +21,7 @@ import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid
 import { BPMN20__tDefinitions } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { Normalized } from "../normalization/normalize";
 
-export const DEFAULT_BPMN_NAMESPACE_PREFIX = "https://kie.apache.org/bpmn/";
+export const DEFAULT_BPMN_NAMESPACE_PREFIX = "https://kie.apache.org/bpmn";
 
 export function setTargetNamespace({
   definitions,


### PR DESCRIPTION
When opening a BPMN diagram in the editor and checking the **ID & Namespace** panel, the auto-generated namespace previously contained an extra `/` character before the GUID.  
For example:  
```
https://kie.apache.org/bpmn//_4E6C3E...
```

This has been corrected so that the namespace now follows the expected format:  
```
https://kie.apache.org/bpmn/_<GUID>
```
- Removed redundant `/` in auto-generated namespace.  