### PR TITLE
kie-issues#2378: 10.3.x+ stream: Move kogito-apps to drools preserving Git-history and top-level directory structure

### DIFF
--- a/packages/drools-and-kogito/README.md
+++ b/packages/drools-and-kogito/README.md
@@ -17,7 +17,7 @@
 
 ## @kie-tools-core/drools-and-kogito
 
-Builds Drools and Kogito Apps without installing any Maven artifacts to the local Maven repository. This package will skip the `install` phase and deploy the build result to `./dist/1st-party-m2`, so that there's no pollution of the local Maven repository.
+Builds Drools without installing any Maven artifacts to the local Maven repository. This package will skip the `install` phase and deploy the build result to `./dist/1st-party-m2`, so that there's no pollution of the local Maven repository.
 
 A build is only triggered when the Kogito version (defined in [@kie-tools/root-env](../root-env/README.md), via `KOGITO_RUNTIME_version`) ends with `-local` (E.g., `999-20250706-local`). Otherwise, this package assumes that the version is coming from a remote Maven repository, or is already installed locally in the local Maven repository. For versions not ending on `-local`, you can still have this package trigger a build by using the `DROOLS_AND_KOGITO__forceBuild` env var.
 

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -31,14 +31,6 @@ module.exports = composeEnv([rootEnv], {
       default: "9fa488684650e3fb163e34069b8ba9dc83ee89c1",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
-    DROOLS_AND_KOGITO__kogitoAppsRepoUrl: {
-      default: "https://github.com/apache/incubator-kie-kogito-apps",
-      description: "Git repository URL for Kogito Apps",
-    },
-    DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {
-      default: "384193e269eb42f75d1c2652e82f403e2c454dc2",
-      description: "Git ref for the Kogito Apps repository (SHA, branch, or tag)",
-    },
     DROOLS_AND_KOGITO__skip: {
       default: `${false}`,
       description:
@@ -63,10 +55,6 @@ module.exports = composeEnv([rootEnv], {
           drools: {
             url: getOrDefault(this.vars.DROOLS_AND_KOGITO__droolsRepoUrl),
             gitRef: getOrDefault(this.vars.DROOLS_AND_KOGITO__droolsRepoGitRef),
-          },
-          kogitoApps: {
-            url: getOrDefault(this.vars.DROOLS_AND_KOGITO__kogitoAppsRepoUrl),
-            gitRef: getOrDefault(this.vars.DROOLS_AND_KOGITO__kogitoAppsRepoGitRef),
           },
         },
         cache: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "9fa488684650e3fb163e34069b8ba9dc83ee89c1",
+      default: "8816430978be02c31a59d8e35a629c3fab6dd37e",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -50,8 +50,7 @@ console.log(JSON.stringify(buildInfo, null, 2));
 
 const buildInfoMatches =
   buildInfo?.kogitoVersion === buildEnv.versions.kogito &&
-  buildInfo?.droolsRepoGitRef === buildEnv.droolsAndKogito.repos.drools.gitRef &&
-  buildInfo?.kogitoAppsRepoGitRef === buildEnv.droolsAndKogito.repos.kogitoApps.gitRef;
+  buildInfo?.droolsRepoGitRef === buildEnv.droolsAndKogito.repos.drools.gitRef;
 
 const localM2DirExists = fs.existsSync("./dist/1st-party-m2/repository");
 const forceBuild = buildEnv.droolsAndKogito.forceBuild;
@@ -81,7 +80,6 @@ fs.mkdirSync("./dist-tmp", { recursive: true });
 // cloning
 
 const droolsRepoDir = path.join("dist-tmp", "drools");
-const kogitoAppsRepoDir = path.join("dist-tmp", "kogito-apps");
 
 console.log(`[drools-and-kogito] Cloning Drools...`);
 
@@ -89,13 +87,6 @@ execSync(`git clone --depth 1 ${buildEnv.droolsAndKogito.repos.drools.url} "${dr
 execSync(`git fetch origin ${buildEnv.droolsAndKogito.repos.drools.gitRef} && git checkout FETCH_HEAD`, {
   ...execOpts,
   cwd: droolsRepoDir,
-});
-
-console.log(`[drools-and-kogito] Cloning Kogito Apps...`);
-execSync(`git clone --depth 1 ${buildEnv.droolsAndKogito.repos.kogitoApps.url} "${kogitoAppsRepoDir}"`, execOpts);
-execSync(`git fetch origin ${buildEnv.droolsAndKogito.repos.kogitoApps.gitRef} && git checkout FETCH_HEAD`, {
-  ...execOpts,
-  cwd: kogitoAppsRepoDir,
 });
 
 // update versions
@@ -152,15 +143,6 @@ try {
   );
 }
 
-console.log(`[drools-and-kogito] Building Kogito Apps...`);
-execSync(
-  `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=snapshot-repo::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
-  {
-    ...execOpts,
-    cwd: kogitoAppsRepoDir,
-  }
-);
-
 console.log("[drools-and-kogito] Removing source code directory to free up disk space... ");
 fs.rmSync("./dist-tmp", { recursive: true });
 
@@ -172,7 +154,6 @@ fs.writeFileSync(
   JSON.stringify({
     kogitoVersion: buildEnv.versions.kogito,
     droolsRepoGitRef: buildEnv.droolsAndKogito.repos.drools.gitRef,
-    kogitoAppsRepoGitRef: buildEnv.droolsAndKogito.repos.kogitoApps.gitRef,
   }),
   "utf-8"
 );

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -126,7 +126,7 @@ removeMavenModule(`apps\\-integration\\-tests`);
 console.log(`[drools-and-kogito] Building Drools...`);
 try {
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
     {
       ...execOpts,
       cwd: droolsRepoDir,
@@ -135,7 +135,7 @@ try {
 } catch (e) {
   // Try it again!
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
     {
       ...execOpts,
       cwd: droolsRepoDir,

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -126,7 +126,7 @@ removeMavenModule(`apps\\-integration\\-tests`);
 console.log(`[drools-and-kogito] Building Drools...`);
 try {
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
     {
       ...execOpts,
       cwd: droolsRepoDir,
@@ -135,7 +135,7 @@ try {
 } catch (e) {
   // Try it again!
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
     {
       ...execOpts,
       cwd: droolsRepoDir,

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -126,7 +126,7 @@ removeMavenModule(`apps\\-integration\\-tests`);
 console.log(`[drools-and-kogito] Building Drools...`);
 try {
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
     {
       ...execOpts,
       cwd: droolsRepoDir,
@@ -135,7 +135,7 @@ try {
 } catch (e) {
   // Try it again!
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -T 0.5C -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO}`,
     {
       ...execOpts,
       cwd: droolsRepoDir,

--- a/packages/drools-and-kogito/install.js
+++ b/packages/drools-and-kogito/install.js
@@ -126,7 +126,7 @@ removeMavenModule(`apps\\-integration\\-tests`);
 console.log(`[drools-and-kogito] Building Drools...`);
 try {
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
     {
       ...execOpts,
       cwd: droolsRepoDir,
@@ -135,7 +135,7 @@ try {
 } catch (e) {
   // Try it again!
   execSync(
-    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -Dmaven.repo.local.tail=${DIST_REPO} -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
+    `mvn deploy -ntp -DskipTests -DskipITs -Dformatter.skip -Denforcer.skip=true -Dcheckstyle.skip=true -Dmaven.install.skip=true -DaltDeploymentRepository=drools-and-kogito--dist-1st-party-m2::default::file:${DIST_REPO} -Dquarkus.container-image.build=false`,
     {
       ...execOpts,
       cwd: droolsRepoDir,

--- a/packages/drools-and-kogito/printCacheKey.js
+++ b/packages/drools-and-kogito/printCacheKey.js
@@ -21,6 +21,4 @@
 const { env } = require("./env");
 const repos = env.droolsAndKogito.repos;
 
-console.log(
-  `droolsRepoGitRef-${repos.drools.gitRef}-kogitoAppsRepoGitRef-${repos.kogitoApps.gitRef}-kogitoVersion-${env.versions.kogito}`
-);
+console.log(`droolsRepoGitRef-${repos.drools.gitRef}-kogitoVersion-${env.versions.kogito}`);

--- a/scripts/update-kogito-version/README.md
+++ b/scripts/update-kogito-version/README.md
@@ -21,7 +21,7 @@ Updates the default value of `KOGITO_RUNTIME_version` of `packages/root-env`, op
 
 ### Usage
 
-`pnpm update-kogito-version-to --maven {new-version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]`
+`pnpm update-kogito-version-to --maven {new-version} [--droolsGitRef {ref}]`
 
 ---
 

--- a/scripts/update-kogito-version/update_kogito_version.js
+++ b/scripts/update-kogito-version/update_kogito_version.js
@@ -23,28 +23,19 @@ const execSync = require("child_process").execSync;
 
 const newMavenVersion = process.argv[3];
 if (!newMavenVersion) {
-  console.error(
-    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]"
-  );
+  console.error("Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref}]");
   return 1;
 }
 
 const newDroolsGitRef = process.argv[5] ?? "drools--n/a";
-const newKogitoAppsGitRef = process.argv[7] ?? "kogito-apps--n/a";
 
 console.log(`[update-kogito-version] process.argv:`);
 console.log(process.argv);
 
-if (
-  process.argv[2] !== "--maven" ||
-  (process.argv[4] && process.argv[4] !== "--droolsGitRef") ||
-  (process.argv[6] && process.argv[6] !== "--kogitoAppsGitRef")
-) {
+if (process.argv[2] !== "--maven" || (process.argv[4] && process.argv[4] !== "--droolsGitRef")) {
   console.error("Arguments need to be passed in the correct order.");
   console.error(`Argv: ${process.argv.join(", ")}`);
-  console.error(
-    "Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref} --kogitoAppsGitRef {ref}]"
-  );
+  console.error("Usage 'node update_kogito_version.js --maven {version} [--droolsGitRef {ref}]");
   process.exit(1);
 }
 
@@ -73,16 +64,6 @@ try {
         `DROOLS_AND_KOGITO__droolsRepoGitRef: {\n      default: "${newDroolsGitRef}"`
       )
   );
-  fs.writeFileSync(
-    droolsAndKogitoEnvPath,
-    fs
-      .readFileSync(droolsAndKogitoEnvPath, "utf-8")
-      .replace(
-        /DROOLS_AND_KOGITO__kogitoAppsRepoGitRef:[\s\n]*{[\s\n]*default:[\s\n]*".*"/,
-        `DROOLS_AND_KOGITO__kogitoAppsRepoGitRef: {\n      default: "${newKogitoAppsGitRef}"`
-      )
-  );
-
   console.info(`[update-kogito-version] Bootstrapping with updated Kogito version...`);
   execSync(`pnpm bootstrap`, execOpts);
 


### PR DESCRIPTION
Updates kie-tools to reflect optaplanner and kogito-runtimes being merged with drools.
To be merged after https://github.com/apache/incubator-kie-drools/pull/6834
Will update the github ref once the above PR goes in.

Related PRs:
- https://github.com/apache/incubator-kie-drools/pull/6834 Merges kogito-apps into the drools repository
- https://github.com/apache/incubator-kie-kogito-pipelines/pull/1306 Updates the kogito-pipelines repo to no longer build kogito-apps in the build chain
- https://github.com/apache/incubator-kie-kogito-apps/pull/2351 Update kogito-apps readme to show new archived state
