### PR TITLE
kie-issues#3705: BPMN Editor: Not able to assign a list type variable for Multi-instance reusable subprocess node

### DIFF
--- a/packages/bpmn-editor/src/mutations/_dataMapping.ts
+++ b/packages/bpmn-editor/src/mutations/_dataMapping.ts
@@ -40,6 +40,17 @@ export type Task = Normalized<
   >
 >;
 
+export function addOrGetIoSpecification(e: WithDataMapping): NonNullable<WithDataMapping["ioSpecification"]> {
+  e.ioSpecification ??= {
+    "@_id": generateUuid(),
+    inputSet: [{ "@_id": generateUuid(), dataInputRefs: [] }],
+    outputSet: [{ "@_id": generateUuid(), dataOutputRefs: [] }],
+    dataInput: [],
+    dataOutput: [],
+  };
+  return e.ioSpecification;
+}
+
 export type UserTaskReservedDataMappingInputNames =
   | typeof USER_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS_FOR_DMN_BINDING.TASK_NAME
   | typeof USER_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS_FOR_DMN_BINDING.SKIPPABLE

--- a/packages/bpmn-editor/src/mutations/_dataMapping.ts
+++ b/packages/bpmn-editor/src/mutations/_dataMapping.ts
@@ -40,17 +40,6 @@ export type Task = Normalized<
   >
 >;
 
-export function addOrGetIoSpecification(e: WithDataMapping): NonNullable<WithDataMapping["ioSpecification"]> {
-  e.ioSpecification ??= {
-    "@_id": generateUuid(),
-    inputSet: [{ "@_id": generateUuid(), dataInputRefs: [] }],
-    outputSet: [{ "@_id": generateUuid(), dataOutputRefs: [] }],
-    dataInput: [],
-    dataOutput: [],
-  };
-  return e.ioSpecification;
-}
-
 export type UserTaskReservedDataMappingInputNames =
   | typeof USER_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS_FOR_DMN_BINDING.TASK_NAME
   | typeof USER_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS_FOR_DMN_BINDING.SKIPPABLE

--- a/packages/bpmn-editor/src/mutations/addOrGetIoSpecification.ts
+++ b/packages/bpmn-editor/src/mutations/addOrGetIoSpecification.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { generateUuid } from "@kie-tools/xyflow-react-kie-diagram/dist/uuid/uuid";
+import { WithDataMapping } from "./_dataMapping";
+
+export function addOrGetIoSpecification(e: WithDataMapping): NonNullable<WithDataMapping["ioSpecification"]> {
+  e.ioSpecification ??= {
+    "@_id": generateUuid(),
+    inputSet: [{ "@_id": generateUuid(), dataInputRefs: [] }],
+    outputSet: [{ "@_id": generateUuid(), dataOutputRefs: [] }],
+    dataInput: [],
+    dataOutput: [],
+  };
+  return e.ioSpecification;
+}

--- a/packages/bpmn-editor/src/propertiesPanel/multiInstance/MultiInstanceProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/multiInstance/MultiInstanceProperties.tsx
@@ -44,6 +44,7 @@ import {
   MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS,
   updateDataMappingWithVariableRef,
   setOutputDataMapping,
+  addOrGetIoSpecification,
 } from "../../mutations/_dataMapping";
 import { addOrGetItemDefinitions, DEFAULT_DATA_TYPES } from "../../mutations/addOrGetItemDefinitions";
 import { useBpmnEditorI18n } from "../../i18n";
