### PR TITLE
kie-issues#2356: BPMN Editor: Subprocess with an Error Start Event causes BPMN code generation to fail

### DIFF
--- a/packages/bpmn-editor/src/diagram/nodes/morphing/useEventNodeMorphingActions.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/morphing/useEventNodeMorphingActions.tsx
@@ -30,6 +30,10 @@ import { BPMN20__tProcess } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2
 import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 import { NODE_COLORS } from "../NodeSvgs";
 import { deleteEdge } from "../../../mutations/deleteEdge";
+import { addOrGetErrors } from "../../../mutations/addOrGetErrors";
+import { addOrGetSignals } from "../../../mutations/addOrGetSignals";
+import { addOrGetMessages } from "../../../mutations/addOrGetMessages";
+import { addOrGetEscalations } from "../../../mutations/addOrGetEscalations";
 import { setBpmn20Drools10MetaData } from "@kie-tools/bpmn-marshaller/dist/drools-extension-metaData";
 
 export type Event = Normalized<
@@ -112,15 +116,25 @@ export function useEventNodeMorphingActions(event: Event) {
                 };
                 break;
               case "errorEventDefinition":
+                const { errorRef } = addOrGetErrors({
+                  definitions: s.bpmn.model.definitions,
+                  errorName: "Error_" + generateUuid().substring(0, 8),
+                });
                 element.eventDefinition[0] = {
                   "@_id": generateUuid(),
                   __$$element: "errorEventDefinition",
+                  "@_errorRef": errorRef,
                 };
                 break;
               case "escalationEventDefinition":
+                const { escalationRef } = addOrGetEscalations({
+                  definitions: s.bpmn.model.definitions,
+                  escalationName: "Escalation_" + generateUuid().substring(0, 8),
+                });
                 element.eventDefinition[0] = {
                   "@_id": generateUuid(),
                   __$$element: "escalationEventDefinition",
+                  "@_escalationRef": escalationRef,
                 };
                 break;
               case "linkEventDefinition":
@@ -131,15 +145,25 @@ export function useEventNodeMorphingActions(event: Event) {
                 };
                 break;
               case "messageEventDefinition":
+                const { messageRef } = addOrGetMessages({
+                  definitions: s.bpmn.model.definitions,
+                  messageName: "Message_" + generateUuid().substring(0, 8),
+                });
                 element.eventDefinition[0] = {
                   "@_id": generateUuid(),
                   __$$element: "messageEventDefinition",
+                  "@_messageRef": messageRef,
                 };
                 break;
               case "signalEventDefinition":
+                const { signalRef } = addOrGetSignals({
+                  definitions: s.bpmn.model.definitions,
+                  signalName: "Signal_" + generateUuid().substring(0, 8),
+                });
                 element.eventDefinition[0] = {
                   "@_id": generateUuid(),
                   __$$element: "signalEventDefinition",
+                  "@_signalRef": signalRef,
                 };
                 // Add default extensionElements for intermediateThrowEvent and endEvent
                 if (element.__$$element === "intermediateThrowEvent" || element.__$$element === "endEvent") {
@@ -159,11 +183,8 @@ export function useEventNodeMorphingActions(event: Event) {
                 };
                 break;
             }
-            element.eventDefinition[0] = {
-              "@_id": generateUuid(),
-              __$$element: eventDefinitionElement as any,
-            };
-            return true; // Will continue visiting.
+
+            return false; // Will stop visiting.
           }
         });
 

--- a/packages/bpmn-editor/src/mutations/addEdge.ts
+++ b/packages/bpmn-editor/src/mutations/addEdge.ts
@@ -42,6 +42,28 @@ import { Unpacked } from "@kie-tools/xyflow-react-kie-diagram/dist/tsExt/tsExt";
 import { visitFlowElementsAndArtifacts } from "./_elementVisitor";
 import { ElementFilter } from "@kie-tools/xml-parser-ts/dist/elementFilter";
 
