### PR TITLE
NO-ISSUE:Upgrade Quarkus from 3.27.4.1 to 3.27.5.1 , Netty 4.2.15.Final to 4.2.16.final, Vertx 4.5.27 to 4.5.31

### DIFF
--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "8816430978be02c31a59d8e35a629c3fab6dd37e",
+      default: "578d0c51c655c94c4cf03419d16b0996bf96eb8b",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/quarkus-bom/pom.xml
+++ b/packages/quarkus-bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Bill of Materials for KIE Tools Quarkus-based projects</description>
 
   <properties>
-    <version.quarkus>3.27.4.1</version.quarkus>
+    <version.quarkus>3.27.5.1</version.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260616-local",
+      default: "999-20260807-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,7 +69,7 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.27.4.1",
+      default: "3.27.5.1",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */


### PR DESCRIPTION
## Summary

Upgrades Quarkus from `3.27.4.1` → `3.27.5.1` across all affected modules to remediate two CVEs.

## Fix Strategy

- **CVE-2026-55831 (netty 4.1.x):** Quarkus 3.27.5.1 BOM pins `io.netty:netty-codec-http:4.1.136.Final` — resolves automatically via upgrade.
- **CVE-2026-8484 (jansi):** Quarkus 3.27.5 upgraded `readline` from `2.6` → `2.6.3`, which replaces the unmaintained `org.fusesource.jansi:jansi:2.4.0` with the maintained `org.jline:jansi:4.2.1`. No separate exclusion needed.

##Related PRs:
-https://github.com/apache/incubator-kie/pull/6882
https://github.com/apache/incubator-kie-examples/pull/2223
