### PR TITLE
NO-ISSUE: Simplify Playwright base Containerfile using Playwright's official image

### DIFF
--- a/packages/playwright-base/Containerfile
+++ b/packages/playwright-base/Containerfile
@@ -15,30 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:24.04
+# This base image already ships Ubuntu 24.04, Node.js 24, and pre-installed/pre-configured
+# Chromium, Firefox and WebKit browsers (with their OS-level deps).
+# The tag's version must be kept in sync with the `@playwright/test` version resolved in
+# pnpm-lock.yaml, otherwise the browsers preinstalled here won't match the version used to run the tests.
+FROM mcr.microsoft.com/playwright:v1.62.0-noble
 
 # Set non-interactive mode to prevent tzdata prompt
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install required dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    wget \
-    jq \
-    && rm -rf /var/lib/apt/lists/*
-
-# Adding all dependencies available in GHA `ubuntu-latest`
-RUN curl https://raw.githubusercontent.com/actions/runner-images/refs/heads/main/images/ubuntu/toolsets/toolset-2404.json > toolset-2404.json && \
-    export APT_PACKAGES="$(cat toolset-2404.json | sed s/netcat/netcat-traditional/g | jq -r '.apt | [.vital_packages[], .common_packages[], .cmd_packages[]] | join(" ")')" && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends $APT_PACKAGES && \
-    rm -rf /var/lib/apt/lists/* toolset-2404.json
-
-    
 # Configure deb installer to automatically accept mscorefonts eula and install fonts
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
     apt-get update && apt-get install -y --no-install-recommends \
+        jq \
         fonts-ubuntu-classic \
         fonts-dejavu-core \
         fonts-dejavu-extra \
@@ -54,23 +43,12 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
     rm -rf /var/lib/apt/lists/* && \
     fc-cache -fv
 
-# Set Node.js version
-ENV NODE_VERSION=24.13.1
-
-# Download and install Node.js
-RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" -o /tmp/node.tar.gz && \
-    tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 && \
-    rm -rf /tmp/node.tar.gz
-
-# Set Playwright cache folder
-ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/kie-tools-playwright/.cache/ms-playwright
-
 # Installing `pnpm` to keep it consistent with the kie-tools repository
 RUN npm install --global pnpm@10.34.4
-# Installing Playwright browser and dependencies
-# This version must be kept in sync with the `@playwright/test` version resolved in pnpm-lock.yaml,
-# otherwise the browsers downloaded here won't match the version used to run the tests.
-RUN npx playwright@1.62.0 install-deps && npx playwright@1.62.0 install chrome chromium webkit
+
+# The base image only preinstalls Chromium/Firefox/WebKit; the branded Google Chrome channel
+# used by the test suite is installed separately here, on top of the browsers already present.
+RUN npx playwright@1.62.0 install chrome
 
 WORKDIR /home/node/kie-tools-playwright
 


### PR DESCRIPTION
Switches `packages/playwright-base/Containerfile`'s base image from `ubuntu:24.04` to Playwright's own `mcr.microsoft.com/playwright:v1.62.0-noble` image (pinned to match the `@playwright/test` version in `pnpm-lock.yaml`).

This lets us drop almost every manual dependency installation from the image, reducing its build time from 7~8 minutes to 50s (on my machine).

---

This PR was built on top of https://github.com/apache/incubator-kie-tools/pull/3678, I'll rebase once it's merged.
Check the diff by looking into the https://github.com/apache/incubator-kie-tools/commit/6bb6d735d2d0c9a8f76b34c31ccdff42ef954181 commit.