### PR TITLE
[10.2.x] kie-issues#2310 [DMN-Editor] Backport fix to 10.2.x branch

### DIFF
--- a/packages/dmn-feel-antlr4-parser/src/parser/grammar/visitor/FeelVisitorImpl.ts
+++ b/packages/dmn-feel-antlr4-parser/src/parser/grammar/visitor/FeelVisitorImpl.ts
@@ -135,7 +135,7 @@ export class FeelVisitorImpl extends FEEL_1_1Visitor<VisitorResult | undefined> 
     const afterDot = this.resolveNames(ctx.qualifiedName());
 
     // Here, we care about the first result after dot
-    if (beforeDot && beforeDot.dataType.properties.has(afterDot[0].text)) {
+    if (afterDot?.length > 0 && beforeDot?.dataType.properties.has(afterDot[0].text)) {
       const startIndex = ctx.qualifiedName().start.start - 1;
       this._semanticTokens.push(
         new SemanticToken({
@@ -179,7 +179,10 @@ export class FeelVisitorImpl extends FEEL_1_1Visitor<VisitorResult | undefined> 
       }
     }
 
-    return new VisitorResult({ text: ctx.getText(), dataType: beforeDot?.dataType.properties.get(afterDot[0].text) });
+    return new VisitorResult({
+      text: ctx.getText(),
+      dataType: afterDot?.length > 0 ? beforeDot?.dataType.properties.get(afterDot[0].text) : undefined,
+    });
   };
 
   public override visitPrimaryParens = (ctx: PrimaryParensContext) => {
@@ -233,7 +236,7 @@ export class FeelVisitorImpl extends FEEL_1_1Visitor<VisitorResult | undefined> 
     const afterDot = this.resolveNames(ctx.qualifiedName());
 
     // Here, we care about the first result after dot
-    if (beforeDot?.dataType.properties.has(afterDot[0].text)) {
+    if (afterDot?.length > 0 && beforeDot?.dataType.properties.has(afterDot[0].text)) {
       const startIndex = ctx.qualifiedName().start.start - 1;
       this._semanticTokens.push(
         new SemanticToken({
@@ -248,7 +251,10 @@ export class FeelVisitorImpl extends FEEL_1_1Visitor<VisitorResult | undefined> 
       );
     }
 
-    return new VisitorResult({ text: ctx.getText(), dataType: beforeDot?.dataType.properties.get(afterDot[0].text) });
+    return new VisitorResult({
+      text: ctx.getText(),
+      dataType: afterDot?.length > 0 ? beforeDot?.dataType.properties.get(afterDot[0].text) : undefined,
+    });
   };
 
   public override visitFnInvocation = (ctx: FnInvocationContext) => {


### PR DESCRIPTION
Backport fix from main for kie-issues#2310, "KIE DMN editor crash on items[1].score with Any-typed list"

As suggested by @yesamer to facilitate a 10.2.1 patch release.