+type ElementOwner = Normalized<
+  | ElementFilter<Unpacked<NonNullable<BPMN20__tDefinitions["rootElement"]>>, "process">
+  | ElementFilter<
+      Unpacked<NonNullable<BPMN20__tProcess["flowElement"]>>,
+      "subProcess" | "adHocSubProcess" | "transaction"
+    >
+>;
+
+function findNodeContainer(definitions: Normalized<BPMN20__tDefinitions>, nodeId: string): ElementOwner {
+  const { process } = addOrGetProcessAndDiagramElements({ definitions });
+  let container: ElementOwner = process;
+
+  visitFlowElementsAndArtifacts(process, ({ element, owner }) => {
+    if (element["@_id"] === nodeId) {
+      container = owner;
+      return false; // Stop visiting
+    }
+  });
+
+  return container;
+}
+
 export function addEdge({
   definitions,
   __readonly_sourceNode,
@@ -87,14 +109,17 @@ export function addEdge({
   let newEdgeId = generateUuid();
 
   const { process, diagramElements } = addOrGetProcessAndDiagramElements({ definitions });
+  const parentContainer = findNodeContainer(definitions, __readonly_sourceNode.href);
 
   let existingEdgeId: string | undefined = undefined;
 
   // Associations (incl. Compensation Associations)
   if (__readonly_edge.type === EDGE_TYPES.association || __readonly_edge.type === EDGE_TYPES.compensationAssociation) {
-    const targetArtifacts = __readonly_parentArtifacts ?? process.artifact ?? [];
-    if (!process.artifact) {
-      process.artifact = targetArtifacts;
+    parentContainer.artifact ??= [];
+
+    const targetArtifacts = __readonly_parentArtifacts ?? parentContainer.artifact ?? [];
+    if (!parentContainer.artifact) {
+      parentContainer.artifact = targetArtifacts;
     }
 
     const newAssociation: Normalized<BPMN20__tAssociation> = {
@@ -121,9 +146,11 @@ export function addEdge({
 
   // Sequence Flows
   else {
-    const targetFlowElements = __readonly_parentFlowElements ?? process.flowElement ?? [];
-    if (!process.flowElement) {
-      process.flowElement = targetFlowElements;
+    parentContainer.flowElement ??= [];
+
+    const targetFlowElements = __readonly_parentFlowElements ?? parentContainer.flowElement ?? [];
+    if (!parentContainer.flowElement) {
+      parentContainer.flowElement = targetFlowElements;
     }
 
     const newSequenceFlow: Normalized<BPMN20__tSequenceFlow> = {
@@ -151,7 +178,7 @@ export function addEdge({
   }
 
   // <incoming> and <outgoing> elements of Flow Elements
-  visitFlowElementsAndArtifacts(process, ({ element }) => {
+  visitFlowElementsAndArtifacts(parentContainer, ({ element }) => {
     if (
       element.__$$element !== "association" &&
       element.__$$element !== "group" &&

--- a/packages/bpmn-editor/src/mutations/moveNodesOutOfSubProcess.ts
+++ b/packages/bpmn-editor/src/mutations/moveNodesOutOfSubProcess.ts
@@ -197,17 +197,31 @@ export function moveNodesOutOfSubProcess({
     }
   }
 
-  // BPMN 2.0 Spec: When moving Start Events from Event Sub-Process to top level,
-  // only convert event types that are NOT supported at top level
+  // BPMN 2.0 Spec: When moving Start Events out of an Event Sub-Process,
+  // only convert event types that are NOT supported by the target container.
+  // Event Sub-Processes allow: Message, Timer, Error, Escalation, Compensation, Conditional, Signal
   // Top-level allows: None, Message, Timer, Conditional, Signal
-  // Top-level does NOT allow: Error, Escalation, Compensation, Link, Terminate
+  // Regular embedded Sub-Processes allow: None only
   if (isEventSubProcess) {
+    const isTargetEventSubProcess =
+      targetSubProcess?.__$$element === "subProcess" && (targetSubProcess["@_triggeredByEvent"] ?? false);
+    const isMovingToTopLevel = __readonly_targetSubProcessId === null;
+
     for (const flowElement of flowElementsToMove) {
       if (
         flowElement.__$$element === "startEvent" &&
         flowElement.eventDefinition &&
         flowElement.eventDefinition.length > 0
       ) {
+        if (!isMovingToTopLevel && isTargetEventSubProcess) {
+          continue;
+        }
+
+        if (!isMovingToTopLevel && __readonly_targetSubProcessId && !isTargetEventSubProcess) {
+          flowElement.eventDefinition = undefined;
+          continue;
+        }
+
         const eventDefType = flowElement.eventDefinition[0].__$$element;
         const unsupportedAtTopLevel =
           eventDefType === "errorEventDefinition" ||
@@ -220,7 +234,6 @@ export function moveNodesOutOfSubProcess({
           // Convert to "None" Start Event because this event type is not allowed at top level
           flowElement.eventDefinition = undefined;
         }
-        // Otherwise keep the event definition (Message, Timer, Conditional, Signal are valid at top level)
       }
     }
   }

--- a/packages/bpmn-editor/tests-e2e/flowElements/addStartEvent.spec.ts
+++ b/packages/bpmn-editor/tests-e2e/flowElements/addStartEvent.spec.ts
@@ -151,6 +151,27 @@ test.describe("Add node - Start Event", () => {
         expect(subProcessStartEvent?.__$$element).toBe("startEvent");
         expect(subProcessStartEvent?.eventDefinition).toMatchObject([{ __$$element: eventDefinition }]);
       });
+
+      test(`should keep ${morphType} Start Event when moved within the same Event Sub-Process`, async ({
+        jsonModel,
+        nodes,
+      }) => {
+        const startEvent = nodes.getByType(NodeType.START_EVENT);
+        await nodes.morph({ node: startEvent, to: morphType });
+
+        const startEventId = await nodes.getIdByType(NodeType.START_EVENT);
+        await nodes.dragNodeToPosition({
+          id: startEventId,
+          fromPosition: NodePosition.CENTER,
+          toPosition: { x: 200, y: 320 },
+        });
+
+        const subProcesses = await jsonModel.getSubProcesses();
+        expect(subProcesses.length).toBe(1);
+        const subProcessStartEvent = (await jsonModel.getStartEvents(subProcesses[0].flowElement))[0];
+        expect(subProcessStartEvent?.__$$element).toBe("startEvent");
+        expect(subProcessStartEvent?.eventDefinition).toMatchObject([{ __$$element: eventDefinition }]);
+      });
     }
   });
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/2356

## Problem
Event Subprocess with Error Start Event fails with "Could not find source node for connection" error.

## Root Causes
1. **Missing Event References**: Event definitions (error, signal, message, escalation) lacked required reference attributes like `errorRef`, causing nodes to be invalid and not registered in the process model.
2. **Wrong Scope**: SequenceFlows were placed at process level instead of inside the subprocess, so runtime couldn't find the connected nodes.

## Fix
- Added proper event definition references in `useEventNodeMorphingActions.tsx`
- Implemented container detection in `addEdge.ts` to place flows in correct scope

## Testing
✅ Canvas tested - no errors
✅ BPMN XML validated - correct structure


