### PR TITLE
[NO-ISSUE]: Fixed CI issue related to pnpm setup

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -61,15 +61,14 @@ runs:
         cd ${{ inputs.working_dir }}
         mkdir tmp
 
-    - name: "Setup pnpm"
-      uses: pnpm/action-setup@v3
-      with:
-        version: 10.34.4
-
     - name: "Setup Node"
       uses: actions/setup-node@v4
       with:
         node-version: 24.13.0
+
+    - name: "Setup pnpm"
+      shell: bash
+      run: npm -g install pnpm@10.34.4
 
     - name: "Setup JDK 17"
       uses: actions/setup-java@v4

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -57,15 +57,14 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
 
-      - name: "Setup pnpm"
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10.34.4
-
       - name: "Setup Node"
         uses: actions/setup-node@v4
         with:
           node-version: 24.13.0
+
+      - name: "Setup pnpm"
+        shell: bash
+        run: npm -g install pnpm@10.34.4
 
       - name: "Setup CI patterns"
         id: ci_patterns


### PR DESCRIPTION
Root cause:

Apache security policy only allows official GitHub actions (actions/*) and Apache-owned actions.
pnpm/action-setup is a third-party action under the pnpm/ namespace, so GitHub blocks it.

Fix:

- Remove uses: pnpm/action-setup@v3.
- Run actions/setup-node@v4 first (allowed official action).
- Install pnpm using a shell command via npm

