### PR TITLE
NO-ISSUE:Updating  undici to   ^6.27.0 to fix cve

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   minimatch@^10: 10.2.1
   minimatch@^5: 5.1.9
   minimatch@^4: 5.1.9
-  undici: 8.5.0
+  undici: ^6.27.0
   uuid: ^11.1.1
   picomatch@3: 3.0.2
   picomatch@4: 4.0.4
@@ -1270,7 +1270,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1324,13 +1324,13 @@ importers:
         version: 7.6.13(encoding@0.1.13)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -6694,7 +6694,7 @@ importers:
         version: 1.0.5
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -6926,7 +6926,7 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.107.1))(webpack@5.107.1)
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -7702,10 +7702,10 @@ importers:
         version: 7.4.6(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.5
-        version: 3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+        version: 3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: ^7.3.2
         version: 7.6.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7723,7 +7723,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+        version: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -22831,9 +22831,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -27887,14 +27887,14 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -27906,7 +27906,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
@@ -29864,10 +29864,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       '@babel/core': 7.28.3
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -29982,30 +29982,90 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      css-loader: 6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       es-module-lexer: 1.7.0
       express: 4.22.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      html-webpack-plugin: 5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.8.0
-      style-loader: 3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      style-loader: 3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
-      webpack-dev-middleware: 6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      webpack-dev-middleware: 6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      webpack-hot-middleware: 2.25.4
+      webpack-virtual-modules: 0.5.0
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@rspack/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - encoding
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
+  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@storybook/channels': 7.6.13
+      '@storybook/client-logger': 7.6.13
+      '@storybook/core-common': 7.6.13(encoding@0.1.13)
+      '@storybook/core-events': 7.6.13
+      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
+      '@storybook/node-logger': 7.6.13
+      '@storybook/preview': 7.6.13
+      '@storybook/preview-api': 7.6.13
+      '@swc/core': 1.3.92
+      '@types/node': 18.19.130
+      '@types/semver': 7.7.1
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1)
+      browser-assert: 1.2.1
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 1.2.3
+      constants-browserify: 1.0.0
+      css-loader: 6.7.1(webpack@5.107.1)
+      es-module-lexer: 1.7.0
+      express: 4.22.2
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1)
+      fs-extra: 11.2.0
+      html-webpack-plugin: 5.6.4(webpack@5.107.1)
+      magic-string: 0.30.17
+      path-browserify: 1.0.1
+      process: 0.11.10
+      semver: 7.8.0
+      style-loader: 3.3.3(webpack@5.107.1)
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1)
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
+      ts-dedent: 2.2.0
+      url: 0.11.3
+      util: 0.12.5
+      util-deprecate: 1.0.2
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack-dev-middleware: 6.1.1(webpack@5.107.1)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -30466,16 +30526,16 @@ snapshots:
 
   '@storybook/postinstall@7.4.6': {}
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)(webpack@5.107.1)
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1)
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -30486,7 +30546,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30534,6 +30594,53 @@ snapshots:
       react-refresh: 0.14.0
       semver: 7.8.0
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - '@types/webpack'
+      - clean-css
+      - cssnano
+      - csso
+      - encoding
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
+    dependencies:
+      '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
+      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
+      '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
+      '@storybook/node-logger': 7.6.13
+      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      '@types/node': 18.19.130
+      '@types/semver': 7.7.1
+      babel-plugin-add-react-displayname: 0.0.5
+      fs-extra: 11.2.0
+      magic-string: 0.30.17
+      react: 18.3.1
+      react-docgen: 7.0.3
+      react-dom: 18.3.1(react@18.3.1)
+      react-refresh: 0.14.0
+      semver: 7.8.0
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30643,7 +30750,7 @@ snapshots:
 
   '@storybook/preview@7.6.13': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -30653,7 +30760,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -30667,7 +30774,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -30681,10 +30788,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -30721,6 +30828,42 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@types/node': 18.19.130
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/helpers'
+      - '@swc/html'
+      - '@types/webpack'
+      - clean-css
+      - cssnano
+      - csso
+      - encoding
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - uglify-js
+      - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
+    dependencies:
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -31940,17 +32083,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -32858,12 +33001,12 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1):
     dependencies:
@@ -33977,7 +34120,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
 
   copy-webpack-plugin@13.0.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -34186,7 +34329,7 @@ snapshots:
       semver: 7.8.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  css-loader@6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  css-loader@6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34196,7 +34339,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   css-loader@6.7.1(webpack@5.107.1):
     dependencies:
@@ -34208,7 +34351,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   css-loader@7.1.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -35703,7 +35846,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   file-selector@0.4.0:
     dependencies:
@@ -35728,7 +35871,7 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   filename-reserved-regex@2.0.0: {}
 
@@ -35870,7 +36013,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -35885,7 +36028,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1):
     dependencies:
@@ -35902,7 +36045,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   form-data-encoder@4.0.2: {}
 
@@ -36423,16 +36566,6 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.3
-    optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
-
   html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(postcss@8.5.6)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36444,6 +36577,16 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)
     optional: true
 
+  html-webpack-plugin@5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.18.1
+      pretty-error: 4.0.0
+      tapable: 2.3.3
+    optionalDependencies:
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+
   html-webpack-plugin@5.6.4(webpack@5.107.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36452,7 +36595,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -38644,7 +38787,7 @@ snapshots:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   monaco-editor@0.39.0: {}
 
@@ -39184,7 +39327,7 @@ snapshots:
       mime: 3.0.0
       prettier: 2.8.8
       tiny-glob: 0.2.9
-      undici: 8.5.0
+      undici: 6.27.0
       yargs-parser: 21.1.1
 
   opener@1.5.2: {}
@@ -40109,7 +40252,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1
+      webpack: 5.107.1(webpack-cli@5.1.4)
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -41733,13 +41876,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  style-loader@3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  style-loader@3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   style-loader@3.3.3(webpack@5.107.1):
     dependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -41799,15 +41942,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   symbol-observable@1.2.0: {}
 
@@ -41936,13 +42079,25 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+    optionalDependencies:
+      '@swc/core': 1.3.92
+      esbuild: 0.18.20
+      postcss: 8.5.6
+
+  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.47.1
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.3.92
       esbuild: 0.18.20
@@ -42002,6 +42157,17 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.92
 
+  terser-webpack-plugin@5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.47.1
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+    optionalDependencies:
+      esbuild: 0.18.20
+      postcss: 8.5.6
+
   terser-webpack-plugin@5.6.0(postcss@8.5.6)(webpack@5.107.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -42018,7 +42184,7 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1
+      webpack: 5.107.1(webpack-cli@5.1.4)
 
   terser@5.43.1:
     dependencies:
@@ -42186,6 +42352,25 @@ snapshots:
   ts-invariant@0.4.4:
     dependencies:
       tslib: 1.14.1
+
+  ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.3)
+      esbuild: 0.18.20
 
   ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -42410,7 +42595,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@8.5.0: {}
+  undici@6.27.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -43004,7 +43189,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -43024,7 +43209,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -43046,7 +43231,7 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+  webpack-dev-middleware@6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -43054,7 +43239,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
 
   webpack-dev-middleware@6.1.1(webpack@5.107.1):
     dependencies:
@@ -43064,7 +43249,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -43114,7 +43299,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - tslib
 
@@ -43188,7 +43373,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.1)
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - bufferutil
@@ -43412,9 +43597,50 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.6
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
+      watchpack: 2.5.1
+      webpack-sources: 3.4.1
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -43535,7 +43761,46 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack@5.107.1)
+      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.6
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      watchpack: 2.5.1
+      webpack-sources: 3.4.1
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   minimatch@^10: 10.2.1
   minimatch@^5: 5.1.9
   minimatch@^4: 5.1.9
-  undici: ^6.24.0
+  undici: 8.5.0
   uuid: ^11.1.1
   picomatch@3: 3.0.2
   picomatch@4: 4.0.4
