### PR TITLE
NO-ISSUE: CVE-2026-53666 : Upgrade react-router-dom to 7.18.0

### DIFF
--- a/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
@@ -27,7 +27,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.108.4",

--- a/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
+++ b/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/package.json
@@ -27,7 +27,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^7.18.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.9.3",
     "webpack": "^5.108.4",

--- a/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/src/App.tsx
+++ b/examples/micro-frontends-multiplying-architecture-ping-pong-views-on-webapp/src/App.tsx
@@ -23,7 +23,7 @@ import { Brand } from "@patternfly/react-core/dist/js/components/Brand";
 import { Nav, NavItem, NavList } from "@patternfly/react-core/dist/js/components/Nav";
 import { Page } from "@patternfly/react-core/dist/js/components/Page";
 import { PageHeader } from "@patternfly/react-core/deprecated";
-import { HashRouter as Router, Link, Route, Routes } from "react-router-dom";
+import { HashRouter as Router, Link, Route, Routes } from "react-router";
 import { PingPongReactIFrameViewsPage } from "./React/PingPongReactIFrameViewsPage";
 import { PingPongReactDivViewsPage } from "./React/PingPongReactDivViewsPage";
 import { PingPongAngularIFrameViewsPage } from "./Angular/PingPongAngularIFrameViewsPage";

--- a/packages/dev-deployment-dmn-form-webapp/package.json
+++ b/packages/dev-deployment-dmn-form-webapp/package.json
@@ -38,7 +38,7 @@
     "@readme/openapi-parser": "^2.5.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.18.1",
-    "react-router-dom": "^7.18.0"
+    "react-router": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/dev-deployment-dmn-form-webapp/package.json
+++ b/packages/dev-deployment-dmn-form-webapp/package.json
@@ -38,7 +38,7 @@
     "@readme/openapi-parser": "^2.5.0",
     "json-refs": "^3.0.15",
     "lodash": "^4.18.1",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormApp.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormApp.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { I18nDictionariesProvider } from "@kie-tools-core/i18n/dist/react-components";
-import { HashRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
+import { HashRouter, Navigate, Route, Routes, useParams } from "react-router";
 import { AppContext, AppContextType } from "./AppContext";
 import { AppContextProvider } from "./AppContextProvider";
 import { DmnFormErrorPage } from "./DmnFormErrorPage";

--- a/packages/dev-deployment-dmn-form-webapp/src/DmnFormToolbar.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/src/DmnFormToolbar.tsx
@@ -33,7 +33,7 @@ import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 import { EllipsisVIcon } from "@patternfly/react-icons/dist/js/icons/ellipsis-v-icon";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons/dist/js/icons/external-link-alt-icon";
 import HelpIcon from "@patternfly/react-icons/dist/js/icons/help-icon";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useApp } from "./AppContext";
 import { useDmnFormI18n } from "./i18n";
 import { routes } from "./Routes";

--- a/packages/dev-deployment-dmn-form-webapp/tests/jest.setup.ts
+++ b/packages/dev-deployment-dmn-form-webapp/tests/jest.setup.ts
@@ -18,3 +18,6 @@
  */
 
 import "@testing-library/jest-dom";
+import { TextEncoder } from "util";
+
+global.TextEncoder = TextEncoder;

--- a/packages/dev-deployment-dmn-form-webapp/tests/testing_utils.tsx
+++ b/packages/dev-deployment-dmn-form-webapp/tests/testing_utils.tsx
@@ -21,7 +21,7 @@ import { I18nDictionariesProvider, I18nDictionariesProviderProps } from "@kie-to
 import React from "react";
 import { AppContext, AppContextType } from "../src/AppContext";
 import { DmnFormI18n, DmnFormI18nContext, dmnFormI18nDefaults, dmnFormI18nDictionaries } from "../src/i18n";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 export function usingTestingDmnFormI18nContext(
   children: React.ReactElement,

--- a/packages/dev-deployment-dmn-form-webapp/tsconfig.tests.json
+++ b/packages/dev-deployment-dmn-form-webapp/tsconfig.tests.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom", "node"]
   }
 }

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -81,7 +81,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^11.4.2",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.3.1",
     "uuid": "^14.0.0"

--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -81,7 +81,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^11.4.2",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^7.18.0",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.3.1",
     "uuid": "^14.0.0"

--- a/packages/online-editor/src/App.tsx
+++ b/packages/online-editor/src/App.tsx
@@ -19,8 +19,15 @@
 
 import * as React from "react";
 import { useMemo } from "react";
-import { createHashRouter, createRoutesFromElements, Navigate, Outlet, Route, useParams } from "react-router";
-import { RouterProvider } from "react-router/dom";
+import {
+  createHashRouter,
+  RouterProvider,
+  createRoutesFromElements,
+  Navigate,
+  Outlet,
+  Route,
+  useParams,
+} from "react-router";
 import { EditorEnvelopeLocatorContextProvider } from "./envelopeLocator/hooks/EditorEnvelopeLocatorContext";
 import { EditorPage } from "./editor/EditorPage";
 import { OnlineI18nContextProvider } from "./i18n";

--- a/packages/online-editor/src/App.tsx
+++ b/packages/online-editor/src/App.tsx
@@ -19,15 +19,8 @@
 
 import * as React from "react";
 import { useMemo } from "react";
-import {
-  createHashRouter,
-  createRoutesFromElements,
-  Navigate,
-  Outlet,
-  Route,
-  RouterProvider,
-  useParams,
-} from "react-router-dom";
+import { createHashRouter, createRoutesFromElements, Navigate, Outlet, Route, useParams } from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { EditorEnvelopeLocatorContextProvider } from "./envelopeLocator/hooks/EditorEnvelopeLocatorContext";
 import { EditorPage } from "./editor/EditorPage";
 import { OnlineI18nContextProvider } from "./i18n";

