### PR TITLE
[incubator-kie-6902] Upgrade Quarkus to 3.33.3.2 (LTS)

### DIFF
--- a/examples/process-accelerator/src/main/resources/application.properties
+++ b/examples/process-accelerator/src/main/resources/application.properties
@@ -21,7 +21,7 @@
 # Quarkus settings 
 #####################################
 #https://quarkus.io/guides/openapi-swaggerui
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-business-calendar/pom.xml
+++ b/examples/process-business-calendar/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/process-compact-architecture/src/main/resources/application.properties
+++ b/examples/process-compact-architecture/src/main/resources/application.properties
@@ -90,7 +90,7 @@ kogito.data-index.url=http://0.0.0.0:8080
 # Swagger Dev UI configuration.
 # More at https://quarkus.io/guides/openapi-swaggerui
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-event-driven/hotels/src/main/resources/application.properties
+++ b/examples/process-event-driven/hotels/src/main/resources/application.properties
@@ -57,7 +57,7 @@ kogito.auth.enabled=false
 # Swagger Dev UI configuration.
 # More at https://quarkus.io/guides/openapi-swaggerui
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-event-driven/travelers/src/main/resources/application.properties
+++ b/examples/process-event-driven/travelers/src/main/resources/application.properties
@@ -57,7 +57,7 @@ kogito.auth.enabled=false
 # Swagger Dev UI configuration.
 # More at https://quarkus.io/guides/openapi-swaggerui
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-security/kie-service-1/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-1/src/main/resources/application.properties
@@ -19,7 +19,7 @@
 
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.port=8081
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-security/kie-service-2/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-2/src/main/resources/application.properties
@@ -19,7 +19,7 @@
 
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.port=8082
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-security/kie-service-3/src/main/resources/application.properties
+++ b/examples/process-security/kie-service-3/src/main/resources/application.properties
@@ -19,7 +19,7 @@
 
 #https://quarkus.io/guides/openapi-swaggerui
 quarkus.http.port=8083
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/examples/process-user-tasks-subsystem/pom.xml
+++ b/examples/process-user-tasks-subsystem/pom.xml
@@ -65,7 +65,7 @@
     <!-- Test -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/process-user-tasks-subsystem/src/main/resources/application.properties
+++ b/examples/process-user-tasks-subsystem/src/main/resources/application.properties
@@ -94,7 +94,7 @@ kogito.data-index.url=http://localhost:${quarkus.http.port}
 # Swagger Dev UI configuration.
 # More at https://quarkus.io/guides/openapi-swaggerui
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 quarkus.smallrye-openapi.path=/docs/openapi.json

--- a/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/src/main/resources/application.properties
+++ b/packages/dev-deployment-dmn-form-webapp/dev-webapp/quarkus-app/src/main/resources/application.properties
@@ -24,7 +24,7 @@ kogito.security.auth.enabled=false
 
 quarkus.oidc.enabled=false
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 
 # Misc.

--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -58,9 +58,8 @@
     <version.junit>4.13.2</version.junit>
     <version.org.apache.commons.commons-compress>1.28.0</version.org.apache.commons.commons-compress>
     <version.org.iq80.snappy>0.5</version.org.iq80.snappy>
-    <version.commons-io>2.20.0</version.commons-io>
+    <version.commons-io>2.21.0</version.commons-io>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
-    <version.io.netty>4.1.136.Final</version.io.netty>
 
     <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities.
            They need to be checked with Quarkus and Spring Boot upgrades and eventually removed, if they are not needed anymore. -->
