### PR TITLE
kie-issues#2379:Workflow Runtime: Live reload breaks in Quarkus Dev UI

### DIFF
--- a/examples/process-compact-architecture-springboot/src/main/resources/application-dev.properties
+++ b/examples/process-compact-architecture-springboot/src/main/resources/application-dev.properties
@@ -18,7 +18,7 @@
 #
 
 # Development profile: in-memory H2 database, no containers needed.
-spring.datasource.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+spring.datasource.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=kie
 spring.datasource.password=kie
 spring.datasource.driver-class-name=org.h2.Driver

--- a/examples/process-compact-architecture/src/main/resources/application.properties
+++ b/examples/process-compact-architecture/src/main/resources/application.properties
@@ -41,7 +41,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://0
 # Development DS
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-event-driven/hotels/src/main/resources/application.properties
+++ b/examples/process-event-driven/hotels/src/main/resources/application.properties
@@ -25,7 +25,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=hotel-user
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 ############
 # Security #

--- a/examples/process-event-driven/travelers/src/main/resources/application.properties
+++ b/examples/process-event-driven/travelers/src/main/resources/application.properties
@@ -25,7 +25,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=hotel-user
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 ############
 # Security #

--- a/examples/process-security/kie-service-1/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-1/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie1
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-security/kie-service-2/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-2/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie2
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-security/kie-service-3/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-3/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.datasource.reactive.url=${QUARKUS_DATASOURCE_REACTIVE_URL:postgresql://l
 # Development application datasource properties
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie3
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/examples/process-user-tasks-subsystem/src/main/resources/application.properties
+++ b/examples/process-user-tasks-subsystem/src/main/resources/application.properties
@@ -45,7 +45,7 @@
 %dev.kogito.persistence.type=jdbc
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kie
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
+++ b/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
@@ -58,7 +58,7 @@ kogito.persistence.type=jdbc
 # Default DS
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kie
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Disabling Hibernate schema generation
 quarkus.hibernate-orm.database.generation=none

--- a/packages/jbpm-addons-springboot-dev-console/dev/src/main/resources/application.properties
+++ b/packages/jbpm-addons-springboot-dev-console/dev/src/main/resources/application.properties
@@ -30,7 +30,7 @@ kogito.data-index.url=http://localhost:${server.port}
 
 # Persistence
 kogito.persistence.type=jdbc
-spring.datasource.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+spring.datasource.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=sa
 spring.datasource.driver-class-name=org.h2.Driver

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -30,7 +30,7 @@ kie.flyway.enabled=true
 kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kogito
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Security
 kogito.security.auth.enabled=false

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
@@ -40,7 +40,7 @@ kogito.persistence.type=jdbc
 %dev.kie.flyway.enabled=true
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.username=kogito
-%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+%dev.quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 
 

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
@@ -32,7 +32,7 @@ kie.flyway.enabled=true
 kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kogito
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Security
 kogito.security.auth.enabled=true

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
@@ -27,7 +27,7 @@ kie.flyway.enabled=true
 kogito.persistence.type=jdbc
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=kogito
-quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
 # Security
 kogito.security.auth.enabled=false


### PR DESCRIPTION
**Description**
When running a Kogito/jBPM application in Quarkus dev mode, live reload breaks after ~60 seconds of inactivity with EntityManagerFactory is closed.

**Why it happens:** Quarkus dev mode hot-reload does not restart the JVM — it restarts the application inside the same JVM using a new classloader. When the old classloader is torn down, all JDBC connections to the H2 in-memory database are closed. H2's default behaviour is DB_CLOSE_ON_EXIT=TRUE, which registers a JVM shutdown hook that closes the in-memory database engine when it detects zero active connections. Since the JVM is still running, this hook fires asynchronously — roughly 60 seconds later. When the new classloader then tries to boot Hibernate and open a session, the H2 database engine is already gone, causing the crash.

**Why this fix works:** Adding ;DB_CLOSE_ON_EXIT=FALSE disables that JVM shutdown hook entirely. The in-memory database now survives for the full lifetime of the JVM process, across as many classloader restarts as Quarkus dev mode performs. The existing DB_CLOSE_DELAY=-1 prevents closure when the last connection is released (classloader teardown); DB_CLOSE_ON_EXIT=FALSE prevents closure by the exit hook. Both flags are required together for the database to remain stable across live reloads.

Issue link -> https://github.com/apache/incubator-kie-issues/issues/2379

