### PR TITLE
NO-ISSUE: force global qs override to patched 6.15.2 to address CVE-2026-8723

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   minimatch@^3>brace-expansion: 1.1.16
   minimatch@^5>brace-expansion: 2.1.2
   openapi-types: 7.2.3
-  '@cypress/request@3>qs': 6.15.2
+  qs: 6.15.2
   path-to-regexp@^0: 0.1.13
   react-dropzone: ^11.4.2
   superagent: 10.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,8 +16,9 @@ overrides:
   "minimatch@^5>brace-expansion": "2.1.2"
   "openapi-types": "7.2.3"
   # CVE-2026-8723: Fix TypeError in qs.stringify (comma arrayFormat + encodeValuesOnly with null/undefined)
-  # Overriding transitive dependency until @cypress/request updates to patched qs version
-  "@cypress/request@3>qs": "6.15.2"
+  # Vulnerable qs (<6.15.2) is reachable through multiple transitive paths (e.g. express@4.22.1 and
+  # @cypress/request@3), so force every transitive qs to the patched 6.15.2 instead of a scoped override.
+  "qs": "6.15.2"
   "path-to-regexp@^0": "0.1.13"
   "react-dropzone": "^11.4.2"
   "superagent": "10.2.2"


### PR DESCRIPTION
Follow-up to #3612, which added a scoped `@cypress/request@3>qs` override for CVE-2026-8723. That scope only covered one path, but a vulnerable `qs@6.14.2` is also reachable through `@kie-tools/cors-proxy → express@4.22.1 → qs`, which the scoped override doesn't affect.

This replaces the scoped override with a global one so every transitive qs resolves to the patched 6.15.2:

```
- "@cypress/request@3>qs": "6.15.2"
+ "qs": "6.15.2"
```
