### PR TITLE
NO-ISSUE: Update qs to 6.15.2 address CVE-2026-8723

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   minimatch@^3>brace-expansion: 1.1.13
   minimatch@^5>brace-expansion: ^2.0.3
   openapi-types: 7.2.3
-  qs: 6.15.2
+  '@cypress/request@3>qs': 6.15.2
   path-to-regexp@^0: 0.1.13
   react-dropzone: ^11.4.2
   superagent: 10.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   minimatch@^3>brace-expansion: 1.1.13
   minimatch@^5>brace-expansion: ^2.0.3
   openapi-types: 7.2.3
+  qs: 6.15.2
   path-to-regexp@^0: 0.1.13
   react-dropzone: ^11.4.2
   superagent: 10.2.2
@@ -21001,10 +21002,6 @@ packages:
     resolution: {integrity: sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==}
     engines: {node: '>=0.9'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -26022,7 +26019,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.1
+      qs: 6.15.2
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -40114,10 +40111,6 @@ snapshots:
   q@1.5.1: {}
 
   qjobs@1.2.0: {}
-
-  qs@6.14.1:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,8 @@ overrides:
   "minimatch@^5>brace-expansion": "^2.0.3"
   "openapi-types": "7.2.3"
   # CVE-2026-8723: Fix TypeError in qs.stringify (comma arrayFormat + encodeValuesOnly with null/undefined)
-  "qs": "6.15.2"
+  # Overriding transitive dependency until @cypress/request updates to patched qs version
+  "@cypress/request@3>qs": "6.15.2"
   "path-to-regexp@^0": "0.1.13"
   "react-dropzone": "^11.4.2"
   "superagent": "10.2.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,8 @@ overrides:
   "minimatch@^3>brace-expansion": "1.1.13"
   "minimatch@^5>brace-expansion": "^2.0.3"
   "openapi-types": "7.2.3"
+  # CVE-2026-8723: Fix TypeError in qs.stringify (comma arrayFormat + encodeValuesOnly with null/undefined)
+  "qs": "6.15.2"
   "path-to-regexp@^0": "0.1.13"
   "react-dropzone": "^11.4.2"
   "superagent": "10.2.2"


### PR DESCRIPTION
Adds a qs override to `6.15.2` to address CVE-2026-8723