--- a/packages/online-editor/src/NoMatchPage.tsx
+++ b/packages/online-editor/src/NoMatchPage.tsx
@@ -23,7 +23,7 @@ import { Text, TextContent } from "@patternfly/react-core/dist/js/components/Tex
 import { EmptyState, EmptyStateBody, EmptyStateFooter } from "@patternfly/react-core/dist/js/components/EmptyState";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { useRoutes } from "./navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { EmptyStateActions } from "@patternfly/react-core/dist/js/components/EmptyState";
 

--- a/packages/online-editor/src/accelerators/AcceleratorsHooks.tsx
+++ b/packages/online-editor/src/accelerators/AcceleratorsHooks.tsx
@@ -31,7 +31,7 @@ import {
 } from "./AcceleratorsApi";
 import { WorkspaceFile, useWorkspaces } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { dirname, join } from "path";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { useGlobalAlert } from "../alerts";
 import { Alert } from "@patternfly/react-core/dist/js/components/Alert";

--- a/packages/online-editor/src/editor/EditorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPage.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { EditorToolbar } from "./Toolbar/EditorToolbar";
 import { useOnlineI18n } from "../i18n";

--- a/packages/online-editor/src/editor/EditorPageErrorPage.tsx
+++ b/packages/online-editor/src/editor/EditorPageErrorPage.tsx
@@ -31,7 +31,7 @@ import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components
 import * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { useRoutes } from "../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ClipboardCopy, ClipboardCopyVariant } from "@patternfly/react-core/dist/js/components/ClipboardCopy";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 

--- a/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/EditorToolbar.tsx
@@ -31,7 +31,7 @@ import { useOnlineI18n } from "../../i18n";
 import { ExtendedServicesButtons } from "../ExtendedServices/ExtendedServicesButtons";
 import { useNavigationBlockersBypass, useRoutes } from "../../navigation/Hooks";
 import { EmbeddedEditorRef } from "@kie-tools-core/editor/dist/embedded";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useWorkspaces, WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { PlusIcon } from "@patternfly/react-icons/dist/js/icons/plus-icon";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";

--- a/packages/online-editor/src/editor/Toolbar/GitIntegration/GitIntegrationContextProvider.tsx
+++ b/packages/online-editor/src/editor/Toolbar/GitIntegration/GitIntegrationContextProvider.tsx
@@ -51,7 +51,7 @@ import {
   GIT_ORIGIN_REMOTE_NAME,
 } from "@kie-tools-core/workspaces-git-fs/dist/constants/GitConstants";
 import { useNavigationBlockersBypass, useRoutes } from "../../../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useGitIntegrationAlerts } from "./GitIntegrationAlerts";
 import { AuthProviderGroup, isGistEnabledAuthProviderType } from "../../../authProviders/AuthProvidersApi";
 import { useEditorToolbarDispatchContext } from "../EditorToolbarContextProvider";

--- a/packages/online-editor/src/editor/Toolbar/Workspace/Hooks.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Workspace/Hooks.tsx
@@ -32,7 +32,7 @@ import { PushToGitAlertActionLinks } from "../GitIntegration/PushToGitAlertActio
 import { useGitIntegration } from "../GitIntegration/GitIntegrationContextProvider";
 import { switchExpression } from "@kie-tools-core/switch-expression-ts";
 import { GIT_ORIGIN_REMOTE_NAME } from "@kie-tools-core/workspaces-git-fs/dist/constants/GitConstants";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useEditorToolbarContext } from "../EditorToolbarContextProvider";
 
 export function useWorkspaceNavigationBlocker(workspace: ActiveWorkspace) {

--- a/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
+++ b/packages/online-editor/src/editor/Toolbar/Workspace/WorkspaceToolbar.tsx
@@ -21,7 +21,7 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { ActiveWorkspace } from "@kie-tools-core/workspaces-git-fs/dist/model/ActiveWorkspace";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../../../navigation/Hooks";
 import AngleLeftIcon from "@patternfly/react-icons/dist/js/icons/angle-left-icon";
 import { AuthSessionSelect } from "../../../authSessions/AuthSessionSelect";

--- a/packages/online-editor/src/filesList/FileDataList.tsx
+++ b/packages/online-editor/src/filesList/FileDataList.tsx
@@ -30,7 +30,7 @@ import {
   DataListItemCells,
   DataListItemRow,
 } from "@patternfly/react-core/dist/js/components/DataList";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { TaskIcon } from "@patternfly/react-icons/dist/js/icons/task-icon";
 import { WorkspaceDescriptor } from "@kie-tools-core/workspaces-git-fs/dist/worker/api/WorkspaceDescriptor";

--- a/packages/online-editor/src/gitlab/ParseGitLabUrl.ts
+++ b/packages/online-editor/src/gitlab/ParseGitLabUrl.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { matchPath } from "react-router-dom";
+import { matchPath } from "react-router";
 import { ImportableUrl, UrlType } from "../importFromUrl/ImportableUrlHooks";
 
 const GITLAB_NAMESPACE_REGEX = "([^\\/]+(?:\\/[^\\/]+)*)"; // group or nested group(s)

--- a/packages/online-editor/src/home/HomePage.tsx
+++ b/packages/online-editor/src/home/HomePage.tsx
@@ -23,7 +23,7 @@ import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { Label } from "@patternfly/react-core/dist/js/components/Label";
 import { useEditorEnvelopeLocator } from "../envelopeLocator/hooks/EditorEnvelopeLocatorContext";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link } from "react-router";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";

