### PR TITLE
[NO-ISSUE] Update fast-uri to 3.1.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4789,28 +4789,6 @@ importers:
         specifier: ^5.9.0
         version: 5.10.0
 
-  packages/jbpm-spring-boot-dev-console:
-    dependencies:
-      '@kie-tools/jbpm-dev-console-commons':
-        specifier: workspace:*
-        version: link:../jbpm-dev-console-commons
-      '@kie-tools/maven-base':
-        specifier: workspace:*
-        version: link:../maven-base
-      '@kie-tools/spring-boot-bom':
-        specifier: workspace:*
-        version: link:../spring-boot-bom
-    devDependencies:
-      '@kie-tools/root-env':
-        specifier: workspace:*
-        version: link:../root-env
-      '@kie-tools/runtime-tools-process-dev-ui-webapp':
-        specifier: workspace:*
-        version: link:../runtime-tools-process-dev-ui-webapp
-      run-script-os:
-        specifier: ^1.1.6
-        version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
-
   packages/jbpm-dev-console-commons:
     dependencies:
       '@kie-tools/maven-base':
@@ -4905,6 +4883,28 @@ importers:
       '@kie-tools/quarkus-bom':
         specifier: workspace:*
         version: link:../quarkus-bom
+    devDependencies:
+      '@kie-tools/root-env':
+        specifier: workspace:*
+        version: link:../root-env
+      '@kie-tools/runtime-tools-process-dev-ui-webapp':
+        specifier: workspace:*
+        version: link:../runtime-tools-process-dev-ui-webapp
+      run-script-os:
+        specifier: ^1.1.6
+        version: 1.1.6(patch_hash=82e28a047ef68998aa768f2d01885d4c96b061f05645c133026c22738f9a8753)
+
+  packages/jbpm-spring-boot-dev-console:
+    dependencies:
+      '@kie-tools/jbpm-dev-console-commons':
+        specifier: workspace:*
+        version: link:../jbpm-dev-console-commons
+      '@kie-tools/maven-base':
+        specifier: workspace:*
+        version: link:../maven-base
+      '@kie-tools/spring-boot-bom':
+        specifier: workspace:*
+        version: link:../spring-boot-bom
     devDependencies:
       '@kie-tools/root-env':
         specifier: workspace:*
@@ -16977,8 +16977,8 @@ packages:
   fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
@@ -18546,12 +18546,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
-    hasBin: true
-
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
   js-yaml@4.3.0:
@@ -26593,7 +26589,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -31474,12 +31470,12 @@ snapshots:
 
   '@yarnpkg/parsers@2.6.0':
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       tslib: 1.14.1
 
   '@yarnpkg/parsers@3.0.3':
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       tslib: 2.8.1
 
   '@yarnpkg/pnp@2.3.2':
@@ -31677,14 +31673,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -34981,7 +34977,7 @@ snapshots:
 
   fast-text-encoding@1.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.7: {}
 
   fast-url-parser@1.1.3:
     dependencies:
@@ -36911,12 +36907,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -37033,7 +37024,7 @@ snapshots:
     dependencies:
       commander: 4.1.1
       graphlib: 2.1.8
-      js-yaml: 3.15.0
+      js-yaml: 3.15.2
       lodash: 4.18.1
       native-promise-only: 0.8.1
       path-loader: 1.0.12
@@ -43310,7 +43301,7 @@ snapshots:
       '@oozcitak/infra': 1.0.8
       '@oozcitak/util': 8.3.8
       '@types/node': 24.13.3
-      js-yaml: 3.15.0
+      js-yaml: 3.15.2
 
   xmlbuilder@11.0.1: {}
 


### PR DESCRIPTION
Update pnpm lockfile for fast-uri to 3.1.7 to fix cve CVE-2026-76172, CVE-2026-18446, CVE-2026-75899, CVE-2026-75975, CVE-2026-75931