### PR TITLE
NO-ISSUE: Add X-Content-Type-Options header to Extended Services responses

### DIFF
--- a/packages/extended-services-java/src/main/resources/application.properties
+++ b/packages/extended-services-java/src/main/resources/application.properties
@@ -17,6 +17,7 @@
 
 quarkus.http.cors=true
 quarkus.http.cors.origins=/.*/
+quarkus.http.header."X-Content-Type-Options".value=nosniff
 quarkus.devservices.enabled=false
 
 extendedServicesJava.version=${project.version}

--- a/packages/extended-services-java/src/test/java/org/kie/tools/PingResourceTest.java
+++ b/packages/extended-services-java/src/test/java/org/kie/tools/PingResourceTest.java
@@ -35,6 +35,7 @@
            .then()
                  .statusCode(200)
                  .contentType(ContentType.JSON)
+                 .header("X-Content-Type-Options", "nosniff")
                  .body("version", equalTo(expectedVersion))
                  .body("started", equalTo(expectedStarted));
      }


### PR DESCRIPTION
Extended Services set no HTTP security headers, so every response was missing `X-Content-Type-Options`. Without it, browsers can MIME-sniff a response away from its declared `Content-Type`. 

One Quarkus property adds `nosniff` to every endpoint, including `/jitdmn/*`, `/jitbpmn/*`, `/ping`, and error responses. `PingResourceTest` asserts the header.