--- a/packages/online-editor/src/home/UploadCard.tsx
+++ b/packages/online-editor/src/home/UploadCard.tsx
@@ -26,7 +26,7 @@ import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { Card, CardBody, CardFooter, CardTitle } from "@patternfly/react-core/dist/js/components/Card";
 import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 import { useRoutes } from "../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { Button, ButtonVariant } from "@patternfly/react-core/dist/js/components/Button";
 import { Spinner } from "@patternfly/react-core/dist/js/components/Spinner";
 import { UploadIcon } from "@patternfly/react-icons/dist/js/icons/upload-icon";

--- a/packages/online-editor/src/importFromUrl/ImportFromUrlHomePageCard.tsx
+++ b/packages/online-editor/src/importFromUrl/ImportFromUrlHomePageCard.tsx
@@ -28,7 +28,7 @@ import { CodeIcon } from "@patternfly/react-icons/dist/js/icons/code-icon";
 import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { AccountsDispatchActionKind, useAccountsDispatch } from "../accounts/AccountsContext";
 import { useAuthProviders } from "../authProviders/AuthProvidersContext";
 import { AUTH_SESSION_NONE, AuthSession } from "../authSessions/AuthSessionApi";

--- a/packages/online-editor/src/importFromUrl/ImportableUrlHooks.tsx
+++ b/packages/online-editor/src/importFromUrl/ImportableUrlHooks.tsx
@@ -26,7 +26,7 @@ import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { extname } from "path";
 import * as React from "react";
 import { useCallback, useMemo } from "react";
-import { matchPath } from "react-router-dom";
+import { matchPath } from "react-router";
 import { AuthProviderIcon } from "../authProviders/AuthProviderIcon";
 import { useAuthProvider, useAuthProviders } from "../authProviders/AuthProvidersContext";
 import { AuthSession, AUTH_SESSION_NONE } from "../authSessions/AuthSessionApi";

--- a/packages/online-editor/src/importFromUrl/NewWorkspaceFromUrlPage.tsx
+++ b/packages/online-editor/src/importFromUrl/NewWorkspaceFromUrlPage.tsx
@@ -24,7 +24,7 @@ import { Text, TextContent, TextVariants } from "@patternfly/react-core/dist/js/
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { basename } from "path";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { EditorPageErrorPage } from "../editor/EditorPageErrorPage";
 import { useRoutes } from "../navigation/Hooks";
 import { QueryParams } from "../navigation/Routes";

--- a/packages/online-editor/src/importFromUrl/NewWorkspaceWithEmptyFilePage.tsx
+++ b/packages/online-editor/src/importFromUrl/NewWorkspaceWithEmptyFilePage.tsx
@@ -20,7 +20,7 @@
 import * as React from "react";
 import { useWorkspaces } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { OnlineEditorPage } from "../pageTemplate/OnlineEditorPage";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";

--- a/packages/online-editor/src/navigation/NavigationContextProvider.tsx
+++ b/packages/online-editor/src/navigation/NavigationContextProvider.tsx
@@ -19,7 +19,7 @@
 
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useBlocker, Location } from "react-router-dom";
+import { useBlocker, Location } from "react-router";
 
 export type BlockerDelegate = (args: { location: Location }) => boolean;
 

--- a/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
+++ b/packages/online-editor/src/pageTemplate/OnlineEditorPage.tsx
@@ -22,7 +22,7 @@ import { PageHeaderToolsItem } from "@patternfly/react-core/deprecated";
 
 import * as React from "react";
 import { useRoutes } from "../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { Masthead, MastheadBrand, MastheadMain } from "@patternfly/react-core/dist/js/components/Masthead";
 import { SettingsButton } from "../settings/SettingsButton";
 import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";

--- a/packages/online-editor/src/queryParams/QueryParamsContext.ts
+++ b/packages/online-editor/src/queryParams/QueryParamsContext.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useMemo } from "react";
 import { newQueryParamsImpl, QueryParamsImpl } from "../navigation/Routes";
 

--- a/packages/online-editor/src/settings/SettingsContext.tsx
+++ b/packages/online-editor/src/settings/SettingsContext.tsx
@@ -24,7 +24,7 @@ import { decoder, encoder } from "@kie-tools-core/workspaces-git-fs/dist/encoder
 import { LfsFsCache } from "@kie-tools-core/workspaces-git-fs/dist/lfs/LfsFsCache";
 import { LfsStorageFile, LfsStorageService } from "@kie-tools-core/workspaces-git-fs/dist/lfs/LfsStorageService";
 import { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useEnv } from "../env/hooks/EnvContext";
 import { QueryParams } from "../navigation/Routes";
 import { useQueryParams } from "../queryParams/QueryParamsContext";

--- a/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
+++ b/packages/online-editor/src/workspace/components/WorkspaceStatusIndicator.tsx
@@ -30,7 +30,7 @@ import { OutlinedClockIcon } from "@patternfly/react-icons/dist/js/icons/outline
 import { SecurityIcon } from "@patternfly/react-icons/dist/js/icons/security-icon";
 import { CheckCircleIcon } from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
 import { useNavigationBlocker, useRoutes } from "../../navigation/Hooks";
-import { matchPath } from "react-router-dom";
+import { matchPath } from "react-router";
 import { WorkspaceFile } from "@kie-tools-core/workspaces-git-fs/dist/context/WorkspacesContext";
 import { switchExpression } from "@kie-tools-core/switch-expression-ts";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -51,7 +51,7 @@
     "react-cool-onclickoutside": "^1.6.1",
     "react-monaco-editor": "^0.49.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "react-sortable-hoc": "^2.0.0",
     "react-transition-group": "^4.4.1",
     "redux": "^4.1.0",