@@ -85,28 +84,6 @@
         <version>${version.org.kie.kogito}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <!-- Forcing of netty version to fix vulnerabilities. -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${version.io.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
-        <version>${version.io.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec</artifactId>
-        <version>${version.io.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http</artifactId>
-        <version>${version.io.netty}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/packages/dev-deployment-quarkus-blank-app/pom.xml
+++ b/packages/dev-deployment-quarkus-blank-app/pom.xml
@@ -189,7 +189,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
+++ b/packages/dev-deployment-quarkus-blank-app/src/main/resources/application.properties
@@ -25,7 +25,7 @@
 # More at https://quarkus.io/guides/openapi-swaggerui
 
 quarkus.swagger-ui.always-include=true
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.dev-ui.cors.enabled=false
 

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -24,11 +24,11 @@ const rootEnv = require("@kie-tools/root-env/env");
 module.exports = composeEnv([rootEnv], {
   vars: varsWithName({
     DROOLS_AND_KOGITO__droolsRepoUrl: {
-      default: "https://github.com/apache/incubator-kie-drools",
+      default: "https://github.com/apache/incubator-kie",
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "08c76b5c9655ad900fcf5e564d8d3e274ad248ff",
+      default: "13d28287aec18723549707e0f3bf8f060b88a988",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kie",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "c6591dc7a97c7dd4fa4cad0a0d4e2799a33e420e",
+      default: "8c9c01ab687b2406b7f2c6a29be4b7e1dd529875",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kie",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "2b91940462bb57ac79912a8139e7e19b37346856",
+      default: "c6591dc7a97c7dd4fa4cad0a0d4e2799a33e420e",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -25,10 +25,10 @@ module.exports = composeEnv([rootEnv], {
   vars: varsWithName({
     DROOLS_AND_KOGITO__droolsRepoUrl: {
       default: "https://github.com/apache/incubator-kie",
-      description: "Git repository URL for Drools",
+      description: "Git repository URL for Kie",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "af67f73d3debb4d7fad5a2e13373a7c8fdc45ad8",
+      default: "2b91940462bb57ac79912a8139e7e19b37346856",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kie",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "8c9c01ab687b2406b7f2c6a29be4b7e1dd529875",
+      default: "26ac0bbc368f904330e437c24218f6695b194394",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "6ab0313956906fa04703a4dc53197104739dbc8e",
+      default: "af67f73d3debb4d7fad5a2e13373a7c8fdc45ad8",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Kie",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "26ac0bbc368f904330e437c24218f6695b194394",
+      default: "7cc005d3dcd16481e1f2230e932de2ab5c229d8a",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/drools-and-kogito/env/index.js
+++ b/packages/drools-and-kogito/env/index.js
@@ -28,7 +28,7 @@ module.exports = composeEnv([rootEnv], {
       description: "Git repository URL for Drools",
     },
     DROOLS_AND_KOGITO__droolsRepoGitRef: {
-      default: "13d28287aec18723549707e0f3bf8f060b88a988",
+      default: "6ab0313956906fa04703a4dc53197104739dbc8e",
       description: "Git ref for the Drools repository (SHA, branch, or tag)",
     },
     DROOLS_AND_KOGITO__skip: {

--- a/packages/extended-services-java/pom.xml
+++ b/packages/extended-services-java/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/packages/extended-services-java/src/main/resources/application.properties
+++ b/packages/extended-services-java/src/main/resources/application.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=/.*/
 quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.devservices.enabled=false

--- a/packages/jbpm-quarkus-devui/dev/pom.xml
+++ b/packages/jbpm-quarkus-devui/dev/pom.xml
@@ -162,7 +162,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
+++ b/packages/jbpm-quarkus-devui/dev/src/main/resources/application.properties
@@ -35,7 +35,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;NON_KEYWORDS=VALUE,KEY;DB_CLOSE_
 # Security
 kogito.security.auth.enabled=false
 quarkus.oidc.enabled=false
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=/.*/
 
 # Misc.

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/pom.xml
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-deployment/pom.xml
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
+      <artifactId>quarkus-junit-internal</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/pom.xml
+++ b/packages/jbpm-quarkus-devui/jbpm-quarkus-devui-runtime/pom.xml
@@ -120,13 +120,13 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-mockito</artifactId>
+      <artifactId>quarkus-junit-mockito</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
+++ b/packages/kie-sandbox-accelerator-quarkus/git-repo-content-src/src/main/resources/application.properties
@@ -62,13 +62,13 @@ kogito.persistence.type=jdbc
 %prod.quarkus.http.auth.permission.public.paths=/q/*,/docs/openapi.json
 %prod.quarkus.http.auth.permission.public.policy=permit
 
-%prod.quarkus.http.cors=false
+%prod.quarkus.http.cors.enabled=false
 %prod.quarkus.http.cors.origins=<TODO>
 
 # Dev
 %dev.kogito.auth.enabled=false
 %dev.quarkus.oidc.enabled=false
-%dev.quarkus.http.cors=true
+%dev.quarkus.http.cors.enabled=true
 %dev.quarkus.http.cors.origins=*
 
 

--- a/packages/quarkus-bom/pom.xml
+++ b/packages/quarkus-bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Bill of Materials for KIE Tools Quarkus-based projects</description>
 
   <properties>
-    <version.quarkus>3.33.3.1</version.quarkus>
+    <version.quarkus>3.33.3.2</version.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/packages/quarkus-bom/pom.xml
+++ b/packages/quarkus-bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Bill of Materials for KIE Tools Quarkus-based projects</description>
 
   <properties>
-    <version.quarkus>3.27.5.1</version.quarkus>
+    <version.quarkus>3.33.3.1</version.quarkus>
   </properties>
 
   <dependencyManagement>

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,7 +69,7 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.33.3.1",
+      default: "3.33.3.2",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260818-local",
+      default: "999-20260902-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -69,7 +69,7 @@ module.exports = composeEnv([], {
     },
     /* (end) */
     QUARKUS_PLATFORM_version: {
-      default: "3.27.5.1",
+      default: "3.33.3.1",
       description: "Quarkus version to be used on dependency declaration.",
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260902-local",
+      default: "999-20260907-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/root-env/env/index.js
+++ b/packages/root-env/env/index.js
@@ -74,7 +74,7 @@ module.exports = composeEnv([], {
     },
     /* (begin) This part of the file is referenced in `scripts/update-kogito-version` */
     KOGITO_RUNTIME_version: {
-      default: "999-20260907-local",
+      default: "999-20260908-local",
       description: "Kogito version to be used on dependency declaration.",
     },
     /* (end) */

--- a/packages/runtime-tools-management-console-webapp/README.md
+++ b/packages/runtime-tools-management-console-webapp/README.md
@@ -73,7 +73,7 @@ quarkus.http.auth.permission.public.policy=permit
 > In both cases, if using CORS, remember to allow the Management Console origin:
 >
 > ```properties
-> quarkus.http.cors=true
+> quarkus.http.cors.enabled=true
 > quarkus.http.cors.origins=<MANAGEMENT_CONSOLE_ORIGIN> # Using `*` will allow all origins.
 > ```
 

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml
@@ -119,7 +119,8 @@
     <dependency>
       <groupId>io.quarkiverse.oidc-proxy</groupId>
       <artifactId>quarkus-oidc-proxy</artifactId>
-      <version>0.3.2</version>
+      <!-- Quarkiverse release baselined on Quarkus 3.32.x; 0.6.x and later require Quarkus 3.35+ -->
+      <version>0.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/src/main/resources/application.properties
@@ -19,7 +19,7 @@
 
 # quarkus.http.port= --> This is set on package.json. See 'start:runtime' script.
 quarkus.http.host=0.0.0.0
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 quarkus.http.root-path=/my-subpath
 

--- a/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
+++ b/packages/runtime-tools-management-console-webapp/dev-webapp/unsecured-runtime/src/main/resources/application.properties
@@ -34,7 +34,7 @@ kogito.security.auth.enabled=false
 
 quarkus.oidc.enabled=false
 
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 
 # Misc.


### PR DESCRIPTION
**Issue:** Closes https://github.com/apache/incubator-kie/issues/6902

**Related:** 
- https://github.com/apache/incubator-kie-examples/pull/2244 [MERGED]
- https://github.com/apache/incubator-kie/pull/6903  [MERGED]
- https://github.com/apache/incubator-kie-examples/pull/2245


Quarkus 3.27 LTS support ends September 2026; 3.33 is the next LTS (supported until March 2027) and 3.33.3.2 its latest respin. apache/incubator-kie#6903 moves the KIE runtimes to it. kie-tools declares its own Quarkus version in two places and builds its Java packages against KIE jars compiled from a pinned KIE commit — left as-is, the 3.33-built KIE jars would mix with a 3.27 platform here: the same version mismatch that makes the pinned examples fail on #6903.

### What changed

- packages/quarkus-bom/pom.xml — version.quarkus 3.27.5.1 → 3.33.3.2. This BOM pins quarkus-maven-plugin / quarkus-extension-maven-plugin for every Quarkus-based package.
- packages/root-env/env/index.js — QUARKUS_PLATFORM_version default 3.27.5.1 → 3.33.3.2 (the version stamped into dependency declarations).
- packages/drools-and-kogito/env/index.js — the source the local KIE jars are built from: repo apache/incubator-kie-drools → apache/incubator-kie (the quarkus-3_33_x branch only exists on the monorepo), git ref → 13d2828, the head of #6903. The default KOGITO_RUNTIME_version (999-20260818-local) ends in -local, so bootstrap builds these jars from source — this pin is what puts the 3.33-built KIE runtime under the kie-tools build.
- packages/dev-deployment-quarkus-blank-app/pom.xml — the four-artifact netty CVE pin (netty-handler/-common/-codec/-codec-http 4.1.136.Final) and its version.io.netty property are deleted: quarkus-bom 3.33.3.2 (imported via kogito-apps-quarkus-bom) manages netty at exactly that version, so the override is redundant — the pom's own comment asks for these to be dropped once the platform catches up. version.commons-io 2.20.0 → 2.21.0, matching the 3.33.3.2 BOM; this pin stays because it sits on the maven-resources-plugin plugin classpath (CVE-2024-47554), which dependencyManagement does not cover.
- packages/runtime-tools-management-console-webapp/dev-webapp/secured-runtime/pom.xml — quarkus-oidc-proxy 0.3.2 → 0.5.0: the newest Quarkiverse release compatible with a 3.33 baseline (0.5.0 builds against Quarkus 3.32.3; 0.6.0+ build against 3.35.3).

