### PR TITLE
NO-ISSUE: Fix SCESIM story book due to stricter xml-parser-ts validation

### DIFF
--- a/packages/scesim-editor/stories/dev/DevWebApp.stories.tsx
+++ b/packages/scesim-editor/stories/dev/DevWebApp.stories.tsx
@@ -273,7 +273,7 @@ export const WebApp: Story = {
   render: (args) => DevWebApp(args),
   args: {
     issueTrackerHref: "https://github.com/apache/incubator-kie-issues/issues/new",
-    model: getMarshaller(emptyFileName).parser.parse(),
+    model: getMarshaller(EMPTY_ONE_EIGHT).parser.parse(),
     openFileNormalizedPosixPathRelativeToTheWorkspaceRoot: "Untitled.scesim",
   },
 };

--- a/packages/scesim-editor/stories/examples/ExternalDmnModels.ts
+++ b/packages/scesim-editor/stories/examples/ExternalDmnModels.ts
@@ -1012,7 +1012,7 @@ export const SIMPLE = `<?xml version="1.0" encoding="UTF-8" ?>
       <requiredInput href="#_926B9E31-3CEA-4A0E-8A66-97F875EFB428" />
     </informationRequirement>
     <literalExpression id="_1E199E0A-2CC3-4EEE-AA8C-B4F5320EE1DE">
-      <text>Input &gt; 18<text>
+      <text>Input &gt; 18</text>
     </literalExpression>
   </decision>
   <dmndi:DMNDI>


### PR DESCRIPTION
After the `xml-parser-ts` fix (#3570) that filters `<parsererror>` elements and throws on malformed XML was merged (as part of the broader BPMN/DMN/SCESIM parser error fix), the SCESIM editor Storybook stories broke in local development.

**Root Cause**

The Storybook stories for the SCESIM editor had two latent bugs that were always present but previously silent:

1. **Malformed XML in the SIMPLE model** — a tag like `<text>Input &gt; 18<text>` was missing the `/` in its closing tag, making it invalid XML.
2. **DevWebApp story passing a filename string instead of XML content** — the story was calling `getMarshaller(emptyFileName).parser.parse()` where `emptyFileName` is `"Untitled.scesim"`, a filename string, instead of actual XML content. `getMarshaller()` expects XML, so the DOMParser tried to parse the filename as XML and silently failed.

These bugs never surfaced before because the browser's `DOMParser` was producing empty `<parsererror>` elements for these inputs, and the old code only threw when `hasRealError` was true (i.e., the parsererror element had non-empty text content). The stricter error handling introduced in the parser fix now correctly detects and throws on these malformed inputs.