### PR TITLE
kie-issues##2371: 10.3.x+ stream: Move kogito-runtimes to drools preserving Git-history and top-level directory structure

### DIFF
--- a/packages/drools-and-kogito/README.md
+++ b/packages/drools-and-kogito/README.md
@@ -17,7 +17,7 @@
 
 ## @kie-tools-core/drools-and-kogito
 
-Builds Drools, OptaPlanner, Kogito Runtimes, and Kogito Apps without installing any Maven artifacts to the local Maven repository. This package will skip the `install` phase and deploy the build result to `./dist/1st-party-m2`, so that there's no pollution of the local Maven repository.
+Builds Drools and Kogito Apps without installing any Maven artifacts to the local Maven repository. This package will skip the `install` phase and deploy the build result to `./dist/1st-party-m2`, so that there's no pollution of the local Maven repository.
 
 A build is only triggered when the Kogito version (defined in [@kie-tools/root-env](../root-env/README.md), via `KOGITO_RUNTIME_version`) ends with `-local` (E.g., `999-20250706-local`). Otherwise, this package assumes that the version is coming from a remote Maven repository, or is already installed locally in the local Maven repository. For versions not ending on `-local`, you can still have this package trigger a build by using the `DROOLS_AND_KOGITO__forceBuild` env var.
 

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "3b5010c99441ac642f93b1d97dcfd2b2952dd29a",
+      default: "9fa488684650e3fb163e34069b8ba9dc83ee89c1",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
@@ -36,7 +36,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kogito Apps",
     },
     DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "5c636bae421b56a717650f5bf9dfa807fbadaa86",
