### PR TITLE
NO-ISSUE: update picomatch versions to address CVE-2026-33671 and CVE-2026-3367

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,6 @@ overrides:
   minimatch@^4: 5.1.9
   undici: ^6.24.0
   uuid: ^11.1.1
-  picomatch@3: 3.0.2
   picomatch@4: 4.0.4
 
 packageExtensionsChecksum: sha256-oxPwESKKSHRelJQnCQTHzgtG1xkcQOHjfgjFdIfqMfg=
@@ -17268,7 +17267,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 3.0.2
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   minimatch@^4: 5.1.9
   undici: ^6.24.0
   uuid: ^11.1.1
+  picomatch@3: 3.0.2
+  picomatch@4: 4.0.4
 
 packageExtensionsChecksum: sha256-oxPwESKKSHRelJQnCQTHzgtG1xkcQOHjfgjFdIfqMfg=
 
@@ -17266,7 +17268,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 3.0.2
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -20490,12 +20492,12 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@3.0.1:
-    resolution: {integrity: sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==}
+  picomatch@3.0.2:
+    resolution: {integrity: sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==}
     engines: {node: '>=10'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -24016,7 +24018,7 @@ snapshots:
       mini-css-extract-plugin: 2.9.4(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6))
       open: 10.2.0
       ora: 8.2.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       piscina: 5.1.3
       postcss: 8.5.6
       postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6))
@@ -24087,7 +24089,7 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       jsonc-parser: 3.3.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       rxjs: 7.8.2
       source-map: 0.7.6
     optionalDependencies:
@@ -24124,7 +24126,7 @@ snapshots:
       magic-string: 0.30.17
       mrmime: 2.0.1
       parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       piscina: 5.1.3
       rollup: 4.52.3
       sass: 1.90.0
@@ -27738,7 +27740,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -35733,9 +35735,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@2.1.2: {}
 
@@ -39617,9 +39619,9 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@3.0.1: {}
+  picomatch@3.0.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pify@2.3.0: {}
 
@@ -39953,7 +39955,7 @@ snapshots:
       ignore: 5.3.1
       mri: 1.2.0
       picocolors: 1.1.1
-      picomatch: 3.0.1
+      picomatch: 3.0.2
       prettier: 3.3.2
       tslib: 2.8.1
 
@@ -42150,13 +42152,13 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinylogic@1.0.3:
     dependencies:
@@ -42912,8 +42914,8 @@ snapshots:
   vite@7.1.11(@types/node@24.12.4)(jiti@1.21.7)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.57.1
       tinyglobby: 0.2.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   minimatch@^4: 5.1.9
   undici: ^6.24.0
   uuid: ^11.1.1
+  picomatch@3: 3.0.2
   picomatch@4: 4.0.4
 
 packageExtensionsChecksum: sha256-oxPwESKKSHRelJQnCQTHzgtG1xkcQOHjfgjFdIfqMfg=
@@ -17267,7 +17268,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: 3.0.2
     peerDependenciesMeta:
       picomatch:
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,8 +30,6 @@ overrides:
   # CVE-2026-41907: Fix security vulnerability in uuid
   # Transitive dependencies (node-notifier@8.0.2, jest-junit@16.0.0) still use uuid@8.3.2
   "uuid": "^11.1.1"
-  # CVE-2026-33671 (High) / CVE-2026-33672 (Medium): picomatch POSIX bracket method injection.
-  # Transitive dep of vite, @angular/build, @parcel/watcher, fdir, tinyglobby (4.x) and pretty-quick (3.x).
-  # The 2.x line already resolves to the patched 2.3.2.
-  "picomatch@3": "3.0.2"
+  # CVE-2026-33671 (High) / CVE-2026-33672 (Medium): picomatch POSIX bracket method injection and ReDoS.
+  # Transitive dep of @angular-devkit/build-angular still uses vulnerable 4.0.3
   "picomatch@4": "4.0.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,3 +30,8 @@ overrides:
   # CVE-2026-41907: Fix security vulnerability in uuid
   # Transitive dependencies (node-notifier@8.0.2, jest-junit@16.0.0) still use uuid@8.3.2
   "uuid": "^11.1.1"
+  # CVE-2026-33671 (High) / CVE-2026-33672 (Medium): picomatch POSIX bracket method injection.
+  # Transitive dep of vite, @angular/build, @parcel/watcher, fdir, tinyglobby (4.x) and pretty-quick (3.x).
+  # The 2.x line already resolves to the patched 2.3.2.
+  "picomatch@3": "3.0.2"
+  "picomatch@4": "4.0.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,5 +31,5 @@ overrides:
   # Transitive dependencies (node-notifier@8.0.2, jest-junit@16.0.0) still use uuid@8.3.2
   "uuid": "^11.1.1"
   # CVE-2026-33671 (High) / CVE-2026-33672 (Medium): picomatch POSIX bracket method injection and ReDoS.
-  # Transitive dep of @angular-devkit/build-angular still uses vulnerable 4.0.3
+  "picomatch@3": "3.0.2"
   "picomatch@4": "4.0.4"


### PR DESCRIPTION
Updated picomatch package versions to `3.0.2` and `4.0.4` address security vulnerabilities CVE-2026-33671 and CVE-2026-33672.