--- a/packages/pmml-editor/package.json
+++ b/packages/pmml-editor/package.json
@@ -51,7 +51,7 @@
     "react-cool-onclickoutside": "^1.6.1",
     "react-monaco-editor": "^0.49.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^7.18.0",
     "react-sortable-hoc": "^2.0.0",
     "react-transition-group": "^4.4.1",
     "redux": "^4.1.0",

--- a/packages/pmml-editor/src/editor/PMMLEditor.tsx
+++ b/packages/pmml-editor/src/editor/PMMLEditor.tsx
@@ -35,7 +35,7 @@ import mergeReducers from "combine-reducer";
 import { HistoryContext, HistoryService } from "./history";
 import { LandingPage } from "./components/LandingPage/templates";
 import { Page } from "@patternfly/react-core/dist/js/components/Page";
-import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
+import { HashRouter, Navigate, Route, Routes } from "react-router";
 import { EmptyStateNoContent } from "./components/LandingPage/organisms";
 import { SingleEditorRouter } from "./components/EditorCore/organisms";
 import { PMMLModelMapping, PMMLModels, SupportedCapability } from "./PMMLModelHelper";

--- a/packages/pmml-editor/src/editor/components/EditorCore/organisms/SingleEditorRouter.tsx
+++ b/packages/pmml-editor/src/editor/components/EditorCore/organisms/SingleEditorRouter.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import * as React from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { ScorecardEditorPage } from "../../EditorScorecard/templates";
 import { getModelType, isSupportedModelType } from "../../..";
 import { Model, PMML } from "@kie-tools/pmml-editor-marshaller";

