### PR TITLE
NO-ISSUE: Updated locale in Import java classes component

### DIFF
--- a/packages/dmn-editor/src/dataTypes/DataTypes.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypes.tsx
@@ -97,7 +97,7 @@ export type EditItemDefinition = (
 ) => void;
 
 export function DataTypes() {
-  const { i18n } = useDmnEditorI18n();
+  const { i18n, locale } = useDmnEditorI18n();
   const thisDmnsNamespace = useDmnEditorStore((s) => s.dmn.model.definitions["@_namespace"]);
   const dmnEditorStoreApi = useDmnEditorStoreApi();
   const activeItemDefinitionId = useDmnEditorStore((s) => s.dataTypesEditor.activeItemDefinitionId);
@@ -213,10 +213,11 @@ export function DataTypes() {
     ];
     if (isImportDataTypesFromJavaClassesSupported && javaCodeCompletionService) {
       dropdownItems.unshift(
-        <ImportJavaClassesI18nDictionariesProvider key={"import-java-classes"}>
+        <ImportJavaClassesI18nDictionariesProvider key={"import-java-classes"} locale={locale}>
           <ImportJavaClassesDropdownItem
             javaCodeCompletionService={javaCodeCompletionService}
             onClick={handleImportJavaClassButtonClick}
+            className="pf-m-icon pf-v5-c-dropdown__menu-item"
           />
         </ImportJavaClassesI18nDictionariesProvider>
       );
@@ -228,6 +229,7 @@ export function DataTypes() {
     handleImportJavaClassButtonClick,
     pasteTopLevelItemDefinition,
     i18n.dataTypes.paste,
+    locale,
   ]);
 
   return (
@@ -359,7 +361,7 @@ export function DataTypes() {
                 />
               )}
               {isOpenImportJavaClassesWizard && javaCodeCompletionService && (
-                <ImportJavaClassesI18nDictionariesProvider>
+                <ImportJavaClassesI18nDictionariesProvider locale={locale}>
                   <ImportJavaClassesWizard
                     javaCodeCompletionService={javaCodeCompletionService}
                     isOpen={isOpenImportJavaClassesWizard}

--- a/packages/dmn-editor/src/dataTypes/DataTypes.tsx
+++ b/packages/dmn-editor/src/dataTypes/DataTypes.tsx
@@ -217,7 +217,6 @@ export function DataTypes() {
           <ImportJavaClassesDropdownItem
             javaCodeCompletionService={javaCodeCompletionService}
             onClick={handleImportJavaClassButtonClick}
-            className="pf-m-icon pf-v5-c-dropdown__menu-item"
           />
         </ImportJavaClassesI18nDictionariesProvider>
       );

--- a/packages/import-java-classes-component/src/components/ImportJavaClasses/ImportJavaClasses.tsx
+++ b/packages/import-java-classes-component/src/components/ImportJavaClasses/ImportJavaClasses.tsx
@@ -42,20 +42,25 @@ interface ImportJavaClassesProps {
   loadJavaClassesInDataTypeEditor?: (javaClasses: JavaClass[]) => void;
 }
 
-const ImportJavaClassesI18nDictionariesProvider = (
-  props: Omit<
-    React.ComponentProps<typeof I18nDictionariesProvider>,
-    "defaults" | "dictionaries" | "initialLocale" | "ctx"
-  >
-) => (
-  <I18nDictionariesProvider
-    defaults={importJavaClassesWizardI18nDefaults}
-    dictionaries={importJavaClassesWizardI18nDictionaries}
-    initialLocale={navigator.language}
-    ctx={ImportJavaClassesWizardI18nContext}
-    {...props}
-  />
-);
+export type ImportJavaClassesI18nDictionariesProviderProps = Omit<
+  React.ComponentProps<typeof I18nDictionariesProvider>,
+  "defaults" | "dictionaries" | "initialLocale" | "ctx"
+> & {
+  locale?: string;
+};
+
+const ImportJavaClassesI18nDictionariesProvider = (props: ImportJavaClassesI18nDictionariesProviderProps) => {
+  const { locale, ...i18nProviderProps } = props;
+  return (
+    <I18nDictionariesProvider
+      defaults={importJavaClassesWizardI18nDefaults}
+      dictionaries={importJavaClassesWizardI18nDictionaries}
+      initialLocale={locale ?? navigator.language}
+      ctx={ImportJavaClassesWizardI18nContext}
+      {...i18nProviderProps}
+    />
+  );
+};
 
 const ImportJavaClasses = ({ javaCodeCompletionService, loadJavaClassesInDataTypeEditor }: ImportJavaClassesProps) => {
   const [isOpenImportJavaClassesWizard, setOpenImportJavaClassesWizard] = useState(false);


### PR DESCRIPTION
Problem:

The Import Java Classes component was not displaying translated text as locale was not being correctly applied.

Fix:

Corrected the locale configuration so that translations render properly across all supported languages.
