### PR TITLE
incubator-kie-tools#3713: [drl-vscode-extension] unknown-type lint honors same-package sibling imports

### DIFF
--- a/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
+++ b/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLCompletionHelper.java
@@ -21,6 +21,7 @@ package org.drools.completion;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -440,10 +441,27 @@ public class DRLCompletionHelper {
     static String resolveFqcn(String patternType, String simpleName,
                               DRL10Parser.CompilationUnitContext compilationUnit,
                               ClassIndex classIndex) {
+        return resolveFqcn(patternType, simpleName, compilationUnit, classIndex, List.of());
+    }
+
+    /**
+     * As {@link #resolveFqcn(String, String, DRL10Parser.CompilationUnitContext, ClassIndex)},
+     * but with {@code extraImports} unioned onto the document's own imports before
+     * resolution — both the exact and the wildcard branch see the union. Lets the
+     * unknown-type lint honor imports declared in same-package sibling files (which
+     * Drools merges into one namespace) without re-resolving. The four-argument
+     * overload delegates here with an empty collection, so its behavior is unchanged.
+     */
+    static String resolveFqcn(String patternType, String simpleName,
+                              DRL10Parser.CompilationUnitContext compilationUnit,
+                              ClassIndex classIndex, Collection<String> extraImports) {
         if (patternType.indexOf('.') >= 0) {
             return patternType;
         }
-        Set<String> imports = extractImports(compilationUnit);
+        Set<String> imports = new HashSet<>(extractImports(compilationUnit));
+        if (extraImports != null) {
+            imports.addAll(extraImports);
+        }
         // 1. Exact import.
         for (String imported : imports) {
             if (imported.endsWith("." + simpleName)) {
@@ -554,12 +572,22 @@ public class DRLCompletionHelper {
         return items;
     }
 
+    /**
+     * Non-static type imports as qualified names. A wildcard import keeps its
+     * {@code .*} suffix, which the grammar carries as a separate
+     * {@code (DOT MUL)} outside {@code drlQualifiedName} — reconstructed here so
+     * the wildcard branch of {@link #resolveFqcn} sees local wildcards the same
+     * way it sees the sibling-file ones from
+     * {@link DRLDeclaredTypeParser#cachedFileInfo}.
+     */
     private static Set<String> extractImports(DRL10Parser.CompilationUnitContext compilationUnit) {
         Set<String> imports = new HashSet<>();
         for (DRL10Parser.DrlStatementdefContext stmt : compilationUnit.drlStatementdef()) {
             if (stmt.importdef() instanceof DRL10Parser.ImportStandardDefContext importDef) {
-                if (importDef.DRL_FUNCTION() == null && importDef.STATIC() == null) {
-                    imports.add(importDef.drlQualifiedName().getText());
+                if (importDef.DRL_FUNCTION() == null && importDef.STATIC() == null
+                        && importDef.drlQualifiedName() != null) {
+                    String name = importDef.drlQualifiedName().getText();
+                    imports.add(importDef.MUL() != null ? name + ".*" : name);
                 }
             }
         }

--- a/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
+++ b/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLDeclaredTypeParser.java
@@ -48,9 +48,36 @@ public final class DRLDeclaredTypeParser {
     private static final class CachedEntry {
         final long modMillis;
         final List<DeclaredType> types;
+        final String packageName;
+        final List<String> imports;
 
-        CachedEntry(long modMillis, List<DeclaredType> types) {
+        CachedEntry(long modMillis, List<DeclaredType> types, String packageName,
+                    List<String> imports) {
             this.modMillis = modMillis;
+            this.types = types;
+            this.packageName = packageName;
+            this.imports = imports;
+        }
+    }
+
+    /**
+     * A file's package name, imports, and declared types, all read from a single
+     * parse. The package name is the empty string when the file declares none;
+     * imports keep any {@code .*} wildcard suffix so they can drive
+     * class-index-verified wildcard resolution, matching what
+     * {@code DRLCompletionHelper} extracts for the current document. All lists
+     * are unmodifiable.
+     */
+    public static final class FileInfo {
+        static final FileInfo EMPTY = new FileInfo("", List.of(), List.of());
+
+        final String packageName;
+        final List<String> imports;
+        final List<DeclaredType> types;
+
+        FileInfo(String packageName, List<String> imports, List<DeclaredType> types) {
+            this.packageName = packageName == null ? "" : packageName;
+            this.imports = imports;
             this.types = types;
         }
     }
@@ -74,23 +101,53 @@ public final class DRLDeclaredTypeParser {
      * an empty list.
      */
     public static List<DeclaredType> parseDeclaredTypesCached(Path file) {
+        return cachedFileInfo(file).types;
+    }
+
+    /**
+     * Returns the package name, imports, and declared types of {@code file},
+     * serving a cached result while the file's modification time is unchanged.
+     * Missing/unreadable files yield {@link FileInfo#EMPTY}. Shares the one
+     * mtime-keyed cache with {@link #parseDeclaredTypesCached}, so a sibling is
+     * parsed once for both its declares and its imports.
+     */
+    public static FileInfo cachedFileInfo(Path file) {
         if (file == null || !Files.isRegularFile(file)) {
-            return Collections.emptyList();
+            return FileInfo.EMPTY;
         }
         try {
             Path key = file.toAbsolutePath().normalize();
             long modMillis = Files.getLastModifiedTime(file).toMillis();
             CachedEntry cached = FILE_CACHE.get(key);
             if (cached != null && cached.modMillis == modMillis) {
-                return cached.types;
+                return new FileInfo(cached.packageName, cached.imports, cached.types);
             }
-            List<DeclaredType> types =
-                    Collections.unmodifiableList(parseDeclaredTypes(Files.readString(file)));
-            FILE_CACHE.put(key, new CachedEntry(modMillis, types));
-            return types;
+            FileInfo info = parseFileInfo(Files.readString(file));
+            FILE_CACHE.put(key, new CachedEntry(modMillis, info.types, info.packageName, info.imports));
+            return info;
         } catch (Exception e) {
             logger.fine(() -> "Failed to read/parse " + file + ": " + e.getMessage());
-            return Collections.emptyList();
+            return FileInfo.EMPTY;
+        }
+    }
+
+    /**
+     * Parses the package name, imports, and declared types from {@code text}
+     * (uncached — for open unsaved buffers). Parser errors are swallowed so a
+     * partial file still yields partial results.
+     */
+    public static FileInfo parseFileInfo(String text) {
+        try {
+            DRL10Parser.CompilationUnitContext cu = DRLParsers.silent(text).compilationUnit();
+            if (cu == null) {
+                return FileInfo.EMPTY;
+            }
+            return new FileInfo(extractPackageName(cu),
+                    Collections.unmodifiableList(extractImports(cu)),
+                    Collections.unmodifiableList(extractFromCompilationUnit(cu)));
+        } catch (Exception e) {
+            logger.fine(() -> "Failed to parse DRL for file info: " + e.getMessage());
+            return FileInfo.EMPTY;
         }
     }
 
@@ -168,6 +225,40 @@ public final class DRLDeclaredTypeParser {
             }
         }
         return types;
+    }
+
+    /**
+     * The compilation unit's declared package, or the empty string when it
+     * declares none. Grammar: {@code packagedef : PACKAGE name=drlQualifiedName SEMI?}.
+     */
+    static String extractPackageName(DRL10Parser.CompilationUnitContext cu) {
+        if (cu == null || cu.packagedef() == null || cu.packagedef().drlQualifiedName() == null) {
+            return "";
+        }
+        return cu.packagedef().drlQualifiedName().getText();
+    }
+
+    /**
+     * The compilation unit's standard imports (excluding {@code import function}
+     * and {@code import static}), each as its qualified name. A wildcard import
+     * keeps its {@code .*} suffix, which the grammar carries as a separate
+     * {@code (DOT MUL)} outside {@code drlQualifiedName} — reconstructed here so
+     * wildcard imports read the same way local ones do downstream.
+     */
+    private static List<String> extractImports(DRL10Parser.CompilationUnitContext cu) {
+        List<String> imports = new ArrayList<>();
+        for (DRL10Parser.DrlStatementdefContext stmt : cu.drlStatementdef()) {
+            if (stmt.importdef() instanceof DRL10Parser.ImportStandardDefContext importDef
+                    && importDef.DRL_FUNCTION() == null && importDef.STATIC() == null
+                    && importDef.drlQualifiedName() != null) {
+                String name = importDef.drlQualifiedName().getText();
+                if (importDef.MUL() != null) {
+                    name = name + ".*";
+                }
+                imports.add(name);
+            }
+        }
+        return imports;
     }
 
     private static DeclaredType extractTypeDeclaration(DRL10Parser.TypeDeclarationContext ctx) {

--- a/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLLintHelper.java
+++ b/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLLintHelper.java
@@ -21,6 +21,7 @@ package org.drools.completion;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -815,10 +816,17 @@ public final class DRLLintHelper {
         Set<String> suggestions = new HashSet<>(known);
         suggestions.addAll(classIndex.simpleNames());
 
+        // Imports declared in same-package sibling files are in scope here too
+        // (Drools merges files by package), so resolution must see them. Computed
+        // once and threaded through all three scan paths.
+        Collection<String> siblingImports = DRLWorkspaceTypeIndex.siblingImports(
+                documentPath, DRLDeclaredTypeParser.extractPackageName(cu), openFiles);
+
         List<Diagnostic> out = new ArrayList<>();
-        collectPatternTypes(cu, cu, known, suggestions, classIndex, classpathResolved, severity, out);
+        collectPatternTypes(cu, cu, known, suggestions, classIndex, siblingImports,
+                            classpathResolved, severity, out);
         scanQualifiedRefs(cu, sanitized, declared, suggestions, cu, classIndex, memberIndex,
-                          classpathResolved, severity, out);
+                          siblingImports, classpathResolved, severity, out);
 
         Matcher then = THEN_END_BLOCK.matcher(sanitized);
         while (then.find() && out.size() < MAX_UNKNOWN_TYPE_DIAGNOSTICS) {
@@ -827,7 +835,7 @@ public final class DRLLintHelper {
             while (newType.find() && out.size() < MAX_UNKNOWN_TYPE_DIAGNOSTICS) {
                 Range range = rangeOf(sanitized, base + newType.start(1), base + newType.end(1));
                 addUnknown(newType.group(1), range, known, suggestions, cu, classIndex,
-                           classpathResolved, severity, out);
+                           siblingImports, classpathResolved, severity, out);
             }
         }
         return out;
@@ -836,7 +844,8 @@ public final class DRLLintHelper {
     /** Walks {@code node}, checking each pattern's object type against {@code cu}'s resolution. */
     private static void collectPatternTypes(ParseTree node, DRL10Parser.CompilationUnitContext cu,
                                             Set<String> known, Set<String> suggestions,
-                                            ClassIndex classIndex, boolean classpathResolved,
+                                            ClassIndex classIndex, Collection<String> extraImports,
+                                            boolean classpathResolved,
                                             DiagnosticSeverity severity, List<Diagnostic> out) {
         if (out.size() >= MAX_UNKNOWN_TYPE_DIAGNOSTICS) {
             return;
@@ -850,12 +859,12 @@ public final class DRLLintHelper {
                         new Position(stop.getLine() - 1,
                                      stop.getCharPositionInLine() + stop.getText().length()));
                 addUnknown(pattern.objectType.getText(), range, known, suggestions, cu, classIndex,
-                           classpathResolved, severity, out);
+                           extraImports, classpathResolved, severity, out);
             }
         }
         for (int i = 0; i < node.getChildCount(); i++) {
-            collectPatternTypes(node.getChild(i), cu, known, suggestions, classIndex, classpathResolved,
-                                severity, out);
+            collectPatternTypes(node.getChild(i), cu, known, suggestions, classIndex, extraImports,
+                                classpathResolved, severity, out);
         }
     }
 
@@ -869,7 +878,8 @@ public final class DRLLintHelper {
     private static void scanQualifiedRefs(ParseTree node, String sanitized,
                                           Map<String, DeclaredType> declared, Set<String> suggestions,
                                           DRL10Parser.CompilationUnitContext cu, ClassIndex classIndex,
-                                          ClassMemberIndex memberIndex, boolean classpathResolved,
+                                          ClassMemberIndex memberIndex, Collection<String> extraImports,
+                                          boolean classpathResolved,
                                           DiagnosticSeverity severity, List<Diagnostic> out) {
         if (out.size() >= MAX_UNKNOWN_TYPE_DIAGNOSTICS) {
             return;
@@ -881,14 +891,14 @@ public final class DRLLintHelper {
                 Matcher m = QUALIFIED_REF.matcher(sanitized.substring(start, stop + 1));
                 while (m.find() && out.size() < MAX_UNKNOWN_TYPE_DIAGNOSTICS) {
                     checkChain(m.group(1), start + m.start(1), sanitized, declared, suggestions,
-                               cu, classIndex, memberIndex, classpathResolved, severity, out);
+                               cu, classIndex, memberIndex, extraImports, classpathResolved, severity, out);
                 }
             }
             return; // the section's whole text is covered; no nested when-sections
         }
         for (int i = 0; i < node.getChildCount(); i++) {
             scanQualifiedRefs(node.getChild(i), sanitized, declared, suggestions, cu, classIndex,
-                              memberIndex, classpathResolved, severity, out);
+                              memberIndex, extraImports, classpathResolved, severity, out);
         }
     }
 
@@ -903,7 +913,8 @@ public final class DRLLintHelper {
     private static void checkChain(String chain, int chainStart, String sanitized,
                                    Map<String, DeclaredType> declared, Set<String> suggestions,
                                    DRL10Parser.CompilationUnitContext cu, ClassIndex classIndex,
-                                   ClassMemberIndex memberIndex, boolean classpathResolved,
+                                   ClassMemberIndex memberIndex, Collection<String> extraImports,
+                                   boolean classpathResolved,
                                    DiagnosticSeverity severity, List<Diagnostic> out) {
         int dot = chain.indexOf('.');
         String head = chain.substring(0, dot);
@@ -927,7 +938,7 @@ public final class DRLLintHelper {
         }
 
         // Classpath head.
-        String headFqcn = DRLCompletionHelper.resolveFqcn(head, head, cu, classIndex);
+        String headFqcn = DRLCompletionHelper.resolveFqcn(head, head, cu, classIndex, extraImports);
         if (headFqcn == null) {
             // Can't be sure it's a typo vs an unresolved real classpath type.
             if (classpathResolved) {
@@ -973,7 +984,8 @@ public final class DRLLintHelper {
      */
     private static void addUnknown(String candidate, Range range, Set<String> known,
                                    Set<String> suggestions, DRL10Parser.CompilationUnitContext cu,
-                                   ClassIndex classIndex, boolean classpathResolved,
+                                   ClassIndex classIndex, Collection<String> extraImports,
+                                   boolean classpathResolved,
                                    DiagnosticSeverity severity, List<Diagnostic> out) {
         if (candidate == null) {
             return;
@@ -984,7 +996,7 @@ public final class DRLLintHelper {
         }
         String simple = toSimpleTypeName(trimmed);
         if (known.contains(simple)
-                || DRLCompletionHelper.resolveFqcn(trimmed, simple, cu, classIndex) != null) {
+                || DRLCompletionHelper.resolveFqcn(trimmed, simple, cu, classIndex, extraImports) != null) {
             return;
         }
         if (!classpathResolved) {

--- a/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLWorkspaceTypeIndex.java
+++ b/packages/drools-lsp/drools-completion/src/main/java/org/drools/completion/DRLWorkspaceTypeIndex.java
@@ -21,6 +21,7 @@ package org.drools.completion;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -254,6 +255,58 @@ public final class DRLWorkspaceTypeIndex {
                 sink.accept(sibling.toUri().toString(), content);
             }
         }
+    }
+
+    /**
+     * Returns the imports contributed by sibling files that declare the
+     * <em>same</em> Drools package as the current document. Drools merges every
+     * file sharing a package into one namespace, so an import declared in any
+     * same-package sibling is in scope here — a consumer that would otherwise
+     * flag such a type (the unknown-type lint) must honor them.
+     *
+     * <p>Siblings come from the active {@link WorkspaceSiblingResolver} alone, so
+     * grouping stays whatever the workspace configured; open unsaved buffers
+     * shadow their on-disk counterpart, matching {@link #forEachSiblingType}.
+     * A null/blank {@code ownPackage} contributes nothing — a package-less file
+     * merges with no other file. Wildcard imports keep their {@code .*} suffix.
+     */
+    public static List<String> siblingImports(Path documentPath, String ownPackage,
+                                              Map<Path, String> openFiles) {
+        if (documentPath == null || ownPackage == null || ownPackage.isBlank()) {
+            return List.of();
+        }
+        String pkg = ownPackage.trim();
+        Path docNorm = documentPath.toAbsolutePath().normalize();
+        Path dir = docNorm.getParent();
+        Set<Path> shadowed = new HashSet<>();
+        List<String> imports = new ArrayList<>();
+
+        // Layer 2: open unsaved siblings (buffer content shadows disk).
+        if (openFiles != null) {
+            for (Map.Entry<Path, String> e : openFiles.entrySet()) {
+                Path p = normalizedSibling(e.getKey(), docNorm, dir);
+                if (p == null) {
+                    continue;
+                }
+                shadowed.add(p);
+                DRLDeclaredTypeParser.FileInfo info = DRLDeclaredTypeParser.parseFileInfo(e.getValue());
+                if (pkg.equals(info.packageName)) {
+                    imports.addAll(info.imports);
+                }
+            }
+        }
+
+        // Layer 3: on-disk siblings not shadowed by an open buffer.
+        for (Path sibling : WorkspaceSiblingResolvers.active().resolveSiblings(documentPath)) {
+            if (shadowed.contains(sibling.toAbsolutePath().normalize())) {
+                continue;
+            }
+            DRLDeclaredTypeParser.FileInfo info = DRLDeclaredTypeParser.cachedFileInfo(sibling);
+            if (pkg.equals(info.packageName)) {
+                imports.addAll(info.imports);
+            }
+        }
+        return imports;
     }
 
     /**

--- a/packages/drools-lsp/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
+++ b/packages/drools-lsp/drools-completion/src/test/java/org/drools/completion/DRLCompletionHelperTest.java
@@ -25,9 +25,11 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import org.drools.drl.parser.antlr4.DRL10Parser;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.Diagnostic;
@@ -715,6 +717,44 @@ class DRLCompletionHelperTest {
                 text, caretPosition, getLanguageClient());
 
         assertThat(result).isNotNull();
+    }
+
+    /**
+     * A simple name shared by two classpath types is ambiguous on the class
+     * index alone, but a wildcard import picks one package — as it does for the
+     * compiler. This works only if the extractor keeps the {@code .*} suffix,
+     * which the grammar carries outside {@code drlQualifiedName}.
+     */
+    @Test
+    void localWildcardImportResolvesAmbiguousSimpleName() {
+        String text = """
+                package org.example;
+
+                import com.acme.model.*;
+                """;
+
+        ClassIndex classIndex = ClassIndex.of(Map.of(
+                "Order", List.of("com.acme.model.Order", "com.other.Order")));
+        DRL10Parser.CompilationUnitContext cu = ParsedDrl.of(text).compilationUnit;
+
+        assertThat(DRLCompletionHelper.resolveFqcn("Order", "Order", cu, classIndex))
+                .isEqualTo("com.acme.model.Order");
+    }
+
+    /** A wildcard import must not resolve a type its package does not provide. */
+    @Test
+    void localWildcardImportDoesNotReachOutsideItsPackage() {
+        String text = """
+                package org.example;
+
+                import com.acme.model.*;
+                """;
+
+        ClassIndex classIndex = ClassIndex.of(Map.of(
+                "Order", List.of("com.other.Order", "com.third.Order")));
+        DRL10Parser.CompilationUnitContext cu = ParsedDrl.of(text).compilationUnit;
+
+        assertThat(DRLCompletionHelper.resolveFqcn("Order", "Order", cu, classIndex)).isNull();
     }
 
     private List<String> completionItemStrings(List<CompletionItem> result) {

--- a/packages/drools-lsp/drools-completion/src/test/java/org/drools/completion/DRLLintHelperTest.java
+++ b/packages/drools-lsp/drools-completion/src/test/java/org/drools/completion/DRLLintHelperTest.java
@@ -19,13 +19,19 @@
 
 package org.drools.completion;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,6 +73,20 @@ class DRLLintHelperTest {
         System.clearProperty("drools.lsp.lint.unbalancedParens");
         System.clearProperty("drools.lsp.lint.unknownTypes");
         System.clearProperty("drools.lsp.lint.mvelPropertyAccess");
+    }
+
+    // Sibling-import tests pin the active resolver to same-directory grouping so
+    // they never depend on an ambient ServiceLoader-discovered provider; the
+    // default is restored afterwards. Tests that pass a null document path are
+    // unaffected either way.
+    @BeforeEach
+    void useSameDirectoryResolver() {
+        WorkspaceSiblingResolvers.setActive(WorkspaceSiblingResolvers::sameDirectorySiblings);
+    }
+
+    @AfterEach
+    void restoreDefaultResolver() {
+        WorkspaceSiblingResolvers.setActive(null);
     }
 
     // ── missing 'end' ────────────────────────────────────────────────────
@@ -798,5 +818,145 @@ class DRLLintHelperTest {
                 + "declare Animal\n  legs : int\nend\n"
                 + "rule R\n  when\n    Animal( legs == PetKind.CAT.ordinal )\n  then\nend\n";
         assertThat(lintUnknownTypes(text)).isEmpty();
+    }
+
+    // ── sibling imports (same-package) ───────────────────────────────────
+
+    private static final String USES_ORDER =
+            "package demo;\nrule R\n  when\n    Order( )\n  then\nend\n";
+
+    /** Builds a class index from empty {@code .class} files for {@code fqcns}. */
+    private static ClassIndex classIndexOf(Path tempDir, String... fqcns) throws IOException {
+        Path classesDir = tempDir.resolve("classes");
+        Files.createDirectories(classesDir);
+        for (String fqcn : fqcns) {
+            Path classFile = classesDir.resolve(fqcn.replace('.', '/') + ".class");
+            Files.createDirectories(classFile.getParent());
+            Files.createFile(classFile);
+        }
+        return ClassIndex.build(Set.of(classesDir));
+    }
+
+    @Test
+    void siblingImportLegalizesPatternType(@TempDir Path tempDir) throws IOException {
+        // A same-package sibling imports Order; the current file uses it as a
+        // pattern type without importing it itself. The exact sibling import
+        // makes it resolvable, so no unknown-type diagnostic fires.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Files.writeString(tempDir.resolve("sibling.drl"),
+                "package demo;\nimport com.example.model.Order;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, Map.of(), ClassIndex.empty(), members, true);
+
+        assertThat(diags).isEmpty();
+    }
+
+    @Test
+    void siblingWildcardImportLegalizesThroughClassIndex(@TempDir Path tempDir) throws IOException {
+        // A wildcard sibling import (com.example.model.*) legalizes Order only
+        // when the class index confirms that package provides it. Two Order
+        // classes make the bare simple name ambiguous, so only the wildcard's
+        // package can disambiguate it — a path local wildcard imports never
+        // exercise (their extraction yields the bare package name).
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Files.writeString(tempDir.resolve("sibling.drl"),
+                "package demo;\nimport com.example.model.*;\n");
+        ClassIndex classIndex = classIndexOf(tempDir, "com.example.model.Order", "com.other.Order");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, Map.of(), classIndex, members, true);
+
+        assertThat(diags).isEmpty();
+    }
+
+    @Test
+    void differentPackageSiblingContributesNothing(@TempDir Path tempDir) throws IOException {
+        // The sibling imports Order but declares a different package, so Drools
+        // does not merge it with the current file: the import is out of scope
+        // and the unknown-type diagnostic still fires.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Files.writeString(tempDir.resolve("sibling.drl"),
+                "package other;\nimport com.example.model.Order;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, Map.of(), ClassIndex.empty(), members, true);
+
+        assertThat(diags)
+                .singleElement()
+                .satisfies(d -> assertThat(d.getMessage()).contains("Unknown type 'Order'"));
+    }
+
+    @Test
+    void unsavedSiblingBufferImportCounts(@TempDir Path tempDir) throws IOException {
+        // The on-disk sibling lacks the import, but an open unsaved buffer for it
+        // adds one. The buffer shadows disk, so the import is honored immediately.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Path sibling = tempDir.resolve("sibling.drl");
+        Files.writeString(sibling, "package demo;\n");
+        Map<Path, String> openFiles =
+                Map.of(sibling, "package demo;\nimport com.example.model.Order;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, openFiles, ClassIndex.empty(), members, true);
+
+        assertThat(diags).isEmpty();
+    }
+
+    @Test
+    void unsavedSiblingBufferShadowsTheOnDiskImport(@TempDir Path tempDir) throws IOException {
+        // The discriminating direction: the on-disk sibling HAS the import,
+        // but the open unsaved buffer removed it. If disk were (wrongly) read
+        // alongside the buffer, the import would still count — it must not.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Path sibling = tempDir.resolve("sibling.drl");
+        Files.writeString(sibling, "package demo;\nimport com.example.model.Order;\n");
+        Map<Path, String> openFiles = Map.of(sibling, "package demo;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, openFiles, ClassIndex.empty(), members, true);
+
+        assertThat(diags).isNotEmpty();
+    }
+
+    @Test
+    void siblingImportDoesNotBypassClasspathGating(@TempDir Path tempDir) throws IOException {
+        // Same exact sibling import as the positive case, but the classpath has
+        // not resolved and the class index is empty. The exact import resolves
+        // Order without the classpath, so no diagnostic fires — and the pass's
+        // gating (never confirming non-declared names as unknown without a
+        // resolved classpath) is left unchanged.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, USES_ORDER);
+        Files.writeString(tempDir.resolve("sibling.drl"),
+                "package demo;\nimport com.example.model.Order;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, Map.of(), ClassIndex.empty(), members, false);
+
+        assertThat(diags).isEmpty();
+    }
+
+    @Test
+    void noPackageDocumentGetsNoSiblingImports(@TempDir Path tempDir) throws IOException {
+        // The current document has no package declaration, so it merges with
+        // nothing — a same-package sibling's imports do not apply and the
+        // unknown-type diagnostic fires.
+        Path current = tempDir.resolve("current.drl");
+        Files.writeString(current, "rule R\n  when\n    Order( )\n  then\nend\n");
+        Files.writeString(tempDir.resolve("sibling.drl"),
+                "package demo;\nimport com.example.model.Order;\n");
+
+        List<Diagnostic> diags = DRLLintHelper.lintUnknownTypes(
+                Files.readString(current), current, Map.of(), ClassIndex.empty(), members, true);
+
+        assertThat(diags)
+                .singleElement()
+                .satisfies(d -> assertThat(d.getMessage()).contains("Unknown type 'Order'"));
     }
 }


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-tools/issues/3713

**Types imported in other files in the same package are now not flagged as unknown by the linter.**

### What changes

The lint now unions the imports contributed by same-package siblings. Siblings come from the active `WorkspaceSiblingResolver`, so grouping follows whatever the workspace configured rather than assuming a directory; open unsaved buffers shadow their on-disk counterparts. A sibling that declares a *different* package contributes nothing, and documents with no package declarations merges together and with nothing else.

Resolution itself is unchanged: sibling imports are threaded into `resolveFqcn` through a new five-argument overload, and the existing four-argument overload delegates to it with an empty collection, so hover, completion and go-to-definition behave exactly as before.

### One parse, not two

The issue asks whether this can be done with a single parse rather than two. It can, and is. `DRLDeclaredTypeParser` gains a `FileInfo` (package name, imports, declared types) served by `cachedFileInfo`, sharing the one mtime-keyed cache that already backed declared-type lookup. A sibling is therefore parsed once per change and that parse answers both the declares walk and the imports walk.

While there, `DRLLintHelper`'s local package-name extractor was folded into `DRLDeclaredTypeParser.extractPackageName` — the two were identical and in the same package.

### Companion fix: local wildcard imports

`resolveFqcn` has a wildcard-import branch guarded by `endsWith(".*")`, and for the current document that branch was unreachable. The grammar carries the `.*` of a wildcard import as a separate `(DOT MUL)` outside `drlQualifiedName`, so `DRLCompletionHelper.extractImports` yielded the bare package name and nothing ever matched `.*`. Local wildcard imports only ever resolved through the unambiguous-class-index fallback, which means a simple name shared by two classpath types resolved for the compiler but not for the LSP.

`extractImports` now reconstructs the suffix, mirroring the sibling-side extractor this PR adds.

Two consequences worth stating rather than leaving in the diff:

- **This changes hover/completion resolution for ambiguous names**, in the direction of matching the compiler: under `import com.acme.model.*`, a simple name that also exists in another package now resolves to the wildcard's package instead of resolving to nothing. The branch still verifies through the class index, so a wildcard cannot resolve a type its package does not provide.
- It also removes a latent false positive in completion sort priority. That check is exact-FQCN membership, so the bare package `com.acme.model` would match a class whose FQCN is literally that (a class named `model` in package `com.acme`) and boost it as though explicitly imported. `com.acme.model.*` cannot collide with any FQCN.

Co-authored by [Claude Code](https://claude.com/claude-code)
