### PR TITLE
kie-issue#3636: Build is failing for vscode-java-code-completion-extension-plugin 

### DIFF
--- a/packages/vscode-java-code-completion-extension-plugin/pom.xml
+++ b/packages/vscode-java-code-completion-extension-plugin/pom.xml
@@ -59,12 +59,11 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
   </properties>
-  <!--TODO : Added workaround for jdtls 1.43.0 and it needs to be modified once eclipse fixes the issue -->
   <repositories>
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://kubesmarts.github.io/jdtls-repository-custom/1.43.0</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.43.0/repository</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Original Repo is back, so I restored the previous repo's  link.