--- a/packages/pmml-editor/src/editor/components/LandingPage/templates/LandingPage.tsx
+++ b/packages/pmml-editor/src/editor/components/LandingPage/templates/LandingPage.tsx
@@ -27,7 +27,7 @@ import { useSelector } from "react-redux";
 import { getModelName, getModelType, isSupportedModelType, ModelType } from "../../..";
 import { LandingPageHeader, LandingPageToolbar, ModelCard } from "../molecules";
 import { Actions } from "../../../reducers";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useBatchDispatch, useHistoryService } from "../../../history";
 
 interface LandingPageProps {

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -22,7 +22,7 @@ import { LandingPage } from "@kie-tools/pmml-editor/dist/editor/components/Landi
 import { Provider } from "react-redux";
 import { createStore, Store } from "redux";
 import { PMML, Scorecard, TreeModel } from "@kie-tools/pmml-editor-marshaller";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 const PATH: string = "path";
 

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -26,13 +26,6 @@ import { BrowserRouter } from "react-router-dom";
 
 const PATH: string = "path";
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useHistory: () => ({
-    push: jest.fn(),
-  }),
-}));
-
 describe("LandingPage", () => {
   test("render::No Models", () => {
     const pmml: PMML = { version: "1.0", DataDictionary: { DataField: [] }, Header: {} };

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -26,13 +26,6 @@ import { BrowserRouter } from "react-router";
 
 const PATH: string = "path";
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useHistory: () => ({
-    push: jest.fn(),
-  }),
-}));
-
 describe("LandingPage", () => {
   test("render::No Models", () => {
     const pmml: PMML = { version: "1.0", DataDictionary: { DataField: [] }, Header: {} };

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -26,6 +26,13 @@ import { BrowserRouter } from "react-router-dom";
 
 const PATH: string = "path";
 
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
 describe("LandingPage", () => {
   test("render::No Models", () => {
     const pmml: PMML = { version: "1.0", DataDictionary: { DataField: [] }, Header: {} };

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import { LandingPage } from "@kie-tools/pmml-editor/dist/editor/components/LandingPage/templates";
 import { Provider } from "react-redux";
@@ -25,13 +25,6 @@ import { PMML, Scorecard, TreeModel } from "@kie-tools/pmml-editor-marshaller";
 import { BrowserRouter } from "react-router";
 
 const PATH: string = "path";
-
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useHistory: () => ({
-    push: jest.fn(),
-  }),
-}));
 
 describe("LandingPage", () => {
   test("render::No Models", () => {

--- a/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
+++ b/packages/pmml-editor/tests/editor/components/LandingPage/templates/LandingPage.test.tsx
@@ -26,6 +26,13 @@ import { BrowserRouter } from "react-router";
 
 const PATH: string = "path";
 
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
 describe("LandingPage", () => {
   test("render::No Models", () => {
     const pmml: PMML = { version: "1.0", DataDictionary: { DataField: [] }, Header: {} };

--- a/packages/pmml-editor/tests/jest.setup.ts
+++ b/packages/pmml-editor/tests/jest.setup.ts
@@ -18,7 +18,10 @@
  */
 
 import "@testing-library/jest-dom";
+import { TextEncoder } from "util";
 import { enableMapSet, enablePatches } from "immer";
+
+global.TextEncoder = TextEncoder;
 
 enableMapSet();
 enablePatches();

--- a/packages/pmml-editor/tsconfig.tests.json
+++ b/packages/pmml-editor/tsconfig.tests.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom", "node"]
   }
 }

--- a/packages/runtime-tools-components/package.json
+++ b/packages/runtime-tools-components/package.json
@@ -43,7 +43,7 @@
     "monaco-editor": "^0.39.0",
     "react-datetime-picker": "^3.5.0",
     "react-moment": "0.9.7",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^7.18.0",
     "uniforms": "^3.10.2",
     "uniforms-bridge-json-schema": "^3.10.2",
     "uuid": "^14.0.0"

--- a/packages/runtime-tools-components/package.json
+++ b/packages/runtime-tools-components/package.json
@@ -43,7 +43,7 @@
     "monaco-editor": "^0.39.0",
     "react-datetime-picker": "^3.5.0",
     "react-moment": "0.9.7",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "uniforms": "^3.10.2",
     "uniforms-bridge-json-schema": "^3.10.2",
     "uuid": "^14.0.0"

--- a/packages/runtime-tools-components/src/components/PageSectionHeader/PageSectionHeader.tsx
+++ b/packages/runtime-tools-components/src/components/PageSectionHeader/PageSectionHeader.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import * as React from "react";
-import { Link, Location } from "react-router-dom";
+import { Link, Location } from "react-router";
 import { useMemo, ReactElement } from "react";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/js/components/Breadcrumb";

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -51,7 +51,7 @@
     "react-apollo": "3.1.3",
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.0"
+    "react-router": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -51,7 +51,7 @@
     "react-apollo": "3.1.3",
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/components/AuthSessionSelect.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/components/AuthSessionSelect.tsx
@@ -30,7 +30,7 @@ import { Flex, FlexItem } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
 import { AuthSessionStatus, getAuthSessionDisplayInfo } from "../AuthSessionApi";
 import { useRoutes } from "../../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export type AuthSessionSelectProps = {
   isPlain: boolean;

--- a/packages/runtime-tools-management-console-webapp/src/authSessions/components/NewAuthSessionLoginSuccessPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/authSessions/components/NewAuthSessionLoginSuccessPage.tsx
@@ -19,7 +19,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { useAuthSessions, useAuthSessionsDispatch } from "../AuthSessionsContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { AuthSessionsService } from "../AuthSessionsService";
 import { ManagementConsolePageLayout } from "../../managementConsole/ManagementConsolePageLayout";
 import { useRoutes } from "../../navigation/Hooks";

--- a/packages/runtime-tools-management-console-webapp/src/jobs/Jobs.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/jobs/Jobs.tsx
@@ -22,7 +22,7 @@ import {
   JobsManagementState,
 } from "@kie-tools/runtime-tools-process-enveloped-components/dist/jobsManagement";
 import { useJobsManagementChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/JobsManagement";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { useQueryParam, useQueryParams } from "../navigation/queryParams/QueryParamsContext";
 import { RuntimePathSearchParamsRoutes, useRuntimeDispatch } from "../runtime/RuntimeContext";
 import { QueryParams } from "../navigation/Routes";

--- a/packages/runtime-tools-management-console-webapp/src/jobs/JobsPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/jobs/JobsPage.tsx
@@ -20,7 +20,7 @@ import React, { useEffect } from "react";
 import { Card } from "@patternfly/react-core/dist/js/components/Card";
 import { Jobs } from "./Jobs";
 import { AuthSession, useAuthSessionsDispatch } from "../authSessions";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../runtime/RuntimeContext";
 import { useEnv } from "../env/hooks/EnvContext";
 import { useRuntimePageLayoutDispatch } from "../runtime/RuntimePageLayoutContext";

--- a/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsole.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsole.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { AuthSessionsContextProvider } from "../authSessions/AuthSessionsContext";
 import { ManagementConsoleRoutes } from "./ManagementConsoleRoutes";
 import { EnvContextProvider } from "../env/hooks/EnvContextProvider";

--- a/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsoleHome.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsoleHome.tsx
@@ -35,7 +35,7 @@ import { CubesIcon } from "@patternfly/react-icons/dist/js/icons/cubes-icon";
 import { PlusIcon } from "@patternfly/react-icons/dist/js/icons/plus-icon";
 import { useEnv } from "../env/hooks/EnvContext";
 import { AuthSession, AuthSessionsList, isOpenIdConnectAuthSession } from "../authSessions";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { Flex } from "@patternfly/react-core/dist/js/layouts/Flex";
 import { Divider } from "@patternfly/react-core/dist/js/components/Divider";

--- a/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsolePageLayout.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsolePageLayout.tsx
@@ -22,7 +22,7 @@ import { Page, PageSection, PageSidebar, PageSidebarBody } from "@patternfly/rea
 import { PageHeader, PageHeaderTools } from "@patternfly/react-core/deprecated";
 import { useEnv } from "../env/hooks/EnvContext";
 import { useRoutes } from "../navigation/Hooks";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { ManagementConsoleToolbar } from "./ManagementConsoleToolbar";
 import { AboutButton } from "../aboutModal/AboutButton";
 import { PageSectionHeader } from "@kie-tools/runtime-tools-components/dist/components/PageSectionHeader";

--- a/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsoleRoutes.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/managementConsole/ManagementConsoleRoutes.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 import React, { FC, useCallback } from "react";
-import { Outlet, Route } from "react-router-dom";
+import { Outlet, Route } from "react-router";
 import { ProcessListPage, ProcessDefinitionsListPage } from "../process";
-import { Routes, useNavigate, useLocation, useParams } from "react-router-dom";
+import { Routes, useNavigate, useLocation, useParams } from "react-router";
 import { ManagementConsoleHome } from "./ManagementConsoleHome";
 import { NewAuthSessionLoginSuccessPage, NewAuthSessionModal } from "../authSessions/components";
 import { useRoutes } from "../navigation/Hooks";

--- a/packages/runtime-tools-management-console-webapp/src/navigation/queryParams/QueryParamsContext.ts
+++ b/packages/runtime-tools-management-console-webapp/src/navigation/queryParams/QueryParamsContext.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useMemo } from "react";
 import { newQueryParamsImpl, QueryParamsImpl } from "../Routes";
 

--- a/packages/runtime-tools-management-console-webapp/src/process/definitions/ProcessDefinitionsList.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/definitions/ProcessDefinitionsList.tsx
@@ -22,7 +22,7 @@ import {
   ProcessDefinitionsFilter,
   ProcessDefinitionsListState,
 } from "@kie-tools/runtime-tools-process-enveloped-components/dist/processDefinitionsList";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useQueryParam, useQueryParams } from "../../navigation/queryParams/QueryParamsContext";
 import { QueryParams } from "../../navigation/Routes";
 import { RuntimePathSearchParamsRoutes, useRuntimeDispatch } from "../../runtime/RuntimeContext";

--- a/packages/runtime-tools-management-console-webapp/src/process/definitions/ProcessDefinitionsListPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/definitions/ProcessDefinitionsListPage.tsx
@@ -21,7 +21,7 @@ import { Card } from "@patternfly/react-core/dist/js/components/Card";
 import { ProcessDefinitionsList } from "./ProcessDefinitionsList";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../../runtime/RuntimeContext";
 import { AuthSession, useAuthSessionsDispatch } from "../../authSessions";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../../navigation/Hooks";
 import { useEnv } from "../../env/hooks/EnvContext";
 import { useRuntimePageLayoutDispatch } from "../../runtime/RuntimePageLayoutContext";

--- a/packages/runtime-tools-management-console-webapp/src/process/details/ProcessDetails.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/details/ProcessDetails.tsx
@@ -37,7 +37,7 @@ import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancela
 import { EmbeddedProcessDetails } from "@kie-tools/runtime-tools-process-enveloped-components/dist/processDetails";
 import { useProcessDetailsChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/ProcessDetails";
 import { useRuntimeSpecificRoutes } from "../../runtime/RuntimeContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface Props {
   processInstanceId: string;

--- a/packages/runtime-tools-management-console-webapp/src/process/details/ProcessDetailsPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/details/ProcessDetailsPage.tsx
@@ -20,7 +20,7 @@ import React, { useCallback, useEffect } from "react";
 import { ProcessDetails } from "./ProcessDetails";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../../runtime/RuntimeContext";
 import { AuthSession, useAuthSessionsDispatch } from "../../authSessions";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
 import { useEnv } from "../../env/hooks/EnvContext";
 import { useRoutes } from "../../navigation/Hooks";

--- a/packages/runtime-tools-management-console-webapp/src/process/form/ProcessDefinitionFormPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/form/ProcessDefinitionFormPage.tsx
@@ -20,7 +20,7 @@ import React, { useCallback, useEffect } from "react";
 import { ProcessDefinitionForm } from "./ProcessDefinitionForm";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../../runtime/RuntimeContext";
 import { AuthSession, useAuthSessionsDispatch } from "../../authSessions";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
 import { useEnv } from "../../env/hooks/EnvContext";
 import { useRoutes } from "../../navigation/Hooks";

--- a/packages/runtime-tools-management-console-webapp/src/process/list/ProcessList.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/list/ProcessList.tsx
@@ -28,7 +28,7 @@ import {
   EmbeddedProcessList,
   ProcessListState,
 } from "@kie-tools/runtime-tools-process-enveloped-components/dist/processList";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { OrderBy } from "@kie-tools/runtime-tools-shared-gateway-api/dist/types";
 import { useQueryParam, useQueryParams } from "../../navigation/queryParams/QueryParamsContext";
 import { QueryParams } from "../../navigation/Routes";

--- a/packages/runtime-tools-management-console-webapp/src/process/list/ProcessListPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/process/list/ProcessListPage.tsx
@@ -21,7 +21,7 @@ import { Card } from "@patternfly/react-core/dist/js/components/Card";
 import { ProcessList } from "./ProcessList";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../../runtime/RuntimeContext";
 import { AuthSession, useAuthSessionsDispatch } from "../../authSessions";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../../navigation/Hooks";
 import { useEnv } from "../../env/hooks/EnvContext";
 import { useRuntimePageLayoutDispatch } from "../../runtime/RuntimePageLayoutContext";

--- a/packages/runtime-tools-management-console-webapp/src/runtime/RuntimeContext.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/runtime/RuntimeContext.tsx
@@ -28,7 +28,7 @@ import {
   isUnauthenticatedAuthSession,
   OpenIDConnectAuthSession,
 } from "../authSessions/AuthSessionApi";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import ApolloClient from "apollo-client";
 import { InMemoryCache, NormalizedCacheObject } from "apollo-cache-inmemory";

--- a/packages/runtime-tools-management-console-webapp/src/runtime/RuntimeNav.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/runtime/RuntimeNav.tsx
@@ -18,7 +18,7 @@
  */
 import React from "react";
 import { Nav, NavItem, NavList } from "@patternfly/react-core/dist/js/components/Nav";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useRuntimeSpecificRoutes } from "./RuntimeContext";
 
 export const RuntimeNav: React.FC = () => {

--- a/packages/runtime-tools-management-console-webapp/src/tasks/TaskDetails.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/tasks/TaskDetails.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import {
   Drawer,
   DrawerActions,

--- a/packages/runtime-tools-management-console-webapp/src/tasks/TaskDetailsPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/tasks/TaskDetailsPage.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useCallback, useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../runtime/RuntimeContext";
 import { AuthSession, useAuthSessionsDispatch } from "../authSessions";
 import { useEnv } from "../env/hooks/EnvContext";

--- a/packages/runtime-tools-management-console-webapp/src/tasks/Tasks.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/tasks/Tasks.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { EmbeddedTaskList } from "@kie-tools/runtime-tools-process-enveloped-components/dist/taskList";
 import { getActiveTaskStates, getAllTaskStates } from "@kie-tools/runtime-tools-process-webapp-components/dist/utils";
 import {
@@ -29,7 +29,7 @@ import { TaskListState } from "@kie-tools/runtime-tools-process-enveloped-compon
 import { RuntimePathSearchParamsRoutes, useRuntimeDispatch } from "../runtime/RuntimeContext";
 import { useQueryParam, useQueryParams } from "../navigation/queryParams/QueryParamsContext";
 import { QueryParams } from "../navigation/Routes";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useTaskListChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/TaskList";
 
 interface Props {

--- a/packages/runtime-tools-management-console-webapp/src/tasks/TasksPage.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/tasks/TasksPage.tsx
@@ -21,7 +21,7 @@ import { Card } from "@patternfly/react-core/dist/js/components/Card";
 import { Tasks } from "./Tasks";
 import { useEnv } from "../env/hooks/EnvContext";
 import { useRuntimeInfo, useRuntimeSpecificRoutes } from "../runtime/RuntimeContext";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useRoutes } from "../navigation/Hooks";
 import { AuthSession, useAuthSessionsDispatch } from "../authSessions";
 import { useRuntimePageLayoutDispatch } from "../runtime/RuntimePageLayoutContext";

--- a/packages/runtime-tools-management-console-webapp/src/tasks/components/ImpersonationPageSection.tsx
+++ b/packages/runtime-tools-management-console-webapp/src/tasks/components/ImpersonationPageSection.tsx
@@ -31,7 +31,7 @@ import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
 import UserTagIcon from "@patternfly/react-icons/dist/esm/icons/user-tag-icon";
 import UserIcon from "@patternfly/react-icons/dist/js/icons/user-icon";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { AuthSessionType, getAuthSessionDisplayInfo, useAuthSessions } from "../../authSessions";
 import { QueryParams } from "../../navigation/Routes";
 import { useQueryParams } from "../../navigation/queryParams/QueryParamsContext";

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -48,7 +48,7 @@
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^18.3.1",
     "react-moment": "0.9.7",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^7.18.0",
     "util": "^0.12.5",
     "uuid": "^14.0.0"
   },

--- a/packages/runtime-tools-process-dev-ui-webapp/package.json
+++ b/packages/runtime-tools-process-dev-ui-webapp/package.json
@@ -48,7 +48,7 @@
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^18.3.1",
     "react-moment": "0.9.7",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "util": "^0.12.5",
     "uuid": "^14.0.0"
   },

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { ApolloProvider } from "react-apollo";
 import { ApolloClient } from "apollo-client";
 import DevUINav from "../DevUINav/DevUINav";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUINav/DevUINav.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUINav/DevUINav.tsx
@@ -18,7 +18,7 @@
  */
 import React from "react";
 import { Nav, NavItem, NavList } from "@patternfly/react-core/dist/js/components/Nav";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { ouiaAttribute } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
 

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUIRoutes/DevUIRoutes.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUIRoutes/DevUIRoutes.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router";
 import { JobsManagementPage, ProcessesPage } from "../../pages";
 import ProcessDetailsPage from "../../pages/ProcessDetailsPage/ProcessDetailsPage";
 import TaskListPage from "../../pages/TaskListPage/TaskListPage";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/FormsListContainer/FormsListContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/FormsListContainer/FormsListContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { FormInfo } from "@kie-tools/runtime-tools-shared-gateway-api/dist/types";
 import { EmbeddedFormsList } from "@kie-tools/runtime-tools-process-enveloped-components/dist/formsList";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessDefinitionListContainer/ProcessDefinitionListContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessDefinitionListContainer/ProcessDefinitionListContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { ProcessDefinition } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 import {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessDetailsContainer/ProcessDetailsContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessDetailsContainer/ProcessDetailsContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { ProcessInstance } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 import { useProcessDetailsChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/ProcessDetails";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessListContainer/ProcessListContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/ProcessListContainer/ProcessListContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import {
   EmbeddedProcessList,

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/TaskListContainer/TaskListContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/TaskListContainer/TaskListContainer.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { useTaskListChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/TaskList";
 import { EmbeddedTaskList, TaskListApi } from "@kie-tools/runtime-tools-process-enveloped-components/dist/taskList";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/FormDetailsPage/FormDetailsPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/FormDetailsPage/FormDetailsPage.tsx
@@ -24,7 +24,7 @@ import { Text, TextVariants } from "@patternfly/react-core/dist/js/components/Te
 import { OUIAProps, ouiaPageTypeAndObjectId } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
 import FormDetailsContainer from "../../containers/FormDetailsContainer/FormDetailsContainer";
 import "../../styles.css";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import Moment from "react-moment";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import { FormInfo } from "@kie-tools/runtime-tools-shared-gateway-api/dist/types";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -25,7 +25,7 @@ import { ServerErrors } from "@kie-tools/runtime-tools-components/dist/component
 import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
 import ProcessDetailsContainer from "../../containers/ProcessDetailsContainer/ProcessDetailsContainer";
 import { useProcessDetailsChannelApi } from "@kie-tools/runtime-tools-process-webapp-components/dist/ProcessDetails";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router";
 import "../../styles.css";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";
 import {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessFormPage/ProcessFormPage.tsx
@@ -19,7 +19,7 @@
 import React, { useState, useCallback, useMemo, ReactElement } from "react";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import ProcessFormContainer from "../../containers/ProcessFormContainer/ProcessFormContainer";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import { InlineEdit } from "./components/InlineEdit/InlineEdit";
 import { ProcessDefinition } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 import { FormNotification, Notification } from "@kie-tools/runtime-tools-components/dist/components/FormNotification";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessesPage/ProcessesPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/ProcessesPage/ProcessesPage.tsx
@@ -20,7 +20,7 @@ import React, { useState } from "react";
 import { Card } from "@patternfly/react-core/dist/js/components/Card";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Tab, Tabs, TabTitleText } from "@patternfly/react-core/dist/js/components/Tabs";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import ProcessListContainer from "../../containers/ProcessListContainer/ProcessListContainer";
 import "../../styles.css";
 import { useDevUIAppContext } from "../../contexts/DevUIAppContext";

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/TaskDetailsPage/TaskDetailsPage.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import React, { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 import {
   Drawer,
   DrawerActions,

--- a/packages/runtime-tools-shared-webapp-components/package.json
+++ b/packages/runtime-tools-shared-webapp-components/package.json
@@ -26,7 +26,7 @@
     "@kie-tools/runtime-tools-components": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
-    "react-router-dom": "^7.18.0"
+    "react-router": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/runtime-tools-shared-webapp-components/package.json
+++ b/packages/runtime-tools-shared-webapp-components/package.json
@@ -26,7 +26,7 @@
     "@kie-tools/runtime-tools-components": "workspace:*",
     "@patternfly/react-core": "^5.4.1",
     "@patternfly/react-icons": "^5.4.1",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^7.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/runtime-tools-shared-webapp-components/src/NoData/NoData.tsx
+++ b/packages/runtime-tools-shared-webapp-components/src/NoData/NoData.tsx
@@ -31,7 +31,7 @@ import { Button } from "@patternfly/react-core/dist/js/components/Button";
 import { PageSection } from "@patternfly/react-core/dist/js/components/Page";
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { SearchIcon } from "@patternfly/react-icons/dist/js/icons/search-icon";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
 
 export interface IOwnProps {

--- a/packages/runtime-tools-shared-webapp-components/src/PageNotFound/PageNotFound.tsx
+++ b/packages/runtime-tools-shared-webapp-components/src/PageNotFound/PageNotFound.tsx
@@ -31,7 +31,7 @@ import { Button } from "@patternfly/react-core/dist/js/components/Button";
 
 import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
 import { ExclamationCircleIcon } from "@patternfly/react-icons/dist/js/icons/exclamation-circle-icon";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { componentOuiaProps, OUIAProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools/OuiaUtils";
 
 interface IOwnProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,7 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rimraf:
@@ -2400,7 +2400,7 @@ importers:
       react-dom:
         specifier: '>=18.3.1 <19.0.0'
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
@@ -5781,7 +5781,7 @@ importers:
       react-dropzone:
         specifier: ^11.4.2
         version: 11.7.1(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer:
@@ -6071,7 +6071,7 @@ importers:
       react-redux:
         specifier: ^9.1.2
         version: 9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-sortable-hoc:
@@ -6459,7 +6459,7 @@ importers:
       react-moment:
         specifier: 0.9.7
         version: 0.9.7(moment@2.30.1)(prop-types@15.8.1)(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uniforms:
@@ -6605,7 +6605,7 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
@@ -6867,7 +6867,7 @@ importers:
       react-moment:
         specifier: 0.9.7
         version: 0.9.7(moment@2.30.1)(prop-types@15.8.1)(react@18.3.1)
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       util:
@@ -7375,7 +7375,7 @@ importers:
       react:
         specifier: '>=18.3.1 <19.0.0'
         version: 18.3.1
-      react-router-dom:
+      react-router:
         specifier: ^7.18.0
         version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
@@ -21125,13 +21125,6 @@ packages:
     peerDependencies:
       react: '>= 16.3'
       react-dom: '>= 16.3'
-
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
 
   react-router@7.18.2:
     resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
@@ -39756,12 +39749,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
-  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,8 +693,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2401,8 +2401,8 @@ importers:
         specifier: '>=18.3.1 <19.0.0'
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -5782,8 +5782,8 @@ importers:
         specifier: ^11.4.2
         version: 11.7.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-virtualized-auto-sizer:
         specifier: ^1.0.7
         version: 1.0.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6072,8 +6072,8 @@ importers:
         specifier: ^9.1.2
         version: 9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@4.2.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-sortable-hoc:
         specifier: ^2.0.0
         version: 2.0.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6460,8 +6460,8 @@ importers:
         specifier: 0.9.7
         version: 0.9.7(moment@2.30.1)(prop-types@15.8.1)(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uniforms:
         specifier: ^3.10.2
         version: 3.10.2(react@18.3.1)
@@ -6606,8 +6606,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -6868,8 +6868,8 @@ importers:
         specifier: 0.9.7
         version: 0.9.7(moment@2.30.1)(prop-types@15.8.1)(react@18.3.1)
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       util:
         specifier: ^0.12.5
         version: 0.12.5
@@ -7376,8 +7376,8 @@ importers:
         specifier: '>=18.3.1 <19.0.0'
         version: 18.3.1
       react-router-dom:
-        specifier: ^6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^7.18.0
+        version: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.16.0
@@ -12809,10 +12809,6 @@ packages:
       selenium-webdriver: '>=4.6.1'
       typescript: '>=4.6.2'
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@repeaterjs/repeater@3.0.4':
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
 
@@ -15695,6 +15691,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -21126,18 +21126,22 @@ packages:
       react: '>= 16.3'
       react-dom: '>= 16.3'
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-side-effect@2.1.2:
     resolution: {integrity: sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==}
@@ -21737,6 +21741,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -28986,8 +28993,6 @@ snapshots:
       type-fest: 4.41.0
       typescript: 5.9.3
 
-  '@remix-run/router@1.23.3': {}
-
   '@repeaterjs/repeater@3.0.4': {}
 
   '@repeaterjs/repeater@3.1.0': {}
@@ -33141,6 +33146,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -39750,17 +39757,19 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-draggable: 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
+      react-router: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-side-effect@2.1.2(react@18.3.1):
     dependencies:
@@ -40515,6 +40524,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
Upgraded react-router-dom from 6.30.4 to 7.18.0 based on https://reactrouter.com/7.18.2/upgrading/v6

changes made:

- Replace react-router-dom dependency with react-router
- Update imports from "react-router-dom" → "react-router"
- Update DOM-specific imports- RouterProvider and HydratedRouter should come from react-router/dom in browser apps
