### PR TITLE
NO-ISSUE: upgrade jsonata from 1.8.7 to 2.2.1 to fix CVE

### DIFF
--- a/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
+++ b/packages/dmn-editor-envelope/src/DmnEditorRoot.tsx
@@ -308,7 +308,7 @@ export class DmnEditorRoot extends React.Component<DmnEditorRootProps, DmnEditor
       return {
         normalizedPosixPathRelativeToTheOpenFile,
         type: "pmml",
-        model: XML2PMML(resource?.content ?? ""),
+        model: await XML2PMML(resource?.content ?? ""),
       };
     } else {
       throw new Error(`Unknown extension '${ext}'.`);
@@ -664,7 +664,7 @@ function ExternalModelsManager({
         }
         return Promise.all(resources);
       })
-      .then((resources) => {
+      .then(async (resources) => {
         const externalModelsIndex: DmnEditor.ExternalModelsIndex = {};
 
         const namespacesSet = new Set(namespaces.split(NAMESPACES_EFFECT_SEPARATOR));
@@ -717,7 +717,7 @@ function ExternalModelsManager({
               // No need to check for namespaces being equal becuase there can't be two files with the same relativePath.
               externalModelsIndex[namespace] = {
                 normalizedPosixPathRelativeToTheOpenFile,
-                model: XML2PMML(resourceContent),
+                model: await XML2PMML(resourceContent),
                 type: "pmml",
               };
             }

--- a/packages/dmn-editor/stories/dev/DevWebApp.stories.tsx
+++ b/packages/dmn-editor/stories/dev/DevWebApp.stories.tsx
@@ -18,14 +18,14 @@
  */
 
 import * as React from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import "@patternfly/react-core/dist/styles/base.css";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Page, PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { DmnLatestModel, DmnMarshaller, getMarshaller } from "@kie-tools/dmn-marshaller";
 import { normalize, Normalized } from "@kie-tools/dmn-marshaller/dist/normalization/normalize";
-import { availableModelsByPath, modelsByNamespace } from "./availableModelsToInclude";
+import { availableModelsByPathPromise, modelsByNamespacePromise } from "./availableModelsToInclude";
 import { generateEmptyDmn16 } from "../misc/empty/Empty.stories";
 import { loanPreQualificationDmn } from "../useCases/loanPreQualification/LoanPreQualification.stories";
 import { DmnEditorWrapper } from "../dmnEditorStoriesWrapper";
@@ -77,6 +77,16 @@ function DevWebApp(args: DmnEditorProps) {
       pointer: 0,
     };
   });
+
+  const [availableModelsByPath, setAvailableModelsByPath] = useState<
+    Record<string, import("../../src/DmnEditor").ExternalModel>
+  >({});
+  const [modelsByNamespace, setModelsByNamespace] = useState<ExternalModelsIndex>({} as ExternalModelsIndex);
+
+  useEffect(() => {
+    availableModelsByPathPromise.then(setAvailableModelsByPath);
+    modelsByNamespacePromise.then(setModelsByNamespace);
+  }, []);
 
   const onDrop = useCallback((e: React.DragEvent) => {
     console.log("DMN Editor :: Dev webapp :: File(s) dropped! Opening it.");
@@ -162,15 +172,18 @@ function DevWebApp(args: DmnEditorProps) {
       acc[i["@_namespace"]] = modelsByNamespace[i["@_namespace"]];
       return acc;
     }, {} as ExternalModelsIndex);
-  }, [currentModel.definitions.import]);
+  }, [currentModel.definitions.import, modelsByNamespace]);
 
-  const onRequestExternalModelByPath = useCallback<OnRequestExternalModelByPath>(async (path) => {
-    return availableModelsByPath[path] ?? null;
-  }, []);
+  const onRequestExternalModelByPath = useCallback<OnRequestExternalModelByPath>(
+    async (path) => {
+      return availableModelsByPath[path] ?? null;
+    },
+    [availableModelsByPath]
+  );
 
   const onRequestExternalModelsAvailableToInclude = useCallback<OnRequestExternalModelsAvailableToInclude>(async () => {
     return Object.keys(availableModelsByPath);
-  }, []);
+  }, [availableModelsByPath]);
 
   const isUndoEnabled = state.pointer > 0;
   const isRedoEnabled = state.pointer !== state.stack.length - 1;

