### PR TITLE
NO-ISSUE: CVE-2026-12590 : updated express to resolve CVE from body parser

### DIFF
--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.22.1",
+    "express": "^4.22.2",
     "https-proxy-agent": "^7.0.6",
     "minimatch": "^4.2.5",
     "node-fetch": "^3.3.2"

--- a/packages/runtime-tools-management-console-webapp/package.json
+++ b/packages/runtime-tools-management-console-webapp/package.json
@@ -84,7 +84,7 @@
     "cors": "^2.8.5",
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^5.0.1",
-    "express": "^4.22.1",
+    "express": "^4.22.2",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
     "https-browserify": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2207,7 +2207,7 @@ importers:
         specifier: ^2.8.5
         version: 2.8.6
       express:
-        specifier: ^4.22.1
+        specifier: ^4.22.2
         version: 4.22.2
       https-proxy-agent:
         specifier: ^7.0.6
@@ -6700,7 +6700,7 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(webpack@5.108.4)
       express:
-        specifier: ^4.22.1
+        specifier: ^4.22.2
         version: 4.22.2
       file-loader:
         specifier: ^6.2.0


### PR DESCRIPTION
## Details

`body-parser@1.20.4` was detected as a vulnerable transitive dependency.

In versions prior to `1.20.6`, when configured with an invalid `limit` value (e.g. NaN or an unparseable string), `body-parser` silently skips the request body size check — allowing arbitrarily large payloads, leading to excessive memory/CPU usage and denial of service.

## Fix

Upgraded `express` from `^4.22.1` to `^4.22.2` in:
- `packages/cors-proxy/package.json`
- `packages/runtime-tools-management-console-webapp/package.json`

`express@4.22.2` pulls in `body-parser@1.20.6` (patched), replacing `1.20.4` across the entire workspace.