@@ -1270,7 +1270,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1324,13 +1324,13 @@ importers:
         version: 7.6.13(encoding@0.1.13)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -6694,7 +6694,7 @@ importers:
         version: 1.0.5
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -6926,7 +6926,7 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.107.1))(webpack@5.107.1)
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -7702,10 +7702,10 @@ importers:
         version: 7.4.6(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.5
-        version: 3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+        version: 3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: ^7.3.2
         version: 7.6.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7723,7 +7723,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -22831,9 +22831,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.24.0:
-    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
-    engines: {node: '>=18.17'}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -27887,14 +27887,14 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -27906,7 +27906,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
@@ -29864,10 +29864,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       '@babel/core': 7.28.3
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -29982,90 +29982,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      css-loader: 6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       es-module-lexer: 1.7.0
       express: 4.22.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      html-webpack-plugin: 5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.8.0
-      style-loader: 3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      style-loader: 3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
-      webpack-dev-middleware: 6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      webpack-hot-middleware: 2.25.4
-      webpack-virtual-modules: 0.5.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@rspack/core'
-      - '@swc/css'
-      - '@swc/helpers'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@storybook/channels': 7.6.13
-      '@storybook/client-logger': 7.6.13
-      '@storybook/core-common': 7.6.13(encoding@0.1.13)
-      '@storybook/core-events': 7.6.13
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/preview': 7.6.13
-      '@storybook/preview-api': 7.6.13
-      '@swc/core': 1.3.92
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1)
-      browser-assert: 1.2.1
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.2.3
-      constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.107.1)
-      es-module-lexer: 1.7.0
-      express: 4.22.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1)
-      fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.107.1)
-      magic-string: 0.30.17
-      path-browserify: 1.0.1
-      process: 0.11.10
-      semver: 7.8.0
-      style-loader: 3.3.3(webpack@5.107.1)
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
-      ts-dedent: 2.2.0
-      url: 0.11.3
-      util: 0.12.5
-      util-deprecate: 1.0.2
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 6.1.1(webpack@5.107.1)
+      webpack-dev-middleware: 6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -30526,16 +30466,16 @@ snapshots:
 
   '@storybook/postinstall@7.4.6': {}
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)(webpack@5.107.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -30546,7 +30486,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30594,53 +30534,6 @@ snapshots:
       react-refresh: 0.14.0
       semver: 7.8.0
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - '@types/webpack'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-plugin-add-react-displayname: 0.0.5
-      fs-extra: 11.2.0
-      magic-string: 0.30.17
-      react: 18.3.1
-      react-docgen: 7.0.3
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      semver: 7.8.0
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30750,7 +30643,7 @@ snapshots:
 
   '@storybook/preview@7.6.13': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -30760,7 +30653,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -30774,7 +30667,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -30788,10 +30681,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -30828,42 +30721,6 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@types/node': 18.19.130
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/helpers'
-      - '@swc/html'
-      - '@types/webpack'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -32083,17 +31940,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -33001,12 +32858,12 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1):
     dependencies:
@@ -34120,7 +33977,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   copy-webpack-plugin@13.0.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -34329,7 +34186,7 @@ snapshots:
       semver: 7.8.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  css-loader@6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  css-loader@6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34339,7 +34196,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   css-loader@6.7.1(webpack@5.107.1):
     dependencies:
@@ -34351,7 +34208,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   css-loader@7.1.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -35846,7 +35703,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
   file-selector@0.4.0:
     dependencies:
@@ -35871,7 +35728,7 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   filename-reserved-regex@2.0.0: {}
 
@@ -36013,7 +35870,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -36028,7 +35885,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1):
     dependencies:
@@ -36045,7 +35902,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   form-data-encoder@4.0.2: {}
 
@@ -36566,6 +36423,16 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.18.1
+      pretty-error: 4.0.0
+      tapable: 2.3.3
+    optionalDependencies:
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+
   html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(postcss@8.5.6)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36577,16 +36444,6 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)
     optional: true
 