--- a/packages/dmn-editor/stories/dev/availableModelsToInclude.ts
+++ b/packages/dmn-editor/stories/dev/availableModelsToInclude.ts
@@ -28,21 +28,21 @@ export const sumBkmModel = normalize(getMarshaller(sumBkm, { upgradeTo: "latest"
 export const sumDiffDsModel = normalize(getMarshaller(sumDiffDs, { upgradeTo: "latest" }).parser.parse());
 export const testTreePmmlModel = XML2PMML(testTreePmml);
 
-export const avaiableModels: DmnEditor.ExternalModel[] = [
+export const avaiableModelsPromise: Promise<DmnEditor.ExternalModel[]> = testTreePmmlModel.then((pmmlModel) => [
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: sumBkmModel,
     svg: "",
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/sumBkm.dmn",
   },
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: sumDiffDsModel,
     svg: "",
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/sumDiffDs.dmn",
   },
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: normalize(
       getMarshaller(`<definitions xmlns="https://www.omg.org/spec/DMN/20240513/MODEL/" />`, {
         upgradeTo: "latest",
@@ -52,25 +52,31 @@ export const avaiableModels: DmnEditor.ExternalModel[] = [
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/empty.dmn",
   },
   {
-    type: "pmml",
-    model: testTreePmmlModel,
+    type: "pmml" as const,
+    model: pmmlModel,
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/testTree.pmml",
   },
-];
+]);
 
-export const availableModelsByPath: Record<string, DmnEditor.ExternalModel> = Object.values(avaiableModels).reduce(
-  (acc, v) => {
-    acc[v.normalizedPosixPathRelativeToTheOpenFile] = v;
+export const availableModelsByPathPromise: Promise<Record<string, DmnEditor.ExternalModel>> =
+  avaiableModelsPromise.then((models) =>
+    Object.values(models).reduce(
+      (acc, v) => {
+        acc[v.normalizedPosixPathRelativeToTheOpenFile] = v;
+        return acc;
+      },
+      {} as Record<string, DmnEditor.ExternalModel>
+    )
+  );
+
+export const modelsByNamespacePromise: Promise<DmnEditor.ExternalModelsIndex> = avaiableModelsPromise.then((models) =>
+  Object.values(models).reduce((acc, v) => {
+    if (v.type === "dmn") {
+      acc[v.model.definitions["@_namespace"]] = v;
+    } else if (v.type === "pmml") {
+      acc[getPmmlNamespace({ normalizedPosixPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] =
+        v;
+    }
     return acc;
-  },
-  {} as Record<string, DmnEditor.ExternalModel>
+  }, {} as DmnEditor.ExternalModelsIndex)
 );
-
-export const modelsByNamespace = Object.values(avaiableModels).reduce((acc, v) => {
-  if (v.type === "dmn") {
-    acc[v.model.definitions["@_namespace"]] = v;
-  } else if (v.type === "pmml") {
-    acc[getPmmlNamespace({ normalizedPosixPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] = v;
-  }
-  return acc;
-}, {} as DmnEditor.ExternalModelsIndex);

--- a/packages/dmn-editor/stories/misc/emptyWithAvailableExternalModels/EmptyWithAvailableExternalModels.stories.tsx
+++ b/packages/dmn-editor/stories/misc/emptyWithAvailableExternalModels/EmptyWithAvailableExternalModels.stories.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { DmnLatestModel, DmnMarshaller, getMarshaller } from "@kie-tools/dmn-marshaller";
 import { ns as dmn16ns } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_6/ts-gen/meta";
@@ -27,6 +27,7 @@ import { DMN16_SPEC } from "@kie-tools/dmn-marshaller/dist/schemas/dmn-1_6/Dmn16
 import {
   DmnEditor,
   DmnEditorProps,
+  ExternalModel,
   ExternalModelsIndex,
   OnRequestExternalModelByPath,
   OnRequestExternalModelsAvailableToInclude,
@@ -36,7 +37,7 @@ import { normalize, Normalized } from "@kie-tools/dmn-marshaller/dist/normalizat
 
 import { DmnEditorWrapper } from "../../dmnEditorStoriesWrapper";
 
-import { availableModelsByPath, modelsByNamespace } from "./availableModelsToInclude";
+import { availableModelsByPathPromise, modelsByNamespacePromise } from "./availableModelsToInclude";
 
 export const generateEmptyDmn16 = () => `<?xml version="1.0" encoding="UTF-8"?>
 <definitions
@@ -63,6 +64,14 @@ function EmptyStoryWithIncludedModels(args: DmnEditorProps) {
     };
   });
 
+  const [availableModelsByPath, setAvailableModelsByPath] = useState<Record<string, ExternalModel>>({});
+  const [modelsByNamespace, setModelsByNamespace] = useState<ExternalModelsIndex>({} as ExternalModelsIndex);
+
+  useEffect(() => {
+    availableModelsByPathPromise.then(setAvailableModelsByPath);
+    modelsByNamespacePromise.then(setModelsByNamespace);
+  }, []);
+
   const currentModel = state.stack[state.pointer];
 
   const externalModelsByNamespace = useMemo<ExternalModelsIndex>(() => {
@@ -70,15 +79,18 @@ function EmptyStoryWithIncludedModels(args: DmnEditorProps) {
       acc[i["@_namespace"]] = modelsByNamespace[i["@_namespace"]];
       return acc;
     }, {} as ExternalModelsIndex);
-  }, [currentModel.definitions.import]);
+  }, [currentModel.definitions.import, modelsByNamespace]);
 
-  const onRequestExternalModelByPath = useCallback<OnRequestExternalModelByPath>(async (path) => {
-    return availableModelsByPath[path] ?? null;
-  }, []);
+  const onRequestExternalModelByPath = useCallback<OnRequestExternalModelByPath>(
+    async (path) => {
+      return availableModelsByPath[path] ?? null;
+    },
+    [availableModelsByPath]
+  );
 
   const onRequestExternalModelsAvailableToInclude = useCallback<OnRequestExternalModelsAvailableToInclude>(async () => {
     return Object.keys(availableModelsByPath);
-  }, []);
+  }, [availableModelsByPath]);
 
   const onModelChange = useCallback<OnDmnModelChange>((model) => {
     setState((prev) => {

--- a/packages/dmn-editor/stories/misc/emptyWithAvailableExternalModels/availableModelsToInclude.ts
+++ b/packages/dmn-editor/stories/misc/emptyWithAvailableExternalModels/availableModelsToInclude.ts
@@ -28,21 +28,21 @@ export const sumBkmModel = normalize(getMarshaller(sumBkm, { upgradeTo: "latest"
 export const sumDiffDsModel = normalize(getMarshaller(sumDiffDs, { upgradeTo: "latest" }).parser.parse());
 export const testTreePmmlModel = XML2PMML(testTreePmml);
 
-export const availableModels: DmnEditor.ExternalModel[] = [
+export const availableModelsPromise: Promise<DmnEditor.ExternalModel[]> = testTreePmmlModel.then((pmmlModel) => [
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: sumBkmModel,
     svg: "",
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/sumBkm.dmn",
   },
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: sumDiffDsModel,
     svg: "",
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/sumDiffDs.dmn",
   },
   {
-    type: "dmn",
+    type: "dmn" as const,
     model: normalize(
       getMarshaller(`<definitions xmlns="https://www.omg.org/spec/DMN/20240513/MODEL/" />`, {
         upgradeTo: "latest",
@@ -52,25 +52,31 @@ export const availableModels: DmnEditor.ExternalModel[] = [
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/empty.dmn",
   },
   {
-    type: "pmml",
-    model: testTreePmmlModel,
+    type: "pmml" as const,
+    model: pmmlModel,
     normalizedPosixPathRelativeToTheOpenFile: "dev-webapp/available-models-to-include/testTree.pmml",
   },
-];
+]);
 
-export const availableModelsByPath: Record<string, DmnEditor.ExternalModel> = Object.values(availableModels).reduce(
-  (acc, v) => {
-    acc[v.normalizedPosixPathRelativeToTheOpenFile] = v;
+export const availableModelsByPathPromise: Promise<Record<string, DmnEditor.ExternalModel>> =
+  availableModelsPromise.then((models) =>
+    Object.values(models).reduce(
+      (acc, v) => {
+        acc[v.normalizedPosixPathRelativeToTheOpenFile] = v;
+        return acc;
+      },
+      {} as Record<string, DmnEditor.ExternalModel>
+    )
+  );
+
+export const modelsByNamespacePromise: Promise<DmnEditor.ExternalModelsIndex> = availableModelsPromise.then((models) =>
+  Object.values(models).reduce((acc, v) => {
+    if (v.type === "dmn") {
+      acc[v.model.definitions["@_namespace"]] = v;
+    } else if (v.type === "pmml") {
+      acc[getPmmlNamespace({ normalizedPosixPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] =
+        v;
+    }
     return acc;
-  },
-  {} as Record<string, DmnEditor.ExternalModel>
+  }, {} as DmnEditor.ExternalModelsIndex)
 );
-
-export const modelsByNamespace = Object.values(availableModels).reduce((acc, v) => {
-  if (v.type === "dmn") {
-    acc[v.model.definitions["@_namespace"]] = v;
-  } else if (v.type === "pmml") {
-    acc[getPmmlNamespace({ normalizedPosixPathRelativeToTheOpenFile: v.normalizedPosixPathRelativeToTheOpenFile })] = v;
-  }
-  return acc;
-}, {} as DmnEditor.ExternalModelsIndex);

--- a/packages/pmml-editor-marshaller/package.json
+++ b/packages/pmml-editor-marshaller/package.json
@@ -24,7 +24,7 @@
     "test": "run-script-if --ignore-errors \"$(build-env tests.ignoreFailures)\" --bool \"$(build-env tests.run)\" --then \"jest --silent --verbose --passWithNoTests\""
   },
   "dependencies": {
-    "jsonata": "^1.8.7",
+    "jsonata": "2.2.1",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/pmml-editor-marshaller/src/api/PMMLEditorMarshallerService.ts
+++ b/packages/pmml-editor-marshaller/src/api/PMMLEditorMarshallerService.ts
@@ -45,8 +45,8 @@ import { PMMLModelData } from "./PMMLModelData";
 import { PMMLFieldData } from "./PMMLFieldData";
 
 export class PMMLEditorMarshallerService {
-  public getPMMLDocumentData(xmlContent: string): PMMLDocumentData {
-    const pmml = XML2PMML(xmlContent);
+  public async getPMMLDocumentData(xmlContent: string): Promise<PMMLDocumentData> {
+    const pmml = await XML2PMML(xmlContent);
     const models: PMMLModelData[] = [];
     const document = new PMMLDocumentData(models);
 

--- a/packages/pmml-editor-marshaller/src/marshaller/Marshaller.ts
+++ b/packages/pmml-editor-marshaller/src/marshaller/Marshaller.ts
@@ -43,7 +43,7 @@ import { treeModelFactory } from "./jsonata/json2ui/TreeModel";
 import { UI2JSON_TRANSFORMATION as ui2json } from "./jsonata/UI2JSON";
 import { CompoundPredicate, False, PMML, SimplePredicate, True } from "./model/pmml4_4";
 
-export function XML2PMML(xml: string): PMML {
+export async function XML2PMML(xml: string): Promise<PMML> {
   const doc: XMLJS.Element = XMLJS.xml2js(xml) as XMLJS.Element;
   const expression: Expression = JSONata(json2ui);
   expression.registerFunction("merge", merge);
@@ -74,7 +74,7 @@ export function XML2PMML(xml: string): PMML {
   expression.registerFunction("json2uiTruePredicateFactory", json2uiTruePredicateFactory);
   expression.registerFunction("json2uiFalsePredicateFactory", json2uiFalsePredicateFactory);
 
-  const pmml: PMML = expression.evaluate(doc);
+  const pmml: PMML = await expression.evaluate(doc);
 
   return pmml;
 }
@@ -151,13 +151,13 @@ function json2uiFalsePredicateFactory(): False {
   return new False({});
 }
 
-export function PMML2XML(pmml: PMML): string {
+export async function PMML2XML(pmml: PMML): Promise<string> {
   const expression: Expression = JSONata(ui2json);
   expression.registerFunction("singletonArray", singletonArray);
 
   //See the note on clone(..) above: JSONata (since 1.8.8) returns objects built with Object.create(null),
   //which xml-js can't serialize (it calls hasOwnProperty(..) on them). Normalize to plain objects first.
-  const json: any = clone(expression.evaluate(pmml));
+  const json: any = clone(await expression.evaluate(pmml));
   const xml: string = XMLJS.js2xml(json, { spaces: 2 });
 
   return xml;

--- a/packages/pmml-editor-marshaller/tests/marshaller/AnomalyDetectionModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/AnomalyDetectionModel.test.ts
@@ -21,8 +21,8 @@ import { AnomalyDetectionModel, DataDictionary, Model, PMML, XML2PMML } from "@k
 import { ANOMALY_DETECTION_MODEL_1 } from "./TestData_AnomalyDetectionModel";
 
 describe("AnomalyDetectionModel tests", () => {
-  test("AnomalyDetectionModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(ANOMALY_DETECTION_MODEL_1);
+  test("AnomalyDetectionModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(ANOMALY_DETECTION_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/AssociationModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/AssociationModel.test.ts
@@ -21,8 +21,8 @@ import { AssociationModel, DataDictionary, Model, PMML, XML2PMML } from "@kie-to
 import { ASSOCIATION_MODEL_1 } from "./TestData_AssociationModel";
 
 describe("AssociationModel tests", () => {
-  test("AssociationModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(ASSOCIATION_MODEL_1);
+  test("AssociationModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(ASSOCIATION_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/BaselineModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/BaselineModel.test.ts
@@ -21,8 +21,8 @@ import { BaselineModel, DataDictionary, Model, PMML, XML2PMML } from "@kie-tools
 import { BASELINE_MODEL_1 } from "./TestData_BaselineModel";
 
 describe("BaselineModel tests", () => {
-  test("BaselineModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(BASELINE_MODEL_1);
+  test("BaselineModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(BASELINE_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/BayesianNetworkModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/BayesianNetworkModel.test.ts
@@ -21,8 +21,8 @@ import { BayesianNetworkModel, DataDictionary, Model, PMML, XML2PMML } from "@ki
 import { BAYESIAN_NETWORK_MODEL_1 } from "./TestData_BayesianNetworkModel";
 
 describe("BayesianNetworkModel tests", () => {
-  test("BayesianNetworkModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(BAYESIAN_NETWORK_MODEL_1);
+  test("BayesianNetworkModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(BAYESIAN_NETWORK_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/ClusteringModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/ClusteringModel.test.ts
@@ -21,8 +21,8 @@ import { ClusteringModel, DataDictionary, Model, PMML, XML2PMML } from "@kie-too
 import { CLUSTERING_MODEL_1 } from "./TestData_ClusteringModel";
 
 describe("ClusteringModel tests", () => {
-  test("ClusteringModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(CLUSTERING_MODEL_1);
+  test("ClusteringModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(CLUSTERING_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/DataDictionary.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/DataDictionary.test.ts
@@ -20,8 +20,8 @@
 import { DataDictionary, DataField, PMML, PMML2XML, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
 
 describe("DataDictionary tests", () => {
-  test("Empty", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Empty", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary/>
       </PMML>
@@ -34,13 +34,13 @@ describe("DataDictionary tests", () => {
     expect(dataDictionary.numberOfFields).toBeUndefined();
     expect(dataDictionary.DataField).not.toBeUndefined();
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataDictionary/>`);
   });
 
-  test("Add DataField", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Add DataField", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary/>
       </PMML>
@@ -57,14 +57,14 @@ describe("DataDictionary tests", () => {
 
     dataDictionary.DataField.push(dataField);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataDictionary numberOfFields="1">`);
     expect(xml).toContain(`<DataField name="field1" optype="categorical" dataType="string"/>`);
   });
 
-  test("Update DataField", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Update DataField", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary numberOfFields="1">
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -85,14 +85,14 @@ describe("DataDictionary tests", () => {
     dataDictionary.DataField[0].optype = "continuous";
     dataDictionary.DataField[0].dataType = "integer";
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataDictionary numberOfFields="1">`);
     expect(xml).toContain(`<DataField name="field1-changed" optype="continuous" dataType="integer"/>`);
   });
 
-  test("Delete DataField", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Delete DataField", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary numberOfFields="1">
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -107,7 +107,7 @@ describe("DataDictionary tests", () => {
 
     dataDictionary.DataField.splice(0, 1);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataDictionary/>`);
   });

--- a/packages/pmml-editor-marshaller/tests/marshaller/GaussianProcessModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/GaussianProcessModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, GaussianProcessModel, Model, PMML, XML2PMML } from "@ki
 import { GAUSSIAN_PROCESS_MODEL_1 } from "./TestData_GaussianProcessModel";
 
 describe("GaussianProcessModel tests", () => {
-  test("GaussianProcessModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(GAUSSIAN_PROCESS_MODEL_1);
+  test("GaussianProcessModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(GAUSSIAN_PROCESS_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/GeneralRegressionModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/GeneralRegressionModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, GeneralRegressionModel, Model, PMML, XML2PMML } from "@
 import { GENERAL_REGRESSION_MODEL_1 } from "./TestData_GeneralRegressionModel";
 
 describe("GeneralRegressionModel tests", () => {
-  test("GeneralRegressionModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(GENERAL_REGRESSION_MODEL_1);
+  test("GeneralRegressionModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(GENERAL_REGRESSION_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/Header.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/Header.test.ts
@@ -20,8 +20,8 @@
 import { Annotation, Header, PMML, PMML2XML, Timestamp, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
 
 describe("Header tests", () => {
-  test("Attributes", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Attributes", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <Header copyright="copyright" description="description" modelVersion="modelVersion"/>
       </PMML>
@@ -43,15 +43,15 @@ describe("Header tests", () => {
     pmml.Header.description = "description-changed";
     pmml.Header.modelVersion = "modelVersion-changed";
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(
       `<Header copyright="copyright-changed" description="description-changed" modelVersion="modelVersion-changed"/>`
     );
   });
 
-  test("Application", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Application", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <Header>
           <Application name="name" version="version"/>
@@ -75,13 +75,13 @@ describe("Header tests", () => {
       header.Application.version = "version-changed";
     }
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Application name="name-changed" version="version-changed"/>`);
   });
 
-  test("Annotation", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Annotation", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <Header>
           <Annotation>annotation1</Annotation>
@@ -111,14 +111,14 @@ describe("Header tests", () => {
     expect(annotations.length).toBe(2);
     expect(annotations[1]).not.toBeUndefined();
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Annotation>annotation1</Annotation>`);
     expect(xml).toContain(`<Annotation>annotation2</Annotation>`);
   });
 
-  test("Timestamp", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Timestamp", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <Header>
           <Timestamp>timestamp</Timestamp>
@@ -138,7 +138,7 @@ describe("Header tests", () => {
     expect((timestamp[0] as any)["text"]).toBe("timestamp");
 
     (timestamp[0] as any)["text"] = "timestamp-changed";
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).toContain(`<Timestamp>timestamp-changed</Timestamp>`);
   });
 });

--- a/packages/pmml-editor-marshaller/tests/marshaller/Interval.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/Interval.test.ts
@@ -20,8 +20,8 @@
 import { DataDictionary, DataField, Interval, PMML, PMML2XML, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
 
 describe("Interval tests", () => {
-  test("Empty collection on DataField", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Empty collection on DataField", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -36,13 +36,13 @@ describe("Interval tests", () => {
     expect(dataDictionary.DataField[0].Interval).not.toBeUndefined();
     expect(dataDictionary.DataField[0].Interval?.length).toBe(0);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataField name="field1" optype="categorical" dataType="string"/>`);
   });
 
-  test("Add Interval", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Add Interval", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -57,13 +57,13 @@ describe("Interval tests", () => {
 
     dataField.Interval?.push(interval);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Interval closure="openOpen" leftMargin="0" rightMargin="100"/>`);
   });
 
-  test("Add Interval::No leftMargin", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Add Interval::No leftMargin", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -78,13 +78,13 @@ describe("Interval tests", () => {
 
     dataField.Interval?.push(interval);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Interval closure="openOpen" rightMargin="100"/>`);
   });
 
-  test("Add Interval::No rightMargin", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Add Interval::No rightMargin", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -99,13 +99,13 @@ describe("Interval tests", () => {
 
     dataField.Interval?.push(interval);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Interval closure="openOpen" leftMargin="10"/>`);
   });
 
-  test("Update Interval", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Update Interval", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string">
@@ -131,13 +131,13 @@ describe("Interval tests", () => {
     interval.leftMargin = 25;
     interval.rightMargin = 500;
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Interval closure="closedClosed" leftMargin="25" rightMargin="500"/>`);
   });
 
-  test("Delete Interval", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Delete Interval", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string">
@@ -159,7 +159,7 @@ describe("Interval tests", () => {
 
     intervals.splice(0, 1);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataField name="field1" optype="categorical" dataType="string"/>`);
   });

--- a/packages/pmml-editor-marshaller/tests/marshaller/MiningModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/MiningModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, MiningModel, Model, PMML, XML2PMML } from "@kie-tools/p
 import { MINING_MODEL_1 } from "./TestData_MiningModel";
 
 describe("MiningModel tests", () => {
-  test("MiningModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(MINING_MODEL_1);
+  test("MiningModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(MINING_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/MiningSchema.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/MiningSchema.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, Scorecard, XML2PMML } from "@kie-tools/pmm
 import { MINING_SCHEMA_1 } from "./TestData_MiningSchema";
 
 describe("MiningSchema tests", () => {
-  test("MiningSchema::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(MINING_SCHEMA_1);
+  test("MiningSchema::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(MINING_SCHEMA_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/NaiveBayesModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/NaiveBayesModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, NaiveBayesModel, PMML, XML2PMML } from "@kie-too
 import { NAIVE_BAYES_MODEL_1 } from "./TestData_NaiveBayesModel";
 
 describe("NaiveBayesModel tests", () => {
-  test("NaiveBayesModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(NAIVE_BAYES_MODEL_1);
+  test("NaiveBayesModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(NAIVE_BAYES_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/NearestNeighborModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/NearestNeighborModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, NearestNeighborModel, PMML, XML2PMML } from "@ki
 import { NEAREST_NEIGHBOUR_MODEL_1 } from "./TestData_NearestNeighborModel";
 
 describe("NearestNeighborModel tests", () => {
-  test("NearestNeighborModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(NEAREST_NEIGHBOUR_MODEL_1);
+  test("NearestNeighborModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(NEAREST_NEIGHBOUR_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/NeuralNetwork.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/NeuralNetwork.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, NeuralNetwork, PMML, XML2PMML } from "@kie-tools
 import { NEURAL_NETWORK_MODEL_1 } from "./TestData_NeuralNetwork";
 
 describe("NeuralNetwork tests", () => {
-  test("NeuralNetwork::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(NEURAL_NETWORK_MODEL_1);
+  test("NeuralNetwork::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(NEURAL_NETWORK_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/RegressionModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/RegressionModel.test.ts
@@ -36,8 +36,8 @@ import {
 } from "./TestData_LinearRegressions";
 
 describe("RegressionModel tests", () => {
-  test("RegressionModel::DataDictionary", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::DataDictionary", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
 
     expect(pmml).not.toBeNull();
 
@@ -60,8 +60,8 @@ describe("RegressionModel tests", () => {
     expect(dataDictionary.DataField[3].optype).toBe("continuous");
   });
 
-  test("RegressionModel::Models", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::Models", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
 
     expect(pmml).not.toBeNull();
 
@@ -81,8 +81,8 @@ describe("RegressionModel tests", () => {
     expect(regressionModel.isScorable).toBeUndefined();
   });
 
-  test("RegressionModel::MiningSchema", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::MiningSchema", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
     const models: Model[] = pmml.models ?? [];
     const regressionModel: RegressionModel = models[0] as RegressionModel;
 
@@ -105,16 +105,16 @@ describe("RegressionModel tests", () => {
     expect(miningFields[3].invalidValueTreatment).toBeUndefined();
   });
 
-  test("RegressionModel::Output", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::Output", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
     const models: Model[] = pmml.models ?? [];
     const regressionModel: RegressionModel = models[0] as RegressionModel;
 
     expect(regressionModel.Output?.OutputField.length).toBe(0);
   });
 
-  test("RegressionModel::RegressionTable", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::RegressionTable", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
     const models: Model[] = pmml.models ?? [];
     const regressionModel: RegressionModel = models[0] as RegressionModel;
 
@@ -125,8 +125,8 @@ describe("RegressionModel tests", () => {
     expect(regressionTable.intercept).toBe(132.37);
   });
 
-  test("RegressionModel::RegressionTable::NumericPredictor", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::RegressionTable::NumericPredictor", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
     const models: Model[] = pmml.models ?? [];
     const regressionModel: RegressionModel = models[0] as RegressionModel;
     const regressionTable: RegressionTable = regressionModel.RegressionTable[0];
@@ -143,8 +143,8 @@ describe("RegressionModel tests", () => {
     expect(numericPredictor.exponent).toBe(1);
   });
 
-  test("RegressionModel::RegressionTable::CategoricalPredictor", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
+  test("RegressionModel::RegressionTable::CategoricalPredictor", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
     const models: Model[] = pmml.models ?? [];
     const regressionModel: RegressionModel = models[0] as RegressionModel;
     const regressionTable: RegressionTable = regressionModel.RegressionTable[0];
@@ -171,30 +171,30 @@ describe("RegressionModel tests", () => {
     expect(categoricalPredicator2.value).toBe("garage");
   });
 
-  test("RegressionModel::RoundTrip1", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_1);
-    const xml: string = PMML2XML(pmml);
+  test("RegressionModel::RoundTrip1", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_1);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 
-  test("RegressionModel::RoundTrip2", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_2);
-    const xml: string = PMML2XML(pmml);
+  test("RegressionModel::RoundTrip2", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_2);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 
-  test("RegressionModel::RoundTrip3", () => {
-    const pmml: PMML = XML2PMML(LINEAR_REGRESSION_MODEL_3);
-    const xml: string = PMML2XML(pmml);
+  test("RegressionModel::RoundTrip3", async () => {
+    const pmml: PMML = await XML2PMML(LINEAR_REGRESSION_MODEL_3);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 });

--- a/packages/pmml-editor-marshaller/tests/marshaller/RuleSetModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/RuleSetModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, RuleSetModel, XML2PMML } from "@kie-tools/
 import { RULE_SET_MODEL_1 } from "./TestData_RuleSetModel";
 
 describe("RuleSetModel tests", () => {
-  test("RuleSetModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(RULE_SET_MODEL_1);
+  test("RuleSetModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(RULE_SET_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/Scorecard.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/Scorecard.test.ts
@@ -50,8 +50,8 @@ import {
 describe("Scorecard tests", () => {
   type PredicateAssertion = (predicate: Predicate) => void;
 
-  test("Scorecard::DataDictionary", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::DataDictionary", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
 
     expect(pmml).not.toBeNull();
 
@@ -70,8 +70,8 @@ describe("Scorecard tests", () => {
     expect(dataDictionary.DataField[2].optype).toBe("continuous");
   });
 
-  test("Scorecard::Models", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::Models", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
 
     expect(pmml).not.toBeNull();
 
@@ -92,13 +92,13 @@ describe("Scorecard tests", () => {
     expect(scorecard.baselineScore).toBe(6);
   });
 
-  test("Scorecard::Models::No modelName", () => {
+  test("Scorecard::Models::No modelName", async () => {
     const xml: string = `<PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
       <Header/>
       <DataDictionary/>
       <Scorecard/>
     </PMML>`;
-    const pmml: PMML = XML2PMML(xml);
+    const pmml: PMML = await XML2PMML(xml);
 
     expect(pmml).not.toBeNull();
 
@@ -112,8 +112,8 @@ describe("Scorecard tests", () => {
     expect(scorecard.modelName).toBeUndefined();
   });
 
-  test("Scorecard::MiningSchema", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::MiningSchema", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -132,8 +132,8 @@ describe("Scorecard tests", () => {
     expect(miningFields[2].invalidValueTreatment).toBeUndefined();
   });
 
-  test("Scorecard::Output", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::Output", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -157,8 +157,8 @@ describe("Scorecard tests", () => {
     expect(outputFields[2].optype).toBe("categorical");
   });
 
-  test("Scorecard::Characteristics", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::Characteristics", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -174,8 +174,8 @@ describe("Scorecard tests", () => {
     expect(characteristics[1].reasonCode).toBe("Input2ReasonCode");
   });
 
-  test("Scorecard::Characteristics:Attributes", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::Characteristics:Attributes", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
     const characteristics: Characteristic[] = scorecard.Characteristics?.Characteristic as Characteristic[];
@@ -189,8 +189,8 @@ describe("Scorecard tests", () => {
     expect(characteristics[1].Attribute[1].partialScore).toBe(32);
   });
 
-  test("Scorecard::Characteristics:Attributes::SimplePredicate", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
+  test("Scorecard::Characteristics:Attributes::SimplePredicate", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
     const characteristics: Characteristic[] = scorecard.Characteristics?.Characteristic as Characteristic[];
@@ -219,8 +219,8 @@ describe("Scorecard tests", () => {
     });
   });
 
-  test("Scorecard::Characteristics:Attributes::SimplePredicate::Single", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_SIMPLE_PREDICATE_SINGLE);
+  test("Scorecard::Characteristics:Attributes::SimplePredicate::Single", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_SIMPLE_PREDICATE_SINGLE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
     const characteristics: Characteristic[] = scorecard.Characteristics?.Characteristic as Characteristic[];
@@ -233,15 +233,15 @@ describe("Scorecard tests", () => {
     });
 
     //Check round-trip
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 
-  test("Scorecard::Characteristics:Attributes::CompoundPredicate", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_COMPOUND_PREDICATE);
+  test("Scorecard::Characteristics:Attributes::CompoundPredicate", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_COMPOUND_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -376,8 +376,8 @@ describe("Scorecard tests", () => {
     ]);
   });
 
-  test("Scorecard::Characteristics:Attributes::NestedCompoundPredicate", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_NESTED_COMPOUND_PREDICATE);
+  test("Scorecard::Characteristics:Attributes::NestedCompoundPredicate", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_NESTED_COMPOUND_PREDICATE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -501,8 +501,8 @@ describe("Scorecard tests", () => {
     ]);
   });
 
-  test("Scorecard::BasicComplexPartialScore", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_BASIC_COMPLEX_PARTIAL_SCORE);
+  test("Scorecard::BasicComplexPartialScore", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_BASIC_COMPLEX_PARTIAL_SCORE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -547,15 +547,15 @@ describe("Scorecard tests", () => {
     expect(c1a0cps).toBe(`<Apply function="*"><FieldRef field="input1"/><FieldRef field="input2"/></Apply>`);
 
     //Check round-trip
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 
-  test("Scorecard::NestedComplexPartialScore", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_NESTED_COMPLEX_PARTIAL_SCORE);
+  test("Scorecard::NestedComplexPartialScore", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_NESTED_COMPLEX_PARTIAL_SCORE);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
 
@@ -604,15 +604,15 @@ describe("Scorecard tests", () => {
     );
 
     //Check round-trip
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
     expect(xml).not.toBeNull();
 
-    const pmml2: PMML = XML2PMML(xml);
+    const pmml2: PMML = await XML2PMML(xml);
     expect(pmml).toEqual(pmml2);
   });
 
-  test("Scorecard::prototype::preservation", () => {
-    const pmml: PMML = XML2PMML(SCORE_CARD_PROTOTYPES);
+  test("Scorecard::prototype::preservation", async () => {
+    const pmml: PMML = await XML2PMML(SCORE_CARD_PROTOTYPES);
     const models: Model[] = pmml.models ?? [];
     const scorecard: Scorecard = models[0] as Scorecard;
     const miningSchema = scorecard.MiningSchema;
@@ -643,23 +643,23 @@ describe("Scorecard tests", () => {
     expect(Object.getPrototypeOf(characteristicFields[1])).toBe(Object.prototype);
   });
 
-  test("Scorecard::Models::isScorable::true", () => {
-    const scorecard: Scorecard = makeScorecardWithIsScorable(true);
+  test("Scorecard::Models::isScorable::true", async () => {
+    const scorecard: Scorecard = await makeScorecardWithIsScorable(true);
     expect(scorecard.isScorable).toBeTruthy();
   });
 
-  test("Scorecard::Models::isScorable::false", () => {
-    const scorecard: Scorecard = makeScorecardWithIsScorable(false);
+  test("Scorecard::Models::isScorable::false", async () => {
+    const scorecard: Scorecard = await makeScorecardWithIsScorable(false);
     expect(scorecard.isScorable).toBeFalsy();
   });
 
-  function makeScorecardWithIsScorable(isScorable: boolean): Scorecard {
+  async function makeScorecardWithIsScorable(isScorable: boolean): Promise<Scorecard> {
     const xml: string = `<PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
       <Header/>
       <DataDictionary/>
       <Scorecard isScorable="${isScorable}"/>
     </PMML>`;
-    const pmml: PMML = XML2PMML(xml);
+    const pmml: PMML = await XML2PMML(xml);
 
     expect(pmml).not.toBeNull();
 
@@ -672,23 +672,23 @@ describe("Scorecard tests", () => {
     return model as Scorecard;
   }
 
-  test("Scorecard::Models::useReasonCodes::true", () => {
-    const scorecard: Scorecard = makeScorecardWithUseReasonCodes(true);
+  test("Scorecard::Models::useReasonCodes::true", async () => {
+    const scorecard: Scorecard = await makeScorecardWithUseReasonCodes(true);
     expect(scorecard.useReasonCodes).toBeTruthy();
   });
 
-  test("Scorecard::Models::useReasonCodes::false", () => {
-    const scorecard: Scorecard = makeScorecardWithUseReasonCodes(false);
+  test("Scorecard::Models::useReasonCodes::false", async () => {
+    const scorecard: Scorecard = await makeScorecardWithUseReasonCodes(false);
     expect(scorecard.useReasonCodes).toBeFalsy();
   });
 
-  function makeScorecardWithUseReasonCodes(useReasonCodes: boolean): Scorecard {
+  async function makeScorecardWithUseReasonCodes(useReasonCodes: boolean): Promise<Scorecard> {
     const xml: string = `<PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
       <Header/>
       <DataDictionary/>
       <Scorecard useReasonCodes="${useReasonCodes}"/>
     </PMML>`;
-    const pmml: PMML = XML2PMML(xml);
+    const pmml: PMML = await XML2PMML(xml);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/SequenceModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/SequenceModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, SequenceModel, XML2PMML } from "@kie-tools
 import { SEQUENCE_MODEL_1 } from "./TestData_SequenceModel";
 
 describe("SequenceModel tests", () => {
-  test("SequenceModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(SEQUENCE_MODEL_1);
+  test("SequenceModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(SEQUENCE_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/SupportVectorMachineModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/SupportVectorMachineModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, SupportVectorMachineModel, XML2PMML } from
 import { SUPPORT_VECTOR_MACHINE_MODEL_1 } from "./TestData_SupportVectorMachineModel";
 
 describe("SupportVectorMachineModel tests", () => {
-  test("SupportVectorMachineModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(SUPPORT_VECTOR_MACHINE_MODEL_1);
+  test("SupportVectorMachineModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(SUPPORT_VECTOR_MACHINE_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/TextModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/TextModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, TextModel, XML2PMML } from "@kie-tools/pmm
 import { TEXT_MODEL_1 } from "./TestData_TextModel";
 
 describe("TextModel tests", () => {
-  test("TextModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(TEXT_MODEL_1);
+  test("TextModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(TEXT_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/TimeSeriesModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/TimeSeriesModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, TimeSeriesModel, XML2PMML } from "@kie-too
 import { TIME_SERIES_MODEL_1 } from "./TestData_TimeSeriesModel";
 
 describe("TimeSeriesModel tests", () => {
-  test("TimeSeriesModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(TIME_SERIES_MODEL_1);
+  test("TimeSeriesModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(TIME_SERIES_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/TreeModel.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/TreeModel.test.ts
@@ -21,8 +21,8 @@ import { DataDictionary, Model, PMML, TreeModel, XML2PMML } from "@kie-tools/pmm
 import { TREE_MODEL_1 } from "./TestData_TreeModel";
 
 describe("TreeModel tests", () => {
-  test("TreeModel::Basics for DMN", () => {
-    const pmml: PMML = XML2PMML(TREE_MODEL_1);
+  test("TreeModel::Basics for DMN", async () => {
+    const pmml: PMML = await XML2PMML(TREE_MODEL_1);
 
     expect(pmml).not.toBeNull();
 

--- a/packages/pmml-editor-marshaller/tests/marshaller/Value.test.ts
+++ b/packages/pmml-editor-marshaller/tests/marshaller/Value.test.ts
@@ -20,8 +20,8 @@
 import { DataDictionary, DataField, PMML, PMML2XML, Value, XML2PMML } from "@kie-tools/pmml-editor-marshaller";
 
 describe("Value tests", () => {
-  test("Empty", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Empty", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -36,13 +36,13 @@ describe("Value tests", () => {
     expect(dataDictionary.DataField[0].Value).not.toBeUndefined();
     expect(dataDictionary.DataField[0].Value?.length).toBe(0);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataField name="field1" optype="categorical" dataType="string"/>`);
   });
 
-  test("Add Value", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Add Value", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string"/>
@@ -57,13 +57,13 @@ describe("Value tests", () => {
 
     dataField.Value?.push(value);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Value value="value" displayValue="displayValue" property="valid"/>`);
   });
 
-  test("Update Value", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Update Value", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string">
@@ -89,13 +89,13 @@ describe("Value tests", () => {
     value.displayValue = "displayValue-changed";
     value.property = "invalid";
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<Value value="value-changed" displayValue="displayValue-changed" property="invalid"/>`);
   });
 
-  test("Delete Value", () => {
-    const pmml: PMML = XML2PMML(`
+  test("Delete Value", async () => {
+    const pmml: PMML = await XML2PMML(`
       <PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4">
         <DataDictionary>
           <DataField name="field1" optype="categorical" dataType="string">
@@ -117,7 +117,7 @@ describe("Value tests", () => {
 
     values.splice(0, 1);
 
-    const xml: string = PMML2XML(pmml);
+    const xml: string = await PMML2XML(pmml);
 
     expect(xml).toContain(`<DataField name="field1" optype="categorical" dataType="string"/>`);
   });

--- a/packages/pmml-editor/src/editor/PMMLEditor.tsx
+++ b/packages/pmml-editor/src/editor/PMMLEditor.tsx
@@ -128,24 +128,23 @@ export class PMMLEditor extends React.Component<Props, State> {
     });
   }
 
-  public setContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): Promise<void> {
+  public async setContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): Promise<void> {
     try {
-      this.doSetContent(normalizedPosixPathRelativeToTheWorkspaceRoot, content);
+      await this.doSetContent(normalizedPosixPathRelativeToTheWorkspaceRoot, content);
       this.props.setNotifications(this.state.path, this.validate());
-      return Promise.resolve();
     } catch (e) {
       console.error(e);
-      return Promise.reject();
+      throw e;
     }
   }
 
-  private doSetContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): void {
+  private async doSetContent(normalizedPosixPathRelativeToTheWorkspaceRoot: string, content: string): Promise<void> {
     let pmml: PMML;
     let _content: string = content;
 
     if (content === "") {
       _content = EMPTY_PMML;
-      pmml = XML2PMML(_content);
+      pmml = await XML2PMML(_content);
 
       //If there is only one supported type of model then create a default entry
       const supportedEditorTypes: Array<PMMLModelMapping<any>> = PMMLModels.filter(
@@ -158,7 +157,7 @@ export class PMMLEditor extends React.Component<Props, State> {
         }
       }
     } else {
-      pmml = XML2PMML(_content);
+      pmml = await XML2PMML(_content);
     }
 
     //Create and validate store before setting state to ensure Validation is complete before the UI renders
@@ -177,12 +176,12 @@ export class PMMLEditor extends React.Component<Props, State> {
   }
 
   public getContent(): Promise<string> {
-    return Promise.resolve(this.doGetContent());
+    return this.doGetContent();
   }
 
-  private doGetContent(): string {
+  private async doGetContent(): Promise<string> {
     const pmml: PMML | undefined = this.store?.getState();
-    return pmml ? PMML2XML(pmml) : "";
+    return pmml ? await PMML2XML(pmml) : "";
   }
 
   public async undo(): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6226,8 +6226,8 @@ importers:
   packages/pmml-editor-marshaller:
     dependencies:
       jsonata:
-        specifier: ^1.8.7
-        version: 1.8.8
+        specifier: 2.2.1
+        version: 2.2.1
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -18642,8 +18642,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonata@1.8.8:
-    resolution: {integrity: sha512-nAGqrWc7M4T77AjEtnK1hhhR5M66zPeLXgLyfdwdD1nDAkzKcNWTus8cVaYRLTqEWK/jBDWBk7KD0zLYi4k/eg==}
+  jsonata@2.2.1:
+    resolution: {integrity: sha512-xd1uwUrKeIcJbsWhaoS3qAX4Ea8m0Mw0G5nlnAQvPT7TbZ5qaPdzBVTQia9KfyuyQm+nenfyjvzUDTRYHsC2sw==}
     engines: {node: '>= 8'}
 
   jsonc-parser@3.3.1:
@@ -37067,7 +37067,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonata@1.8.8: {}
+  jsonata@2.2.1: {}
 
   jsonc-parser@3.3.1: {}
 


### PR DESCRIPTION
Summary

upgrade jsonata from 1.8.7 to 2.2.1 to fix CVE

CVEs Remediated:
[High] https://github.com/advisories/GHSA-86vw-mfpg-wwv9
[Medium] https://github.com/advisories/GHSA-663r-x48j-fg8p