### PR TITLE
Revert Netty version from 4.1.133.Final to 4.1.132.Final  to address native build compatibility issues

### DIFF
--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -60,7 +60,7 @@
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
     <version.commons-io>2.20.0</version.commons-io>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
-    <version.io.netty>4.1.133.Final</version.io.netty>
+    <version.io.netty>4.1.132.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->


### PR DESCRIPTION
Revert Netty version from 4.1.133.Final to 4.1.132.Final  to address native build compatibility issues