### PR TITLE
[CVE][Critical] CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 spring-boot-4.0.5.jar

### DIFF
--- a/packages/maven-base/not-reproducible-plugins.properties
+++ b/packages/maven-base/not-reproducible-plugins.properties
@@ -84,7 +84,7 @@ org.eclipse.jetty+jetty-jspc-maven-plugin=fail:https://github.com/eclipse/jetty.
 
 org.jboss.jandex+jandex-maven-plugin=fail:https://github.com/wildfly/jandex-maven-plugin/pull/35
 
-org.springframework.boot+spring-boot-maven-plugin=4.0.5
+org.springframework.boot+spring-boot-maven-plugin=4.0.6
 # https://github.com/spring-projects/spring-boot/issues/21005
 
 org.vafer+jdeb=1.10

--- a/packages/spring-boot-bom/pom.xml
+++ b/packages/spring-boot-bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Bill of Materials for KIE Tools Spring Boot-based projects</description>
 
   <properties>
-    <version.org.springframework.boot>4.0.5</version.org.springframework.boot>
+    <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Summary
Bumps the managed **Spring Boot version from 4.0.5 → 4.0.6** in optaplanner.
Because no Spring Security version is pinned, this also pulls **Spring Security
7.0.4 → 7.0.5** transitively via `spring-boot-dependencies`, remediating the
Spring Boot CVEs flagged in this repo.

## CVEs remediated
| Package | CVEs |
|---------|------|
| spring-boot | CVE-2026-40973, CVE-2026-40975, CVE-2026-40976, CVE-2026-40977 |
| spring-boot-autoconfigure | CVE-2026-40974, CVE-2026-40971 |
| spring-boot-security | CVE-2026-40976 |
| spring-security-oauth2-jose | CVE-2026-22748 |
| spring-security-web | CVE-2026-22747 |
| spring-security-config | CVE-2026-22754, CVE-2026-22753 |
| spring-security-core | CVE-2026-22751, CVE-2026-22746 |

## Changes
Spring Boot BOM / build:
- `packages/spring-boot-bom/pom.xml` — `version.org.springframework.boot` 4.0.5 → 4.0.6
- `packages/maven-base/not-reproducible-plugins.properties` — spring-boot-maven-plugin 4.0.5 → 4.0.6

## Connected PRs
- optaplanner — https://github.com/apache/incubator-kie-optaplanner/pull/3232
- kogito-runtimes — https://github.com/apache/incubator-kie-kogito-runtimes/pull/4309
- kogito-examples - https://github.com/apache/incubator-kie-kogito-examples/pull/2215
