### PR TITLE
NO-ISSUE: Upgrade js-yaml from 4.1.1 to ^4.2.0 to address security vulnerabilities.  updates transitive js-yaml 3.x dependencies to ^3.15.0.

### DIFF
--- a/packages/k8s-yaml-to-apiserver-requests/package.json
+++ b/packages/k8s-yaml-to-apiserver-requests/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "fast-json-patch": "^3.1.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "jsonpath-rfc9535": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -74,7 +74,7 @@
     "cross-env": "^7.0.3",
     "deep-object-diff": "^1.1.9",
     "isomorphic-git": "^1.30.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.18.1",
     "moment": "^2.29.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@apidevtools/json-schema-ref-parser>js-yaml': ^3.14.2
-  '@istanbuljs/load-nyc-config>js-yaml': ^3.14.2
+  '@apidevtools/json-schema-ref-parser>js-yaml': ^3.15.0
+  '@istanbuljs/load-nyc-config>js-yaml': ^3.15.0
   cross-spawn: ^7.0.6
   d3-color: 3.1.0
   graphql: 14.3.1
-  json-refs>js-yaml: ^3.14.2
+  json-refs>js-yaml: ^3.15.0
   minimatch@^3>brace-expansion: 1.1.13
   minimatch@^5>brace-expansion: ^2.0.3
   openapi-types: 7.2.3
@@ -18,7 +18,8 @@ overrides:
   path-to-regexp@^0: 0.1.13
   react-dropzone: ^11.4.2
   superagent: 10.2.2
-  xmlbuilder2>js-yaml: ^3.14.2
+  xmlbuilder2>js-yaml: ^3.15.0
+  js-yaml: ^4.2.0
   minimatch@^3: 3.1.5
   minimatch@^9: 9.0.8
   minimatch@^10: 10.2.1
@@ -1270,7 +1271,7 @@ importers:
         version: 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1324,13 +1325,13 @@ importers:
         version: 7.6.13(encoding@0.1.13)
       ts-jest:
         specifier: ^29.1.5
-        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -4852,8 +4853,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
       jsonpath-rfc9535:
         specifier: ^1.3.0
         version: 1.3.0
@@ -5685,8 +5686,8 @@ importers:
         specifier: ^1.30.1
         version: 1.30.1
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
       json-refs:
         specifier: ^3.0.15
         version: 3.0.15
