### PR TITLE
NO-ISSUE: Upgrading Quarkus from 3.27.4 to 3.27.4.1

### DIFF
--- a/packages/quarkus-bom/pom.xml
+++ b/packages/quarkus-bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Bill of Materials for KIE Tools Quarkus-based projects</description>
 
   <properties>
-    <version.quarkus>3.27.4</version.quarkus>
+    <version.quarkus>3.27.4.1</version.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,7 +69,7 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.27.4",
+      default: "3.27.4.1",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */


### PR DESCRIPTION

**Summary**

Upgrading Quarkus from 3.27.4 to 3.27.4.1 to address security vulnerability

**CVE Remediated:**

[HIGH] [CVE-2026-50559](https://github.com/quarkusio/quarkus/security/advisories/GHSA-qcxp-gm7m-4j5v)

**Related PR** 
incubator-kie-drools: https://github.com/apache/incubator-kie-drools/pull/6793
incubator-kie-optaplanner: https://github.com/apache/incubator-kie-optaplanner/pull/3236
incubator-kie-kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4328
incubator-kie-kogito-examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2222****