@@ -202,12 +203,10 @@ export function MultiInstanceProperties({ element }: { element: WithMultiInstanc
                       .map((i) => [i["@_structureRef"]!, i["@_id"]!])
                   );
 
-                  if (e.ioSpecification) {
-                    setInputDataMapping(itemDefinitionIdByDataTypes, inputDataMapping, e.ioSpecification, e);
-                  }
+                  setInputDataMapping(itemDefinitionIdByDataTypes, inputDataMapping, addOrGetIoSpecification(e), e);
 
                   if (newVariableRef) {
-                    const ioSpecificationReference = e.ioSpecification?.dataInput?.find(
+                    const ioSpecificationReference = addOrGetIoSpecification(e).dataInput?.find(
                       (dIn) =>
                         dIn["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.IN_COLLECTION
                     )?.["@_id"];
@@ -262,18 +261,16 @@ export function MultiInstanceProperties({ element }: { element: WithMultiInstanc
                         .map((i) => [i["@_structureRef"]!, i["@_id"]!])
                     );
 
-                    if (e.ioSpecification) {
-                      setInputDataMapping(itemDefinitionIdByDataTypes, inputDataMapping, e.ioSpecification, e);
+                    setInputDataMapping(itemDefinitionIdByDataTypes, inputDataMapping, addOrGetIoSpecification(e), e);
 
-                      const ioSpecificationReference = e.ioSpecification?.dataInput?.find(
-                        (dIn) =>
-                          dIn["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.IN_COLLECTION
-                      )?.["@_id"];
+                    const ioSpecificationReference = addOrGetIoSpecification(e).dataInput?.find(
+                      (dIn) =>
+                        dIn["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.IN_COLLECTION
+                    )?.["@_id"];
 
-                      e.loopCharacteristics.loopDataInputRef = ioSpecificationReference
-                        ? { __$$text: ioSpecificationReference }
-                        : undefined;
-                    }
+                    e.loopCharacteristics.loopDataInputRef = ioSpecificationReference
+                      ? { __$$text: ioSpecificationReference }
+                      : undefined;
 
                     // Update inputDataItem name
                     e.loopCharacteristics.inputDataItem ??= { "@_id": generateUuid() };
@@ -354,12 +351,10 @@ export function MultiInstanceProperties({ element }: { element: WithMultiInstanc
                       .map((i) => [i["@_structureRef"]!, i["@_id"]!])
                   );
 
-                  if (e.ioSpecification) {
-                    setOutputDataMapping(itemDefinitionIdByDataTypes, outputDataMapping, e.ioSpecification, e);
-                  }
+                  setOutputDataMapping(itemDefinitionIdByDataTypes, outputDataMapping, addOrGetIoSpecification(e), e);
 
                   if (newVariableRef) {
-                    const ioSpecificationReference = e.ioSpecification?.dataOutput?.find(
+                    const ioSpecificationReference = addOrGetIoSpecification(e).dataOutput?.find(
                       (dOut) =>
                         dOut["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.OUT_COLLECTION
                     )?.["@_id"];
@@ -417,18 +412,16 @@ export function MultiInstanceProperties({ element }: { element: WithMultiInstanc
                         .map((i) => [i["@_structureRef"]!, i["@_id"]!])
                     );
 
-                    if (e.ioSpecification) {
-                      setOutputDataMapping(itemDefinitionIdByDataTypes, outputDataMapping, e.ioSpecification, e);
+                    setOutputDataMapping(itemDefinitionIdByDataTypes, outputDataMapping, addOrGetIoSpecification(e), e);
 
-                      const ioSpecificationReference = e.ioSpecification?.dataOutput?.find(
-                        (dOut) =>
-                          dOut["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.OUT_COLLECTION
-                      )?.["@_id"];
+                    const ioSpecificationReference = addOrGetIoSpecification(e).dataOutput?.find(
+                      (dOut) =>
+                        dOut["@_name"] === MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS.OUT_COLLECTION
+                    )?.["@_id"];
 
-                      e.loopCharacteristics.loopDataOutputRef = ioSpecificationReference
-                        ? { __$$text: ioSpecificationReference }
-                        : undefined;
-                    }
+                    e.loopCharacteristics.loopDataOutputRef = ioSpecificationReference
+                      ? { __$$text: ioSpecificationReference }
+                      : undefined;
 
                     e.loopCharacteristics.outputDataItem ??= { "@_id": generateUuid() };
                     e.loopCharacteristics.outputDataItem["@_name"] = newDataOutput;

--- a/packages/bpmn-editor/src/propertiesPanel/multiInstance/MultiInstanceProperties.tsx
+++ b/packages/bpmn-editor/src/propertiesPanel/multiInstance/MultiInstanceProperties.tsx
@@ -44,8 +44,8 @@ import {
   MULTI_INSTANCE_TASK_IO_SPECIFICATION_DATA_INPUTS_CONSTANTS,
   updateDataMappingWithVariableRef,
   setOutputDataMapping,
-  addOrGetIoSpecification,
 } from "../../mutations/_dataMapping";
+import { addOrGetIoSpecification } from "../../mutations/addOrGetIoSpecification";
 import { addOrGetItemDefinitions, DEFAULT_DATA_TYPES } from "../../mutations/addOrGetItemDefinitions";
 import { useBpmnEditorI18n } from "../../i18n";
 

--- a/packages/bpmn-editor/tests-e2e/propertiesPanel/changeSubProcessProperties.spec.ts
+++ b/packages/bpmn-editor/tests-e2e/propertiesPanel/changeSubProcessProperties.spec.ts
@@ -153,12 +153,17 @@ test.describe("Change Properties - Ad-Hoc Sub-Process", () => {
 });
 
 test.describe("Change Properties - Call Activity Multi-Instance", () => {
-  test.beforeEach(async ({ palette, nodes }) => {
+  test.beforeEach(async ({ palette, nodes, subProcessPropertiesPanel }) => {
     await palette.addProcessVariable({ name: "varlist", dataType: "Object" });
 
     await palette.dragNewNode({ type: NodeType.CALL_ACTIVITY, targetPosition: { x: 200, y: 200 } });
 
     await expect(nodes.get({ name: DefaultNodeName.CALL_ACTIVITY })).toBeAttached();
+
+    await subProcessPropertiesPanel
+      .panel()
+      .getByRole("checkbox", { name: /multi-instance/i })
+      .click();
   });
 
   test("should assign a collection variable to a multi-instance call activity with no prior ioSpecification", async ({

--- a/packages/bpmn-editor/tests-e2e/propertiesPanel/changeSubProcessProperties.spec.ts
+++ b/packages/bpmn-editor/tests-e2e/propertiesPanel/changeSubProcessProperties.spec.ts
@@ -151,3 +151,31 @@ test.describe("Change Properties - Ad-Hoc Sub-Process", () => {
     expect(adHocSubProcess.completionCondition?.__$$text).toBe("${allTasksCompleted}");
   });
 });
+
+test.describe("Change Properties - Call Activity Multi-Instance", () => {
+  test.beforeEach(async ({ palette, nodes }) => {
+    await palette.addProcessVariable({ name: "varlist", dataType: "Object" });
+
+    await palette.dragNewNode({ type: NodeType.CALL_ACTIVITY, targetPosition: { x: 200, y: 200 } });
+
+    await expect(nodes.get({ name: DefaultNodeName.CALL_ACTIVITY })).toBeAttached();
+  });
+
+  test("should assign a collection variable to a multi-instance call activity with no prior ioSpecification", async ({
+    subProcessPropertiesPanel,
+    jsonModel,
+  }) => {
+    // Enable multi-instance — the callActivity has no ioSpecification
+    await subProcessPropertiesPanel.setMultiInstance({ type: "parallel" });
+    await subProcessPropertiesPanel.setCollectionExpression({ expression: "varlist" });
+
+    await expect(subProcessPropertiesPanel.panel().getByRole("checkbox", { name: /multi-instance/i })).toBeChecked();
+
+    const loopCharacteristics = (await jsonModel.getCallActivities())[0].loopCharacteristics;
+    expect(loopCharacteristics?.__$$element).toBe("multiInstanceLoopCharacteristics");
+
+    const multiInstanceLoop =
+      loopCharacteristics?.__$$element === "multiInstanceLoopCharacteristics" ? loopCharacteristics : undefined;
+    expect(multiInstanceLoop?.loopDataInputRef?.__$$text).toBeDefined();
+  });
+});


### PR DESCRIPTION
closes https://github.com/apache/incubator-kie-tools/issues/3705,

Root cause: When a user enables multi-instance mode on a Call Activity and then tries to assign a list variable to the Collection Input field, the assignment is silently ignored because the node has no I/O specification object at that point — and the properties panel code only wrote the variable mapping when one already existed.

Fix: The properties panel was updated to automatically create the I/O specification if it is missing, so the variable assignment always goes through regardless of whether the node had one beforehand.

Test the fix with below bpmn:
[MainProcess.txt](https://github.com/user-attachments/files/31043118/MainProcess.txt)