@@ -6694,7 +6695,7 @@ importers:
         version: 1.0.5
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -6926,7 +6927,7 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@5.107.1))(webpack@5.107.1)
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+        version: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
@@ -7702,10 +7703,10 @@ importers:
         version: 7.4.6(@types/react-dom@18.3.7(@types/react@18.3.30))(@types/react@18.3.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.5
-        version: 3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+        version: 3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@storybook/react-webpack5':
         specifier: ^7.3.2
-        version: 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
+        version: 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/theming':
         specifier: ^7.3.2
         version: 7.6.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7723,7 +7724,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.107.1
-        version: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+        version: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
       webpack-merge:
         specifier: ^5.9.0
         version: 5.10.0
@@ -14492,10 +14493,6 @@ packages:
     resolution: {integrity: sha512-xoSqbd1iuV/dSID+OjTjQc/0wId/vhEqYBXbFu9SzpXGxhuzK6QN6CaF8i8v86q0FXX4n3/qD9ewUT6N5ngFQg==}
     engines: {node: '>=10.13'}
 
-  '@zkochan/js-yaml@0.0.6':
-    resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
-    hasBin: true
-
   '@zkochan/retry@0.2.0':
     resolution: {integrity: sha512-WhB+2B/ZPlW2Xy/kMJBrMbqecWXcbDDgn0K0wKBAgO2OlBTz1iLJrRWduo+DGGn0Akvz1Lu4Xvls7dJojximWw==}
     engines: {node: '>=10'}
@@ -18687,12 +18684,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -24169,13 +24166,13 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@13.0.5':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
 
   '@apidevtools/json-schema-ref-parser@9.0.6':
     dependencies:
       '@jsdevtools/ono': 7.1.3
       call-me-maybe: 1.0.2
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -26181,7 +26178,7 @@ snapshots:
       globals: 13.20.0
       ignore: 5.3.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -26600,7 +26597,7 @@ snapshots:
       http-proxy-agent: 6.1.1
       https-proxy-agent: 6.2.1
       jose: 4.14.6
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json-stable-stringify: 1.0.2
       lodash: 4.18.1
       scuid: 1.1.0
@@ -26865,7 +26862,7 @@ snapshots:
     dependencies:
       camelcase: 5.3.1
       find-up: 4.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -27887,14 +27884,14 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
       webpack-hot-middleware: 2.25.4
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -27906,7 +27903,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@types/webpack': 4.41.39
       type-fest: 4.41.0
@@ -28300,7 +28297,7 @@ snapshots:
       '@pnpm/types': 8.5.0
       '@zkochan/rimraf': 2.1.2
       comver-to-semver: 1.0.0
-      js-yaml: '@zkochan/js-yaml@0.0.6'
+      js-yaml: 4.3.0
       normalize-path: 3.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.8.0
@@ -29099,7 +29096,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
 
   '@readme/openapi-parser@2.5.0(openapi-types@7.2.3)':
     dependencies:
@@ -29864,10 +29861,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.5(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       '@babel/core': 7.28.3
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -29982,90 +29979,30 @@ snapshots:
       '@swc/core': 1.3.92
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
       constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      css-loader: 6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       es-module-lexer: 1.7.0
       express: 4.22.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      html-webpack-plugin: 5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       magic-string: 0.30.17
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.8.0
-      style-loader: 3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      style-loader: 3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
-      webpack-dev-middleware: 6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      webpack-hot-middleware: 2.25.4
-      webpack-virtual-modules: 0.5.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@rspack/core'
-      - '@swc/css'
-      - '@swc/helpers'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/builder-webpack5@7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@storybook/channels': 7.6.13
-      '@storybook/client-logger': 7.6.13
-      '@storybook/core-common': 7.6.13(encoding@0.1.13)
-      '@storybook/core-events': 7.6.13
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/preview': 7.6.13
-      '@storybook/preview-api': 7.6.13
-      '@swc/core': 1.3.92
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.3)(webpack@5.107.1)
-      browser-assert: 1.2.1
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.2.3
-      constants-browserify: 1.0.0
-      css-loader: 6.7.1(webpack@5.107.1)
-      es-module-lexer: 1.7.0
-      express: 4.22.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.107.1)
-      fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.4(webpack@5.107.1)
-      magic-string: 0.30.17
-      path-browserify: 1.0.1
-      process: 0.11.10
-      semver: 7.8.0
-      style-loader: 3.3.3(webpack@5.107.1)
-      swc-loader: 0.2.3(@swc/core@1.3.92)(webpack@5.107.1)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
-      ts-dedent: 2.2.0
-      url: 0.11.3
-      util: 0.12.5
-      util-deprecate: 1.0.2
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 6.1.1(webpack@5.107.1)
+      webpack-dev-middleware: 6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -30526,16 +30463,16 @@ snapshots:
 
   '@storybook/postinstall@7.4.6': {}
 
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
+  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
       '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
       '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)(webpack@5.107.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
       '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
       '@storybook/node-logger': 7.6.13
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       '@types/node': 18.19.130
       '@types/semver': 7.7.1
       babel-plugin-add-react-displayname: 0.0.5
@@ -30546,7 +30483,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30594,53 +30531,6 @@ snapshots:
       react-refresh: 0.14.0
       semver: 7.8.0
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - '@types/webpack'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/preset-react-webpack@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@babel/preset-flow': 7.22.15(@babel/core@7.28.3)
-      '@babel/preset-react': 7.22.15(@babel/core@7.28.3)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(@types/webpack@4.41.39)(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.25.4)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      '@storybook/core-webpack': 7.6.13(encoding@0.1.13)
-      '@storybook/docs-tools': 7.6.13(encoding@0.1.13)
-      '@storybook/node-logger': 7.6.13
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      '@types/node': 18.19.130
-      '@types/semver': 7.7.1
-      babel-plugin-add-react-displayname: 0.0.5
-      fs-extra: 11.2.0
-      magic-string: 0.30.17
-      react: 18.3.1
-      react-docgen: 7.0.3
-      react-dom: 18.3.1(react@18.3.1)
-      react-refresh: 0.14.0
-      semver: 7.8.0
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@babel/core': 7.28.3
       typescript: 5.9.3
