### PR TITLE
[incubator-kie-6891] DRL10 ANTLR4 parser does not support lambdas and methods in functions

### DIFF
--- a/packages/drools-lsp/drools-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Parser.g4
+++ b/packages/drools-lsp/drools-parser/src/main/antlr4/org/drools/drl/parser/antlr4/DRL10Parser.g4
@@ -270,10 +270,15 @@ backReferenceExpression : (DOT DOT DIV)+  drlExpression ;
 
 /* extending JavaParser methodCall in order to accept drl keywords as method name */
 drlMethodCall
-    : drlIdentifier LPAREN expressionList? RPAREN
-    | THIS LPAREN expressionList? RPAREN
-    | SUPER LPAREN expressionList? RPAREN
+    : drlIdentifier LPAREN drlExpressionList? RPAREN
+    | THIS LPAREN drlExpressionList? RPAREN
+    | SUPER LPAREN drlExpressionList? RPAREN
     ;
+
+drlExpressionList
+    : drlExpression (COMMA drlExpression)*
+    ;
+
 
 temporalOperator : DRL_NOT? bop=(DRL_AFTER | DRL_BEFORE | DRL_COINCIDES | DRL_DURING | DRL_INCLUDES | DRL_FINISHES | DRL_FINISHED_BY | DRL_MEETS | DRL_MET_BY | DRL_OVERLAPS | DRL_OVERLAPPED_BY | DRL_STARTS | DRL_STARTED_BY) timeAmount? ;
 


### PR DESCRIPTION
- Update grammar in lsp

- Related to https://github.com/apache/incubator-kie/issues/6891