+      default: "384193e269eb42f75d1c2652e82f403e2c454dc2",
       description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -31,22 +31,6 @@ module.exports = composeEnv([rootEnv], {
       default: "3b5010c99441ac642f93b1d97dcfd2b2952dd29a",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
-    DROOLS_AND_KOGITO__optaplannerRepoUrl: {
-      default: "https://github.com/apache/incubator-kie-optaplanner",
-      description: "Git repository URL for OptaPlanner",
-    },
-    DROOLS_AND_KOGITO__optaplannerRepoGitRef: {
-      default: "d8c7e2f773ad1629eff4e4ae745a521bffa178c8",
-      description: "Git ref for the OptaPlanner repository (SHA, branch, or tag)",
-    },
-    DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl: {
-      default: "https://github.com/apache/incubator-kie-kogito-runtimes",
-      description: "Git repository URL for Kogito Runtimes",
-    },
-    DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {
-      default: "32f4515f1cacb85dc12988aaae64e276efdb59ec",
-      description: "Git ref for the Kogito Runtimes repository (SHA, branch, or tag)",
-    },
     DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
       default: "https://github.com/apache/incubator-kie-kogito-apps",
       description: "Git repository URL for Kogito Apps",
@@ -79,14 +63,6 @@ module.exports = composeEnv([rootEnv], {
           drools: {
             url: getOrDefault(this.vars.DROOLS_AND_KOGITO__droolsRepoUrl),
             gitRef: getOrDefault(this.vars.DROOLS_AND_KOGITO__droolsRepoGitRef),
-          },
-          optaplanner: {
-            url: getOrDefault(this.vars.DROOLS_AND_KOGITO__optaplannerRepoUrl),
-            gitRef: getOrDefault(this.vars.DROOLS_AND_KOGITO__optaplannerRepoGitRef),
-          },
-          kogitoRuntimes: {
-            url: getOrDefault(this.vars.DROOLS_AND_KOGITO__kogitoRuntimesRepoUrl),
-            gitRef: getOrDefault(this.vars.DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef),
           },
           kogitoApps: {
             url: getOrDefault(this.vars.DROOLS_AND_KOGITO__kogitoAppsRepoUrl),

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -51,8 +51,6 @@ console.log(JSON.stringify(buildInfo, null, 2));
 const buildInfoMatches =
   buildInfo?.kogitoVersion === buildEnv.versions.kogito &&
   buildInfo?.droolsRepoGitRef === buildEnv.droolsAndKogito.repos.drools.gitRef &&
-  buildInfo?.optaplannerRepoGitRef === buildEnv.droolsAndKogito.repos.optaplanner.gitRef &&
-  buildInfo?.kogitoRuntimesRepoGitRef === buildEnv.droolsAndKogito.repos.kogitoRuntimes.gitRef &&
   buildInfo?.kogitoAppsRepoGitRef === buildEnv.droolsAndKogito.repos.kogitoApps.gitRef;
 
 const localM2DirExists = fs.existsSync("./dist/1st-party-m2/repository");
@@ -83,8 +81,6 @@ fs.mkdirSync("./dist-tmp", { recursive: true });
 // cloning
 
 const droolsRepoDir = path.join("dist-tmp", "drools");
-const optaplannerRepoDir = path.join("dist-tmp", "optaplanner");
-const kogitoRuntimesRepoDir = path.join("dist-tmp", "kogito-runtimes");
 const kogitoAppsRepoDir = path.join("dist-tmp", "kogito-apps");
 
 console.log(`[drools-and-kogito] Cloning Drools...`);
@@ -93,23 +89,6 @@ execSync(`git clone --depth 1 ${buildEnv.droolsAndKogito.repos.drools.url} "${dr
 execSync(`git fetch origin ${buildEnv.droolsAndKogito.repos.drools.gitRef} && git checkout FETCH_HEAD`, {
   ...execOpts,
   cwd: droolsRepoDir,
-});
-
-console.log(`[drools-and-kogito] Cloning OptaPlanner...`);
-execSync(`git clone --depth 1 ${buildEnv.droolsAndKogito.repos.optaplanner.url} "${optaplannerRepoDir}"`, execOpts);
-execSync(`git fetch origin ${buildEnv.droolsAndKogito.repos.optaplanner.gitRef} && git checkout FETCH_HEAD`, {
-  ...execOpts,
-  cwd: optaplannerRepoDir,
-});
-
-console.log(`[drools-and-kogito] Cloning Kogito Runtimes...`);
-execSync(
-  `git clone --depth 1 ${buildEnv.droolsAndKogito.repos.kogitoRuntimes.url} "${kogitoRuntimesRepoDir}"`,
-  execOpts
-);
-execSync(`git fetch origin ${buildEnv.droolsAndKogito.repos.kogitoRuntimes.gitRef} && git checkout FETCH_HEAD`, {
-  ...execOpts,
-  cwd: kogitoRuntimesRepoDir,
 });
 
 console.log(`[drools-and-kogito] Cloning Kogito Apps...`);
@@ -173,24 +152,6 @@ try {
   );
 }
 
-console.log(`[drools-and-kogito] Building OptaPlanner...`);
-execSync(
-  `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
-  {
-    ...execOpts,
-    cwd: optaplannerRepoDir,
-  }
-);
-
-console.log(`[drools-and-kogito] Building Kogito Runtimes...`);
-execSync(
-  `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
-  {
-    ...execOpts,
-    cwd: kogitoRuntimesRepoDir,
-  }
-);
-
 console.log(`[drools-and-kogito] Building Kogito Apps...`);
 execSync(
   `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=snapshot-repo::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
@@ -211,8 +172,6 @@ fs.writeFileSync(
   JSON.stringify({
     kogitoVersion: buildEnv.versions.kogito,
     droolsRepoGitRef: buildEnv.droolsAndKogito.repos.drools.gitRef,
-    optaplannerRepoGitRef: buildEnv.droolsAndKogito.repos.optaplanner.gitRef,
-    kogitoRuntimesRepoGitRef: buildEnv.droolsAndKogito.repos.kogitoRuntimes.gitRef,
     kogitoAppsRepoGitRef: buildEnv.droolsAndKogito.repos.kogitoApps.gitRef,
   }),
   "utf-8"

--- a/packages/drools-and-kogito/printCacheKey.js
+++ b/packages/drools-and-kogito/printCacheKey.js
@@ -22,5 +22,5 @@ const { env } = require("./env");
 const repos = env.droolsAndKogito.repos;
 
 console.log(
-  `droolsRepoGitRef-${repos.drools.gitRef}-optaplannerRepoGitRef-${repos.optaplanner.gitRef}-kogitoRuntimesRepoGitRef-${repos.kogitoRuntimes.gitRef}-kogitoAppsRepoGitRef-${repos.kogitoApps.gitRef}-kogitoVersion-${env.versions.kogito}`
+  `droolsRepoGitRef-${repos.drools.gitRef}-kogitoAppsRepoGitRef-${repos.kogitoApps.gitRef}-kogitoVersion-${env.versions.kogito}`
 );

--- a/scripts/update-kogito-version/README.md
+++ b/scripts/update-kogito-version/README.md
@@ -21,7 +21,7 @@ Updates the default value of `KOGITO_RUNTIME_version` of `packages/root-env`, op
 
 ### Usage
 
-`pnpm update-kogito-version-to --maven {new-version} [--droolsGitRef {ref} --optaplannerGitRef {ref} --kogitoRuntimesGitRef {ref} --kogitoAppsGitRef {ref}]`
+`pnpm update-kogito-version-to --maven {new-version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]`
 
 ---
 

--- a/scripts/update-kogito-version/update_kogito_version.js
+++ b/scripts/update-kogito-version/update_kogito_version.js
@@ -24,15 +24,13 @@ const execSync = require("child_process").execSync;
 const newMavenVersion = process.argv[3];
 if (!newMavenVersion) {
   console.error(
-    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --optaplannerGitRef {ref} --kogitoRuntimesGitRef {ref} --kogitoAppsGitRef {ref}]"
+    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]"
   );
   return 1;
 }
 
 const newDroolsGitRef = process.argv[5] ?? "drools--n/a";
-const newOptaPlannerGitRef = process.argv[7] ?? "optaplanner--n/a";
-const newKogitoRuntimesGitRef = process.argv[9] ?? "kogito-runtimes--n/a";
-const newKogitoAppsGitRef = process.argv[11] ?? "kogito-apps--n/a";
+const newKogitoAppsGitRef = process.argv[7] ?? "kogito-apps--n/a";
 
 console.log(`[update-kogito-version] process.argv:`);
 console.log(process.argv);
@@ -40,14 +38,12 @@ console.log(process.argv);
 if (
   process.argv[2] !== "--maven" ||
   (process.argv[4] && process.argv[4] !== "--droolsGitRef") ||
-  (process.argv[6] && process.argv[6] !== "--optaplannerGitRef") ||
-  (process.argv[8] && process.argv[8] !== "--kogitoRuntimesGitRef") ||
-  (process.argv[10] && process.argv[10] !== "--kogitoAppsGitRef")
+  (process.argv[6] && process.argv[6] !== "--kogitoAppsGitRef")
 ) {
   console.error("Arguments need to be passed in the correct order.");
   console.error(`Argv: ${process.argv.join(", ")}`);
   console.error(
-    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --optaplannerGitRef {ref} --kogitoRuntimesGitRef {ref} --kogitoAppsGitRef {ref}]"
+    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]"
   );
   process.exit(1);
 }
@@ -75,24 +71,6 @@ try {
       .replace(
         /DROOLS_AND_KOGITO__droolsRepoGitRef:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
         `DROOLS_AND_KOGITO__droolsRepoGitRef: {\n      default: "${newDroolsGitRef}"`
-      )
-  );
-  fs.writeFileSync(
-    droolsAndKogitoEnvPath,
-    fs
-      .readFileSync(droolsAndKogitoEnvPath, "utf-8")
-      .replace(
-        /DROOLS_AND_KOGITO__optaplannerRepoGitRef:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
-        `DROOLS_AND_KOGITO__optaplannerRepoGitRef: {\n      default: "${newOptaPlannerGitRef}"`
-      )
-  );
-  fs.writeFileSync(
-    droolsAndKogitoEnvPath,
-    fs
-      .readFileSync(droolsAndKogitoEnvPath, "utf-8")
-      .replace(
-        /DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
-        `DROOLS_AND_KOGITO__kogitoRuntimesRepoGitRef: {\n      default: "${newKogitoRuntimesGitRef}"`
       )
   );
   fs.writeFileSync(


### PR DESCRIPTION
Updates kie-tools to reflect optaplanner and kogito-runtimes being merged with drools.
To be merged after https://github.com/apache/incubator-kie-drools/pull/6804
Will update the github ref once the above PR goes in.

Related PRs:
- https://github.com/apache/incubator-kie-kogito-pipelines/pull/1305 Updates the kogito-pipelines repo to no longer build kogito-runtimes in the build chain
- https://github.com/apache/incubator-kie-kogito-runtimes/pull/4347 Update kogito-runtimes readme to show new archived state
- https://github.com/apache/incubator-kie-drools/pull/6804 Merges kogito-runtimes into the drools repository