-  html-webpack-plugin@5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.3
-    optionalDependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-
   html-webpack-plugin@5.6.4(webpack@5.107.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36595,7 +36452,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -38787,7 +38644,7 @@ snapshots:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   monaco-editor@0.39.0: {}
 
@@ -39327,7 +39184,7 @@ snapshots:
       mime: 3.0.0
       prettier: 2.8.8
       tiny-glob: 0.2.9
-      undici: 6.24.0
+      undici: 8.5.0
       yargs-parser: 21.1.1
 
   opener@1.5.2: {}
@@ -40252,7 +40109,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -41876,13 +41733,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  style-loader@3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  style-loader@3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   style-loader@3.3.3(webpack@5.107.1):
     dependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -41942,15 +41799,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   symbol-observable@1.2.0: {}
 
@@ -42079,25 +41936,13 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-      esbuild: 0.18.20
-      postcss: 8.5.6
-
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.47.1
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@swc/core': 1.3.92
       esbuild: 0.18.20
@@ -42157,17 +42002,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.92
 
-  terser-webpack-plugin@5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.47.1
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-    optionalDependencies:
-      esbuild: 0.18.20
-      postcss: 8.5.6
-
   terser-webpack-plugin@5.6.0(postcss@8.5.6)(webpack@5.107.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -42184,7 +42018,7 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1
 
   terser@5.43.1:
     dependencies:
@@ -42352,25 +42186,6 @@ snapshots:
   ts-invariant@0.4.4:
     dependencies:
       tslib: 1.14.1
-
-  ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      esbuild: 0.18.20
 
   ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -42595,7 +42410,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.24.0: {}
+  undici@8.5.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -43189,7 +43004,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -43209,7 +43024,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -43231,7 +43046,7 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  webpack-dev-middleware@6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -43239,7 +43054,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   webpack-dev-middleware@6.1.1(webpack@5.107.1):
     dependencies:
@@ -43249,7 +43064,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -43299,7 +43114,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - tslib
 
@@ -43373,7 +43188,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.1)
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - bufferutil
@@ -43597,50 +43412,9 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.6
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -43761,46 +43535,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.6
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
+      webpack-cli: 5.1.4(webpack@5.107.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,9 +26,9 @@ overrides:
   "minimatch@^10": "10.2.1"
   "minimatch@^5": "5.1.9"
   "minimatch@^4": "5.1.9"
-  # CVE-2026-12151, CVE-2026-9679, CVE-2026-11525, CVE-2026-6733 Fix security vulnerability in undici
-  # Transitive: @openapi-contrib/openapi-schema-to-json-schema -> openapi-typescript -> undici
-  "undici": "8.5.0"
+  # CVE-2026-1526, CVE-2026-2229, CVE-2026-1528, CVE-2026-1527, CVE-2026-1525, CVE-2026-2203, CVE-2026-12151, CVE-2026-9679, CVE-2026-11525, CVE-2026-6733: Fix security vulnerability in undici
+  # Waiting for @openapi-contrib/openapi-schema-to-json-schema to release patched version
+  "undici": "^6.27.0"
   # CVE-2026-41907: Fix security vulnerability in uuid
   # Transitive dependencies (node-notifier@8.0.2, jest-junit@16.0.0) still use uuid@8.3.2
   "uuid": "^11.1.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,9 +26,9 @@ overrides:
   "minimatch@^10": "10.2.1"
   "minimatch@^5": "5.1.9"
   "minimatch@^4": "5.1.9"
-  # CVE-2026-1526, CVE-2026-2229, CVE-2026-1528, CVE-2026-1527, CVE-2026-1525, CVE-2026-2203: Fix security vulnerability in undici
-  # Waiting for @openapi-contrib/openapi-schema-to-json-schema to release patched version
-  "undici": "^6.24.0"
+  # CVE-2026-12151, CVE-2026-9679, CVE-2026-11525, CVE-2026-6733 Fix security vulnerability in undici
+  # Transitive: @openapi-contrib/openapi-schema-to-json-schema -> openapi-typescript -> undici
+  "undici": "8.5.0"
   # CVE-2026-41907: Fix security vulnerability in uuid
   # Transitive dependencies (node-notifier@8.0.2, jest-junit@16.0.0) still use uuid@8.3.2
   "uuid": "^11.1.1"


### PR DESCRIPTION
**Summary**
Updating  undici to  ^6.27.0 to address security vulnerability

**CVEs Remediated:**

[High][ CVE-2026-12151](https://github.com/advisories/ghsa-vxpw-j846-p89q)
 [Medium] [CVE-2026-9679](https://github.com/advisories/GHSA-p88m-4jfj-68fv)
  [Low] [CVE-2026-11525](https://github.com/advisories/GHSA-g8m3-5g58-fq7m), [CVE-2026-6733 ](https://github.com/advisories/GHSA-35p6-xmwp-9g52)
  
  