### PR TITLE
NO-ISSUE: Improve and refactor subprocess mutations

### DIFF
--- a/packages/bpmn-editor/src/mutations/moveNodesInsideSubProcess.ts
+++ b/packages/bpmn-editor/src/mutations/moveNodesInsideSubProcess.ts
@@ -41,10 +41,8 @@ export function moveNodesInsideSubProcess({
     throw new Error(`Cannot find subprocess with ID: ${__readonly_subProcessId}`);
   }
 
-  const flowElementsToMove: Normalized<Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>>[] = [];
-  const artifactsToMove: Normalized<
-    ElementExclusion<Unpacked<Normalized<BPMN20__tProcess>["artifact"]>, "association">
-  >[] = [];
+  const flowElementsToMove: Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>[] = [];
+  const artifactsToMove: ElementExclusion<Unpacked<Normalized<BPMN20__tProcess>["artifact"]>, "association">[] = [];
 
   const nodeIdsToMoveInside = new Set(__readonly_nodeIds);
   const subProcessNodes = new Set<string>();
@@ -54,9 +52,10 @@ export function moveNodesInsideSubProcess({
     }
   });
 
-  const toMove: Normalized<Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>>[] = [];
-
-  const collectElements = (flowElements: Normalized<BPMN20__tProcess>["flowElement"]): void => {
+  const collectElements = (
+    flowElements: Normalized<BPMN20__tProcess>["flowElement"],
+    collected: Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>[]
+  ): void => {
     if (!flowElements) {
       return;
     }
@@ -68,25 +67,24 @@ export function moveNodesInsideSubProcess({
           flowElement["@_attachedToRef"] &&
           nodeIdsToMoveInside.has(flowElement["@_attachedToRef"]))
       ) {
-        toMove.push(...flowElements.splice(i, 1));
+        collected.push(...flowElements.splice(i, 1));
       } else if (shouldMoveSequenceFlow(flowElement, nodeIdsToMoveInside, subProcessNodes)) {
         // If the source and target are both outside of the sub-process
         // or if the source and target is already in the sub process the sequenceFlow must be copied
-        toMove.push(...flowElements.splice(i, 1));
+        collected.push(...flowElements.splice(i, 1));
       } else if (isSubProcessElement(flowElement) && flowElement.flowElement) {
-        collectElements(flowElement.flowElement);
+        collectElements(flowElement.flowElement, collected);
       }
     }
   };
 
-  collectElements(process.flowElement ?? []);
-  flowElementsToMove.push(...toMove);
+  collectElements(process.flowElement ?? [], flowElementsToMove);
 
   for (let i = 0; i < (process.artifact ?? []).length; i++) {
     const artifact = (process.artifact ?? [])[i];
     if (artifact.__$$element !== "association" && nodeIdsToMoveInside.has(artifact["@_id"])) {
-      const spliced = process.artifact?.splice(i, 1) ?? [];
-      artifactsToMove.push(...spliced.filter((a) => a.__$$element !== "association"));
+      const removedArtifacts = process.artifact?.splice(i, 1) ?? [];
+      artifactsToMove.push(...removedArtifacts.filter((a) => a.__$$element !== "association"));
       i--; // repeat one index because we just altered the array we're iterating over.
     }
   }

--- a/packages/bpmn-editor/src/mutations/moveNodesOutOfSubProcess.ts
+++ b/packages/bpmn-editor/src/mutations/moveNodesOutOfSubProcess.ts
@@ -157,10 +157,8 @@ export function moveNodesOutOfSubProcess({
       findParentFlowElements(process.flowElement ?? [], __readonly_subProcessId ?? "") ?? process.flowElement ?? [];
   }
 
-  const flowElementsToMove: Normalized<Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>>[] = [];
-  const artifactsToMove: Normalized<
-    ElementExclusion<Unpacked<Normalized<BPMN20__tProcess>["artifact"]>, "association">
-  >[] = [];
+  const flowElementsToMove: Unpacked<Normalized<BPMN20__tProcess>["flowElement"]>[] = [];
+  const artifactsToMove: ElementExclusion<Unpacked<Normalized<BPMN20__tProcess>["artifact"]>, "association">[] = [];
 
   const nodeIdsToMoveOut = new Set(__readonly_nodeIds);
 
@@ -230,8 +228,8 @@ export function moveNodesOutOfSubProcess({
   for (let i = 0; i < (subProcess.artifact ?? []).length; i++) {
     const artifact = (subProcess.artifact ?? [])[i];
     if (artifact.__$$element !== "association" && nodeIdsToMoveOut.has(artifact["@_id"])) {
-      const spliced = subProcess.artifact?.splice(i, 1) ?? [];
-      artifactsToMove.push(...spliced.filter((a) => a.__$$element !== "association"));
+      const removedArtifacts = subProcess.artifact?.splice(i, 1) ?? [];
+      artifactsToMove.push(...removedArtifacts.filter((a) => a.__$$element !== "association"));
       i--; // repeat one index because we just altered the array we're iterating over.
     }
   }


### PR DESCRIPTION
This is a follow-up to #3580 ([kie-issues#2312](https://github.com/apache/incubator-kie-issues/issues/2312)), addressing review comments. 
Removes redundant `Normalized<>` wrappers from `flowElementsToMove` and `artifactsToMove` array element types in both `moveNodesInsideSubProcess.ts` and `moveNodesOutOfSubProcess.ts`. 
Refactors `collectElements()` to accept the collection array as an explicit parameter instead of relying on closure mutation, and renames the `spliced` variable to `removedArtifacts` for clearer semantic intent.