@@ -30750,7 +30640,7 @@ snapshots:
 
   '@storybook/preview@7.6.13': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -30760,7 +30650,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -30774,7 +30664,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -30788,10 +30678,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)':
+  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
     dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
+      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -30828,42 +30718,6 @@ snapshots:
     dependencies:
       '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(postcss@8.5.6)(typescript@5.9.3)(webpack-cli@5.1.4)
       '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@swc/core@1.3.92)(@types/webpack@4.41.39)(encoding@0.1.13)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack-hot-middleware@2.25.4)
-      '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@types/node': 18.19.130
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/helpers'
-      - '@swc/html'
-      - '@types/webpack'
-      - clean-css
-      - cssnano
-      - csso
-      - encoding
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/react-webpack5@7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)':
-    dependencies:
-      '@storybook/builder-webpack5': 7.6.13(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 7.6.13(@babel/core@7.28.3)(@types/webpack@4.41.39)(encoding@0.1.13)(esbuild@0.18.20)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.25.4)
       '@storybook/react': 7.6.13(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@types/node': 18.19.130
       react: 18.3.1
@@ -31156,7 +31010,7 @@ snapshots:
       '@textlint/types': 15.5.1
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -32083,17 +31937,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.5)(webpack@5.107.1)':
     dependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -32309,12 +32163,12 @@ snapshots:
 
   '@yarnpkg/parsers@2.5.1':
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.3.0
       tslib: 1.14.1
 
   '@yarnpkg/parsers@3.0.3':
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.3.0
       tslib: 2.8.1
 
   '@yarnpkg/pnp@2.3.2':
@@ -32375,10 +32229,6 @@ snapshots:
     dependencies:
       cmd-extension: 1.0.2
       is-windows: 1.0.2
-
-  '@zkochan/js-yaml@0.0.6':
-    dependencies:
-      argparse: 2.0.1
 
   '@zkochan/retry@0.2.0': {}
 
@@ -33001,12 +32851,12 @@ snapshots:
       find-up: 5.0.0
       webpack: 5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)
 
-  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/core': 7.28.3
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   babel-loader@9.2.1(@babel/core@7.28.3)(webpack@5.107.1):
     dependencies:
@@ -34120,7 +33970,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   copy-webpack-plugin@13.0.1(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -34186,7 +34036,7 @@ snapshots:
   cosmiconfig@8.0.0:
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
 
@@ -34194,7 +34044,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -34329,7 +34179,7 @@ snapshots:
       semver: 7.8.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  css-loader@6.7.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  css-loader@6.7.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -34339,7 +34189,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   css-loader@6.7.1(webpack@5.107.1):
     dependencies:
@@ -34351,7 +34201,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.8.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   css-loader@7.1.2(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -35465,7 +35315,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -35846,7 +35696,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
   file-selector@0.4.0:
     dependencies:
@@ -35871,7 +35721,7 @@ snapshots:
       is-glob: 4.0.3
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   filename-reserved-regex@2.0.0: {}
 
@@ -36013,7 +35863,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -36028,7 +35878,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.107.1):
     dependencies:
@@ -36045,7 +35895,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   form-data-encoder@4.0.2: {}
 
@@ -36566,6 +36416,16 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.18.1
+      pretty-error: 4.0.0
+      tapable: 2.3.3
+    optionalDependencies:
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
+
   html-webpack-plugin@5.6.4(webpack@5.107.1(@swc/core@1.3.92)(postcss@8.5.6)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36577,16 +36437,6 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)
     optional: true
 
-  html-webpack-plugin@5.6.4(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.18.1
-      pretty-error: 4.0.0
-      tapable: 2.3.3
-    optionalDependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-
   html-webpack-plugin@5.6.4(webpack@5.107.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -36595,7 +36445,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
 
   htmlparser2@10.1.0:
     dependencies:
@@ -37663,12 +37513,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -37784,7 +37634,7 @@ snapshots:
     dependencies:
       commander: 4.1.1
       graphlib: 2.1.8
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       lodash: 4.18.1
       native-promise-only: 0.8.1
       path-loader: 1.0.12
@@ -38768,7 +38618,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
@@ -38787,7 +38637,7 @@ snapshots:
       loader-utils: 2.0.4
       monaco-editor: 0.39.0
       monaco-yaml: 4.0.4(monaco-editor@0.39.0)
-      webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   monaco-editor@0.39.0: {}
 
@@ -39323,7 +39173,7 @@ snapshots:
 
   openapi-typescript@5.4.2:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       mime: 3.0.0
       prettier: 2.8.8
       tiny-glob: 0.2.9
@@ -40252,12 +40102,12 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1
 
   rc-config-loader@4.1.3:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -40710,7 +40560,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       strip-bom: 4.0.0
 
   read@1.0.7:
@@ -41876,13 +41726,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
 
-  style-loader@3.3.3(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  style-loader@3.3.3(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   style-loader@3.3.3(webpack@5.107.1):
     dependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -41942,15 +41792,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   swc-loader@0.2.3(@swc/core@1.3.92)(webpack@5.107.1):
     dependencies:
       '@swc/core': 1.3.92
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   symbol-observable@1.2.0: {}
 
@@ -42079,25 +41929,13 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-    optionalDependencies:
-      '@swc/core': 1.3.92
-      esbuild: 0.18.20
-      postcss: 8.5.6
-
-  terser-webpack-plugin@5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.47.1
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
     optionalDependencies:
       '@swc/core': 1.3.92
       esbuild: 0.18.20
@@ -42157,17 +41995,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.92
 
-  terser-webpack-plugin@5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.47.1
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
-    optionalDependencies:
-      esbuild: 0.18.20
-      postcss: 8.5.6
-
   terser-webpack-plugin@5.6.0(postcss@8.5.6)(webpack@5.107.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -42184,7 +42011,7 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1
 
   terser@5.43.1:
     dependencies:
@@ -42352,25 +42179,6 @@ snapshots:
   ts-invariant@0.4.4:
     dependencies:
       tslib: 1.14.1
-
-  ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.18.20)(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      esbuild: 0.18.20
 
   ts-jest@29.1.5(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest@29.7.0(@types/node@24.12.4)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.3.92)(@types/node@24.12.4)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -43073,7 +42881,7 @@ snapshots:
       glob: 11.0.1
       got: 14.4.5
       hpagent: 1.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       mocha: 10.6.0
       sanitize-filename: 1.6.3
       selenium-webdriver: 4.27.0
@@ -43189,7 +42997,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -43209,7 +43017,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.1)
@@ -43231,7 +43039,7 @@ snapshots:
       webpack: 5.107.1(@swc/core@1.3.92)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@6.1.1(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6)):
+  webpack-dev-middleware@6.1.1(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.1
@@ -43239,7 +43047,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(esbuild@0.18.20)(postcss@8.5.6)
+      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)
 
   webpack-dev-middleware@6.1.1(webpack@5.107.1):
     dependencies:
@@ -43249,7 +43057,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4)
+      webpack: 5.107.1(@swc/core@1.3.92)(postcss@8.5.6)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.2(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.3.92)(esbuild@0.25.9)(postcss@8.5.6)):
     dependencies:
@@ -43299,7 +43107,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - tslib
 
@@ -43373,7 +43181,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.1)
       ws: 8.20.1
     optionalDependencies:
-      webpack: 5.107.1(webpack-cli@5.1.4)
+      webpack: 5.107.1(postcss@8.5.6)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - bufferutil
@@ -43597,50 +43405,9 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.107.1(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.6
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.3.92)(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1)
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -43761,46 +43528,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-dev-server@5.2.5)(webpack@5.107.1)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.6
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.18.20)(postcss@8.5.6)(webpack@5.107.1(esbuild@0.18.20)(postcss@8.5.6))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.1
+      webpack-cli: 5.1.4(webpack@5.107.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -44044,7 +43772,7 @@ snapshots:
 
   write-yaml-file@4.2.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       write-file-atomic: 3.0.3
 
   ws@6.2.2:
@@ -44084,7 +43812,7 @@ snapshots:
       '@oozcitak/infra': 1.0.8
       '@oozcitak/util': 8.3.8
       '@types/node': 24.12.4
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
 
   xmlbuilder@11.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   react-dropzone: ^11.4.2
   superagent: 10.2.2
   xmlbuilder2>js-yaml: ^3.15.0
-  js-yaml: ^4.2.0
+  js-yaml@^4: ^4.2.0
   minimatch@^3: 3.1.5
   minimatch@^9: 9.0.8
   minimatch@^10: 10.2.1
@@ -14493,6 +14493,10 @@ packages:
     resolution: {integrity: sha512-xoSqbd1iuV/dSID+OjTjQc/0wId/vhEqYBXbFu9SzpXGxhuzK6QN6CaF8i8v86q0FXX4n3/qD9ewUT6N5ngFQg==}
     engines: {node: '>=10.13'}
 
+  '@zkochan/js-yaml@0.0.6':
+    resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
+    hasBin: true
+
   '@zkochan/retry@0.2.0':
     resolution: {integrity: sha512-WhB+2B/ZPlW2Xy/kMJBrMbqecWXcbDDgn0K0wKBAgO2OlBTz1iLJrRWduo+DGGn0Akvz1Lu4Xvls7dJojximWw==}
     engines: {node: '>=10'}
@@ -28297,7 +28301,7 @@ snapshots:
       '@pnpm/types': 8.5.0
       '@zkochan/rimraf': 2.1.2
       comver-to-semver: 1.0.0
-      js-yaml: 4.3.0
+      js-yaml: '@zkochan/js-yaml@0.0.6'
       normalize-path: 3.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.8.0
@@ -32163,12 +32167,12 @@ snapshots:
 
   '@yarnpkg/parsers@2.5.1':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 3.15.0
       tslib: 1.14.1
 
   '@yarnpkg/parsers@3.0.3':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 3.15.0
       tslib: 2.8.1
 
   '@yarnpkg/pnp@2.3.2':
@@ -32229,6 +32233,10 @@ snapshots:
     dependencies:
       cmd-extension: 1.0.2
       is-windows: 1.0.2
+
+  '@zkochan/js-yaml@0.0.6':
+    dependencies:
+      argparse: 2.0.1
 
   '@zkochan/retry@0.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,13 @@ packages:
   - "examples/*"
   - "scripts/*"
 overrides:
-  "@apidevtools/json-schema-ref-parser>js-yaml": "^3.14.2"
-  "@istanbuljs/load-nyc-config>js-yaml": "^3.14.2"
+  # GHSA-h67p-54hq-rp68: js-yaml 3.x prototype-pollution/ReDoS — upgrade transitive consumers to patched 3.15.0
+  "@apidevtools/json-schema-ref-parser>js-yaml": "^3.15.0"
+  "@istanbuljs/load-nyc-config>js-yaml": "^3.15.0"
   "cross-spawn": "^7.0.6"
   "d3-color": "3.1.0"
   "graphql": "14.3.1"
-  "json-refs>js-yaml": "^3.14.2"
+  "json-refs>js-yaml": "^3.15.0"
   # CVE-2026-33750: Fix security vulnerability in brace-expansion
   # Overriding transitive dependency until minimatch updates to patched brace-expansion version
   "minimatch@^3>brace-expansion": "1.1.13"
@@ -20,7 +21,10 @@ overrides:
   "path-to-regexp@^0": "0.1.13"
   "react-dropzone": "^11.4.2"
   "superagent": "10.2.2"
-  "xmlbuilder2>js-yaml": "^3.14.2"
+  "xmlbuilder2>js-yaml": "^3.15.0"
+  # GHSA-h67p-54hq-rp68: Fix ReDoS / prototype-pollution vulnerability in js-yaml
+  # Upgrade all consumers of js-yaml@^4 to the patched 4.2.0 release
+  "js-yaml": "^4.2.0"
   "minimatch@^3": "3.1.5"
   "minimatch@^9": "9.0.8"
   "minimatch@^10": "10.2.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ overrides:
   "xmlbuilder2>js-yaml": "^3.15.0"
   # GHSA-h67p-54hq-rp68: Fix ReDoS / prototype-pollution vulnerability in js-yaml
   # Upgrade all consumers of js-yaml@^4 to the patched 4.2.0 release
-  "js-yaml": "^4.2.0"
+  "js-yaml@^4": "^4.2.0"
   "minimatch@^3": "3.1.5"
   "minimatch@^9": "9.0.8"
   "minimatch@^10": "10.2.1"


### PR DESCRIPTION
**Summary**
Upgrade js-yaml from 4.1.1 to ^4.2.0 to address security vulnerabilities.  updates transitive js-yaml 3.x dependencies to ^3.15.0.

CVEs Remediated:

[High],[Medium] CVE-2026-53550
