### PR TITLE
NO-ISSUE: pin Maven version in mvnw bootstrap via build-dependencies-versions.json

### DIFF
--- a/packages/maven-base/env/index.js
+++ b/packages/maven-base/env/index.js
@@ -18,6 +18,7 @@
  */
 
 const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
+const buildDeps = require("../../../repo/build-dependencies-versions.json");
 
 module.exports = composeEnv([require("@kie-tools/root-env/env")], {
   vars: varsWithName({
@@ -42,6 +43,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       },
       mvnw: {
         version: "3.3.0",
+        mavenVersion: buildDeps.maven,
       },
       maven: {
         deploy: {

--- a/packages/maven-base/env/index.js
+++ b/packages/maven-base/env/index.js
@@ -18,7 +18,6 @@
  */
 
 const { varsWithName, composeEnv, getOrDefault } = require("@kie-tools-scripts/build-env");
-const buildDeps = require("../../../repo/build-dependencies-versions.json");
 
 module.exports = composeEnv([require("@kie-tools/root-env/env")], {
   vars: varsWithName({
@@ -43,7 +42,7 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       },
       mvnw: {
         version: "3.3.0",
-        mavenVersion: buildDeps.maven,
+        mavenVersion: "3.9.11",
       },
       maven: {
         deploy: {

--- a/packages/maven-base/index.js
+++ b/packages/maven-base/index.js
@@ -86,7 +86,7 @@ module.exports = {
     console.info(`[maven-base] Installing mvnw...`);
     console.time(`[maven-base] Installing mvnw...`);
 
-    const cmd = `mvn -e org.apache.maven.plugins:maven-wrapper-plugin:${env.mvnw.version}:wrapper ${BOOTSTRAP_CLI_ARGS}`;
+    const cmd = `mvn -e org.apache.maven.plugins:maven-wrapper-plugin:${env.mvnw.version}:wrapper -Dmaven=${env.mvnw.mavenVersion} ${BOOTSTRAP_CLI_ARGS}`;
 
     if (process.platform === "win32") {
       cp.execSync(cmd.replaceAll(" -", " `-"), { stdio: "inherit", shell: "powershell.exe" });


### PR DESCRIPTION
maven-wrapper-plugin:3.3.0 hardcodes Maven 3.9.9 as its default when invoked without -Dmaven=, causing maven-wrapper.properties to be generated with 3.9.9 which ships plexus-utils-3.5.1.jar in its lib/.

packages/maven-base/env/index.js: add mvnw.mavenVersion = '3.9.11'
packages/maven-base/index.js: pass -Dmaven=${env.mvnw.mavenVersion} to maven-wrapper-plugin so it generates maven-wrapper.properties with the pinned version instead of its hardcoded default