### PR TITLE
kie-tools#3845: [BPMN Editor] Re-anchor connections to the facing border side when moving nodes

### DIFF
--- a/packages/bpmn-editor/src/mutations/repositionNode.ts
+++ b/packages/bpmn-editor/src/mutations/repositionNode.ts
@@ -20,9 +20,26 @@
 import { switchExpression } from "@kie-tools-core/switch-expression-ts";
 import { BPMN20__tDefinitions, BPMNDI__BPMNEdge } from "@kie-tools/bpmn-marshaller/dist/schemas/bpmn-2_0/ts-gen/types";
 import { DC__Shape } from "@kie-tools/xyflow-react-kie-diagram/dist/maths/model";
+import {
+  Bounds,
+  getBoundsCenterPoint,
+  getPositionalHandlePosition,
+} from "@kie-tools/xyflow-react-kie-diagram/dist/maths/Maths";
 import { BpmnNodeType } from "../diagram/BpmnDiagramDomain";
 import { Normalized } from "../normalization/normalize";
 import { addOrGetProcessAndDiagramElements } from "./addOrGetProcessAndDiagramElements";
+
+function getShapeBoundsById(diagramElements: { "@_id"?: string }[], shapeId: string | undefined): Bounds | undefined {
+  if (!shapeId) {
+    return undefined;
+  }
+  const bounds = (diagramElements.find((e) => e["@_id"] === shapeId) as Normalized<DC__Shape> | undefined)?.[
+    "dc:Bounds"
+  ];
+  return bounds
+    ? { x: bounds["@_x"], y: bounds["@_y"], width: bounds["@_width"], height: bounds["@_height"] }
+    : undefined;
+}
 
 export function repositionNode({
   definitions,
@@ -76,6 +93,19 @@ export function repositionNode({
     throw new Error(`BPMN MUTATION: Unknown type of node position change '${(__readonly_change as any).type}'.`);
   }
 
+  const movedNodeBoundsNew: Bounds = {
+    x: shapeBounds["@_x"],
+    y: shapeBounds["@_y"],
+    width: shapeBounds["@_width"],
+    height: shapeBounds["@_height"],
+  };
+  const movedNodeBoundsOld: Bounds = {
+    ...movedNodeBoundsNew,
+    x: (movedNodeBoundsNew.x ?? 0) - deltaX,
+    y: (movedNodeBoundsNew.y ?? 0) - deltaY,
+  };
+  const movedNodeCenterNew = getBoundsCenterPoint(movedNodeBoundsNew);
+
   const offsetEdges = (args: { edgeIndexes: number[]; waypoint: "last" | "first" }) => {
     for (const edgeIndex of args.edgeIndexes) {
       const edge = diagramElements[edgeIndex] as Normalized<BPMNDI__BPMNEdge> | undefined;
@@ -84,6 +114,21 @@ export function repositionNode({
       }
 
       const isEdgeSelected = __readonly_change.selectedEdges.indexOf(edge["@_bpmnElement"]!) >= 0;
+
+      const endpointIndex = args.waypoint === "first" ? 0 : edge["di:waypoint"].length - 1;
+
+      // Reset the anchor to auto (node center) only when the node crossed into a different zone
+      // relative to the connected node. Same side/zone -> keep the (possibly pinned) anchor.
+      const otherNodeBounds = getShapeBoundsById(
+        diagramElements,
+        args.waypoint === "first" ? edge["@_targetElement"] : edge["@_sourceElement"]
+      );
+      let shouldResetEndpointToAuto = false;
+      if (otherNodeBounds) {
+        const [, , zoneBefore] = getPositionalHandlePosition(movedNodeBoundsOld, otherNodeBounds, undefined);
+        const [, , zoneAfter] = getPositionalHandlePosition(movedNodeBoundsNew, otherNodeBounds, undefined);
+        shouldResetEndpointToAuto = zoneBefore !== zoneAfter;
+      }
 
       const waypointIndexes = switchExpression(args.waypoint, {
         first: isEdgeSelected
@@ -104,8 +149,13 @@ export function repositionNode({
         }
 
         const w = edge["di:waypoint"][wi];
-        w["@_x"] += deltaX;
-        w["@_y"] += deltaY;
+        if (wi === endpointIndex && shouldResetEndpointToAuto) {
+          w["@_x"] = movedNodeCenterNew["@_x"];
+          w["@_y"] = movedNodeCenterNew["@_y"];
+        } else {
+          w["@_x"] += deltaX;
+          w["@_y"] += deltaY;
+        }
       }
     }
   };

--- a/packages/bpmn-editor/stories/misc/connectionReanchor/ConnectionReanchor.stories.tsx
+++ b/packages/bpmn-editor/stories/misc/connectionReanchor/ConnectionReanchor.stories.tsx
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { getMarshaller } from "@kie-tools/bpmn-marshaller";
+import { BpmnEditorWrapper, StorybookBpmnEditorProps } from "../../bpmnEditorStoriesWrapper";
+import { BpmnEditor, BpmnEditorProps } from "../../../src/BpmnEditor";
+
+// Start -> First Function -> Second Function -> End. First Function's incoming flow is pinned to its
+// left border and its outgoing flow to its right border (see the waypoints below).
+const startToEndProcess = `<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  targetNamespace="https://kie.apache.org/bpmn/connection-reanchor"
+  id="connection-reanchor-definitions">
+  <process id="connection_reanchor_process" name="Connection Reanchor" isExecutable="true">
+    <startEvent id="StartEvent_1" name="Start" />
+    <task id="Task_1" name="First Function" />
+    <task id="Task_2" name="Second Function" />
+    <endEvent id="EndEvent_1" name="End" />
+    <sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="Task_2" />
+    <sequenceFlow id="Flow_3" sourceRef="Task_2" targetRef="EndEvent_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="connection_reanchor_process">
+      <bpmndi:BPMNShape id="Shape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="100" y="200" width="56" height="56" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Task_1" bpmnElement="Task_1">
+        <dc:Bounds x="240" y="188" width="160" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Task_2" bpmnElement="Task_2">
+        <dc:Bounds x="480" y="188" width="160" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds x="720" y="200" width="56" height="56" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_Flow_1" bpmnElement="Flow_1" sourceElement="Shape_StartEvent_1" targetElement="Shape_Task_1">
+        <di:waypoint x="128" y="228" />
+        <di:waypoint x="240" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_Flow_2" bpmnElement="Flow_2" sourceElement="Shape_Task_1" targetElement="Shape_Task_2">
+        <di:waypoint x="400" y="228" />
+        <di:waypoint x="480" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_Flow_3" bpmnElement="Flow_3" sourceElement="Shape_Task_2" targetElement="Shape_EndEvent_1">
+        <di:waypoint x="640" y="228" />
+        <di:waypoint x="720" y="228" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>`;
+
+const meta: Meta<BpmnEditorProps> = {
+  title: "Misc/Connection Reanchor",
+  component: BpmnEditor,
+  includeStories: /^[A-Z]/,
+};
+
+export default meta;
+type Story = StoryObj<StorybookBpmnEditorProps>;
+
+const marshaller = getMarshaller(startToEndProcess, { upgradeTo: "latest" });
+const model = marshaller.parser.parse();
+
+export const StartToEnd: Story = {
+  render: (args) => BpmnEditorWrapper(),
+  args: {
+    model: model,
+    originalVersion: "2.0",
+    externalContextDescription: "The Storybook for the BPMN Editor",
+    externalContextName: "Apache KIE :: BPMN Editor :: Storybook",
+    issueTrackerHref: "",
+    xml: marshaller.builder.build(model),
+  },
+};

--- a/packages/bpmn-editor/tests-e2e/flowElements/connectionReanchorOnNodeMove.spec.ts
+++ b/packages/bpmn-editor/tests-e2e/flowElements/connectionReanchorOnNodeMove.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect } from "../__fixtures__/base";
+import { JsonModel } from "../__fixtures__/jsonModel";
+import { NodeType } from "../__fixtures__/nodes";
+
+// 0 = node's left border, 0.5 = centre (auto-anchored), 1 = right border.
+async function getEndpointRelativeX(args: {
+  jsonModel: JsonModel;
+  nodeId: string;
+  direction: "incoming" | "outgoing";
+}): Promise<number> {
+  const flows = await args.jsonModel.getSequenceFlows();
+  const flow =
+    args.direction === "incoming"
+      ? flows.find((f) => f["@_targetRef"] === args.nodeId)
+      : flows.find((f) => f["@_sourceRef"] === args.nodeId);
+  expect(flow).toBeTruthy();
+
+  const elements = (await args.jsonModel.getPlane())?.["di:DiagramElement"] ?? [];
+  const shape = elements.find(
+    (e: any) => e.__$$element === "bpmndi:BPMNShape" && e["@_bpmnElement"] === args.nodeId
+  ) as any;
+  const edge = elements.find(
+    (e: any) => e.__$$element === "bpmndi:BPMNEdge" && e["@_bpmnElement"] === flow!["@_id"]
+  ) as any;
+
+  const bounds = shape["dc:Bounds"];
+  const waypoints = edge["di:waypoint"];
+  const endpoint = args.direction === "incoming" ? waypoints[waypoints.length - 1] : waypoints[0];
+
+  return (endpoint["@_x"] - bounds["@_x"]) / bounds["@_width"];
+}
+
+test.beforeEach(async ({ page, baseURL }) => {
+  await page.goto(`${baseURL}/iframe.html?args=&id=misc-connection-reanchor--start-to-end&viewMode=story`);
+  await expect(page.getByTestId("kie-bpmn-editor--diagram-container")).toBeVisible();
+});
+
+test.describe("Connection - re-anchor on node move", () => {
+  test("should re-optimise both incoming and outgoing connections when the task crosses into a different zone", async ({
+    nodes,
+    jsonModel,
+  }) => {
+    const taskId = await nodes.getId({ name: "First Function" });
+
+    // Nudge within the same zones - pinned anchors are kept (also commits a change so the model reads).
+    const box = await nodes.getNodeBounds({ name: "First Function" });
+    await nodes.dragNodeToPosition({
+      name: "First Function",
+      toPosition: { x: box.x + box.width / 2 + 40, y: box.y + box.height / 2 },
+    });
+    expect(await getEndpointRelativeX({ jsonModel, nodeId: taskId, direction: "incoming" })).toBeLessThan(0.2);
+    expect(await getEndpointRelativeX({ jsonModel, nodeId: taskId, direction: "outgoing" })).toBeGreaterThan(0.8);
+
+    // Move it below both neighbours - both endpoints cross into a new zone and reset to auto.
+    const startId = await nodes.getIdByType(NodeType.START_EVENT);
+    const startBox = await nodes.getNodeBounds({ id: startId });
+    await nodes.dragNodeToPosition({
+      name: "First Function",
+      toPosition: { x: startBox.x + startBox.width / 2, y: startBox.y + startBox.height + 350 },
+    });
+
+    const incomingAfter = await getEndpointRelativeX({ jsonModel, nodeId: taskId, direction: "incoming" });
+    expect(incomingAfter).toBeGreaterThan(0.35);
+    expect(incomingAfter).toBeLessThan(0.65);
+
+    const outgoingAfter = await getEndpointRelativeX({ jsonModel, nodeId: taskId, direction: "outgoing" });
+    expect(outgoingAfter).toBeGreaterThan(0.35);
+    expect(outgoingAfter).toBeLessThan(0.65);
+  });
+});

--- a/packages/xyflow-react-kie-diagram/src/edges/getSnappedMultiPointAnchoredEdgePath.tsx
+++ b/packages/xyflow-react-kie-diagram/src/edges/getSnappedMultiPointAnchoredEdgePath.tsx
@@ -21,7 +21,7 @@ import { switchExpression } from "@kie-tools-core/switch-expression-ts";
 import { DC__Point, DC__Shape } from "../maths/model";
 import { SnapGrid, snapPoint } from "../snapgrid/SnapGrid";
 import { PositionalNodeHandleId } from "../nodes/PositionalNodeHandles";
-import { getHandlePosition, getLineRectangleIntersectionPoint, pointsToPath } from "../maths/DcMaths";
+import { getBorderMidpointTowards, getHandlePosition, pointsToPath } from "../maths/DcMaths";
 import { Bounds, getBoundsCenterPoint, getDiscretelyAutoPositionedEdgeParams } from "../maths/Maths";
 import { AutoPositionedEdgeMarker } from "./AutoPositionedEdgeMarker";
 
@@ -142,7 +142,6 @@ export function getSnappedHandlePosition(
   snappedSecondWaypoint: DC__Point,
   handlePosition: PositionalNodeHandleId
 ): DC__Point {
-  const centerHandleWaypoint = getBoundsCenterPoint(snappedNode);
   const nodeRectangle = {
     x: snappedNode.x ?? 0,
     y: snappedNode.y ?? 0,
@@ -161,10 +160,7 @@ export function getSnappedHandlePosition(
       "@_y": nodeRectangle.y + nodeRectangle.height,
     },
     [PositionalNodeHandleId.Left]: { "@_x": nodeRectangle.x, "@_y": nodeRectangle.y + nodeRectangle.height / 2 },
-    [PositionalNodeHandleId.Center]: getLineRectangleIntersectionPoint(
-      snappedSecondWaypoint,
-      centerHandleWaypoint,
-      nodeRectangle
-    ),
+    // Auto-anchored end: attach to the border midpoint facing the connected node.
+    [PositionalNodeHandleId.Center]: getBorderMidpointTowards(nodeRectangle, snappedSecondWaypoint),
   });
 }

--- a/packages/xyflow-react-kie-diagram/src/maths/DcMaths.ts
+++ b/packages/xyflow-react-kie-diagram/src/maths/DcMaths.ts
@@ -21,7 +21,7 @@ import { SnapGrid } from "../snapgrid/SnapGrid";
 import { snapBoundsDimensions, snapBoundsPosition } from "../snapgrid/SnapGrid";
 import { PositionalNodeHandleId } from "../nodes/PositionalNodeHandles";
 import { AutoPositionedEdgeMarker } from "../edges/AutoPositionedEdgeMarker";
-import { getCenter } from "./Maths";
+import { Bounds, getCenter, getPositionalHandlePosition } from "./Maths";
 import { DC__Point, DC__Bounds, DC__Dimension } from "./model";
 
 export const DEFAULT_INTRACTION_WIDTH = 40;
@@ -56,6 +56,12 @@ export function getPointForHandle({
   } else {
     throw new Error(`Invalid target handle id '${handle}'.`);
   }
+}
+
+/** Midpoint of `node`'s border on the side facing `towards`, by the same dominant-axis rule as auto-positioned edges. */
+export function getBorderMidpointTowards(node: Bounds, towards: DC__Point): DC__Point {
+  const [x, y] = getPositionalHandlePosition(node, node, towards);
+  return { "@_x": x, "@_y": y };
 }
 
 export function getHandlePosition({


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-tools/issues/3845

Moving a node in the BPMN editor doesn't recalculate where its sequence flows connect, so the line often ends up meeting the shape at an odd spot (usually a corner of the bounding box) rather than the side facing the other node. It's most obvious on events, since they're circles and the connection clearly lands off-centre.

The fix picks the anchor from where the connected node sits relative to this one (left, right, above or below) and attaches to the middle of that side. That's the same dominant-axis logic the auto-positioned edges already use, so I reused it instead of writing a second copy.

On a move it only re-picks the side when the node actually crosses into a different zone. So if you've dragged an anchor onto a particular side and then nudge the node a little, it stays where you put it; move it far enough that it's now on a different side of the target and it snaps across. It covers all node types, and because the side midpoints fall on an event's circle it lines up on events too.

Roughly where the changes are:

- `xyflow-react-kie-diagram`: the auto-anchored (Center) end uses a small `getBorderMidpointTowards` helper that wraps the existing `getPositionalHandlePosition`.
- `bpmn-editor` `repositionNode`: on a move it compares the node's zone before and after, and if it changed, resets that endpoint back to the node centre (which renders as auto) instead of dragging it along.

To try it:

1. Connect an event to a task and move the event below, above and beside it.
2. Drag an endpoint to pin it, nudge the node a bit (should stay), then move it to another side (should re-optimise).

Happy to take feedback on the zone rule and how the pinned-anchor behaviour feels.

- [x] Linked to a GitHub issue
- [x] `pnpm bootstrap` run (formatting + lockfile)
- [ ] `pnpm -F @kie-tools/bpmn-editor... build:prod` passes
- [ ] Tests pass (unit + E2E)
- [x] License headers on new files (n/a, no new files)
