### PR TITLE
NO-ISSUE: Fix BPMN and DMN editors never loading in the VS Code extension

### DIFF
--- a/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceIsomorphicGitFs.ts
+++ b/packages/vscode-extension/src/workspace/VsCodeResourceContentServiceIsomorphicGitFs.ts
@@ -92,4 +92,18 @@ export class ReadonlyIsomorphicGitFsForVsCodeWorkspaceFolders {
       return false;
     }
   }
+
+  // isomorphic-git 1.36.0 added discoverGitdir(), which calls these internals that the flag above stops it from creating.
+  async _stat(path: string) {
+    const stat = await vscode.workspace.fs.stat(vscode.Uri.file(path));
+    return {
+      isDirectory: () => (stat.type & vscode.FileType.Directory) !== 0,
+      isFile: () => (stat.type & vscode.FileType.File) !== 0,
+    };
+  }
+
+  async _readFile(path: string, encoding?: BufferEncoding) {
+    const buffer = Buffer.from(await vscode.workspace.fs.readFile(vscode.Uri.file(path)));
+    return encoding ? buffer.toString(encoding) : buffer;
+  }
 }


### PR DESCRIPTION
### Problem

Opening a BPMN or DMN file inside a workspace leaves the editor on the loading screen. The extension host reports `TypeError: fsp._stat is not a function`.

### Root cause

`ReadonlyIsomorphicGitFsForVsCodeWorkspaceFolders` declares `_original_unwrapped_fs`, which tells isomorphic-git to skip its own `FileSystem` wrapper and use the object as given. That wrapper is what normally creates the `_stat` and `_readFile` methods.

isomorphic-git 1.36.0 and later call `discoverGitdir()` from `isIgnored()` before anything else, and `discoverGitdir()` uses `_stat`. The class never received it, so `isIgnored()` throws. `VsCodeResourceContentServiceForWorkspaces.list()` calls `isIgnored()` for every file in the workspace, so the whole call rejects and the editor never receives its file list.

`packages/vscode-extension/package.json` declares `^1.30.1`, and `pnpm-lock.yaml` currently resolves to 1.38.10, which is within that range.

### Fix

Add `_stat` and `_readFile` to the class, implemented against `vscode.workspace.fs`. Both work on 1.30.1 and on every later release, so the declared version range needs no change.