### PR TITLE
NO-ISSUE: Fix wrong translation in BPMN Editor - Data output

### DIFF
--- a/packages/bpmn-editor/src/i18n/locales/en.ts
+++ b/packages/bpmn-editor/src/i18n/locales/en.ts
@@ -155,7 +155,7 @@ export const en: BpmnEditorI18n = {
     dataInputPlaceholder: "Enter a Data input...",
     dataType: "Data Type",
     collectionOutput: "Collection output",
-    dataOutput: "Collection output",
+    dataOutput: "Data output",
     dataOutputPlaceholder: "Enter a Data output...",
     multiInstance: "Multi-instance",
     enterNamePlaceholder: "Enter a name...",


### PR DESCRIPTION
This is small fix for this translation
<img width="436" height="253" alt="Screenshot 2026-07-17 151436" src="https://github.com/user-attachments/assets/bd73471e-f12f-4453-885f-006a962a2444" />
